### PR TITLE
mod: 初期ユーザのメールアドレスは空にする

### DIFF
--- a/database/seeds/DefaultUsersTableSeeder.php
+++ b/database/seeds/DefaultUsersTableSeeder.php
@@ -17,7 +17,7 @@ class DefaultUsersTableSeeder extends Seeder
                     /** 初期管理者 */
                     [
                         'name'=>'システム管理者',
-                        'email'=>'info@opensource-workshop.jp',
+                        'email'=>'',
                         'userid'=>'admin',
                         'password'=>bcrypt('C-admin'),
                         'remember_token'=>'',


### PR DESCRIPTION
弊社以外がConnectCMSを使う想定で、初期ユーザのメールアドレスに弊社のメールアドレスが入ってるのはよくない。
なので空に修正。

これでseederやConnectCMSが動作するのか未テストなので、後でテストしてまたコメントします。
