### PR TITLE
add: Buckets モデルにホワイトリストのfillable を追加

### DIFF
--- a/app/Models/Common/Buckets.php
+++ b/app/Models/Common/Buckets.php
@@ -8,6 +8,15 @@ use App\Models\Common\BucketsRoles;
 
 class Buckets extends Model
 {
+    /**
+     * create()やupdate()で入力を受け付ける ホワイトリスト
+     */
+    protected $fillable = [
+        'id',
+        'bucket_name',
+        'plugin_name',
+    ];
+
     // Buckets のrole
     private $buckets_roles = null;
 


### PR DESCRIPTION
Buckets モデルはfillable が未定義だったので、定義しました。

一般プラグインのsaveBuckets()で下記のような実装を行いたいです。
モデルにfillable かguardedが定義されていないと、モデルのfirstOrNew()が利用できないんです。
これをすると、下記のif文かかなくてよくなります。

## これまでの実装
```php 
        if ($request->timetable_id) {
            // 更新
            $timetables= Timetables::find($request->timetable_id);
        } else {
            // 登録
            $timetables= new Timetables();                    
        }
        $timetables->bucket_id            = $buckets->id;
        $timetables->timetable_name       = $request->timetable_name;
        $timetables->school_code          = $request->school_code;
        $timetables->save();
```
## saveBuckets実装例

```php
    public function saveBuckets($request, $page_id, $frame_id, $id = null)
    {
//（中略）
        // バケツの取得 or New
        $buckets = Buckets::firstOrNew(['id' => $request->bucket_id]);
        $buckets->bucket_name = $request->timetable_name;
        $buckets->plugin_name = 'Timetables';
        $buckets->save();

        // Timetablesの取得 or New
        $timetables = Timetables::firstOrNew(['id' => $request->timetable_id]);
        $timetables->bucket_id            = $buckets->id;
        $timetables->timetable_name       = $request->timetable_name;
        $timetables->school_code          = $request->school_code;
        $timetables->save();
//（中略）
    }
```