### PR TITLE
refactor: コード管理表示設定、並び順->表示順に統一　他2件

### DIFF
--- a/app/Plugins/Manage/CodeManage/CodeManage.php
+++ b/app/Plugins/Manage/CodeManage/CodeManage.php
@@ -44,6 +44,7 @@ class CodeManage extends ManagePluginBase
 
         // (コード一覧)表示設定
         $role_ckeck_table["display"]            = array('admin_site');
+        $role_ckeck_table["displayStore"]       = array('admin_site');
         $role_ckeck_table["displayUpdate"]      = array('admin_site');
 
         // 検索条件
@@ -167,6 +168,7 @@ class CodeManage extends ManagePluginBase
 
         // Configsから一覧表示設定の取得
         $config = $this->getConfigCodeListDisplayColums();
+        //var_dump($config);
 
         // 記録した検索条件取得
         $codes_searches = CodesSearches::orderBy('display_sequence')->get();
@@ -418,9 +420,17 @@ class CodeManage extends ManagePluginBase
     }
 
     /**
+     * (コード一覧)表示設定 登録処理
+     */
+    public function displayStore($request)
+    {
+        return $this->displayUpdate($request, null);
+    }
+
+    /**
      * (コード一覧)表示設定 更新処理
      */
-    public function displayUpdate($request, $id = null)
+    public function displayUpdate($request, $id)
     {
         if ($id) {
             // 更新

--- a/resources/views/plugins/manage/code/code.blade.php
+++ b/resources/views/plugins/manage/code/code.blade.php
@@ -20,6 +20,13 @@
 </div>
 <div class="card-body">
 
+{{-- 警告メッセージエリア --}}
+@if (! $config)
+    <div class="alert alert-warning" role="alert">
+        表示設定が未設定です。<a href="{{url('/')}}/manage/code/display" class="alert-link">表示設定</a>から設定してください。
+    </div>
+@endif
+
 {{-- 検索エリア --}}
 <form action="{{url('/')}}/manage/code/index/{{$config->id}}" method="GET" class="form-horizontal">
     <div class="input-group">

--- a/resources/views/plugins/manage/code/display.blade.php
+++ b/resources/views/plugins/manage/code/display.blade.php
@@ -24,10 +24,8 @@
         コード一覧に表示する項目を設定します。
     </div>
 
-    <form action="{{url('/')}}/manage/code/displayUpdate/{{$config->id}}" method="POST" class="form-horizontal">
+    <form action="" method="POST" class="form-horizontal">
         {{ csrf_field() }}
-
-        <!-- Code form  -->
 
         <div class="form-group row">
             <div class="col-md-3 text-md-right">プラグイン</div>
@@ -232,9 +230,15 @@
         <div class="form-group row">
             <div class="offset-sm-3 col-sm-6">
                 <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/')}}/manage/code?page={{$paginate_page}}'"><i class="fas fa-times"></i> キャンセル</button>
-                <button type="submit" class="btn btn-primary form-horizontal mr-2">
+                @if ($config->id)
+                <button type="button" class="btn btn-primary form-horizontal mr-2" onclick="this.form.action='{{url('/')}}/manage/code/displayUpdate/{{$config->id}}'; this.form.submit();">
                     <i class="fas fa-check"></i> 更新
                 </button>
+                @else
+                <button type="button" class="btn btn-primary form-horizontal mr-2" onclick="this.form.action='{{url('/')}}/manage/code/displayStore'; this.form.submit();">
+                    <i class="fas fa-check"></i> 登録
+                </button>
+                @endif
             </div>
         </div>
     </form>

--- a/resources/views/plugins/manage/code/display.blade.php
+++ b/resources/views/plugins/manage/code/display.blade.php
@@ -218,7 +218,7 @@
         </div>
 
         <div class="form-group row">
-            <div class="col-md-3 text-md-right">並び順</div>
+            <div class="col-md-3 text-md-right">表示順</div>
             <div class="col-md-9">
                 <div class="form-check">
                     <label class="form-check-label">


### PR DESCRIPTION
## 概要（Overview）
* refactor: コード管理表示設定、並び順->表示順に統一
* bugfix: コード管理の表示設定、初回登録がされない不具合修正 
* add: 表示設定が未設定だったら、コード一覧に未設定の警告メッセージを表示

マージします。

## 関連Pull requests/Issues（Links to related pull requests or issues）
このプルリクの続き　https://github.com/opensource-workshop/connect-cms/pull/333

https://github.com/opensource-workshop/connect-cms/issues/199

## 参考（Reference）

なし

## チェックリスト（Checklist）

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer

### 実行したコマンド

```
./vendor/bin/phpcs --standard=phpcs.xml ./app/Plugins/Manage/CodeManage/
./vendor/bin/phpcbf --standard=phpcs.xml ./app/Plugins/Manage/CodeManage/
```
