### PR TITLE
bugfix: ログイン時、「ログイン状態を維持する」ONで1日たってからブラウザアクセスすると例外が発生するバグに対応4

### DIFF
--- a/app/Models/Common/Buckets.php
+++ b/app/Models/Common/Buckets.php
@@ -90,7 +90,7 @@ class Buckets extends Model
             return false;
         }
 
-        if (!array_key_exists('base', $user->user_roles)) {
+        if (!array_key_exists('base', (array)$user->user_roles)) {
             return false;
         }
 

--- a/app/User.php
+++ b/app/User.php
@@ -47,15 +47,4 @@ class User extends Authenticatable
     {
         $this->notify(new PasswordResetNotification($token));
     }
-
-    /**
-     * ユーザーのロールを取得
-     * bugfix: ログイン時、「ログイン状態を維持する」ONで1日たってからブラウザアクセスすると例外が発生するバグに対応
-     *         アクセサを定義して、user_rolesがnullの場合、arrayを返す
-     *         アクセサ定義の参考 https://readouble.com/laravel/5.5/ja/eloquent-mutators.html#accessors-and-mutators
-     */
-    public function getUserRolesAttribute($value)
-    {
-        return is_null($value) ? [] : $value;
-    }
 }


### PR DESCRIPTION
* bugfix: ログイン時、「ログイン状態を維持する」ONで1日たってからブラウザアクセスすると例外が発生するバグに対応3
https://github.com/opensource-workshop/connect-cms/pull/257  ⇒ バグ修正に効果ないためrevert
* bugfix: ログイン時、「ログイン状態を維持する」ONで1日たってからブラウザアクセスすると例外が発生するバグに対応2
https://github.com/opensource-workshop/connect-cms/pull/223
* bugfix: ログイン時、「ログイン状態を維持する」ONで1日たってからブラウザアクセスすると例外が発生するバグに対応
https://github.com/opensource-workshop/connect-cms/pull/221

対応3でバグ修正できてなかった。
対応3は取り消し。
対応4で`$user->user_roles`を使ってる箇所（Buckets.php）を修正する

## 修正箇所

Buckets.php
https://github.com/opensource-workshop/connect-cms/blob/cb9c52e5bd30910f3471fac3abea3ea161ce1394/app/Models/Common/Buckets.php#L93

