### PR TITLE
（サイト管理、ページ管理）カラーパレット追加

### DIFF
--- a/resources/views/plugins/manage/page/page_form.blade.php
+++ b/resources/views/plugins/manage/page/page_form.blade.php
@@ -74,16 +74,37 @@
             <small class="form-text text-muted">ページにパスワードで閲覧制限を設ける場合に使用します。</small>
         </div>
     </div>
-    <div class="form-group row">
-        <label for="permanent_link" class="col-md-3 col-form-label text-md-right">背景色</label>
-        <div class="col-md-9">
-            <input type="text" name="background_color" id="background_color" value="{{$page->background_color}}" class="form-control">
+    <div id="app">
+        @php
+            // IEか判定
+            $ua = $_SERVER['HTTP_USER_AGENT'];
+            $is_ie = false;
+            $placeholder_message = 'HTMLカラーコードを入力';
+            if (strstr($ua, 'Trident') || strstr($ua, 'MSIE')) {
+                $is_ie = true;
+            }
+        @endphp
+        <div class="form-group row">
+            <label for="permanent_link" class="col-md-3 col-form-label text-md-right">背景色</label>
+            <div class="col-md-9">
+                <input type="text" name="background_color" id="background_color" value="{{$page->background_color}}" class="form-control" v-model="v_background_color" placeholder="{{ $placeholder_message }}">
+                @if (!$is_ie)
+                    {{-- IEなら表示しない --}}
+                    <input type="color" v-model="v_background_color">
+                    <small class="text-muted">左のカラーパレットから選択することも可能です。</small>
+                @endif
+            </div>
         </div>
-    </div>
-    <div class="form-group row">
-        <label for="permanent_link" class="col-md-3 col-form-label text-md-right">ヘッダーの背景色</label>
-        <div class="col-md-9">
-            <input type="text" name="header_color" id="header_color" value="{{$page->header_color}}" class="form-control">
+        <div class="form-group row">
+            <label for="permanent_link" class="col-md-3 col-form-label text-md-right">ヘッダーの背景色</label>
+            <div class="col-md-9">
+                <input type="text" name="header_color" id="header_color" value="{{$page->header_color}}" class="form-control" v-model="v_header_color" placeholder="{{ $placeholder_message }}">
+                @if (!$is_ie)
+                    {{-- IEなら表示しない --}}
+                    <input type="color" v-model="v_header_color">
+                    <small class="text-muted">左のカラーパレットから選択することも可能です。</small>
+                @endif
+            </div>
         </div>
     </div>
 
@@ -323,3 +344,12 @@
         </div>
     </div>
 </form>
+<script>
+    new Vue({
+        el: "#app",
+        data: {
+            v_background_color: document.getElementById('background_color').value,
+            v_header_color: document.getElementById('header_color').value
+        },
+    })
+</script>

--- a/resources/views/plugins/manage/site/site.blade.php
+++ b/resources/views/plugins/manage/site/site.blade.php
@@ -49,20 +49,40 @@
             </select>
         </div>
 
-        {{-- 背景色 --}}
-        <div class="form-group">
-            <label class="col-form-label">背景色</label>
-            <input type="text" name="base_background_color" value="{{$configs["base_background_color"]}}" class="form-control">
-            <small class="form-text text-muted">画面の基本の背景色（各ページで上書き可能）</small>
-        </div>
+        <div id="app">
+            @php
+                // IEか判定
+                $ua = $_SERVER['HTTP_USER_AGENT'];
+                $is_ie = false;
+                $placeholder_message = 'HTMLカラーコードを入力';
+                if (strstr($ua, 'Trident') || strstr($ua, 'MSIE')) {
+                    $is_ie = true;
+                }
+            @endphp
+            {{-- 背景色 --}}
+            <div class="form-group">
+                <label class="col-form-label">背景色</label>
+                <input type="text" name="base_background_color" id="base_background_color" value="{{$configs["base_background_color"]}}" class="form-control" v-model="v_base_background_color" placeholder="{{ $placeholder_message }}">
+                <small class="form-text text-muted">画面の基本の背景色（各ページで上書き可能）</small>
+                @if (!$is_ie)
+                    {{-- IEなら表示しない --}}
+                    <input type="color" v-model="v_base_background_color">
+                    <small class="text-muted">左のカラーパレットから選択することも可能です。</small>
+                @endif
+            </div>
 
-        {{-- ヘッダーの背景色 --}}
-        <div class="form-group">
-            <label class="col-form-label">ヘッダーの背景色</label>
-            <input type="text" name="base_header_color" value="{{$configs["base_header_color"]}}" class="form-control">
-            <small class="form-text text-muted">画面の基本のヘッダー背景色（各ページで上書き可能）</small>
+            {{-- ヘッダーの背景色 --}}
+            <div class="form-group">
+                <label class="col-form-label">ヘッダーの背景色</label>
+                <input type="text" name="base_header_color" id="base_header_color" value="{{$configs["base_header_color"]}}" class="form-control" v-model="v_base_header_color" placeholder="{{ $placeholder_message }}">
+                <small class="form-text text-muted">画面の基本のヘッダー背景色（各ページで上書き可能）</small>
+                @if (!$is_ie)
+                    {{-- IEなら表示しない --}}
+                    <input type="color" v-model="v_base_header_color">
+                    <small class="text-muted">左のカラーパレットから選択することも可能です。</small>
+                @endif
+            </div>
         </div>
-
         {{-- ヘッダーの表示指定 --}}
         <div class="form-group">
             <label class="col-form-label">ヘッダーの表示</label>
@@ -229,5 +249,14 @@
     </form>
 </div>
 </div>
+<script>
+    new Vue({
+        el: "#app",
+        data: {
+            v_base_background_color: document.getElementById('base_background_color').value,
+            v_base_header_color: document.getElementById('base_header_color').value
+        },
+    })
+</script>
 
 @endsection


### PR DESCRIPTION
## 概要（Overview）
### （問題）  
- サイト管理、ページ管理における背景色の設定で何を入力すべきかが明示されていない。  
### （対応）
- プレースホルダを追加
- システム側はカラーコードの入力を期待しているのですが、調べさせるのも不親切なのでカラーピッカー項目を追加（vueで入力値と連動させています）
### （補足）
- 当初は現テキストボックスをそのままカラーパレット化しようと考えましたが、初期表示で該当項目がnullの場合、パレット表示は黒で表示されてしまいます。この場合、本当に黒が設定されているのか未設定なのかが判別不可になります。デフォルト値の設定を検討しましたが、この場合はページ管理の方でページ間の承継機能とバッティングしてしまいます。
- ちなみにカラーパレット自体はIEは動作しない為、IEではピッカー項目は非表示としています。
- 下記はEdge、Firefox、chrome、IEでの対応後イメージです。
![image](https://user-images.githubusercontent.com/13323806/82323571-36a41300-9a13-11ea-8260-313c747862b4.png)

## 関連Pull requests/Issues（Links to related pull requests or issues）
なし

## 参考（Reference）
https://developer.mozilla.org/ja/docs/Web/HTML/Element/Input/color

## チェックリスト（Checklist）
- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer