### PR TITLE
delete: database plugin, 「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止

### DIFF
--- a/app/Enums/DatabaseColumnType.php
+++ b/app/Enums/DatabaseColumnType.php
@@ -22,7 +22,8 @@ final class DatabaseColumnType
     const image = 'image';
     const video = 'video';
     const wysiwyg = 'wysiwyg';
-    const group = 'group';
+    // delete:「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止
+    // const group = 'group';
 
     const created_asc    = 'created_asc';
     const created_desc   = 'created_desc';
@@ -47,7 +48,8 @@ final class DatabaseColumnType
         self::image=>'画像型',
         self::video=>'動画型',
         self::wysiwyg=>'ウィジウィグ',
-        self::group=>'まとめ行',
+        // delete:「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止
+        // self::group=>'まとめ行',
 
         self::created_asc    => '登録日（古い順）',
         self::created_desc   => '登録日（新しい順）',

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -312,15 +312,6 @@ class DatabasesPlugin extends UserPluginBase
         $databases_columns_id_select = null;
         if ($database) {
             $databases_columns_id_select = $this->getDatabasesColumnsSelects($database->id);
-            if (DatabasesColumns::query()
-                ->where('databases_id', $database->id)
-                ->where('column_type', \DatabaseColumnType::group)
-                ->whereNull('frame_col')
-                ->get()
-                ->count() > 0) {
-                // データ型が「まとめ行」で、まとめ数の設定がないデータが存在する場合
-                $setting_error_messages[] = 'フレームの設定画面から、項目データ（まとめ行のまとめ数）を設定してください。';
-            }
 
             /**
              * データベースのカラムデータを取得
@@ -698,11 +689,8 @@ class DatabasesPlugin extends UserPluginBase
 
         // カラムの選択肢用データ
         $databases_columns_id_select = null;
-        $databases_columns_errors = null;
         if ($database) {
             $databases_columns_id_select = $this->getDatabasesColumnsSelects($database->id);
-            // データ型が「まとめ行」、且つ、まとめ数の設定がないデータを取得
-            $databases_columns_errors = DatabasesColumns::query()->where('databases_id', $database->id)->where('column_type', \DatabaseColumnType::group)->whereNull('frame_col')->get();
         }
 
         // データ詳細の取得
@@ -722,7 +710,6 @@ class DatabasesPlugin extends UserPluginBase
             'database' => $database,
             'databases_columns' => $databases_columns,
             'databases_columns_id_select' => $databases_columns_id_select,
-            'databases_columns_errors' => $databases_columns_errors,
             'input_cols'  => $input_cols,
             'errors'      => $errors,
             ]
@@ -1764,13 +1751,6 @@ class DatabasesPlugin extends UserPluginBase
         $validator_values = null;
         $validator_attributes = null;
 
-        // データ型が「まとめ行」の場合はまとめ数について必須チェック
-        if ($column->column_type == \DatabaseColumnType::group) {
-            $validator_values['frame_col'] = [
-                'required'
-            ];
-            $validator_attributes['frame_col'] = 'まとめ数';
-        }
         // 桁数チェックの指定時、入力値が数値であるかチェック
         if ($request->rule_digits_or_less) {
             $validator_values['rule_digits_or_less'] = [

--- a/resources/views/plugins/user/databases/default/databases_confirm.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_confirm.blade.php
@@ -1,10 +1,11 @@
 {{--
  * 確認画面テンプレート。
  *
- * @author 永原　篤 <nagahara@opensource-workshop.jp>, 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
- --}}
+--}}
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
@@ -40,15 +41,6 @@
 
         @switch($database_column->column_type)
 
-        @case(DatabaseColumnType::group)
-            <div class="form-inline">
-                @foreach($database_column->group as $group_row)
-                    <label class="control-label" style="vertical-align: top; margin-right: 10px;@if (!$loop->first) margin-left: 30px;@endif">{{$group_row->column_name}}</label>
-                    {{$request->databases_columns_value[$group_row->id]}}
-                    <input name="databases_columns_value[{{$group_row->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$group_row->id]}}" />
-                @endforeach
-            </div>
-            @break
         @case(DatabaseColumnType::text)
             {{$request->databases_columns_value[$database_column->id]}}
             <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">

--- a/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
@@ -74,10 +74,6 @@
                 )
                 id="detail-button-tip" data-toggle="tooltip" title="選択肢がありません。設定してください。" data-trigger="manual" data-placement="bottom"
             @endif
-            {{-- まとめ数を保持する項目、且つ、まとめ数の設定がない場合、ツールチップで設定を促すメッセージを表示 --}}
-            @if ($column->column_type == DatabaseColumnType::group && !$column->frame_col)
-                id="frame-col-tip" data-toggle="tooltip" title="まとめ数の設定がありません。設定してください。" data-trigger="manual" data-placement="bottom"
-            @endif
             onclick="location.href='{{url('/')}}/plugin/databases/editColumnDetail/{{$page->id}}/{{$frame_id}}/{{ $column->id }}#frame-{{$frame->id}}'"
             >
             <i class="far fa-window-restore"></i>
@@ -106,19 +102,18 @@
     $column->column_type == DatabaseColumnType::radio ||
     $column->column_type == DatabaseColumnType::checkbox ||
     $column->column_type == DatabaseColumnType::select ||
-    $column->column_type == DatabaseColumnType::group ||
     $column->caption
     )
     <tr>
         <td class="pt-3 border border-0"></td>
         <td class="pt-3 border border-0" colspan="7">
-            @if ($column->column_type != DatabaseColumnType::group && $column->select_count > 0)
+            @if ($column->select_count > 0)
                 {{-- 選択肢データがある場合、カンマ付で一覧表示する --}}
                 <div class="small">
                     <i class="far fa-list-alt"></i>
                     {{ $column->select_names }}
                 </div>
-            @elseif($column->column_type != DatabaseColumnType::group && !$column->caption && $column->select_count == 0)
+            @elseif(!$column->caption && $column->select_count == 0)
                 {{-- 選択肢データがなく、キャプションの設定もない場合はツールチップ分、余白として改行する --}}
                 <br>
             @endif
@@ -129,11 +124,6 @@
                     <i class="fas fa-pen"></i>
                     {{ mb_strimwidth($column->caption, 0, 60, '...', 'UTF-8') }}
                 </div>
-            @endif
-
-            @if ($column->column_type == DatabaseColumnType::group && !isset($column->frame_col))
-                {{-- まとめ行でまとめ数の設定がない場合はツールチップ分、余白として改行する --}}
-                <br>
             @endif
         </td>
     </tr>

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -203,7 +203,7 @@
             </div>
         @endif
 
-        @if ($column->column_type == DatabaseColumnType::time || $column->column_type == DatabaseColumnType::group)
+        @if ($column->column_type == DatabaseColumnType::time)
             {{-- 項目毎の固有設定 --}}
             <div class="card mb-4">
                 <h5 class="card-header">項目毎の固有設定</h5>
@@ -224,31 +224,6 @@
                                         </option>
                                     @endforeach
                                 </select>
-                            </div>
-                        </div>
-                    @endif
-
-                    {{-- まとめ数 ※データ型が「まとめ行」のみ表示 --}}
-                    @if ($column->column_type == DatabaseColumnType::group)
-                        <div class="form-group row">
-                            <label class="{{$frame->getSettingLabelClass()}}">まとめ数 
-                                <label class="badge badge-danger">必須
-                                </label>
-                            </label>
-                            <div class="{{$frame->getSettingInputClass()}}">
-                                <select class="form-control" name="frame_col">
-                                    <option value=""></option>
-                                    @for ($i = 1; $i < 5; $i++)
-                                        <option value="{{$i}}"  @if($column->frame_col == $i)  selected @endif>
-                                            {{$i}}
-                                        </option>
-                                    @endfor
-                                </select>
-                                @if ($errors && $errors->has('frame_col'))
-                                    <div class="text-danger">
-                                        {{$errors->first('frame_col')}}
-                                    </div>
-                                @endif
                             </div>
                         </div>
                     @endif


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

 * 「行グループ」「列グループ」追加に伴い、**機能してない 項目の型「まとめ行」を廃止**します。
      * （「まとめ行」は、フォームプラグインを基に作成されたデータベースプラグインの名残で残ってただけ。）

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

PR
https://github.com/opensource-workshop/connect-cms/pull/377

issue
https://github.com/opensource-workshop/connect-cms/issues/375

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## チェックリスト（Checklist）
- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer