### PR TITLE
add: 【ブログ】続きを読む機能 実装

### DIFF
--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -27,6 +27,7 @@ use App\Plugins\User\UserPluginBase;
  * ブログプラグイン
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category ブログプラグイン
  * @package Contoroller
@@ -449,7 +450,8 @@ WHERE status = 0
                       ->where('posted_at', '<=', Carbon::now())
                       ->where(function ($plugin_query) use ($search_keyword) {
                           $plugin_query->where('blogs_posts.post_title', 'like', '?')
-                                       ->orWhere('blogs_posts.post_text', 'like', '?');
+                                       ->orWhere('blogs_posts.post_text', 'like', '?')
+                                       ->orWhere('blogs_posts.post_text2', 'like', '?');
                       })
                       ->whereRaw('CASE
                                   WHEN blogs_frames.scope IS NULL
@@ -478,7 +480,7 @@ WHERE status = 0
                       ->whereNull('blogs_posts.deleted_at');
 
         //$bind = array($page_ids, 0, '%'.$search_keyword.'%', '%'.$search_keyword.'%');
-        $bind = array($page_ids, 0, Carbon::now(), '%'.$search_keyword.'%', '%'.$search_keyword.'%', '', 'top', 'not_important', 'important_only', 1);
+        $bind = array($page_ids, 0, Carbon::now(), '%'.$search_keyword.'%', '%'.$search_keyword.'%', '%'.$search_keyword.'%', '', 'top', 'not_important', 'important_only', 1);
         $return[] = $bind;
         $return[] = 'show_page_frame_post';
         $return[] = '/plugin/blogs/show';
@@ -737,6 +739,7 @@ WHERE status = 0
         $blogs_post->important     = $request->important;
         $blogs_post->posted_at     = $request->posted_at . ':00';
         $blogs_post->post_text     = $request->post_text;
+        $blogs_post->post_text2    = $request->post_text2;
 
         // 承認の要否確認とステータス処理
         if ($this->isApproval($frame_id)) {
@@ -777,7 +780,7 @@ WHERE status = 0
         return $this->index($request, $page_id, $frame_id);
     }
 
-   /**
+    /**
     * データ一時保存関数
     */
     public function temporarysave($request, $page_id = null, $frame_id = null, $id = null)
@@ -798,7 +801,7 @@ WHERE status = 0
             $blogs_post->created_id  = Auth::user()->id;
         } else {
             $blogs_post = BlogsPosts::find($id)->replicate();
- 
+
             // チェック用に記事取得（指定されたPOST ID そのままではなく、権限に応じたPOST を取得する。）
             $check_blogs_post = $this->getPost($id);
 
@@ -815,6 +818,7 @@ WHERE status = 0
         $blogs_post->important  = $request->important;
         $blogs_post->posted_at  = $request->posted_at . ':00';
         $blogs_post->post_text  = $request->post_text;
+        $blogs_post->post_text2 = $request->post_text2;
 
         $blogs_post->save();
 
@@ -850,7 +854,7 @@ WHERE status = 0
         return $this->index($request, $page_id, $frame_id);
     }
 
-   /**
+    /**
     * 承認
     */
     public function approval($request, $page_id = null, $frame_id = null, $id = null)
@@ -1062,7 +1066,7 @@ WHERE status = 0
         // 削除処理はredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
     }
 
-   /**
+    /**
     * データ紐づけ変更関数
     */
     public function changeBuckets($request, $page_id = null, $frame_id = null, $id = null)

--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -2,9 +2,10 @@
  * ブログ画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category ブログプラグイン
- --}}
+--}}
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
@@ -56,6 +57,17 @@
 
             {{-- 記事本文 --}}
             {!! $post->post_text !!}
+
+            {{-- 続きを読む --}}
+            @if ($post->post_text2)
+                <div id="post_text2_button_{{$frame->id}}_{{$post->id}}">
+                    <button type="button" class="btn btn-light btn-sm border" onclick="$('#post_text2_{{$frame->id}}_{{$post->id}}').show(); $('#post_text2_button_{{$frame->id}}_{{$post->id}}').hide();"><i class="fas fa-angle-down"></i> 続きを読む</button>
+                </div>
+                <div id="post_text2_{{$frame->id}}_{{$post->id}}" style="display: none;">
+                    {!! $post->post_text2 !!}
+                    <button type="button" class="btn btn-light btn-sm border" onclick="$('#post_text2_button_{{$frame->id}}_{{$post->id}}').show(); $('#post_text2_{{$frame->id}}_{{$post->id}}').hide();"><i class="fas fa-angle-up"></i> 閉じる</button>
+                </div>
+            @endif
 
             {{-- タグ --}}
             @isset($post->tags)

--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -60,10 +60,11 @@
 
             {{-- 続きを読む --}}
             @if ($post->post_text2)
-                <div id="post_text2_button_{{$frame->id}}_{{$post->id}}">
+                {{-- 続きを読む & タグありなら、続きを読むとタグの間に余白追加 --}}
+                <div id="post_text2_button_{{$frame->id}}_{{$post->id}}" @isset($post->tags) class="mb-2" @endisset>
                     <button type="button" class="btn btn-light btn-sm border" onclick="$('#post_text2_{{$frame->id}}_{{$post->id}}').show(); $('#post_text2_button_{{$frame->id}}_{{$post->id}}').hide();"><i class="fas fa-angle-down"></i> 続きを読む</button>
                 </div>
-                <div id="post_text2_{{$frame->id}}_{{$post->id}}" style="display: none;">
+                <div id="post_text2_{{$frame->id}}_{{$post->id}}" style="display: none;" @isset($post->tags) class="mb-2" @endisset>
                     {!! $post->post_text2 !!}
                     <button type="button" class="btn btn-light btn-sm border" onclick="$('#post_text2_button_{{$frame->id}}_{{$post->id}}').show(); $('#post_text2_{{$frame->id}}_{{$post->id}}').hide();"><i class="fas fa-angle-up"></i> 閉じる</button>
                 </div>

--- a/resources/views/plugins/user/blogs/default/blogs_input.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_input.blade.php
@@ -2,9 +2,10 @@
  * ブログ記事登録画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category コンテンツプラグイン
- --}}
+--}}
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
@@ -72,6 +73,12 @@
         <label class="control-label">本文 <label class="badge badge-danger">必須</label></label>
         <textarea name="post_text">{!!old('post_text', $blogs_posts->post_text)!!}</textarea>
         @if ($errors && $errors->has('post_text')) <div class="text-danger">{{$errors->first('post_text')}}</div> @endif
+    </div>
+
+    <div class="form-group">
+        <label class="control-label">続き</label>
+        <textarea name="post_text2">{!!old('post_text2', $blogs_posts->post_text2)!!}</textarea>
+        @if ($errors && $errors->has('post_text2')) <div class="text-danger">{{$errors->first('post_text2')}}</div> @endif
     </div>
 
     <div class="form-group">

--- a/resources/views/plugins/user/blogs/default/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_show.blade.php
@@ -29,10 +29,11 @@
 
     {{-- 続きを読む --}}
     @if ($post->post_text2)
-        <div id="post_text2_button_{{$frame->id}}_{{$post->id}}">
+        {{-- 続きを読む & タグありなら、続きを読むとタグの間に余白追加 --}}
+        <div id="post_text2_button_{{$frame->id}}_{{$post->id}}" @isset($post_tags) class="mb-2" @endisset>
             <button type="button" class="btn btn-light btn-sm border" onclick="$('#post_text2_{{$frame->id}}_{{$post->id}}').show(); $('#post_text2_button_{{$frame->id}}_{{$post->id}}').hide();"><i class="fas fa-angle-down"></i> 続きを読む</button>
         </div>
-        <div id="post_text2_{{$frame->id}}_{{$post->id}}" style="display: none;">
+        <div id="post_text2_{{$frame->id}}_{{$post->id}}" style="display: none;" @isset($post_tags) class="mb-2" @endisset>
             {!! $post->post_text2 !!}
             <button type="button" class="btn btn-light btn-sm border" onclick="$('#post_text2_button_{{$frame->id}}_{{$post->id}}').show(); $('#post_text2_{{$frame->id}}_{{$post->id}}').hide();"><i class="fas fa-angle-up"></i> 閉じる</button>
         </div>

--- a/resources/views/plugins/user/blogs/default/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_show.blade.php
@@ -2,9 +2,10 @@
  * ブログ記事詳細画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category ブログプラグイン
- --}}
+--}}
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
@@ -25,6 +26,17 @@
 
     {{-- 記事本文 --}}
     {!! $post->post_text !!}
+
+    {{-- 続きを読む --}}
+    @if ($post->post_text2)
+        <div id="post_text2_button_{{$frame->id}}_{{$post->id}}">
+            <button type="button" class="btn btn-light btn-sm border" onclick="$('#post_text2_{{$frame->id}}_{{$post->id}}').show(); $('#post_text2_button_{{$frame->id}}_{{$post->id}}').hide();"><i class="fas fa-angle-down"></i> 続きを読む</button>
+        </div>
+        <div id="post_text2_{{$frame->id}}_{{$post->id}}" style="display: none;">
+            {!! $post->post_text2 !!}
+            <button type="button" class="btn btn-light btn-sm border" onclick="$('#post_text2_button_{{$frame->id}}_{{$post->id}}').show(); $('#post_text2_{{$frame->id}}_{{$post->id}}').hide();"><i class="fas fa-angle-up"></i> 閉じる</button>
+        </div>
+    @endif
 
     {{-- タグ --}}
     @isset($post_tags)


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

追加機能実装です。
ブログで続きを読む機能はよく使われているため。
続きを読むのDBカラムは、既にブログに存在していたため、DBカラム追加はないです。

### 対応内容
* ブログ内検索対応, 「続きを読む」を検索対象に含める
* RSSには「続きを読む」を含めない（いままでと同じ）
* ブログ一覧画面と、詳細画面の「続きを読む」表示は同じ（「続きを読む」ボタンを押して、内容を表示する）
* 続きを読む & タグありなら、続きを読むとタグの間に余白追加

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/386

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

## 一覧画面

![image](https://user-images.githubusercontent.com/2756509/86537380-95710d80-bf29-11ea-9707-dc0d1af50a9b.png)
![image](https://user-images.githubusercontent.com/2756509/86537397-b76a9000-bf29-11ea-9a4c-79d373e3baf8.png)

## 詳細画面

![image](https://user-images.githubusercontent.com/2756509/86537407-cea97d80-bf29-11ea-91ee-d0353ec93e0d.png)
![image](https://user-images.githubusercontent.com/2756509/86537416-e84ac500-bf29-11ea-942b-ed7fca404c7c.png)

## 編集画面

![image](https://user-images.githubusercontent.com/2756509/86537450-17613680-bf2a-11ea-8f33-543245b03108.png)


## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer