### PR TITLE
add: 【データベース】投稿権限の設定追加

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -46,7 +46,7 @@ class DatabasesPlugin extends UserPluginBase
     /* コアから呼び出す関数 */
 
     /**
-     *  関数定義（コアから呼び出す）
+     * 追加の関数定義（コアから呼び出す）
      */
     public function getPublicFunctions()
     {
@@ -63,8 +63,6 @@ class DatabasesPlugin extends UserPluginBase
             'index',
             'detail',
             'input',
-            'publicConfirm',
-            'publicStore',
             'cancel',
             'updateColumn',
             'updateColumnSequence',
@@ -81,39 +79,31 @@ class DatabasesPlugin extends UserPluginBase
     }
 
     /**
-     *  権限定義
+     * 追加の権限定義（コアから呼び出す）
      */
     public function declareRole()
     {
+        // 標準権限以外で設定画面などから呼ばれる権限の定義
+        // 標準権限は右記で定義 config/cc_role.php
+        //
         // 権限チェックテーブル
         $role_ckeck_table = array();
-        $role_ckeck_table["input"]                = array('role_article');
-        $role_ckeck_table["publicConfirm"]        = array('role_article');
-        $role_ckeck_table["publicStore"]          = array('role_article');
-        $role_ckeck_table["delete"]               = array('role_article');
+        $role_ckeck_table["input"]                = array('posts.create', 'posts.update');
+        $role_ckeck_table["publicConfirm"]        = array('posts.create', 'posts.update');
+        $role_ckeck_table["publicStore"]          = array('posts.create', 'posts.update');
 
-        $role_ckeck_table["listBuckets"]          = array('role_arrangement');
-        $role_ckeck_table["createBuckets"]        = array('role_arrangement');
-        $role_ckeck_table["editBuckets"]          = array('role_arrangement');
-        $role_ckeck_table["saveBuckets"]          = array('role_arrangement');
-        $role_ckeck_table["destroyBuckets"]       = array('role_arrangement');
-        $role_ckeck_table["changeBuckets"]        = array('role_arrangement');
-        $role_ckeck_table["addColumn"]            = array('role_arrangement');
-        $role_ckeck_table["editColumnDetail"]     = array('role_arrangement');
-        $role_ckeck_table["editColumn"]           = array('role_arrangement');
-        $role_ckeck_table["deleteColumn"]         = array('role_arrangement');
-        $role_ckeck_table["updateColumn"]         = array('role_arrangement');
-        $role_ckeck_table["updateColumnSequence"] = array('role_arrangement');
-        $role_ckeck_table["updateColumnDetail"]   = array('role_arrangement');
-        $role_ckeck_table["addSelect"]            = array('role_arrangement');
-        $role_ckeck_table["addPref"]              = array('role_arrangement');
-        $role_ckeck_table["updateSelect"]         = array('role_arrangement');
-        $role_ckeck_table["updateSelectSequence"] = array('role_arrangement');
-        $role_ckeck_table["deleteSelect"]         = array('role_arrangement');
-        $role_ckeck_table["deleteColumnsSelects"] = array('role_arrangement');
-        $role_ckeck_table["downloadCsv"]          = array('role_arrangement');
-        $role_ckeck_table["editView"]             = array('role_arrangement');
-        $role_ckeck_table["saveView"]             = array('role_arrangement');
+        $role_ckeck_table["editColumnDetail"]     = array('buckets.editColumn');
+        $role_ckeck_table["updateColumn"]         = array('buckets.editColumn');
+        $role_ckeck_table["updateColumnSequence"] = array('buckets.editColumn');
+        $role_ckeck_table["updateColumnDetail"]   = array('buckets.editColumn');
+        $role_ckeck_table["addSelect"]            = array('buckets.addColumn');
+        $role_ckeck_table["addPref"]              = array('buckets.addColumn');
+        $role_ckeck_table["updateSelect"]         = array('buckets.editColumn');
+        $role_ckeck_table["updateSelectSequence"] = array('buckets.editColumn');
+        $role_ckeck_table["deleteSelect"]         = array('buckets.editColumn');
+        $role_ckeck_table["deleteColumnsSelects"] = array('buckets.editColumn');
+        $role_ckeck_table["editView"]             = array('frames.edit');
+        $role_ckeck_table["saveView"]             = array('frames.edit');
         return $role_ckeck_table;
     }
 
