### PR TITLE
【データベース・バグ】ソート用の値がデータベースの型として設定できてしまうバグの修正　他3件

### DIFF
--- a/app/Enums/DatabaseColumnType.php
+++ b/app/Enums/DatabaseColumnType.php
@@ -2,10 +2,12 @@
 
 namespace App\Enums;
 
+use App\Enums\EnumsBase;
+
 /**
- * フォーム項目区分
+ * データベース項目区分
  */
-final class DatabaseColumnType
+final class DatabaseColumnType extends EnumsBase
 {
     // 定数メンバ
     const text = 'text';
@@ -26,12 +28,13 @@ final class DatabaseColumnType
     // delete:「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止
     // const group = 'group';
 
-    const created_asc    = 'created_asc';
-    const created_desc   = 'created_desc';
-    const updated_asc    = 'updated_asc';
-    const updated_desc   = 'updated_desc';
-    const random_session = 'random_session';
-    const random_every   = 'random_every';
+    // move: ソート用項目のため、App\Enums\DatabaseSortFlag.phpに移動
+    // const created_asc    = 'created_asc';
+    // const created_desc   = 'created_desc';
+    // const updated_asc    = 'updated_asc';
+    // const updated_desc   = 'updated_desc';
+    // const random_session = 'random_session';
+    // const random_every   = 'random_every';
 
     // key/valueの連想配列
     const enum = [
@@ -53,27 +56,12 @@ final class DatabaseColumnType
         // delete:「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止
         // self::group=>'まとめ行',
 
-        self::created_asc    => '登録日（古い順）',
-        self::created_desc   => '登録日（新しい順）',
-        self::updated_asc    => '更新日（古い順）',
-        self::updated_desc   => '更新日（新しい順）',
-        self::random_session => 'ランダム（セッション）',
-        self::random_every   => 'ランダム（毎回）',
+        // move: ソート用項目のため、App\Enums\DatabaseSortFlag.phpに移動
+        // self::created_asc    => '登録日（古い順）',
+        // self::created_desc   => '登録日（新しい順）',
+        // self::updated_asc    => '更新日（古い順）',
+        // self::updated_desc   => '更新日（新しい順）',
+        // self::random_session => 'ランダム（セッション）',
+        // self::random_every   => 'ランダム（毎回）',
     ];
-
-    /*
-    * 対応した和名を返す
-    */
-    public static function getDescription($key): string
-    {
-        return self::enum[$key];
-    }
-
-    /*
-    * key/valueの連想配列を返す
-    */
-    public static function getMembers()
-    {
-        return self::enum;
-    }
 }

--- a/app/Enums/DatabaseSortFlag.php
+++ b/app/Enums/DatabaseSortFlag.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * データベース並べ替え項目
+ */
+final class DatabaseSortFlag extends EnumsBase
+{
+    // 定数メンバ
+    const created_asc    = 'created_asc';
+    const created_desc   = 'created_desc';
+    const updated_asc    = 'updated_asc';
+    const updated_desc   = 'updated_desc';
+    const random_session = 'random_session';
+    const random_every   = 'random_every';
+    const column         = 'column';
+
+    // key/valueの連想配列
+    const enum = [
+        self::created_asc    => '登録日（古い順）',
+        self::created_desc   => '登録日（新しい順）',
+        self::updated_asc    => '更新日（古い順）',
+        self::updated_desc   => '更新日（新しい順）',
+        self::random_session => 'ランダム（セッション）',
+        self::random_every   => 'ランダム（毎回）',
+        self::column         => '各カラム設定',
+    ];
+
+    /**
+     * 並べ替え項目の表示用 のkey/valueの連想配列を返す
+     */
+    public static function getDisplaySortFlags()
+    {
+        return self::getMembers();
+    }
+
+    /**
+     * 並び順 のkey/valueの連想配列を返す
+     */
+    public static function getSortFlags()
+    {
+        $sort_flags = static::enum;
+        // columnは 並べ替え項目の表示用 のため、取り除く
+        unset($sort_flags[self::column]);
+        return $sort_flags;
+    }
+
+    /**
+     * 並び順 のkey配列を返す
+     */
+    public static function getSortFlagsKeys()
+    {
+        $sort_flags = self::getSortFlags();
+        return array_keys($sort_flags);
+    }
+}

--- a/app/Models/User/Databases/DatabasesFrames.php
+++ b/app/Models/User/Databases/DatabasesFrames.php
@@ -71,8 +71,12 @@ class DatabasesFrames extends Model
             return false;
         }
 
+        // 並び順 のkey配列を返す
+        $enums_sort_flags_keys = \DatabaseSortFlag::getSortFlagsKeys();
+
         // 配列にマッチ
-        if (in_array(array('created_asc', 'created_desc', 'updated_asc', 'updated_desc', 'random'), $use_sort_flags)) {
+        // if (in_array(array('created_asc', 'created_desc', 'updated_asc', 'updated_desc', 'random'), $use_sort_flags)) {
+        if (in_array($enums_sort_flags_keys, $use_sort_flags)) {
             return true;
         }
         return false;

--- a/config/app.php
+++ b/config/app.php
@@ -235,6 +235,7 @@ return [
         'ReservationCalendarDisplayType' => \App\Enums\ReservationCalendarDisplayType::class,
         'FormColumnType' => \App\Enums\FormColumnType::class,
         'DatabaseColumnType' => \App\Enums\DatabaseColumnType::class,
+        'DatabaseSortFlag' => \App\Enums\DatabaseSortFlag::class,
         'DayOfWeek' => \App\Enums\DayOfWeek::class,
         'Bs4TextColor' => \App\Enums\Bs4TextColor::class,
         'MinutesIncrements' => \App\Enums\MinutesIncrements::class,

--- a/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
@@ -104,8 +104,8 @@
     $column->caption
     )
     <tr>
-        <td class="pt-3 border border-0"></td>
-        <td class="pt-3 border border-0" colspan="7">
+        <td class="pt-2 border border-0"></td>
+        <td class="pt-2 border border-0" colspan="8">
             @if ($column->select_count > 0)
                 {{-- 選択肢データがある場合、カンマ付で一覧表示する --}}
                 <div class="small">

--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -2,9 +2,10 @@
  * 表示設定画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベースプラグイン
- --}}
+--}}
 @extends('core.cms_frame_base_setting')
 
 @section("core.cms_frame_edit_tab_$frame->id")
@@ -83,41 +84,18 @@
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass(true)}}">並べ替え項目の表示</label>
         <div class="{{$frame->getSettingInputClass(false)}}">
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[created_asc]" value="created_asc" class="custom-control-input" id="use_sort_flag_created_asc" @if(old('use_sort_flag.created_asc', $view_frame->isUseSortFlag('created_asc'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_created_asc">登録日（古い順）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[created_desc]" value="created_desc" class="custom-control-input" id="use_sort_flag_created_desc" @if(old('use_sort_flag.created_desc', $view_frame->isUseSortFlag('created_desc'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_created_desc">登録日（新しい順）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[updated_asc]" value="updated_asc" class="custom-control-input" id="use_sort_flag_updated_asc" @if(old('use_sort_flag.updated_asc', $view_frame->isUseSortFlag('updated_asc'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_updated_asc">更新日（古い順）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[updated_desc]" value="updated_desc" class="custom-control-input" id="use_sort_flag_updated_desc" @if(old('use_sort_flag.updated_desc', $view_frame->isUseSortFlag('updated_desc'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_updated_desc">更新日（新しい順）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[random_session]" value="random_session" class="custom-control-input" id="use_sort_flag_random_session" @if(old('use_sort_flag.random_session', $view_frame->isUseSortFlag('random_session'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_random_session">ランダム（セッション）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[random_every]" value="random_every" class="custom-control-input" id="use_sort_flag_random_every" @if(old('use_sort_flag.random_every', $view_frame->isUseSortFlag('random_every'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_random_every">ランダム（毎回）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[column]" value="column" class="custom-control-input" id="use_sort_flag_column" @if(old('use_sort_flag.column', $view_frame->isUseSortFlag('column'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_column">各カラム設定</label>
-            </div>
+            @foreach (DatabaseSortFlag::getDisplaySortFlags() as $sort_key => $sort_view)
+                {{--
+                <div class="custom-control custom-checkbox custom-control-inline">
+                    <input type="checkbox" name="use_sort_flag[created_asc]" value="created_asc" class="custom-control-input" id="use_sort_flag_created_asc" @ if(old('use_sort_flag.created_asc', $ view_frame->isUseSortFlag('created_asc'))) checked=checked @ endif>
+                    <label class="custom-control-label" for="use_sort_flag_created_asc">登録日（古い順）</label>
+                </div>
+                --}}
+                <div class="custom-control custom-checkbox custom-control-inline">
+                    <input type="checkbox" name="use_sort_flag[{{$sort_key}}]" value="{{$sort_key}}" class="custom-control-input" id="use_sort_flag_{{$sort_key}}" @if(old('use_sort_flag.' . $sort_key, $view_frame->isUseSortFlag($sort_key))) checked=checked @endif>
+                    <label class="custom-control-label" for="use_sort_flag_{{$sort_key}}">{{  $sort_view  }}</label>
+                </div>
+            @endforeach
         </div>
     </div>
 
@@ -134,12 +112,10 @@
 
             <optgroup label="基本設定">
                 <option value="">指定なし</option>
-                <option value="created_asc" @if($default_sort_flag == 'created_asc') selected @endif>登録日（古い順）</option>
-                <option value="created_desc" @if($default_sort_flag == 'created_desc') selected @endif>登録日（新しい順）</option>
-                <option value="updated_asc" @if($default_sort_flag == 'updated_asc') selected @endif>更新日（古い順）</option>
-                <option value="updated_desc" @if($default_sort_flag == 'updated_desc') selected @endif>更新日（新しい順）</option>
-                <option value="random_session" @if($default_sort_flag == 'random_session') selected @endif>ランダム（セッション）</option>
-                <option value="random_every" @if($default_sort_flag == 'random_every') selected @endif>ランダム（毎回）</option>
+                @foreach (DatabaseSortFlag::getSortFlags() as $sort_key => $sort_view)
+                    {{-- <option value="created_asc" @ if($default_sort_flag == 'created_asc') selected @ endif>登録日（古い順）</option> --}}
+                    <option value="{{$sort_key}}" @if($default_sort_flag == $sort_key) selected @endif>{{  $sort_view  }}</option>
+                @endforeach
             </optgroup>
             <optgroup label="各カラム設定">
                 {{-- 1:昇順＆降順、2:昇順のみ、3:降順のみ --}}

--- a/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
@@ -70,11 +70,7 @@
                 <select class="form-control" name="search_column[{{$loop->index}}][value]" onChange="javascript:submit(this.form);">
                     <option value="">{{$select_column->column_name}}</option>
                     @foreach($columns_selects->where('databases_columns_id', $select_column->id) as $columns_select)
-                        @if($columns_select->value == Session::get($session_column_name))
-                        <option value="{{$columns_select->value}}" selected>{{$columns_select->value}}</option>
-                        @else
-                        <option value="{{$columns_select->value}}">{{$columns_select->value}}</option>
-                        @endif
+                        <option value="{{$columns_select->value}}" @if($columns_select->value == Session::get($session_column_name)) selected @endif>{{  $columns_select->value  }}</option>
                     @endforeach
                 </select>
             </div>
@@ -108,11 +104,7 @@
                     <option value="">並べ替え</option>
                     <optgroup label="基本設定">
                         @foreach($databases_frames->getBasicUseSortFlag() as $sort_basic)
-                            @if($sort_basic == ($sort_column_id . '_' . $sort_column_order))
-                                <option value="{{$sort_basic}}" selected>{{DatabaseColumnType::getDescription($sort_basic)}}</option>
-                            @else
-                                <option value="{{$sort_basic}}">{{DatabaseColumnType::getDescription($sort_basic)}}</option>
-                            @endif
+                            <option value="{{$sort_basic}}" @if($sort_basic == ($sort_column_id . '_' . $sort_column_order)) selected @endif>{{  DatabaseSortFlag::getDescription($sort_basic)  }}</option>
                         @endforeach
                     </optgroup>
 
@@ -123,20 +115,13 @@
                         @foreach($columns->whereIn('sort_flag', [1, 2, 3]) as $sort_column)
 
                             @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 2)
-                                @if($sort_column->id == $sort_column_id && $sort_column_order == 'asc')
-                                <option value="{{$sort_column->id}}_asc" selected>{{$sort_column->column_name}}(昇順)</option>
-                                @else
-                                <option value="{{$sort_column->id}}_asc">{{$sort_column->column_name}}(昇順)</option>
-                                @endif
+                                <option value="{{$sort_column->id}}_asc" @if($sort_column->id == $sort_column_id && $sort_column_order == 'asc') selected @endif>{{  $sort_column->column_name  }}(昇順)</option>
                             @endif
 
                             @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 3)
-                                @if($sort_column->id == $sort_column_id && $sort_column_order == 'desc')
-                                <option value="{{$sort_column->id}}_desc" selected>{{$sort_column->column_name}}(降順)</option>
-                                @else
-                                <option value="{{$sort_column->id}}_desc">{{$sort_column->column_name}}(降順)</option>
-                                @endif
+                                <option value="{{$sort_column->id}}_desc" @if($sort_column->id == $sort_column_id && $sort_column_order == 'desc') selected @endif>{{  $sort_column->column_name  }}(降順)</option>
                             @endif
+
                         @endforeach
                     </optgroup>
                     @endif

--- a/resources/views/plugins/user/databases/menu/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/menu/databases_edit_view.blade.php
@@ -2,9 +2,10 @@
  * 表示設定画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベースプラグイン
- --}}
+--}}
 @extends('core.cms_frame_base_setting')
 
 @section("core.cms_frame_edit_tab_$frame->id")
@@ -83,41 +84,18 @@
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass(true)}}">並べ替え項目の表示</label>
         <div class="{{$frame->getSettingInputClass(false)}}">
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[created_asc]" value="created_asc" class="custom-control-input" id="use_sort_flag_created_asc" @if(old('use_sort_flag.created_asc', $view_frame->isUseSortFlag('created_asc'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_created_asc">登録日（古い順）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[created_desc]" value="created_desc" class="custom-control-input" id="use_sort_flag_created_desc" @if(old('use_sort_flag.created_desc', $view_frame->isUseSortFlag('created_desc'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_created_desc">登録日（新しい順）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[updated_asc]" value="updated_asc" class="custom-control-input" id="use_sort_flag_updated_asc" @if(old('use_sort_flag.updated_asc', $view_frame->isUseSortFlag('updated_asc'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_updated_asc">更新日（古い順）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[updated_desc]" value="updated_desc" class="custom-control-input" id="use_sort_flag_updated_desc" @if(old('use_sort_flag.updated_desc', $view_frame->isUseSortFlag('updated_desc'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_updated_desc">更新日（新しい順）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[random_session]" value="random_session" class="custom-control-input" id="use_sort_flag_random_session" @if(old('use_sort_flag.random_session', $view_frame->isUseSortFlag('random_session'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_random_session">ランダム（セッション）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[random_every]" value="random_every" class="custom-control-input" id="use_sort_flag_random_every" @if(old('use_sort_flag.random_every', $view_frame->isUseSortFlag('random_every'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_random_every">ランダム（毎回）</label>
-            </div>
-
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="use_sort_flag[column]" value="column" class="custom-control-input" id="use_sort_flag_column" @if(old('use_sort_flag.column', $view_frame->isUseSortFlag('column'))) checked=checked @endif>
-                <label class="custom-control-label" for="use_sort_flag_column">各カラム設定</label>
-            </div>
+            @foreach (DatabaseSortFlag::getDisplaySortFlags() as $sort_key => $sort_view)
+                {{--
+                <div class="custom-control custom-checkbox custom-control-inline">
+                    <input type="checkbox" name="use_sort_flag[created_asc]" value="created_asc" class="custom-control-input" id="use_sort_flag_created_asc" @ if(old('use_sort_flag.created_asc', $ view_frame->isUseSortFlag('created_asc'))) checked=checked @ endif>
+                    <label class="custom-control-label" for="use_sort_flag_created_asc">登録日（古い順）</label>
+                </div>
+                --}}
+                <div class="custom-control custom-checkbox custom-control-inline">
+                    <input type="checkbox" name="use_sort_flag[{{$sort_key}}]" value="{{$sort_key}}" class="custom-control-input" id="use_sort_flag_{{$sort_key}}" @if(old('use_sort_flag.' . $sort_key, $view_frame->isUseSortFlag($sort_key))) checked=checked @endif>
+                    <label class="custom-control-label" for="use_sort_flag_{{$sort_key}}">{{  $sort_view  }}</label>
+                </div>
+            @endforeach
         </div>
     </div>
 
@@ -134,12 +112,10 @@
 
             <optgroup label="基本設定">
                 <option value="">指定なし</option>
-                <option value="created_asc" @if($default_sort_flag == 'created_asc') selected @endif>登録日（古い順）</option>
-                <option value="created_desc" @if($default_sort_flag == 'created_desc') selected @endif>登録日（新しい順）</option>
-                <option value="updated_asc" @if($default_sort_flag == 'updated_asc') selected @endif>更新日（古い順）</option>
-                <option value="updated_desc" @if($default_sort_flag == 'updated_desc') selected @endif>更新日（新しい順）</option>
-                <option value="random_session" @if($default_sort_flag == 'random_session') selected @endif>ランダム（セッション）</option>
-                <option value="random_every" @if($default_sort_flag == 'random_every') selected @endif>ランダム（毎回）</option>
+                @foreach (DatabaseSortFlag::getSortFlags() as $sort_key => $sort_view)
+                    {{-- <option value="created_asc" @ if($default_sort_flag == 'created_asc') selected @ endif>登録日（古い順）</option> --}}
+                    <option value="{{$sort_key}}" @if($default_sort_flag == $sort_key) selected @endif>{{  $sort_view  }}</option>
+                @endforeach
             </optgroup>
             <optgroup label="各カラム設定">
                 {{-- 1:昇順＆降順、2:昇順のみ、3:降順のみ --}}

--- a/resources/views/plugins/user/databases/single_sheet/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/single_sheet/databases_include_ctrl_head.blade.php
@@ -3,10 +3,11 @@
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @author よたか <info@hanamachi.com>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @copyright Hanamachi All Rights Reserved
  * @category データベース・プラグイン
- --}}
+--}}
 
 <form action="{{url('/')}}/plugin/databases/search/{{$page->id}}/{{$frame_id}}" method="POST">
     <div class="db-list-header form-group row no-gutters mb-3">
@@ -89,11 +90,7 @@
                     <select class="form-control" name="search_column[{{$loop->index}}][value]" onChange="javascript:submit(this.form);">
                         <option value="">{{$select_column->column_name}}</option>
                         @foreach($columns_selects->where('databases_columns_id', $select_column->id) as $columns_select)
-                            @if($columns_select->value == Session::get($session_column_name))
-                                 <option value="{{$columns_select->value}}" selected>{{$columns_select->value}}</option>
-                            @else
-                                <option value="{{$columns_select->value}}">{{$columns_select->value}}</option>
-                            @endif
+                            <option value="{{$columns_select->value}}" @if($columns_select->value == Session::get($session_column_name)) selected @endif>{{  $columns_select->value  }}</option>
                         @endforeach
                     </select>
                 </div>
@@ -102,21 +99,21 @@
             {{-- 並び順 --}}
             @if($sort_count > 0 || $databases_frames->isBasicUseSortFlag())
                 @php
-                  $sort_column_id = '';
-                  $sort_column_order = '';
+                    $sort_column_id = '';
+                    $sort_column_order = '';
 
-                  // 並べ替え項目をセッション優先、次に初期値で変数に整理（選択肢のselected のため）
-                  if (Session::get('sort_column_id.'.$frame_id) && Session::get('sort_column_order.'.$frame_id)) {
-                      $sort_column_id = Session::get('sort_column_id.'.$frame_id);
-                      $sort_column_order = Session::get('sort_column_order.'.$frame_id);
-                  }
-                  else if ($databases_frames && $databases_frames->default_sort_flag) {
-                      $default_sort_flag_part = explode('_', $databases_frames->default_sort_flag);
-                      if (count($default_sort_flag_part) == 2) {
-                          $sort_column_id = $default_sort_flag_part[0];
-                          $sort_column_order = $default_sort_flag_part[1];
-                      }
-                  }
+                    // 並べ替え項目をセッション優先、次に初期値で変数に整理（選択肢のselected のため）
+                    if (Session::get('sort_column_id.'.$frame_id) && Session::get('sort_column_order.'.$frame_id)) {
+                        $sort_column_id = Session::get('sort_column_id.'.$frame_id);
+                        $sort_column_order = Session::get('sort_column_order.'.$frame_id);
+                    }
+                    else if ($databases_frames && $databases_frames->default_sort_flag) {
+                        $default_sort_flag_part = explode('_', $databases_frames->default_sort_flag);
+                        if (count($default_sort_flag_part) == 2) {
+                            $sort_column_id = $default_sort_flag_part[0];
+                            $sort_column_order = $default_sort_flag_part[1];
+                        }
+                    }
                 @endphp
                 <div class="p-1
                     col-{{$col_no * 2}}
@@ -128,11 +125,7 @@
                         <option value="">並べ替え</option>
                         <optgroup label="基本設定">
                             @foreach($databases_frames->getBasicUseSortFlag() as $sort_basic)
-                                @if($sort_basic == ($sort_column_id . '_' . $sort_column_order))
-                                   <option value="{{$sort_basic}}" selected>{{DatabaseColumnType::getDescription($sort_basic)}}</option>
-                                @else
-                                   <option value="{{$sort_basic}}">{{DatabaseColumnType::getDescription($sort_basic)}}</option>
-                                @endif
+                                <option value="{{$sort_basic}}" @if($sort_basic == ($sort_column_id . '_' . $sort_column_order)) selected @endif>{{  DatabaseSortFlag::getDescription($sort_basic)  }}</option>
                             @endforeach
                         </optgroup>
 
@@ -141,20 +134,15 @@
                             <optgroup label="各カラム設定">
                                 {{-- 1:昇順＆降順、2:昇順のみ、3:降順のみ --}}
                                 @foreach($columns->whereIn('sort_flag', [1, 2, 3]) as $sort_column)
+
                                     @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 2)
-                                        @if($sort_column->id == $sort_column_id && $sort_column_order == 'asc')
-                                            <option value="{{$sort_column->id}}_asc" selected>{{$sort_column->column_name}}(昇順)</option>
-                                        @else
-                                            <option value="{{$sort_column->id}}_asc">{{$sort_column->column_name}}(昇順)</option>
-                                        @endif
+                                        <option value="{{$sort_column->id}}_asc" @if($sort_column->id == $sort_column_id && $sort_column_order == 'asc') selected @endif>{{  $sort_column->column_name  }}(昇順)</option>
                                     @endif
+
                                     @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 3)
-                                        @if($sort_column->id == $sort_column_id && $sort_column_order == 'desc')
-                                            <option value="{{$sort_column->id}}_desc" selected>{{$sort_column->column_name}}(降順)</option>
-                                        @else
-                                            <option value="{{$sort_column->id}}_desc">{{$sort_column->column_name}}(降順)</option>
-                                        @endif
+                                        <option value="{{$sort_column->id}}_desc" @if($sort_column->id == $sort_column_id && $sort_column_order == 'desc') selected @endif>{{  $sort_column->column_name  }}(降順)</option>
                                     @endif
+
                                 @endforeach
                             </optgroup>
                         @endif


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

* ソート用の値がデータベースの型として設定できてしまっていたため、修正します。
    * データベースの型は、`DatabaseColumnType`クラスの定数で定義しているので、そこからソート用項目を取り除き、
`App\Enums\DatabaseSortFlag.php`に移動させました。
    * また、ソート用項目の定数を使用しておらず、各所で直書きしてたいのを、ソート用項目の定数を利用するように見直しました。
 
この修正により、`App\Enums\DatabaseSortFlag.php` に新しい定数を追加すると、画面に自動的に反映されるようになりました。

### 修正内容
* move: database plugin, DatabaseColumnType::created_asc等は、ソート用項目のため、App\Enums\DatabaseSortFlag.phpに移動
* bugfix: database plugin, 設定＞項目設定の選択肢を表示する行の余白が広かったため、少し狭める. また、列数(cols指定)が他の行より少なかったため修正.
* refactor: database plugin, EnumsBaseを継承して、同じメソッド・同じ処理は削除
* refactor: databases_include_ctrl_head.blade.php, selectedのON・OFFは1行にまとめる。また、インデントの修正

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/395

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer