### PR TITLE
add: wiygwygで画像の回転できるようにする

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -80,7 +80,7 @@
     }
 
     // plugins
-    $plugins = 'file image link autolink preview textcolor code table lists advlist';
+    $plugins = 'file image imagetools link autolink preview textcolor code table lists advlist';
     if (config('connect.OSWS_TRANSLATE_AGREEMENT') === true) {
         $plugins .= ' translate';
     }

--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -4,7 +4,7 @@
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category プラグイン共通
- --}}
+--}}
 @php
     // テーマ固有書式
     $style_formats_file = '';
@@ -93,6 +93,11 @@
     }
     $toolbar = "toolbar  : '" . $toolbar . "',";
 
+    // imagetools_toolbar (need imagetools plugin)
+    // rotateleft rotateright flipv fliphは、フォーカスが外れないと images_upload_handler が走らないため、使わない。フォーカスが外さないで確定すると、固定記事の場合、コンテンツカラム内にbase64画像（超長い文字列)がそのまま送られ、カラムサイズオーバーでSQLエラーになる。
+    // しかし editimage (画像の編集) であれば、モーダルを開いてそこで編集し「保存」ボタンを押下時に images_upload_handler が走るため、base64問題を回避できる。
+    $imagetools_toolbar = "imagetools_toolbar  : 'editimage imageoptions',";
+
 @endphp
 <input type="hidden" name="page_id" value="{{$page_id}}">
 <script type="text/javascript" src="{{url('/')}}/js/tinymce/tinymce.min.js"></script>
@@ -108,6 +113,9 @@
 
         {{-- plugins --}}
         {!!$plugins!!}
+
+        {{-- imagetools_toolbar --}}
+        {!!$imagetools_toolbar!!}
 
         {{-- formatselect = スタイル, styleselect = 書式 --}}
         {!!$toolbar!!}
@@ -172,6 +180,10 @@
             xhr.onload = function() {
                 var json;
 
+                // アップロード後に押せない全ボタンを解除する
+                $(':button').prop('disabled', false);
+                // console.log("転送が完了しました。");
+
                 if (xhr.status < 200 || xhr.status >= 300) {
                     failure('HTTP Error: ' + xhr.status);
                     return;
@@ -182,20 +194,16 @@
                     failure('Invalid JSON: ' + xhr.responseText);
                     return;
                 }
-                // [debug]
-                // アップロード後に押せないボタンを解除する
-                // $(':button').prop('disabled', false);
-                // console.log("転送が完了しました。");
 
                 success(json.location);
             };
 
-            // [debug]
-            // アップロード中はボタンを押させない
-            // $(':button').prop('disabled', true);
+            // アップロード中は全ボタンを押させない
+            $(':button').prop('disabled', true);
             // console.log("転送開始");
 
             formData = new FormData();
+
             // bugfix: 「blobInfo.blob().name」は新規のアップロードの際しか名前が設定されないが、「blobInfo.filename()」は新規の時も回転などimagetoolsを使用した時も
             // 常に設定されているので、typeofの評価は不要で常に fileName = blobInfo.filename(); でよいのではと思います。
             // https://github.com/opensource-workshop/connect-cms/pull/353#issuecomment-636411186
@@ -211,10 +219,6 @@
             formData.append('file', blobInfo.blob(), fileName);
             formData.append('page_id', {{$page_id}});
             xhr.send(formData);
-
-            // [debug]
-            // console.log("Uploaded images and posted content as an ajax request.");
-            // Close the last shown notification.
         }
     });
 </script>

--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -182,20 +182,39 @@
                     failure('Invalid JSON: ' + xhr.responseText);
                     return;
                 }
+                // [debug]
+                // アップロード後に押せないボタンを解除する
+                // $(':button').prop('disabled', false);
+                // console.log("転送が完了しました。");
+
                 success(json.location);
             };
 
+            // [debug]
+            // アップロード中はボタンを押させない
+            // $(':button').prop('disabled', true);
+            // console.log("転送開始");
+
             formData = new FormData();
-            if( typeof(blobInfo.blob().name) !== undefined )
-                fileName = blobInfo.blob().name;
-            else
-                fileName = blobInfo.filename();
+            // bugfix: 「blobInfo.blob().name」は新規のアップロードの際しか名前が設定されないが、「blobInfo.filename()」は新規の時も回転などimagetoolsを使用した時も
+            // 常に設定されているので、typeofの評価は不要で常に fileName = blobInfo.filename(); でよいのではと思います。
+            // https://github.com/opensource-workshop/connect-cms/pull/353#issuecomment-636411186
+            //
+            // if( typeof(blobInfo.blob().name) !== undefined )
+            //     fileName = blobInfo.blob().name;
+            // else
+            //     fileName = blobInfo.filename();
+            fileName = blobInfo.filename();
 
             var tokens = document.getElementsByName("csrf-token");
             formData.append('_token', tokens[0].content);
             formData.append('file', blobInfo.blob(), fileName);
             formData.append('page_id', {{$page_id}});
             xhr.send(formData);
+
+            // [debug]
+            // console.log("Uploaded images and posted content as an ajax request.");
+            // Close the last shown notification.
         }
     });
 </script>


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

wiygwygで画像の回転できるようにするため、tinymce4のimagetoolsプラグインを設定しました。
imagetoolsプラグインは、既にConnect-CMSにありました。
https://github.com/opensource-workshop/connect-cms/tree/master/public/js/tinymce/plugins/imagetools

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク
https://github.com/opensource-workshop/connect-cms/issues/350

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

https://www.tiny.cloud/docs/plugins/imagetools/
> Warning: This feature requires at least Internet Explorer 10, since it makes use of HTML5 File API.

IE10以上。HTML5 File API.で機能を実現しているようです。

## チェックリスト（Checklist）
- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
bladeファイルのため、対象外です。

## 動作確認

* FireFox OK
* chromeで動作確認しました。

![image](https://user-images.githubusercontent.com/2756509/83326350-50b0e180-a2ae-11ea-910d-2e77c046579c.png)

画像の編集ボタンを押すと、トリミングも可能でした。
![image](https://user-images.githubusercontent.com/2756509/83326365-7d64f900-a2ae-11ea-992b-1b8a921a8873.png)

