### PR TITLE
add: composerのdevにphpcs・phpcbfコマンド追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log
 !.gitkeep
 /connect-cms.code-workspace
 .vscode/launch.json
+composer.phar

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~6.0",
+        "squizlabs/php_codesniffer": "^3.5",
         "symfony/thanks": "^1.0"
     },
     "autoload": {
@@ -50,6 +51,12 @@
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover"
+        ],
+        "phpcs": [
+            "./vendor/bin/phpcs --standard=phpcs.xml ./"
+        ],
+        "phpcbf": [
+            "./vendor/bin/phpcbf --standard=phpcs.xml ./"
         ]
     },
     "config": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset name="PSR2/Laravel">
+    <description>PSR2 compliant rules and settings for Laravel</description>
+
+    <arg name="extensions" value="php" />
+
+    <!-- 適用コーディング規約の指定 -->
+    <rule ref="PSR2" />
+
+    <!-- 出力に色を適用 -->
+    <arg name="colors" />
+
+    <!-- オプション p:進捗表示  s:エラー表示時にルールを表示 -->
+    <arg value="ps" />
+
+    <!-- 除外ディレクトリ -->
+    <exclude-pattern>/bootstrap/</exclude-pattern>
+    <!-- 除外ディレクトリ:要検討 /config/cc_xxxx.phpは CMS独自。phpcs対象とする？それ以外を除外として列挙するのがよさそう -->
+    <exclude-pattern>/config/</exclude-pattern>
+    <exclude-pattern>/database/</exclude-pattern>
+    <exclude-pattern>/node_modules/</exclude-pattern>
+    <exclude-pattern>/public/</exclude-pattern>
+    <exclude-pattern>/routes/</exclude-pattern>
+    <!-- 除外ディレクトリ:要検討 /resources/viewsをphpcs対象とする？viewsそこまでする必要ないかも -->
+    <exclude-pattern>/resources/</exclude-pattern>
+    <exclude-pattern>/storage/</exclude-pattern>
+    <exclude-pattern>/vendor/</exclude-pattern>
+    <exclude-pattern>/server.php</exclude-pattern>
+    <exclude-pattern>/app/Console/Kernel.php</exclude-pattern>
+    <exclude-pattern>/tests/CreatesApplication.php</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
https://github.com/opensource-workshop/connect-cms/issues/316

まずはcomposerのdevにphpcs・phpcbfコマンド追加しました。
どのディレクトリをphpcsから除外するかは、phpcs.xmlに記載していて、
まだ見直しする余地があるため、ドラフトとしてpull requestを送ります。

まずはここまで。

## 情報元

LaravelにPHP_CodeSnifferを導入しコーディング規約（PSR）に沿った記述を行う
https://www.ritolab.com/entry/188