### PR TITLE
【データベース】登録日型・更新日型を追加 

### DIFF
--- a/app/Enums/DatabaseColumnType.php
+++ b/app/Enums/DatabaseColumnType.php
@@ -27,14 +27,8 @@ final class DatabaseColumnType extends EnumsBase
     const wysiwyg = 'wysiwyg';
     // delete:「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止
     // const group = 'group';
-
-    // move: ソート用項目のため、App\Enums\DatabaseSortFlag.phpに移動
-    // const created_asc    = 'created_asc';
-    // const created_desc   = 'created_desc';
-    // const updated_asc    = 'updated_asc';
-    // const updated_desc   = 'updated_desc';
-    // const random_session = 'random_session';
-    // const random_every   = 'random_every';
+    const created    = 'created';
+    const updated    = 'updated';
 
     // key/valueの連想配列
     const enum = [
@@ -52,16 +46,10 @@ final class DatabaseColumnType extends EnumsBase
         self::file=>'ファイル型',
         self::image=>'画像型',
         self::video=>'動画型',
-        self::wysiwyg=>'ウィジウィグ',
+        self::wysiwyg=>'ウィジウィグ型',
         // delete:「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止
         // self::group=>'まとめ行',
-
-        // move: ソート用項目のため、App\Enums\DatabaseSortFlag.phpに移動
-        // self::created_asc    => '登録日（古い順）',
-        // self::created_desc   => '登録日（新しい順）',
-        // self::updated_asc    => '更新日（古い順）',
-        // self::updated_desc   => '更新日（新しい順）',
-        // self::random_session => 'ランダム（セッション）',
-        // self::random_every   => 'ランダム（毎回）',
+        self::created    => '登録日型（自動更新）',
+        self::updated    => '更新日型（自動更新）',
     ];
 }

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -638,6 +638,7 @@ class DatabasesPlugin extends UserPluginBase
                 'database'   => $database,
                 'columns'    => $columns,
                 'group_rows_cols_columns' => $group_rows_cols_columns,
+                // inputにすると値があってもnullになるため、$inputsのままでいく
                 'inputs'     => $inputs,
                 'input_cols' => $input_cols,
             ]
@@ -991,6 +992,12 @@ class DatabasesPlugin extends UserPluginBase
 
         // databases_input_cols 登録
         foreach ($databases_columns as $databases_column) {
+            // 登録日型・更新日型は、databases_inputsテーブルの登録日・更新日を利用するため、登録しない
+            if ($databases_column->column_type == \DatabaseColumnType::created ||
+                    $databases_column->column_type == \DatabaseColumnType::updated) {
+                continue;
+            }
+
             $value = "";
             if (is_array($request->databases_columns_value[$databases_column->id])) {
                 $value = implode(',', $request->databases_columns_value[$databases_column->id]);
@@ -1009,9 +1016,9 @@ class DatabasesPlugin extends UserPluginBase
                 $databases_input_cols->save();
 
                 // ファイルタイプがファイル系の場合は、uploads テーブルの一時フラグを更新
-                if (($databases_column->column_type == "file")  ||
-                    ($databases_column->column_type == "image") ||
-                    ($databases_column->column_type == "video")) {
+                if (($databases_column->column_type == \DatabaseColumnType::file)  ||
+                    ($databases_column->column_type == \DatabaseColumnType::image) ||
+                    ($databases_column->column_type == \DatabaseColumnType::video)) {
                     $uploads_count = Uploads::where('id', $value)->update(['temporary_flag' => 0]);
                 }
             }
@@ -1020,7 +1027,7 @@ class DatabasesPlugin extends UserPluginBase
             $contents_text .= $databases_column->column_name . "：" . $value . "\n";
 
             // メール型
-            if ($databases_column->column_type == "mail") {
+            if ($databases_column->column_type == \DatabaseColumnType::mail) {
                 $user_mailaddresses[] = $value;
             }
         }
@@ -1190,7 +1197,7 @@ class DatabasesPlugin extends UserPluginBase
                 $databases_input_cols->save();
 
                 // ファイルタイプがファイル系の場合は、uploads テーブルの一時フラグを更新
-                if ($databases_column->column_type == "file") {
+                if ($databases_column->column_type == \DatabaseColumnType::file) {
                     $uploads_count = Uploads::where('id', $value)->update(['temporary_flag' => 0]);
                 }
             }
@@ -1199,7 +1206,7 @@ class DatabasesPlugin extends UserPluginBase
             $contents_text .= $databases_column->column_name . "：" . $value . "\n";
 
             // メール型
-            if ($databases_column->column_type == "mail") {
+            if ($databases_column->column_type == \DatabaseColumnType::mail) {
                 $user_mailaddresses[] = $value;
             }
         }

--- a/resources/views/plugins/user/databases/default/databases_confirm.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_confirm.blade.php
@@ -34,110 +34,117 @@
 <form action="" name="databases_store{{$frame_id}}" method="POST">
     {{ csrf_field() }}
     @foreach($databases_columns as $database_column)
-    <div class="form-group container-fluid row">
-        {{-- ラベル --}}
-        <label class="col-sm-2 control-label text-nowrap">{{$database_column->column_name}}</label>
-        {{-- 項目 --}}
-        <div class="col-sm-10">
 
-        @switch($database_column->column_type)
+        {{-- 登録日型・更新日型は入力表示しない --}}
+        @if($database_column->column_type == DatabaseColumnType::created ||
+            $database_column->column_type == DatabaseColumnType::updated)
+            @continue
+        @endif
 
-        @case(DatabaseColumnType::text)
-            {{$request->databases_columns_value[$database_column->id]}}
-            <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
-            @break
-        @case(DatabaseColumnType::textarea)
-            {!!nl2br(e($request->databases_columns_value[$database_column->id]))!!}
-            <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
-            @break
-        @case(DatabaseColumnType::radio)
-            @if (array_key_exists($database_column->id, $request->databases_columns_value))
-                <input name="databases_columns_value[{{$database_column->id}}]" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">{{$request->databases_columns_value[$database_column->id]}}
-            @else
-                <input name="databases_columns_value[{{$database_column->id}}]" type="hidden">
-            @endif
-            @break
-        @case(DatabaseColumnType::checkbox)
-            @if (array_key_exists($database_column->id, $request->databases_columns_value))
-                @foreach($request->databases_columns_value[$database_column->id] as $checkbox_item)
-                    <input name="databases_columns_value[{{$database_column->id}}][]" type="hidden" value="{{$checkbox_item}}">{{$checkbox_item}}@if (!$loop->last), @endif
-                @endforeach
-            @else
-                <input name="databases_columns_value[{{$database_column->id}}][]" type="hidden">
-            @endif
-            @break
-        @case(DatabaseColumnType::select)
-            @if (array_key_exists($database_column->id, $request->databases_columns_value))
-                <input name="databases_columns_value[{{$database_column->id}}]" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">{{$request->databases_columns_value[$database_column->id]}}
-            @else
-                <input name="databases_columns_value[{{$database_column->id}}]" type="hidden">
-            @endif
-            @break
-        @case(DatabaseColumnType::mail)
-            {{$request->databases_columns_value[$database_column->id]}}
-            <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
-            @break
-        @case("date")
-            {{$request->databases_columns_value[$database_column->id]}}
-            <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
-            @break
-        @case(DatabaseColumnType::time)
-            {{$request->databases_columns_value[$database_column->id]}}
-            <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
-            @break
-        @case(DatabaseColumnType::link)
-            <a href="{{$request->databases_columns_value[$database_column->id]}}" target="_blank">{{$request->databases_columns_value[$database_column->id]}}</a>
-            <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
-            @break
-        @case(DatabaseColumnType::file)
-            @php
-                // value 値の取得
-                if ($uploads && $uploads->where('columns_id', $database_column->id)) {
-                    $value_obj = $uploads->where('columns_id', $database_column->id)->first();
-                }
-            @endphp
-            @if(isset($value_obj)) {{-- ファイルがアップロードされた or もともとアップロードされていて変更がない時 --}}
-                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$value_obj->id}}">
-                <a href="{{url('/')}}/file/{{$value_obj->id}}" target="_blank">{{$value_obj->client_original_name}}</a>
-            @else
-                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="">
-            @endif
-            @break
-        @case(DatabaseColumnType::image)
-            @php
-                // value 値の取得
-                if ($uploads && $uploads->where('columns_id', $database_column->id)) {
-                    $value_obj = $uploads->where('columns_id', $database_column->id)->first();
-                }
-            @endphp
-            @if(isset($value_obj)) {{-- ファイルがアップロードされた or もともとアップロードされていて変更がない時 --}}
-                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$value_obj->id}}">
-                <img src="{{url('/')}}/file/{{$value_obj->id}}" class="img-fluid" />
-            @else
-                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="">
-            @endif
-            @break
-        @case(DatabaseColumnType::video)
-            @php
-                // value 値の取得
-                if ($uploads && $uploads->where('columns_id', $database_column->id)) {
-                    $value_obj = $uploads->where('columns_id', $database_column->id)->first();
-                }
-            @endphp
-            @if(isset($value_obj)) {{-- ファイルがアップロードされた or もともとアップロードされていて変更がない時 --}}
-                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$value_obj->id}}">
-                <a href="{{url('/')}}/file/{{$value_obj->id}}" target="_blank">{{$value_obj->client_original_name}}</a>
-            @else
-                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="">
-            @endif
-            @break
-        @case(DatabaseColumnType::wysiwyg)
-            {!!$request->databases_columns_value[$database_column->id]!!}
-            <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
-            @break
-        @endswitch
+        <div class="form-group container-fluid row">
+            {{-- ラベル --}}
+            <label class="col-sm-2 control-label text-nowrap">{{$database_column->column_name}}</label>
+            {{-- 項目 --}}
+            <div class="col-sm-10">
+
+            @switch($database_column->column_type)
+
+            @case(DatabaseColumnType::text)
+                {{$request->databases_columns_value[$database_column->id]}}
+                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
+                @break
+            @case(DatabaseColumnType::textarea)
+                {!!nl2br(e($request->databases_columns_value[$database_column->id]))!!}
+                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
+                @break
+            @case(DatabaseColumnType::radio)
+                @if (array_key_exists($database_column->id, $request->databases_columns_value))
+                    <input name="databases_columns_value[{{$database_column->id}}]" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">{{$request->databases_columns_value[$database_column->id]}}
+                @else
+                    <input name="databases_columns_value[{{$database_column->id}}]" type="hidden">
+                @endif
+                @break
+            @case(DatabaseColumnType::checkbox)
+                @if (array_key_exists($database_column->id, $request->databases_columns_value))
+                    @foreach($request->databases_columns_value[$database_column->id] as $checkbox_item)
+                        <input name="databases_columns_value[{{$database_column->id}}][]" type="hidden" value="{{$checkbox_item}}">{{$checkbox_item}}@if (!$loop->last), @endif
+                    @endforeach
+                @else
+                    <input name="databases_columns_value[{{$database_column->id}}][]" type="hidden">
+                @endif
+                @break
+            @case(DatabaseColumnType::select)
+                @if (array_key_exists($database_column->id, $request->databases_columns_value))
+                    <input name="databases_columns_value[{{$database_column->id}}]" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">{{$request->databases_columns_value[$database_column->id]}}
+                @else
+                    <input name="databases_columns_value[{{$database_column->id}}]" type="hidden">
+                @endif
+                @break
+            @case(DatabaseColumnType::mail)
+                {{$request->databases_columns_value[$database_column->id]}}
+                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
+                @break
+            @case("date")
+                {{$request->databases_columns_value[$database_column->id]}}
+                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
+                @break
+            @case(DatabaseColumnType::time)
+                {{$request->databases_columns_value[$database_column->id]}}
+                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
+                @break
+            @case(DatabaseColumnType::link)
+                <a href="{{$request->databases_columns_value[$database_column->id]}}" target="_blank">{{$request->databases_columns_value[$database_column->id]}}</a>
+                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
+                @break
+            @case(DatabaseColumnType::file)
+                @php
+                    // value 値の取得
+                    if ($uploads && $uploads->where('columns_id', $database_column->id)) {
+                        $value_obj = $uploads->where('columns_id', $database_column->id)->first();
+                    }
+                @endphp
+                @if(isset($value_obj)) {{-- ファイルがアップロードされた or もともとアップロードされていて変更がない時 --}}
+                    <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$value_obj->id}}">
+                    <a href="{{url('/')}}/file/{{$value_obj->id}}" target="_blank">{{$value_obj->client_original_name}}</a>
+                @else
+                    <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="">
+                @endif
+                @break
+            @case(DatabaseColumnType::image)
+                @php
+                    // value 値の取得
+                    if ($uploads && $uploads->where('columns_id', $database_column->id)) {
+                        $value_obj = $uploads->where('columns_id', $database_column->id)->first();
+                    }
+                @endphp
+                @if(isset($value_obj)) {{-- ファイルがアップロードされた or もともとアップロードされていて変更がない時 --}}
+                    <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$value_obj->id}}">
+                    <img src="{{url('/')}}/file/{{$value_obj->id}}" class="img-fluid" />
+                @else
+                    <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="">
+                @endif
+                @break
+            @case(DatabaseColumnType::video)
+                @php
+                    // value 値の取得
+                    if ($uploads && $uploads->where('columns_id', $database_column->id)) {
+                        $value_obj = $uploads->where('columns_id', $database_column->id)->first();
+                    }
+                @endphp
+                @if(isset($value_obj)) {{-- ファイルがアップロードされた or もともとアップロードされていて変更がない時 --}}
+                    <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$value_obj->id}}">
+                    <a href="{{url('/')}}/file/{{$value_obj->id}}" target="_blank">{{$value_obj->client_original_name}}</a>
+                @else
+                    <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="">
+                @endif
+                @break
+            @case(DatabaseColumnType::wysiwyg)
+                {!!$request->databases_columns_value[$database_column->id]!!}
+                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
+                @break
+            @endswitch
+            </div>
         </div>
-    </div>
     @endforeach
 
     {{-- 削除対象のファイルのid --}}

--- a/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
@@ -45,6 +45,15 @@
             $value = '<a href="' . $obj->value . '" target="_blank">' . $obj->value . '</a>';
         }
     }
+    // 登録日型
+    elseif ($column->column_type == DatabaseColumnType::created) {
+        // DatabasesPlugin.phpにて、inputでbladeに値を渡すと、値があってもnullになるため、inputsのままでいく
+        $value = $inputs->created_at;
+    }
+    // 更新日型
+    elseif ($column->column_type == DatabaseColumnType::updated) {
+        $value = $inputs->updated_at;
+    }
     // その他の型
     else {
         $value = $obj ? $obj->value : "";

--- a/resources/views/plugins/user/databases/default/databases_include_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_value.blade.php
@@ -45,6 +45,14 @@
             $value = '<a href="' . $obj->value . '" target="_blank">' . $obj->value . '</a>';
         }
     }
+    // 登録日型
+    elseif ($column->column_type == DatabaseColumnType::created) {
+        $value = $input->created_at;
+    }
+    // 更新日型
+    elseif ($column->column_type == DatabaseColumnType::updated) {
+        $value = $input->updated_at;
+    }
     // その他の型
     else {
         $value = $obj ? $obj->value : "";

--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -23,13 +23,21 @@
 --}}
 
         @foreach($databases_columns as $database_column)
-        <div class="form-group row">
-            <label class="col-sm-3 control-label">{{$database_column->column_name}} @if ($database_column->required)<label class="badge badge-danger">必須</label> @endif</label>
-            <div class="col-sm-9">
-                @include('plugins.user.databases.default.databases_input_' . $database_column->column_type,['database_obj' => $database_column])
-                <div class="small {{ $database_column->caption_color }}">{!! nl2br($database_column->caption) !!}</div>
-            </div>
-        </div>
+            @switch($database_column->column_type)
+            {{-- 登録日型・更新日型は入力表示しない --}}
+            @case(DatabaseColumnType::created)
+            @case(DatabaseColumnType::updated)
+                @break
+            {{-- 通常の項目 --}}
+            @default
+                <div class="form-group row">
+                    <label class="col-sm-3 control-label">{{$database_column->column_name}} @if ($database_column->required)<label class="badge badge-danger">必須</label> @endif</label>
+                    <div class="col-sm-9">
+                        @include('plugins.user.databases.default.databases_input_' . $database_column->column_type,['database_obj' => $database_column])
+                        <div class="small {{ $database_column->caption_color }}">{!! nl2br($database_column->caption) !!}</div>
+                    </div>
+                </div>
+            @endswitch
         @endforeach
         {{-- ボタンエリア --}}
         <div class="form-group text-center">

--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -25,47 +25,10 @@
         @foreach($databases_columns as $database_column)
         <div class="form-group row">
             <label class="col-sm-3 control-label">{{$database_column->column_name}} @if ($database_column->required)<label class="badge badge-danger">必須</label> @endif</label>
-            @switch($database_column->column_type)
-            @case("group")
-                @php
-                    // グループカラムの幅の計算
-                    $col_count = floor(12/count($database_column->group));
-                    if ($col_count < 3) {
-                        $col_count = 3;
-                    }
-                @endphp
-                <div class="col-sm-9 pr-0">
-                <div class="container-fluid row" style="padding: 0;">
-                @foreach($database_column->group as $group_row)
-
-                    {{-- 項目名 --}}
-                    @if ($group_row->column_type == 'radio' || $group_row->column_type == 'checkbox')
-                        <div class="col-sm-{{$col_count}}" style="padding-left: 0px;">
-                        <label class="control-label" style="vertical-align: top; padding-left: 16px; padding-top: 8px;">{{$group_row->column_name}}</label>
-                    @else
-                        <div class="col-sm-{{$col_count}} pr-0">
-                        <label class="control-label">{{$group_row->column_name}}</label>
-                    @endif
-
-                    {{-- 必須 --}}
-                    @if ($group_row->required)<label class="badge badge-danger">必須</label> @endif
-
-                    {{-- 項目 ※まとめ設定行 --}}
-                    @include('plugins.user.databases.default.databases_input_' . $group_row->column_type,['database_obj' => $group_row])
-                    <div class="small {{ $group_row->caption_color }}">{!! nl2br($group_row->caption) !!}</div>
-                        </div>
-                @endforeach
-                    </div>
-                    <div class="small {{ $database_column->caption_color }}">{!! nl2br($database_column->caption) !!}</div>
-                </div>
-                @break
-            {{-- 項目 ※まとめ未設定行 --}}
-            @default
-                <div class="col-sm-9">
-                    @include('plugins.user.databases.default.databases_input_' . $database_column->column_type,['database_obj' => $database_column])
-                    <div class="small {{ $database_column->caption_color }}">{!! nl2br($database_column->caption) !!}</div>
-                </div>
-            @endswitch
+            <div class="col-sm-9">
+                @include('plugins.user.databases.default.databases_input_' . $database_column->column_type,['database_obj' => $database_column])
+                <div class="small {{ $database_column->caption_color }}">{!! nl2br($database_column->caption) !!}</div>
+            </div>
         </div>
         @endforeach
         {{-- ボタンエリア --}}

--- a/resources/views/plugins/user/databases/default/databases_input_link.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input_link.blade.php
@@ -14,7 +14,7 @@
         $value = $value_obj->value;
     }
 @endphp
-<input name="databases_columns_value[{{$database_obj->id}}]" class="form-control" type="{{$database_obj->column_type}}" value="@if ($frame_id == $request->frame_id){{old('databases_columns_value.'.$database_obj->id, $value)}}@endif">
+<input name="databases_columns_value[{{$database_obj->id}}]" class="form-control" type="text" value="@if ($frame_id == $request->frame_id){{old('databases_columns_value.'.$database_obj->id, $value)}}@endif">
 @if ($errors && $errors->has("databases_columns_value.$database_obj->id"))
     <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first("databases_columns_value.$database_obj->id")}}</div>
 @endif


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

* データベースプラグインに、登録日型・更新日型を追加しました。
    * データベースの登録データの登録日・更新日は、`databases_inputs`テーブルに持っていましたので、
登録日型・更新日型は、`databases_inputs`テーブルの`created_at`（登録日）・`updated_at`（更新日）を表示します。
    * データベースの登録データテーブル`databases_input_cols`にはデータ登録しません。
        * この構成により、データベースプラグインを運用後、後から登録日型・更新日型を設定しても、即時に登録日・更新日を表示する事ができます。
        * また、`databases_input_cols`にデータ登録しない・確認画面にも表示しない事から、メール通知の内容に登録日型・更新日型は表示しません。

### 更新内容
* add: database plugin, 登録日型・更新日型を追加 
* bugfix: database plugin, まとめ行"group"の削除漏れ対応
* bugfix: database plugin, リンク型を<input type="text">に修正
* bugifx: 'ウィジウィグ' -> 'ウィジウィグ型'に表示修正
* refactor: database plugin, column_typeのfile, image, video, mailが直書きだったため、DatabaseColumnTypeの定数を使うように見直し

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/397

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

## 登録日型・更新日型の一覧・詳細表示

![image](https://user-images.githubusercontent.com/2756509/86876023-cbc3ae00-c11e-11ea-89c4-d96fb995d863.png)

## 登録日型・更新日型は、登録・更新時に表示しません

![image](https://user-images.githubusercontent.com/2756509/86876101-eb5ad680-c11e-11ea-9cb2-a0c8c8061c3d.png)

### 確認画面
![image](https://user-images.githubusercontent.com/2756509/86876180-134a3a00-c11f-11ea-8ac4-65c1af59c572.png)


## チェックリスト（Checklist）
- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer