### PR TITLE
（サイト管理）センターエリア要素に対して任意のclassを複数設定可能にする機能を追加

### DIFF
--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -130,6 +130,13 @@ class SiteManage extends ManagePluginBase
              'value'    => $request->base_header_color]
         );
 
+        // センターエリア要素のclass属性
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'center_area_optional_class'],
+            ['category' => 'general',
+             'value'    => $request->center_area_optional_class]
+        );
+
         // 基本のヘッダー固定設定
         $configs = Configs::updateOrCreate(
             ['name'     => 'base_header_fix'],

--- a/resources/views/core/cms.blade.php
+++ b/resources/views/core/cms.blade.php
@@ -70,10 +70,18 @@ $(function(){
     @endif
 
     {{-- 中央エリア --}}
+    @php
+        // センターエリア任意クラスを抽出（カンマ設定時はランダムで１つ設定）
+        $center_area_optional_class = null;
+        if(isset($configs_array['center_area_optional_class'])){
+            $classes = explode(',', $configs_array['center_area_optional_class']->value);
+            $center_area_optional_class = $classes[array_rand($classes)];
+        }
+    @endphp
         @if (isset($configs_array['browser_width_center']) && $configs_array['browser_width_center']->value == '100%')
-    <div id="ccCenterArea" class="ccCenterArea row mx-auto p-0 d-flex align-items-start">
+    <div id="ccCenterArea" class="ccCenterArea row mx-auto p-0 d-flex align-items-start {{ $center_area_optional_class }}">
         @else
-    <div id="ccCenterArea" class="ccCenterArea row container mx-auto p-0 d-flex align-items-start">
+    <div id="ccCenterArea" class="ccCenterArea row container mx-auto p-0 d-flex align-items-start {{ $center_area_optional_class }}">
         @endif
         {{-- 左エリア --}}
         @if ($layouts_info[1]['exists'])

--- a/resources/views/plugins/manage/site/site.blade.php
+++ b/resources/views/plugins/manage/site/site.blade.php
@@ -82,6 +82,14 @@
                     <small class="text-muted">左のカラーパレットから選択することも可能です。</small>
                 @endif
             </div>
+
+            {{-- センターエリア任意クラス --}}
+            <div class="form-group">
+                <label class="col-form-label">センターエリア任意クラス</label>
+                <input type="text" name="center_area_optional_class" id="center_area_optional_class" value="{{$configs["center_area_optional_class"]}}" class="form-control">
+                <small class="form-text text-muted">センターエリア要素に任意のclass属性を設定します。カンマ区切りで複数設定した場合、いづれかのクラスをランダムで設定します。</small>
+                <small class="form-text text-muted">（用例）センターエリアCSSのランダム適用等</small>
+            </div>
         </div>
         {{-- ヘッダーの表示指定 --}}
         <div class="form-group">


### PR DESCRIPTION
## 概要（Overview）
- センターエリア背景画像をランダム表示させたい要件あり
- センターエリア要素に対して任意のclassを設定させる機能を追加
※class設定は複数可能。複数設定時はランダムに１つのclassを適用させる

## 関連Pull requests/Issues（Links to related pull requests or issues）
無し

## 参考（Reference）
無し

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>
無し

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
