### PR TITLE
bugfix: 論理削除時、deleted_id・deleted_nameがDBに保存されないバグ修正

### DIFF
--- a/app/Userable.php
+++ b/app/Userable.php
@@ -46,6 +46,8 @@ trait Userable
         static::deleting(function (Model $model) {
             $model->deleted_id   = Auth::user()->id;
             $model->deleted_name = Auth::user()->name;
+            // delete時はsave走らないため、値をセットしても保存されない。そのため明示的にsaveする。
+            $model->save();
         });
     }
 }

--- a/app/UserableNohistory.php
+++ b/app/UserableNohistory.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Facades\Log;
  * 
  * 使用するには、モデルでcreated_id、created_name、updated_id、updated_nameを定義してuseする。
  *
- * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category Core
@@ -46,6 +45,8 @@ trait UserableNohistory
         static::deleting(function (Model $model) {
             $model->deleted_id   = Auth::user()->id;
             $model->deleted_name = Auth::user()->name;
+            // delete時はsave走らないため、値をセットしても保存されない。そのため明示的にsaveする。
+            $model->save();
         });
     }
 }


### PR DESCRIPTION
バグ修正です。

ブログと固定記事は記事削除時、履歴を含めて複数記事をいっぺんに削除するため、コントローラ側でdeleted_id・deleted_nameをupdateしてたので、バグの影響をうけてません。

マージします。
