### PR TITLE
frames.display_sequenceは2019_02_23_150233_add_display_sequence_to_fra…

### DIFF
--- a/database/migrations/2019_02_21_091152_create_frames_table.php
+++ b/database/migrations/2019_02_21_091152_create_frames_table.php
@@ -24,7 +24,8 @@ class CreateFramesTable extends Migration
             $table->string('template')->nullable();
             $table->string('plug_name')->nullable();
             $table->integer('bucket_id')->nullable();
-            $table->integer('display_sequence')->nullable();
+            // 2019_02_23_150233_add_display_sequence_to_frames_table.php で項目追加されるため、ここでは追加しない
+            //$table->integer('display_sequence')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
…mes_table.php で項目追加されるため、ここでは追加しない

マイグレーションでエラーになったため、修正プルリクエストです。
よければマージお願いします。

2019_02_23_150233_add_display_sequence_to_frames_table.php 
https://github.com/opensource-workshop/connect-cms/blob/master/database/migrations/2019_02_23_150233_add_display_sequence_to_frames_table.php

マイグレーションでエラー
```
// 再マイグレーション
# php artisan migrate:refresh

Rolling back: 2019_02_21_092320_create_contents_table
Rolled back:  2019_02_21_092320_create_contents_table
Rolling back: 2019_02_21_092147_create_buckets_table
Rolled back:  2019_02_21_092147_create_buckets_table
Rolling back: 2019_02_21_092004_create_plugins_table
Rolled back:  2019_02_21_092004_create_plugins_table
Rolling back: 2019_02_21_091152_create_frames_table
Rolled back:  2019_02_21_091152_create_frames_table
Rolling back: 2019_02_21_085932_create_pages_table
Rolled back:  2019_02_21_085932_create_pages_table
Rolling back: 2014_10_12_100000_create_password_resets_table
Rolled back:  2014_10_12_100000_create_password_resets_table
Rolling back: 2014_10_12_000000_create_users_table
Rolled back:  2014_10_12_000000_create_users_table

In Connection.php line 664:

  SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'display_sequence' (SQL: alter table `frames` add `display_sequence` int not
  null after `bucket_id`)


In Connection.php line 458:

  SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'display_sequence'
```
