### PR TITLE
bugfix: 【データベース・フォーム・バグ】設定画面＞項目設定＞詳細で、入力エラーになるとラジオボタンの値が保持されない不具合を修正

### DIFF
--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -364,12 +364,8 @@
                     <div class="{{$frame->getSettingInputClass()}}">
                         <select class="form-control" name="caption_color">
                             @foreach (Bs4TextColor::getMembers() as $key=>$value)
-                                <option value="{{$key}}" class="{{ $key }}"
-                                    {{-- 初期表示用 --}}
-                                    @if($key == $column->caption_color) selected="selected" @endif
-                                    {{-- validation用 --}}
-                                    @if($key == old('caption_color')) selected="selected" @endif
-                                    >{{ $value }}
+                                <option value="{{$key}}" class="{{ $key }}" @if($key == old('caption_color', $column->caption_color)) selected @endif>
+                                    {{ $value }}
                                 </option>
                             @endforeach
                         </select>
@@ -395,19 +391,11 @@
                     <label class="{{$frame->getSettingLabelClass(true)}}">一覧への表示指定</label>
                     <div class="{{$frame->getSettingInputClass(true)}}">
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->list_hide_flag == 0)
-                                <input type="radio" value="0" id="list_hide_flag_0" name="list_hide_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="0" id="list_hide_flag_0" name="list_hide_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="0" id="list_hide_flag_0" name="list_hide_flag" class="custom-control-input" @if(old('list_hide_flag', $column->list_hide_flag) == 0) checked="checked" @endif>
                             <label class="custom-control-label" for="list_hide_flag_0">一覧に表示する</label>
                         </div>
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->list_hide_flag == 1)
-                                <input type="radio" value="1" id="list_hide_flag_1" name="list_hide_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="1" id="list_hide_flag_1" name="list_hide_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="1" id="list_hide_flag_1" name="list_hide_flag" class="custom-control-input" @if(old('list_hide_flag', $column->list_hide_flag) == 1) checked="checked" @endif>
                             <label class="custom-control-label" for="list_hide_flag_1">一覧に表示しない</label>
                         </div>
                     </div>
@@ -418,19 +406,11 @@
                     <label class="{{$frame->getSettingLabelClass(true)}}">詳細への表示指定</label>
                     <div class="{{$frame->getSettingInputClass(true)}}">
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->detail_hide_flag == 0)
-                                <input type="radio" value="0" id="detail_hide_flag_0" name="detail_hide_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="0" id="detail_hide_flag_0" name="detail_hide_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="0" id="detail_hide_flag_0" name="detail_hide_flag" class="custom-control-input" @if(old('detail_hide_flag', $column->detail_hide_flag) == 0) checked="checked" @endif>
                             <label class="custom-control-label" for="detail_hide_flag_0">詳細に表示する</label>
                         </div>
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->detail_hide_flag == 1)
-                                <input type="radio" value="1" id="detail_hide_flag_1" name="detail_hide_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="1" id="detail_hide_flag_1" name="detail_hide_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="1" id="detail_hide_flag_1" name="detail_hide_flag" class="custom-control-input" @if(old('detail_hide_flag', $column->detail_hide_flag) == 1) checked="checked" @endif>
                             <label class="custom-control-label" for="detail_hide_flag_1">詳細に表示しない</label>
                         </div>
                     </div>
@@ -441,35 +421,19 @@
                     <label class="{{$frame->getSettingLabelClass(true)}}">並べ替え指定</label>
                     <div class="{{$frame->getSettingInputClass(true)}}">
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->sort_flag == 0)
-                                <input type="radio" value="0" id="sort_flag_0" name="sort_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="0" id="sort_flag_0" name="sort_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="0" id="sort_flag_0" name="sort_flag" class="custom-control-input" @if(old('sort_flag', $column->sort_flag) == 0) checked="checked" @endif>
                             <label class="custom-control-label" for="sort_flag_0">使用しない</label>
                         </div>
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->sort_flag == 1)
-                                <input type="radio" value="1" id="sort_flag_1" name="sort_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="1" id="sort_flag_1" name="sort_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="1" id="sort_flag_1" name="sort_flag" class="custom-control-input" @if(old('sort_flag', $column->sort_flag) == 1) checked="checked" @endif>
                             <label class="custom-control-label" for="sort_flag_1">昇順＆降順</label>
                         </div>
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->sort_flag == 2)
-                                <input type="radio" value="2" id="sort_flag_2" name="sort_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="2" id="sort_flag_2" name="sort_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="2" id="sort_flag_2" name="sort_flag" class="custom-control-input" @if(old('sort_flag', $column->sort_flag) == 2) checked="checked" @endif>
                             <label class="custom-control-label" for="sort_flag_2">昇順のみ</label>
                         </div>
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->sort_flag == 3)
-                                <input type="radio" value="3" id="sort_flag_3" name="sort_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="3" id="sort_flag_3" name="sort_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="3" id="sort_flag_3" name="sort_flag" class="custom-control-input" @if(old('sort_flag', $column->sort_flag) == 3) checked="checked" @endif>
                             <label class="custom-control-label" for="sort_flag_3">降順のみ</label>
                         </div>
                     </div>
@@ -480,19 +444,11 @@
                     <label class="{{$frame->getSettingLabelClass(true)}}">検索対象指定</label>
                     <div class="{{$frame->getSettingInputClass(true)}}">
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->search_flag == 0)
-                                <input type="radio" value="0" id="search_flag_0" name="search_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="0" id="search_flag_0" name="search_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="0" id="search_flag_0" name="search_flag" class="custom-control-input" @if(old('search_flag', $column->search_flag) == 0) checked="checked" @endif>
                             <label class="custom-control-label" for="search_flag_0">検索対象にしない</label>
                         </div>
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if($column->search_flag == 1)
-                                <input type="radio" value="1" id="search_flag_1" name="search_flag" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="1" id="search_flag_1" name="search_flag" class="custom-control-input">
-                            @endif
+                            <input type="radio" value="1" id="search_flag_1" name="search_flag" class="custom-control-input" @if(old('search_flag', $column->search_flag) == 1) checked="checked" @endif>
                             <label class="custom-control-label" for="search_flag_1">検索対象とする</label>
                         </div>
                     </div>
@@ -504,19 +460,11 @@
                         <label class="{{$frame->getSettingLabelClass(true)}}">絞り込み対象指定</label>
                         <div class="{{$frame->getSettingInputClass(true)}}">
                             <div class="custom-control custom-radio custom-control-inline">
-                                @if($column->select_flag == 0)
-                                    <input type="radio" value="0" id="select_flag_0" name="select_flag" class="custom-control-input" checked="checked">
-                                @else
-                                    <input type="radio" value="0" id="select_flag_0" name="select_flag" class="custom-control-input">
-                                @endif
+                                <input type="radio" value="0" id="select_flag_0" name="select_flag" class="custom-control-input" @if(old('select_flag', $column->select_flag) == 0) checked="checked" @endif>
                                 <label class="custom-control-label" for="select_flag_0">絞り込み対象にしない</label>
                             </div>
                             <div class="custom-control custom-radio custom-control-inline">
-                                @if($column->select_flag == 1)
-                                    <input type="radio" value="1" id="select_flag_1" name="select_flag" class="custom-control-input" checked="checked">
-                                @else
-                                    <input type="radio" value="1" id="select_flag_1" name="select_flag" class="custom-control-input">
-                                @endif
+                                <input type="radio" value="1" id="select_flag_1" name="select_flag" class="custom-control-input" @if(old('select_flag', $column->select_flag) == 1) checked="checked" @endif>
                                 <label class="custom-control-label" for="select_flag_1">絞り込み対象とする</label>
                             </div>
                         </div>

--- a/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
@@ -2,17 +2,18 @@
  * フォーム項目の詳細設定画面
  *
  * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
