### PR TITLE
mod:  連番管理、管理画面のテーブル表示はclass=cc-font-90を使うといい感じ

### DIFF
--- a/resources/views/plugins/manage/number/number.blade.php
+++ b/resources/views/plugins/manage/number/number.blade.php
@@ -34,7 +34,7 @@
 </div>
 <div class="card-body">
 
-<table class="table table-bordered table_border_radius table-hover">
+<table class="table table-bordered table_border_radius table-hover cc-font-90">
 <tbody>
     <tr class="bg-light d-none d-sm-table-row">
         <th class="d-block d-sm-table-cell">プラグイン</th>


### PR DESCRIPTION
ユーザ管理、ページ管理ともに`<table>`でclass=cc-font-90を使って、フォントサイズを少し小さくしていました。
連番管理も対応した方がよいと思い、プルリクエスト投げます。

OKならマージお願いします。

コード管理は対応済みです。
https://github.com/opensource-workshop/connect-cms/pull/208/files
