### PR TITLE
change: sso, Connect-CMSにユーザ有りの場合、権限チェックしないでログインさせる。他１件

### DIFF
--- a/app/Plugins/Api/Nc2Sso/Nc2Sso.php
+++ b/app/Plugins/Api/Nc2Sso/Nc2Sso.php
@@ -86,33 +86,41 @@ class Nc2Sso extends ApiPluginBase
             // ユーザはあり、書き込み系の権限がない場合は、自動ログイン
             //if ($users_roles->notRole('role_reporter', $user->id)) {
 
-            // ユーザはあり、記事書き込み権限のみの場合は、自動ログイン
-            if ($users_roles->isOnlyRole('role_reporter', $user->id)) {
-                // ログイン
-                Auth::login($user, true);
+            // // ユーザはあり、記事書き込み権限のみの場合は、自動ログイン
+            // if ($users_roles->isOnlyRole('role_reporter', $user->id)) {
+            //     // ログイン
+            //     Auth::login($user, true);
 
-                // トップページへ
-                return redirect("/");
-            }
+            //     // トップページへ
+            //     return redirect("/");
+            // }
 
-            // 管理者権限の場合は、NC2 側でも管理者の場合、自動ログイン
-            //if ($user->role == config('cc_role.ROLE_SYSTEM_MANAGER') && $check_result['role_authority_id'] == 1) {
-            if ($users_roles->haveAdmin($user->id) && $check_result['role_authority_id'] == 1) {
-                // ログイン
-                Auth::login($user, true);
+            // // 管理者権限の場合は、NC2 側でも管理者の場合、自動ログイン
+            // //if ($user->role == config('cc_role.ROLE_SYSTEM_MANAGER') && $check_result['role_authority_id'] == 1) {
+            // if ($users_roles->haveAdmin($user->id) && $check_result['role_authority_id'] == 1) {
+            //     // ログイン
+            //     Auth::login($user, true);
 
-                // トップページへ
-                return redirect("/");
-            }
+            //     // トップページへ
+            //     return redirect("/");
+            // }
 
-            // 権限エラー
-            abort(403, "SSO 権限エラー。<br />&nbsp;&nbsp;&nbsp;&nbsp;NetCommons2 の権限より高い権限でのログインはできません。");
+            // // 権限エラー
+            // abort(403, "SSO 権限エラー。<br />&nbsp;&nbsp;&nbsp;&nbsp;NetCommons2 の権限より高い権限でのログインはできません。");
+
+            // 権限チェックしない
+            // ログイン
+            Auth::login($user, true);
+
+            // トップページへ
+            return redirect("/");
+
         } else {
             // ユーザが存在しない場合、一般権限でユーザを作成して、自動ログイン
             $user           = new User;
             $user->name     = $check_result['handle'];
             $user->userid   = $login_id;
-            $user->password = 'password';
+            $user->password = 'sso-invalid-password';   // プレーンテキストのパスワードは設定しても、入力パスワードと一致する事はないため、無効になる
             //$user->role     = 0;
             $user->save();
 


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

* change: sso, Connect-CMSにユーザ有りの場合、権限チェックしないでログインさせる。
  * Connect-CMSにユーザがいて、権限に管理者（ここではサイト管理者）を付けると、SSO時に下記エラー画面が表示され、ログインできませんでした
  * ![20200602-085630](https://user-images.githubusercontent.com/2756509/83469467-be315d80-a4ba-11ea-979f-56ef84197c50.jpg)
  * NC2とConnect-CMSの権限はそれぞれ独立しているため、SSO後にユーザができて、Connect-CMSの権限を追加する事はありえるため、権限チェックを外しました。
* change: sso, Connect-CMSにユーザ無し時に設定するパスワードは、無効な事が解るように内容変更
  * SSO時、Connect-CMS側にユーザがいなければ自動作成しますが、そこで設定するパスワードは無効なもののため、DBを見た時にパスワードが無効である事がわかる内容に修正しました。

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

なし

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer