### PR TITLE
refactor: フォーム style="min-width: はforms_edit.blade.phpの<th>タグにまとめる

### DIFF
--- a/resources/views/plugins/user/forms/default/forms_edit.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit.blade.php
@@ -112,8 +112,8 @@
                     <thead>
                         <tr>
                             <th class="text-center" nowrap>表示順</th>
-                            <th class="text-center" nowrap>項目名</th>
-                            <th class="text-center" nowrap>型</th>
+                            <th class="text-center" style="min-width: 165px;" nowrap>項目名</th>
+                            <th class="text-center" style="min-width: 165px;" nowrap>型</th>
                             <th class="text-center" nowrap>必須</th>
                             <th class="text-center" nowrap>詳細 <a href="https://connect-cms.jp/manual/user/form#frame-125" target="_brank"><span class="fas fa-info-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></a></th>
                             <th class="text-center" nowrap>更新</th>

--- a/resources/views/plugins/user/forms/default/forms_edit_row.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row.blade.php
@@ -24,7 +24,7 @@
     </td>
     {{-- 型 --}}
     <td>
-        <select class="form-control" name="column_type_{{ $column->id }}" style="min-width: 140px;">
+        <select class="form-control" name="column_type_{{ $column->id }}">
             <option value="" disabled>型を指定</option>
             @foreach (FormColumnType::getMembers() as $key=>$value)
                 <option value="{{$key}}"

--- a/resources/views/plugins/user/forms/default/forms_edit_row_add.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row_add.blade.php
@@ -11,11 +11,11 @@
     </td>
     {{-- 項目名 --}}
     <td>
-        <input class="form-control" type="text" name="column_name" value="{{ old('column_name') }}" style="min-width: 150px;">
+        <input class="form-control" type="text" name="column_name" value="{{ old('column_name') }}">
     </td>
     {{-- 型 --}}
     <td>
-        <select class="form-control" name="column_type" style="min-width: 100px;">
+        <select class="form-control" name="column_type">
             <option value="" disabled>型を指定</option>
             @foreach (FormColumnType::getMembers() as $key=>$value)
                 <option value="{{$key}}"


### PR DESCRIPTION

## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

【データベース・バグ】設定画面＞項目設定をスマートフォンで見ると入力項目が潰れてる #373

formを参照したところ、直sytleが使われて、min-widthが切られてたため、対応できていた。
formの項目設定画面のファイル構成はこんな感じ。

* forms_edit.blade.php `<table><th>はここで定義`。下記参照
    * forms_edit_row.blade.php `<td>はここで定義` 「型」のみ`style="min-width: 140px;"`
    * forms_edit_row_add.blade.php `<td>はここで定義` 　「項目名」` style="min-width: 150px;"` 「型」 `style="min-width: 100px;"`

他プラグインで真似する時に、`<th>`タグと`<td>`タグが別々のファイルに別れている関係で、どこに`min-width`が切られているか、気づきずらい形になっていた。

`style="min-width:` を切るなら、ここは、forms_edit.blade.phpの`<th>`タグにまとめる方向が、わかりやすいかと思ったので、
これから修正します。


## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/373

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer