### PR TITLE
ブログ 前へ／次へボタンのお試し実装

### DIFF
--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -533,19 +533,31 @@ WHERE status = 0
         $before_post = null;
         $after_post = null;
         if ($blogs_post) {
-            $before_post = BlogsPosts::where('blogs_id', $blogs_post->blogs_id)
-                                     ->where('posted_at', '<', $blogs_post->posted_at)
+            $before_post = BlogsPosts::select('contents_id')
+                                     ->where('blogs_id', $blogs_post->blogs_id)
+                                    //  投稿日時を同値以上とした為、自分以外の条件を追加
+                                     ->whereNotIn('contents_id', [$blogs_post->contents_id])
+                                     ->where('posted_at', '<=', $blogs_post->posted_at)
                                      ->where(function($query){
                                          $query = $this->appendAuthWhere($query);
                                      })
                                      ->orderBy('posted_at', 'desc')
+                                     ->groupBy('contents_id')
+                                    //  before/after間で同一の投稿日時を見分ける為、OFFSETを追加
+                                     ->offset(1)
                                      ->first();
-            $after_post = BlogsPosts::where('blogs_id', $blogs_post->blogs_id)
-                                     ->where('posted_at', '>', $blogs_post->posted_at)
+            $after_post = BlogsPosts::select('contents_id')
+                                     ->where('blogs_id', $blogs_post->blogs_id)
+                                    //  投稿日時を同値以下とした為、自分以外の条件を追加
+                                    ->whereNotIn('contents_id', [$blogs_post->contents_id])
+                                     ->where('posted_at', '>=', $blogs_post->posted_at)
                                      ->where(function($query){
                                          $query = $this->appendAuthWhere($query);
                                      })
                                      ->orderBy('posted_at', 'asc')
+                                     ->groupBy('contents_id')
+                                    //  before/after間で同一の投稿日時を見分ける為、OFFSETを追加
+                                    ->offset(1)
                                      ->first();
         }
 

--- a/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
@@ -66,7 +66,7 @@
 <div class="row">
     <div class="col-12 text-center mt-3">
         @if (isset($before_post))
-        <a href="{{url('/')}}/plugin/blogs/show/{{$page->id}}/{{$frame_id}}/{{$before_post->id}}" class="mr-1">
+        <a href="{{url('/')}}/plugin/blogs/show/{{$page->id}}/{{$frame_id}}/{{$before_post->contents_id}}" class="mr-1">
             <span class="btn btn-info"><i class="fas fa-chevron-left"></i> <span class="hidden-xs">前へ</span></span>
         </a>
         @endif
@@ -74,7 +74,7 @@
             <span class="btn btn-info"><i class="fas fa-list"></i> <span class="hidden-xs">一覧へ</span></span>
         </a>
         @if (isset($after_post))
-        <a href="{{url('/')}}/plugin/blogs/show/{{$page->id}}/{{$frame_id}}/{{$after_post->id}}" class="mr-1">
+        <a href="{{url('/')}}/plugin/blogs/show/{{$page->id}}/{{$frame_id}}/{{$after_post->contents_id}}" class="mr-1">
             <span class="btn btn-info"><i class="fas fa-chevron-right"></i> <span class="hidden-xs">次へ</span></span>
         </a>
         @endif


### PR DESCRIPTION
- 投稿日時が同一の別記事を検索する為、「同値以上（投稿日時の条件に「=」）」を追加
- 投稿日時が同一の自記事が検索されてしまう為、これを除外する条件（whereNotIn）を追加
- 投稿日時が同一の別記事が検索されるようになったが、前へ／次へボタンに同一のIDがセットされてしまう為、条件（OFFSET 1）を追加 ←結局、投稿日時が同一の別記事が飛ばされるようになってしまった為、思案中