### PR TITLE
laravel enum お試し実装

### DIFF
--- a/app/Enums/PermitForArticle.php
+++ b/app/Enums/PermitForArticle.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Enums;
+
+use BenSampo\Enum\Enum;
+
+/*
+* 記事関連の権限
+*/
+final class PermitForArticle extends Enum
+{
+    // 定数メンバ
+    const management = 1;
+    const plugin_placement = 2;
+    const add = 3;
+    const approval = 4;
+    const moderator = 5;
+
+    // key/valueの連想配列
+    const enum = [
+        self::management=>'記事管理者',
+        self::plugin_placement=>'プラグイン配置',
+        self::add=>'記事追加',
+        self::approval=>'記事承認',
+        self::moderator=>'モデレータ',
+    ];
+
+    /*
+    * 対応した和名を返す
+    */
+    public static function getDescription($key): string
+    {
+        return self::enum[$key];
+    }
+
+    /*
+    * key/valueの連想配列を返す
+    */
+    public static function getMembers(){
+        return self::enum;
+    }
+}

--- a/app/Enums/PermitForManage.php
+++ b/app/Enums/PermitForManage.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Enums;
+
+use BenSampo\Enum\Enum;
+
+/*
+* 管理権限
+*/
+final class PermitForManage extends Enum
+{
+    // 定数メンバ
+    const system = 1;
+    const page = 2;
+    const site = 3;
+    const user = 4;
+
+    // key/valueの連想配列
+    const enum = [
+        self::system=>'システム管理者',
+        self::page=>'ページ管理者',
+        self::site=>'サイト管理者',
+        self::user=>'ユーザ管理者',
+    ];
+
+    /*
+    * 対応した和名を返す
+    */
+    public static function getDescription($key): string
+    {
+        return self::enum[$key];
+    }
+
+    /*
+    * key/valueの連想配列を返す
+    */
+    public static function getMembers(){
+        return self::enum;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.2.0",
+        "bensampo/laravel-enum": "1.17.1",
         "fideloper/proxy": "~3.3",
         "kalnoy/nestedset": "4.3.4",
         "laravel/framework": "5.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,70 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73d090d4b49de8e66a3dcbbc2f0c61dd",
+    "content-hash": "d1638c6abd6c6f9801d9dad4a2b1e78c",
     "packages": [
+        {
+            "name": "bensampo/laravel-enum",
+            "version": "1.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/BenSampo/laravel-enum.git",
+                "reference": "612ae4c7a986aaf0e3c4666d48731e1f8e2ee19b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BenSampo/laravel-enum/zipball/612ae4c7a986aaf0e3c4666d48731e1f8e2ee19b",
+                "reference": "612ae4c7a986aaf0e3c4666d48731e1f8e2ee19b",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "~5.4",
+                "php": "~7.1"
+            },
+            "require-dev": {
+                "laravel/framework": "5.8.*",
+                "orchestra/testbench": "3.8.*",
+                "phpunit/phpunit": "7.5.*",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "BenSampo\\Enum\\EnumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "BenSampo\\Enum\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Sampson",
+                    "homepage": "https://sampo.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Simple, extensible and powerful enumeration implementation for Laravel.",
+            "homepage": "https://github.com/bensampo/laravel-enum",
+            "keywords": [
+                "bensampo",
+                "enum",
+                "laravel",
+                "package",
+                "validation"
+            ],
+            "time": "2019-03-05T10:29:46+00:00"
+        },
         {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "0.1",

--- a/config/app.php
+++ b/config/app.php
@@ -228,6 +228,9 @@ return [
         'View' => Illuminate\Support\Facades\View::class,
         'Input' => Illuminate\Support\Facades\Input::class,
 
+        // enums
+        'PermitForArticle' => \App\Enums\PermitForArticle::class,
+        'PermitForManage' => \App\Enums\PermitForManage::class,
     ],
 
 ];

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -95,7 +95,7 @@
                 @else
                     <input name="base[role_article_admin]" value="1" type="checkbox" class="custom-control-input" id="role_article_admin">
                 @endif
-                <label class="custom-control-label" for="role_article_admin">記事管理者</label>
+                <label class="custom-control-label" for="role_article_admin">{{ PermitForArticle::getDescription(PermitForArticle::management) }}</label>
             </div>
             <div class="custom-control custom-checkbox">
                 @if(isset($users_roles["base"]) && isset($users_roles["base"]["role_arrangement"]) && $users_roles["base"]["role_arrangement"] == 1)

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -90,11 +90,9 @@
         <label for="password-confirm" class="col-md-4 text-md-right">記事関連の権限</label>
         <div class="col-md-6">
             <div class="custom-control custom-checkbox">
-                @if(isset($users_roles["base"]) && isset($users_roles["base"]["role_article_admin"]) && $users_roles["base"]["role_article_admin"] == 1)
-                    <input name="base[role_article_admin]" value="1" type="checkbox" class="custom-control-input" id="role_article_admin" checked="checked">
-                @else
-                    <input name="base[role_article_admin]" value="1" type="checkbox" class="custom-control-input" id="role_article_admin">
-                @endif
+                <input name="base[role_article_admin]" value="1" type="checkbox" class="custom-control-input" id="role_article_admin" 
+                    {{ isset($users_roles["base"]) && isset($users_roles["base"]["role_article_admin"]) && $users_roles["base"]["role_article_admin"] == 1 ? 'checked="checked"' : '' }}
+                >
                 <label class="custom-control-label" for="role_article_admin">{{ PermitForArticle::getDescription(PermitForArticle::management) }}</label>
             </div>
             <div class="custom-control custom-checkbox">


### PR DESCRIPTION
- コミット毎に内容を分けています。
- ユーザ管理－登録画面－記事関連の権限－記事管理者の画面テキストのみ、とりあえずでenum表示してます。
- role_valueの登録値が固定で現状は1なので、更新処理の方はenum対応としては弄っていません。なのでenumファイルのvalue値も仮値で実装しています。
- 4つ目のコミットのリファクタリングはおまけです。bladeのif-elseで似た類似HTMLタグを2行書くと修正箇所が増えるので三項演算子でワンライナーで記述した例です。