@@ -650,11 +640,6 @@ class DatabasesPlugin extends UserPluginBase
      */
     public function input($request, $page_id, $frame_id, $id = null, $errors = null)
     {
-        // 権限チェック（まずはモデレータでチェック）
-        if ($this->can('role_article')) {
-            return $this->view_error("403_inframe", null, '関数実行権限がありません。');
-        }
-
         // セッション初期化などのLaravel 処理。
         $request->flash();
 
@@ -801,11 +786,6 @@ class DatabasesPlugin extends UserPluginBase
      */
     public function publicConfirm($request, $page_id, $frame_id, $id = null)
     {
-        // 権限チェック（まずはモデレータでチェック）
-        if ($this->can('role_article')) {
-            return $this->view_error("403_inframe", null, '関数実行権限がありません。');
-        }
-
         // Databases、Frame データ
         $database = $this->getDatabases($frame_id);
 
@@ -929,12 +909,6 @@ class DatabasesPlugin extends UserPluginBase
      */
     public function publicStore($request, $page_id, $frame_id, $id = null)
     {
-
-        // 権限チェック（まずはモデレータでチェック）
-        if ($this->can('role_article')) {
-            return $this->view_error("403_inframe", null, '関数実行権限がありません。');
-        }
-
         // Databases、Frame データ
         $database = $this->getDatabases($frame_id);
 
@@ -1081,12 +1055,6 @@ class DatabasesPlugin extends UserPluginBase
      */
     public function delete($request, $page_id, $frame_id, $id)
     {
-
-        // 権限チェック（まずはモデレータでチェック）
-        if ($this->can('role_article')) {
-            return $this->view_error("403_inframe", null, '関数実行権限がありません。');
-        }
-
         // 行 idがなければ終了
         if (empty($id)) {
             // 表示テンプレートを呼び出す。
@@ -1890,7 +1858,7 @@ class DatabasesPlugin extends UserPluginBase
                 'databases_columns_id' => $request->column_id,
                 'value'                => $pref,
                 'display_sequence'     => $max_display_sequence,
-             ]);
+            ]);
             $max_display_sequence++;
         }
         $message = '選択肢【 '. $request->select_name .' 】を追加しました。';
@@ -2221,5 +2189,27 @@ class DatabasesPlugin extends UserPluginBase
         $return[] = '/page';
 
         return $return;
+    }
+
+    /**
+     * 権限設定変更 画面
+     * [TODO] 一時的に承認権限を使わない設定で修正する。今後承認機能を実装したら、当メソッドを削除する。
+     */
+    public function editBucketsRoles($request, $page_id, $frame_id, $id = null, $use_approval = true)
+    {
+        // 承認を使わない設定にして、親クラスの同メソッドを呼ぶ
+        $use_approval = false;
+        return parent::editBucketsRoles($request, $page_id, $frame_id, $id, $use_approval);
+    }
+
+    /**
+     * 権限設定 保存処理
+     * [TODO] 一時的に承認権限を使わない設定で修正する。今後承認機能を実装したら、当メソッドを削除する。
+     */
+    public function saveBucketsRoles($request, $page_id, $frame_id, $id = null, $use_approval = true)
+    {
+        // 承認を使わない設定にして、親クラスの同メソッドを呼ぶ
+        $use_approval = false;
+        return parent::saveBucketsRoles($request, $page_id, $frame_id, $id, $use_approval);
     }
 }

--- a/resources/views/plugins/user/databases/card/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/card/databases_detail.blade.php
@@ -8,7 +8,7 @@
 --}}
 @extends('core.cms_frame_base')
 @section("plugin_contents_$frame->id")
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">
@@ -50,7 +50,7 @@
         @endforeach
     </div>
 
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">

--- a/resources/views/plugins/user/databases/databases_frame_edit_tab.blade.php
+++ b/resources/views/plugins/user/databases/databases_frame_edit_tab.blade.php
@@ -2,16 +2,17 @@
  * 編集画面tabテンプレート
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベースプラグイン
- --}}
+--}}
 @if ($action == 'editColumn' || $action == 'editColumnDetail'  || $action == '')
     <li role="presentation" class="nav-item">
         <span class="nav-link"><span class="active">項目設定</span></span>
     </li>
 @else
     <li role="presentation" class="nav-item">
-        <a href="{{url('/')}}/plugin/databases/editColumn/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">項目設定</a>
+        <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/editColumn/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">項目設定</a>
     </li>
 @endif
 @if ($action == 'editView')
@@ -20,7 +21,7 @@
     </li>
 @else
     <li role="presentation" class="nav-item">
-        <a href="{{url('/')}}/plugin/databases/editView/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">表示設定</a>
+        <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/editView/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">表示設定</a>
     </li>
 @endif
 @if ($action == 'editBuckets' || $action == '')
@@ -29,7 +30,7 @@
     </li>
 @else
     <li role="presentation" class="nav-item">
-        <a href="{{url('/')}}/plugin/databases/editBuckets/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">DB設定</a>
+        <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/editBuckets/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">DB設定</a>
     </li>
 @endif
 @if ($action == 'createBuckets')
@@ -48,5 +49,14 @@
 @else
     <li role="presentation" class="nav-item">
         <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/listBuckets/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">DB選択</a>
+    </li>
+@endif
+@if ($action == 'editBucketsRoles' || $action == 'saveBucketsRoles')
+    <li role="presentation" class="nav-item">
+        <span class="nav-link"><span class="active">権限設定</span></span>
+    </li>
+@else
+    <li role="presentation" class="nav-item">
+        <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/editBucketsRoles/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">権限設定</a>
     </li>
 @endif

--- a/resources/views/plugins/user/databases/default/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_detail.blade.php
@@ -33,7 +33,7 @@
     @endforeach
 </div>
 
-@can("role_article")
+@can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
 <div class="row mt-2">
     <div class="col-12 text-right mb-1">
         <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">

--- a/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
@@ -9,7 +9,7 @@
 --}}
 
 {{-- 新規登録 --}}
-@can("role_article")
+@can('posts.create', [[null, $frame->plugin_name, $buckets]])
     <div class="row">
         <p class="text-right col-12">
             {{-- 新規登録ボタン --}}

--- a/resources/views/plugins/user/databases/list/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/list/databases_detail.blade.php
@@ -8,7 +8,7 @@
 --}}
 @extends('core.cms_frame_base')
 @section("plugin_contents_$frame->id")
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">
@@ -50,7 +50,7 @@
         @endforeach
     </div>
 
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">

--- a/resources/views/plugins/user/databases/menu/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/menu/databases_detail.blade.php
@@ -8,7 +8,7 @@
 --}}
 @extends('core.cms_frame_base')
 @section("plugin_contents_$frame->id")
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">
@@ -50,7 +50,7 @@
         @endforeach
     </div>
 
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">

--- a/resources/views/plugins/user/databases/single_sheet/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/single_sheet/databases_detail.blade.php
@@ -8,7 +8,7 @@
 --}}
 @extends('core.cms_frame_base')
 @section("plugin_contents_$frame->id")
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">
@@ -50,7 +50,7 @@
         @endforeach
     </div>
 
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">

--- a/resources/views/plugins/user/databases/single_sheet/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/single_sheet/databases_include_ctrl_head.blade.php
@@ -34,7 +34,7 @@
         @endphp
 
         {{-- 新規登録 --}}
-        @can("role_article")
+        @can('posts.create', [[null, $frame->plugin_name, $buckets]])
             @php
                 $add_button_width = 1; // 新規ボタンの幅を確保する。
             @endphp

--- a/resources/views/plugins/user/databases/table/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/table/databases_detail.blade.php
@@ -23,7 +23,7 @@
     @endforeach
 </table>
 
-@can("role_article")
+@can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
 <div class="row">
     <div class="col-12 text-right mb-1">
         <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">

--- a/resources/views/plugins/user/databases/table_responsive/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/table_responsive/databases_detail.blade.php
@@ -8,7 +8,7 @@
 --}}
 @extends('core.cms_frame_base')
 @section("plugin_contents_$frame->id")
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">
@@ -50,7 +50,7 @@
         @endforeach
     </div>
 
-    @can("role_article")
+    @can('posts.update', [[$inputs, $frame->plugin_name, $buckets]])
         <div class="row">
             <div class="col-12 text-right mb-1">
                 <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}'">


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

今まではデータベースプラグインに投稿できるのは、モデレーター以上の権限をもつ人だけでした。
それを見直して、データベース毎に投稿権限の設定できるよう、対応しました。

投稿権限の他に、承認権限もあるのですが、修正が大きくなったため、一旦マージし、
今後承認機能を実装する予定です。

### 修正内容
* add: 【データベース】投稿権限の設定追加
* refactor: database plugin, 追加のget/post関数定義・ 追加の権限定義・各画面を投稿権限を参照するように整理・見直し
* refactor: database plugin, 編集画面tabのプラグイン名は $frame->plugin_name を利用するように見直し

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/402

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

## 権限設定画面（投稿権限）
![image](https://user-images.githubusercontent.com/2756509/86893293-5c5cb700-c13c-11ea-860e-9e76af172995.png)

今後この画面に、承認権限も追加する予定です。

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer