### PR TITLE
bugfix: CC_METHOD_AUTHORITYとCC_METHOD_REQUEST_METHODに、権限設定のeditBucketsRoles、saveBucketsRolesを追加

### DIFF
--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -476,27 +476,22 @@ class UserPluginBase extends PluginBase
         // Buckets の取得
         $buckets = $this->getBuckets($frame_id);
 
-        // buckets がまだない場合
-        $frame_update = false;
-        if (empty($buckets)) {
-            $frame_update = true;
+        // buckets がまだない & 固定記事プラグインの場合
+        if (empty($buckets) && $this->frame->plugin_name == 'contents') {
             $buckets = new Buckets;
             $buckets->bucket_name = '無題';
             $buckets->plugin_name = 'contents';
-        }
+            // Buckets の更新
+            $buckets->save();
 
-        // Buckets の更新
-        $buckets->save();
+            // Frame にbuckets_id を登録
+            Frame::where('id', $frame_id)
+                 ->update(['bucket_id' => $buckets->id]);
+        }
 
         // BucketsRoles の更新
         $this->saveRequestRole($request, $buckets, 'role_reporter');
         $this->saveRequestRole($request, $buckets, 'role_article');
-
-        // Frame にbuckets_id を登録
-        if ($frame_update) {
-            Frame::where('id', $frame_id)
-                 ->update(['bucket_id' => $buckets->id]);
-        }
 
         // 画面の呼び出し
         return $this->commonView(

--- a/config/cc_role.php
+++ b/config/cc_role.php
@@ -140,7 +140,9 @@ return [
         'saveBuckets'         => ['frames.create'],
         'destroyBuckets'      => ['frames.delete'],
         'changeBuckets'       => ['frames.change'],
-
+        'editBucketsRoles'    => ['frames.edit'],
+        'saveBucketsRoles'    => ['frames.edit'],
+        
         'addColumn'           => ['buckets.addColumn'],
         'editColumn'          => ['buckets.editColumn'],
         'deleteColumn'        => ['buckets.deleteColumn'],
@@ -174,9 +176,11 @@ return [
         'listBuckets'         => ['get'],
         'createBuckets'       => ['get'],
         'editBuckets'         => ['get'],
+        'editBucketsRoles'    => ['get'],
         'saveBuckets'         => ['post'],
         'destroyBuckets'      => ['post'],
         'changeBuckets'       => ['post'],
+        'saveBucketsRoles'    => ['post'],
 
         'addColumn'           => ['post'],
         'editColumn'          => ['get'],

--- a/resources/views/plugins/common/frame_edit_buckets.blade.php
+++ b/resources/views/plugins/common/frame_edit_buckets.blade.php
@@ -13,6 +13,11 @@
 @endsection
 
 @section("plugin_setting_$frame->id")
+
+@if($plugin_name == 'contents' || $buckets)
+{{-- 固定記事プラグイン(=コンテンツプラグイン)はバケツありなし、どちらでも表示する。 --}}
+{{-- 固定記事プラグイン(=コンテンツプラグイン)以外はバケツありのみ、表示する。 --}}
+
 <form action="/plugin/{{$frame->plugin_name}}/saveBucketsRoles/{{$page->id}}/{{$frame->frame_id}}" name="{{$frame->plugin_name}}_buckets_form" method="POST" class="mt-3">
     {{ csrf_field() }}
 
@@ -82,4 +87,13 @@
         <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> 更新</button>
     </div>
 </form>
+
+@else
+{{-- 表示しない。 --}}
+<div class="alert alert-warning">
+    <i class="fas fa-exclamation-circle"></i>
+    設定画面から、使用する設定を選択するか、作成してください。
+</div>
+@endif
+
 @endsection


### PR DESCRIPTION
バグ修正のため、マージします。

## 修正内容
* bugfix: CC_METHOD_AUTHORITYとCC_METHOD_REQUEST_METHODに、権限設定のeditBucketsRoles、saveBucketsRolesを追加
* bugfix: saveBucketsRoles()で固定記事プラグイン以外は自動でBucketsを作成しないよう見直し
* bugfix: 権限設定は固定記事プラグイン以外はbuckets未選択の場合、権限設定を表示しない

## 関連issue
https://github.com/opensource-workshop/connect-cms/issues/233

