### PR TITLE
refactor: コード管理の注釈設定->注釈名に統一　他1件

### DIFF
--- a/resources/views/plugins/manage/code/code.blade.php
+++ b/resources/views/plugins/manage/code/code.blade.php
@@ -63,7 +63,7 @@
         <th class="d-block d-sm-table-cell text-break">プラグイン</th>
         @php
         $colums = [
-            'codes_help_messages_name' => '注釈設定',
+            'codes_help_messages_name' => '注釈名',
             'buckets_name' => 'buckets_name',
             'buckets_id' => 'buckets_id',
             'prefix' => 'prefix',

--- a/resources/views/plugins/manage/code/display.blade.php
+++ b/resources/views/plugins/manage/code/display.blade.php
@@ -41,7 +41,7 @@
         </div>
 
         <div class="form-group row">
-            <div class="col-md-3 text-md-right">注釈設定</div>
+            <div class="col-md-3 text-md-right">注釈名</div>
             <div class="col-md-9">
                 <div class="form-check">
                     <label class="form-check-label">

--- a/resources/views/plugins/manage/code/edit.blade.php
+++ b/resources/views/plugins/manage/code/edit.blade.php
@@ -61,7 +61,7 @@
         }
         @endphp
         <div class="form-group form-row">
-            <label for="codes_help_messages_alias_key" class="col-md-3 col-form-label text-md-right">注釈設定</label>
+            <label for="codes_help_messages_alias_key" class="col-md-3 col-form-label text-md-right">注釈名</label>
             <div class="col-md-9">
                 <select name="codes_help_messages_alias_key" id="codes_help_messages_alias_key" class="form-control" onchange="submitAction('{{$view_action_url}}')">
                     <option value=""@if($code->codes_help_messages_alias_key == "") selected @endif>設定なし</option>

--- a/resources/views/plugins/manage/code/help_message_edit.blade.php
+++ b/resources/views/plugins/manage/code/help_message_edit.blade.php
@@ -34,6 +34,11 @@
 </div>
 <div class="card-body">
 
+    <div class="alert alert-info" role="alert">
+        コード登録画面の注釈を登録します。<br>
+        登録した注釈は、コード登録画面の注釈名に表示され、選択すると各項目下部に注釈が表示されます。
+    </div>
+
     <form name="form_code" action="" method="POST" class="form-horizontal">
         {{ csrf_field() }}
         <input name="page" value="{{$paginate_page}}" type="hidden">


### PR DESCRIPTION
## 概要（Overview）
* refactor: コード管理の注釈設定->注釈名に統一
* add: 注釈登録画面に、機能説明文を追加

マージします。

## 関連Pull requests/Issues（Links to related pull requests or issues）
このプルリクの続き　https://github.com/opensource-workshop/connect-cms/pull/333

https://github.com/opensource-workshop/connect-cms/issues/199

## 参考（Reference）

なし

## チェックリスト（Checklist）

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
