### PR TITLE
change: phpcsコマンドでcode:指摘箇所のコードも表示＋ summary:コード毎の要約レポート＋source:ルール毎の要約レポートを同時に出力するように対応

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,6 +13,9 @@
     <!-- オプション p:進捗表示  s:エラー表示時にルールを表示 -->
     <arg value="ps" />
 
+    <!-- オプション code:指摘箇所のコードも表示  summary:コード毎の要約レポート  source:ルール毎の要約レポート -->
+    <arg name="report" value="code,summary,source"/>
+
     <!-- 除外ディレクトリ -->
     <exclude-pattern>/bootstrap/</exclude-pattern>
     <!-- 除外ディレクトリ:要検討 /config/cc_xxxx.phpは CMS独自。phpcs対象とする？それ以外を除外として列挙するのがよさそう -->
@@ -21,7 +24,6 @@
     <exclude-pattern>/node_modules/</exclude-pattern>
     <exclude-pattern>/public/</exclude-pattern>
     <exclude-pattern>/routes/</exclude-pattern>
-    <!-- 除外ディレクトリ:要検討 /resources/viewsをphpcs対象とする？viewsそこまでする必要ないかも -->
     <exclude-pattern>/resources/</exclude-pattern>
     <exclude-pattern>/storage/</exclude-pattern>
     <exclude-pattern>/vendor/</exclude-pattern>


### PR DESCRIPTION
https://github.com/opensource-workshop/connect-cms/issues/316

phpcsコマンド一発で下記が同時に出力するように対応しました。

* code:指摘箇所のコードも表示
    * 実際の修正の参考に
* summary:コード毎の要約レポート
    * どのファイルにエラーが多いか確認
* source:ルール毎の要約レポートを同時に出力するように対応
    * phpcsルールの見直し参考に

別々に出力してましたが、下記が同時出力できるようになりました。

[phpcs_after_code.log](https://github.com/opensource-workshop/connect-cms/files/4618961/phpcs_after_code.log)
[phpcs_after_summary.log](https://github.com/opensource-workshop/connect-cms/files/4618960/phpcs_after_summary.log)
[phpcs_after_source.log](https://github.com/opensource-workshop/connect-cms/files/4618959/phpcs_after_source.log)

現在は大量にエラーが出て見ずらいですが、修正が進めば気にならなくなるかと思ってます。

マージします。
