### PR TITLE
refactor: Form plugin, "group" -> \FormColumnType::groupに見直し

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -127,7 +127,7 @@ class FormsPlugin extends UserPluginBase
         // グループがあれば、結果配列をネストする。
         $ret_array = array();
         for ($i = 0; $i < count($forms_columns); $i++) {
-            if ($forms_columns[$i]->column_type == "group") {
+            if ($forms_columns[$i]->column_type == \FormColumnType::group) {
                 $tmp_group = $forms_columns[$i];
                 $group_row = array();
                 for ($j = 1; $j <= $forms_columns[$i]->frame_col; $j++) {
@@ -469,7 +469,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
 
         // forms_input_cols 登録
         foreach ($forms_columns as $forms_column) {
-            if ($forms_column->column_type == "group") {
+            if ($forms_column->column_type == \FormColumnType::group) {
                 continue;
             }
 


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

フォームプラグインに、enumで定義されている`\FormColumnType::group`あり。
直書きの`"group" `を見つけたので見直し

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

PR
https://github.com/opensource-workshop/connect-cms/pull/388

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer