### PR TITLE
add: composer phpcs-color command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,9 +55,17 @@
         "phpcs": [
             "phpcs --standard=phpcs.xml ./"
         ],
+        "phpcs-color": [
+            "@phpcs --colors"
+        ],
         "phpcbf": [
             "phpcbf --standard=phpcs.xml ./"
         ]
+    },
+    "scripts-descriptions": {
+        "phpcs": "Run all phpcs.",
+        "phpcs-color": "Run all phpcs add option colors(Linux Only).",
+        "phpcbf": "Run all phpcbf."
     },
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
## 概要（Overview）
* phpcsの色つきは、windows環境だと色が反映されず、余計な文字列が出力されるため、コマンドを分けました。
* また、composer scriptsの説明を追記しました。`composer run-script --list`で表示されます。
マージします。

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

なし

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク
https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands

## チェックリスト（Checklist）
- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
composer.jsonのみ修正のため、対象外