- --}}
- @extends('core.cms_frame_base_setting')
+--}}
+@extends('core.cms_frame_base_setting')
 
- @section("core.cms_frame_edit_tab_$frame->id")
-      {{-- プラグイン側のフレームメニュー --}}
-     @include('plugins.user.forms.forms_frame_edit_tab')
- @endsection
- 
- @section("plugin_setting_$frame->id")
+@section("core.cms_frame_edit_tab_$frame->id")
+    {{-- プラグイン側のフレームメニュー --}}
+    @include('plugins.user.forms.forms_frame_edit_tab')
+@endsection
+
+@section("plugin_setting_$frame->id")
 <script type="text/javascript">
 
     /**
@@ -47,7 +48,7 @@
     /**
      * 選択肢の削除ボタン押下
      */
-     function submit_delete_select(select_id) {
+    function submit_delete_select(select_id) {
         if(confirm('選択肢を削除します。\nよろしいですか？')){
             form_column_detail.action = "{{url('/')}}/plugin/forms/deleteSelect/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
             form_column_detail.select_id.value = select_id;
@@ -59,7 +60,7 @@
     /**
      * その他の設定の更新ボタン押下
      */
-     function submit_update_column_detail() {
+    function submit_update_column_detail() {
         form_column_detail.action = "{{url('/')}}/plugin/forms/updateColumnDetail/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
         form_column_detail.submit();
     }
@@ -116,7 +117,7 @@
                                     <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->first) disabled @endif onclick="javascript:submit_display_sequence({{ $select->id }}, {{ $select->display_sequence }}, 'up')">
                                         <i class="fas fa-arrow-up"></i>
                                     </button>
-                            
+
                                     {{-- 下移動 --}}
                                     <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->last) disabled @endif onclick="javascript:submit_display_sequence({{ $select->id }}, {{ $select->display_sequence }}, 'down')">
                                         <i class="fas fa-arrow-down"></i>
@@ -130,8 +131,8 @@
 
                                 {{-- 更新ボタン --}}
                                 <td class="align-middle text-center">
-                                    <button 
-                                        class="btn btn-primary cc-font-90 text-nowrap" 
+                                    <button
+                                        class="btn btn-primary cc-font-90 text-nowrap"
                                         onclick="javascript:submit_update_select({{ $select->id }});"
                                     >
                                         <i class="fas fa-save"></i> <span class="d-sm-none">更新</span>
@@ -139,8 +140,8 @@
                                 </td>
                                 {{-- 削除ボタン --}}
                                 <td class="text-center">
-                                        <button 
-                                        class="btn btn-danger cc-font-90 text-nowrap" 
+                                        <button
+                                        class="btn btn-danger cc-font-90 text-nowrap"
                                         onclick="javascript:return submit_delete_select({{ $select->id }});"
                                     >
                                         <i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span>
@@ -152,7 +153,7 @@
                             <th colspan="7">【選択肢の追加行】</th>
                         </tr>
 
-                       {{-- 新規登録用の行 --}}
+                        {{-- 新規登録用の行 --}}
                         <tr>
                             <td>
                                 {{-- 余白 --}}
@@ -190,22 +191,15 @@
                         <div class="{{$frame->getSettingInputClass()}}">
                             <select class="form-control" name="minutes_increments">
                                 @foreach (MinutesIncrements::getMembers() as $key=>$value)
-                                    <option value="{{$key}}"
-                                        {{-- 初期表示用 --}}
-                                        @if($key == $column->minutes_increments)
-                                            selected="selected"
-                                        @endif
-                                        {{-- validation用 --}}
-                                        @if($key == old('minutes_increments'))
-                                            selected="selected"
-                                        @endif
-                                    >{{ $value }}</option>
+                                    <option value="{{$key}}" @if($key == old('minutes_increments', $column->minutes_increments)) selected @endif>
+                                        {{ $value }}
+                                    </option>
                                 @endforeach
                             </select>
                         </div>
                     </div>
                 @endif
-                    
+
                 {{-- 分刻み指定（From/To） ※データ型が「時間型（From/To）」のみ表示 --}}
                 @if ($column->column_type == FormColumnType::time_from_to)
                     {{-- From --}}
@@ -214,16 +208,9 @@
                         <div class="{{$frame->getSettingInputClass()}}">
                             <select class="form-control" name="minutes_increments_from">
                                 @foreach (MinutesIncrements::getMembers() as $key=>$value)
-                                    <option value="{{$key}}"
-                                        {{-- 初期表示用 --}}
-                                        @if($key == $column->minutes_increments_from)
-                                            selected="selected"
-                                        @endif
-                                        {{-- validation用 --}}
-                                        @if($key == old('minutes_increments_from'))
-                                            selected="selected"
-                                        @endif
-                                    >{{ $value }}</option>
+                                    <option value="{{$key}}" @if($key == old('minutes_increments_from', $column->minutes_increments_from)) selected @endif>
+                                        {{ $value }}
+                                    </option>
                                 @endforeach
                             </select>
                         </div>
@@ -234,16 +221,9 @@
                         <div class="{{$frame->getSettingInputClass()}}">
                             <select class="form-control" name="minutes_increments_to">
                                 @foreach (MinutesIncrements::getMembers() as $key=>$value)
-                                    <option value="{{$key}}"
-                                        {{-- 初期表示用 --}}
-                                        @if($key == $column->minutes_increments_to)
-                                            selected="selected"
-                                        @endif
-                                        {{-- validation用 --}}
-                                        @if($key == old('minutes_increments_to'))
-                                            selected="selected"
-                                        @endif
-                                    >{{ $value }}</option>
+                                    <option value="{{$key}}" @if($key == old('minutes_increments_to', $column->minutes_increments_to)) selected @endif>
+                                        {{ $value }}
+                                    </option>
                                 @endforeach
                             </select>
                         </div>
@@ -258,14 +238,14 @@
                             <select class="form-control" name="frame_col">
                                 <option value=""></option>
                                 @for ($i = 1; $i < 5; $i++)
-                                    <option value="{{$i}}"  @if($column->frame_col == $i)  selected @endif>{{$i}}</option>
+                                    <option value="{{$i}}"  @if(old('frame_col', $column->frame_col) == $i) selected @endif>{{$i}}</option>
                                 @endfor
                             </select>
                             @if ($errors && $errors->has('frame_col')) <div class="text-danger">{{$errors->first('frame_col')}}</div> @endif
                         </div>
                     </div>
                 @endif
-    
+
                 {{-- ボタンエリア --}}
                 <div class="form-group text-center">
                     <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
@@ -384,16 +364,9 @@
                 <div class="{{$frame->getSettingInputClass()}}">
                     <select class="form-control" name="caption_color">
                         @foreach (Bs4TextColor::getMembers() as $key=>$value)
-                            <option value="{{$key}}" class="{{ $key }}"
-                                {{-- 初期表示用 --}}
-                                @if($key == $column->caption_color)
-                                    selected="selected"
-                                @endif
-                                {{-- validation用 --}}
-                                @if($key == old('caption_color'))
-                                    selected="selected"
-                                @endif
-                            >{{ $value }}</option>
+                            <option value="{{$key}}" class="{{ $key }}" @if($key == old('caption_color', $column->caption_color)) selected @endif>
+                                {{ $value }}
+                            </option>
                         @endforeach
                     </select>
                 </div>


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

バグ修正です。

* bugfix: 【データベース・バグ】設定画面＞項目設定＞詳細で、入力エラーになるとラジオボタンの値が保持されない不具合を修正
* refactor: 【フォーム・バグ】設定画面＞項目設定＞詳細で、入力エラーになるとセレクトボックス（キャプションの設定の 文字色）の値が保持されないバグを修正
* refactor: フォーム項目の詳細設定画面, 不要な空白を削除

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/368

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer