### PR TITLE
mod: ・コード管理、orderにcodeは含めない。含めるとdisplay_sequenceの並び順とコード一覧の並び順がずれるため

### DIFF
--- a/app/Plugins/Manage/CodeManage/CodeManage.php
+++ b/app/Plugins/Manage/CodeManage/CodeManage.php
@@ -67,7 +67,7 @@ class CodeManage extends ManagePluginBase
                           ->orderBy('type_code4')
                           ->orderBy('type_code5')
                           ->orderBy('display_sequence')
-                          ->orderBy('code')
+                          //->orderBy('code')
                           ->paginate(10);
 
         // $paginate_page = $request->get('page', 1);

--- a/resources/views/plugins/manage/code/code.blade.php
+++ b/resources/views/plugins/manage/code/code.blade.php
@@ -31,8 +31,8 @@
         <th class="d-block d-sm-table-cell">prefix</th>
         <th class="d-block d-sm-table-cell">type_name</th>
         <th class="d-block d-sm-table-cell">type_code1</th>
-        <th class="d-block d-sm-table-cell">type_code2</th>
 {{--
+        <th class="d-block d-sm-table-cell">type_code2</th>
         <th class="d-block d-sm-table-cell">type_code3</th>
         <th class="d-block d-sm-table-cell">type_code4</th>
         <th class="d-block d-sm-table-cell">type_code5</th>
@@ -57,9 +57,8 @@
         <td class="d-block d-sm-table-cell"><span class="d-sm-none">prefix：</span>{{$code->prefix}}</td>
         <td class="d-block d-sm-table-cell"><span class="d-sm-none">type_name：</span>{{$code->type_name}}</td>
         <td class="d-block d-sm-table-cell"><span class="d-sm-none">type_code1：</span>{{$code->type_code1}}</td>
-        <td class="d-block d-sm-table-cell"><span class="d-sm-none">type_code2：</span>{{$code->type_code2}}</td>
-
 {{--
+        <td class="d-block d-sm-table-cell"><span class="d-sm-none">type_code2：</span>{{$code->type_code2}}</td>
         <td class="d-block d-sm-table-cell"><span class="d-sm-none">type_code3：</span>{{$code->type_code3}}</td>
         <td class="d-block d-sm-table-cell"><span class="d-sm-none">type_code4：</span>{{$code->type_code4}}</td>
         <td class="d-block d-sm-table-cell"><span class="d-sm-none">type_code5：</span>{{$code->type_code5}}</td>


### PR DESCRIPTION
・コード一覧のtype_code2を非表示に変更

https://github.com/opensource-workshop/connect-cms/issues/190

マージします。