### PR TITLE
mod: 表示ブログ選択画面、ページ送りとキャンセル・変更ボタンの間に余白を追加

### DIFF
--- a/resources/views/plugins/user/blogs/default/blogs_list_buckets.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_list_buckets.blade.php
@@ -40,7 +40,7 @@
         </table>
     </div>
 
-    <div class="text-center">
+    <div class="form-group text-center">
         {{ $blogs->links() }}
     </div>
 


### PR DESCRIPTION

## 修正前
![image](https://user-images.githubusercontent.com/2756509/74900889-7e030f00-53e4-11ea-94e8-b32f56cb0d85.png)

## 修正後
![image](https://user-images.githubusercontent.com/2756509/74900911-8d825800-53e4-11ea-9673-50d45561e113.png)
