### PR TITLE
mod: 権限設定に承認を使うかどうかフラグを追加

### DIFF
--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -454,17 +454,17 @@ class UserPluginBase extends PluginBase
     }
 
     /**
-     * 設定変更画面
+     * 権限設定 変更画面
      */
-    public function editBucketsRoles($request, $page_id, $frame_id, $id = null)
+    public function editBucketsRoles($request, $page_id, $frame_id, $id = null, $use_approval = true)
     {
         // Buckets の取得
         $buckets = $this->getBuckets($frame_id);
 
-        return $this->commonView(
-            'frame_edit_buckets', [
-            'buckets'     => $buckets,
-            'plugin_name' => $this->frame->plugin_name,
+        return $this->commonView('frame_edit_buckets', [
+            'buckets'      => $buckets,
+            'plugin_name'  => $this->frame->plugin_name,
+            'use_approval' => $use_approval,
         ]);
     }
 
@@ -510,9 +510,9 @@ class UserPluginBase extends PluginBase
     }
 
     /**
-     * 設定保存処理
+     * 権限設定 保存処理
      */
-    public function saveBucketsRoles($request, $page_id, $frame_id, $id = null)
+    public function saveBucketsRoles($request, $page_id, $frame_id, $id = null, $use_approval = true)
     {
         // Buckets の取得
         $buckets = $this->getBuckets($frame_id);
@@ -535,10 +535,10 @@ class UserPluginBase extends PluginBase
         $this->saveRequestRole($request, $buckets, 'role_article');
 
         // 画面の呼び出し
-        return $this->commonView(
-            'frame_edit_buckets', [
-            'buckets'     => $buckets,
-            'plugin_name' => $this->frame->plugin_name,
+        return $this->commonView('frame_edit_buckets', [
+            'buckets'      => $buckets,
+            'plugin_name'  => $this->frame->plugin_name,
+            'use_approval' => $use_approval,
         ]);
     }
 

--- a/resources/views/plugins/common/frame_edit_buckets.blade.php
+++ b/resources/views/plugins/common/frame_edit_buckets.blade.php
@@ -27,7 +27,9 @@
             <tr>
                 <th class="border-top-0"></th>
                 <th class="border-top-0">投稿</th>
+                @if($use_approval)
                 <th class="border-top-0">承認</th>
+                @endif
             </tr>
         </thead>
         <tbody>
@@ -43,6 +45,8 @@
                         <label class="custom-control-label" for="role_reporter_post">投稿できる</label>
                     </div>
                 </td>
+
+                @if($use_approval)
                 <td>
                     <div class="custom-control custom-checkbox custom-control-inline">
                         @if($buckets && $buckets->needApproval("role_reporter"))
@@ -53,6 +57,7 @@
                         <label class="custom-control-label" for="role_reporter_approval">承認が必要</label>
                     </div>
                 </td>
+                @endif
             </tr>
             <tr>
                 <th>モデレータ</th>
@@ -66,6 +71,8 @@
                         <label class="custom-control-label" for="role_article_post">投稿できる</label>
                     </div>
                 </td>
+
+                @if($use_approval)
                 <td>
                     <div class="custom-control custom-checkbox custom-control-inline">
                         @if($buckets && $buckets->needApproval("role_article"))
@@ -76,6 +83,7 @@
                         <label class="custom-control-label" for="role_article_approval">承認が必要</label>
                     </div>
                 </td>
+                @endif
             </tr>
             </tr>
         </tbody>


### PR DESCRIPTION
権限設定に承認を使うかどうかフラグ`$use_approval`を追加。
承認を使わない場合は、プラグイン側のコントローラでオーバーライトして、`$use_approval = false`をセットする。

相談してからマージする。

## プラグイン側のコントローラでオーバーライト例

```php
    /**
     * 権限設定変更 画面
     */
    public function editBucketsRoles($request, $page_id, $frame_id, $id = null, $use_approval = true)
    {
        // 承認を使わない設定にして、親クラスの同メソッドを呼ぶ
        $use_approval = false;
        return parent::editBucketsRoles($request, $page_id, $frame_id, $id, $use_approval);
    }

    /**
     * 権限設定 保存処理
     */
    public function saveBucketsRoles($request, $page_id, $frame_id, $id = null, $use_approval = true)
    {
        // 承認を使わない設定にして、親クラスの同メソッドを呼ぶ
        $use_approval = false;
        return parent::saveBucketsRoles($request, $page_id, $frame_id, $id, $use_approval);
    }
```

## 画面例

![image](https://user-images.githubusercontent.com/2756509/74995692-f75a3a80-5494-11ea-95aa-bf655429803e.png)
