### PR TITLE
composer.jsonのコマンド修正 phpcs/phpcbf powershell対応

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,10 +53,10 @@
             "@php artisan package:discover"
         ],
         "phpcs": [
-            "./vendor/bin/phpcs --standard=phpcs.xml ./"
+            "phpcs --standard=phpcs.xml ./"
         ],
         "phpcbf": [
-            "./vendor/bin/phpcbf --standard=phpcs.xml ./"
+            "phpcbf --standard=phpcs.xml ./"
         ]
     },
     "config": {


### PR DESCRIPTION
エラー内容
>PS C:\sites\connect-cms\htdocs\connect-cms> composer phpcs
\> ./vendor/bin/phpcs --standard=phpcs.xml ./
'.' is not recognized as an internal or external command,
operable program or batch file.
Script ./vendor/bin/phpcs --standard=phpcs.xml ./ handling the phpcs event returned with error code 1

参考
https://blog.msyk.net/?p=923