### PR TITLE
bugfix: ログイン時、「ログイン状態を維持する」ONで1日たってからブラウザアクセスすると例外が発生するバグに対応

### DIFF
--- a/app/Traits/ConnectCommonTrait.php
+++ b/app/Traits/ConnectCommonTrait.php
@@ -176,7 +176,7 @@ trait ConnectCommonTrait
         foreach (config('cc_role.CC_ROLE_HIERARCHY')[$role] as $checck_role) {
 
             // ユーザの保持しているロールをループ
-            foreach ($user->user_roles as $target) {
+            foreach ((array)$user->user_roles as $target) {
 
                 // ターゲット処理をループ
                 foreach ($target as $user_role => $user_role_value) {


### PR DESCRIPTION
https://github.com/opensource-workshop/connect-cms/issues/220

この対応で様子見です。
マージします。

## エラー内容

Invalid argument supplied for foreach()

## 参考記事
「Invalid argument supplied for foreach() …」エラーの対処法
https://kotori-blog.com/php/foreach_error/

