### PR TITLE
add: composer phpcs-any, phpcbf-any

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,14 +58,22 @@
         "phpcs-color": [
             "@phpcs --colors"
         ],
+        "phpcs-any": [
+            "phpcs --standard=phpcs.xml"
+        ],
         "phpcbf": [
             "phpcbf --standard=phpcs.xml ./"
+        ],
+        "phpcbf-any": [
+            "phpcbf --standard=phpcs.xml"
         ]
     },
     "scripts-descriptions": {
         "phpcs": "Run all phpcs (Dev Only, require ./vendor/bin/phpcs).",
-        "phpcs-color": "Run all phpcs add option colors(Linux Only & Dev Only, require ./vendor/bin/phpcs).",
-        "phpcbf": "Run all phpcbf (Dev Only, require ./vendor/bin/phpcbf)."
+        "phpcs-color": "Run all phpcs add option colors (Linux Only & Dev Only, require ./vendor/bin/phpcs).",
+        "phpcs-any": "Phpcs without check PATH, Use -- specify the PATH to check (Dev Only, require ./vendor/bin/phpcs).",
+        "phpcbf": "Run all phpcbf (Dev Only, require ./vendor/bin/phpcbf).",
+        "phpcbf-any": "Phpcbf without check PATH, Use -- specify the PATH to check (Dev Only, require ./vendor/bin/phpcbf)."
     },
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

修正したのは１ファイルなのに、プルリクエストを送る時、phpcs, phpcbfを全ディレクトリチェックするコマンドしかなく、
１ファイルのみチェックしたいんです。
phpcs, phpcbfのチェックパスなしのコマンド、`composer phpcs-any`, `composer phpcbf-any`を追加しました。

マージします。

### 使い方

```
composer phpcs-any -- app/Plugins/Api/Nc2Sso/Nc2Sso.php
```
// ※ composer phpcs-anyの後ろに ` -- `を付けると、任意のオプションを引き渡せます。


## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/316

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
wikiには後ほど、追加コマンドを追記します。

## チェックリスト（Checklist）
- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer

composer.json１ファイルの修正で、チェック対象外ファイルのため、チェック不要です。

