### PR TITLE
bugfix: 【データベース・バグ】設定画面＞項目設定をスマートフォンで見ると入力項目が潰れてるので、min-widthを設定して対応 他1件

### DIFF
--- a/resources/views/plugins/user/databases/default/databases_edit.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit.blade.php
@@ -112,9 +112,9 @@
                         <table class="table table-hover">
                             <thead class="thead-light">
                                 <tr>
-                                    <th class="text-center w-10 text-nowrap">表示順</th>
-                                    <th class="text-center w-35 text-nowrap">項目名</th>
-                                    <th class="text-center w-30 text-nowrap">型</th>
+                                    <th class="text-center text-nowrap">表示順</th>
+                                    <th class="text-center text-nowrap" style="min-width: 165px;">項目名</th>
+                                    <th class="text-center text-nowrap" style="min-width: 165px;">型</th>
                                     <th class="text-center text-nowrap">必須</th>
                                     <th class="text-center">行<a href="#" data-toggle="tooltip" data-placement="top" title="行グループ">...</a></th>
                                     <th class="text-center">列<a href="#" data-toggle="tooltip" data-placement="top" title="列グループ">...</a></th>

--- a/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
@@ -9,8 +9,7 @@
 --}}
 <tr>
     {{-- 表示順 --}}
-    <td class="text-center text-nowrap p-1">
-
+    <td nowrap>
         {{-- 上移動 --}}
         <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->first) disabled @endif onclick="javascript:submit_display_sequence({{ $column->id }}, {{ $column->display_sequence }}, 'up')">
             <i class="fas fa-arrow-up"></i>
@@ -23,12 +22,12 @@
     </td>
 
     {{-- 項目名 --}}
-    <td class="p-1">
+    <td>
         <input class="form-control" type="text" name="column_name_{{ $column->id }}" value="{{ old('column_name_'.$column->id, $column->column_name)}}">
     </td>
 
     {{-- 型 --}}
-    <td class="p-1">
+    <td>
         <select class="form-control" name="column_type_{{ $column->id }}">
             <option value="" disabled>型を指定</option>
                 @foreach (DatabaseColumnType::getMembers() as $key=>$value)
@@ -44,23 +43,23 @@
     </td>
 
     {{-- 必須 --}}
-    <td class="align-middle text-center p-1">
+    <td class="align-middle text-center">
         <input type="checkbox" name="required_{{ $column->id }}" value="1"
             @if ($column->required == Required::on) checked="checked" @endif>
     </td>
 
     {{-- 行グループ --}}
-    <td class="align-middle text-center p-1">
+    <td class="align-middle text-center">
         {{$column->row_group}}
     </td>
 
     {{-- 列グループ --}}
-    <td class="align-middle text-center p-1">
+    <td class="align-middle text-center">
         {{$column->column_group}}
     </td>
 
     {{-- 詳細設定 --}}
-    <td class="text-center p-1">
+    <td class="text-center">
         {{-- 詳細ボタン --}}
         <button
             type="button"
@@ -81,7 +80,7 @@
     </td>
 
     {{-- 更新ボタン --}}
-    <td class="text-center p-1">
+    <td class="text-center">
         <button
             class="btn btn-primary cc-font-90 text-nowrap"
             onclick="javascript:submit_update_column({{ $column->id }});"
@@ -91,7 +90,7 @@
     </td>
 
     {{-- 削除ボタン --}}
-    <td class="text-center p-1">
+    <td class="text-center">
         <button class="btn btn-danger cc-font-90 text-nowrap" onclick="javascript:return submit_delete_column({{ $column->id }});">
             <i class="fas fa-trash-alt"></i>
         </button>


### PR DESCRIPTION

## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

* bugfix: 【データベース・バグ】設定画面＞項目設定をスマートフォンで見ると入力項目が潰れてるので、min-widthを設定して対応
* change: 項目設定の余白幅を狭くしていたけど、スマートフォン操作で誤タッチの恐れがあるため、もとの余白幅に戻す

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/373

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer