### PR TITLE
共通 Laravelのセッションフラッシュデータ機能を使えるようにする

### DIFF
--- a/app/Http/Controllers/Core/DefaultController.php
+++ b/app/Http/Controllers/Core/DefaultController.php
@@ -511,7 +511,12 @@ class DefaultController extends ConnectController
 
         // redirect_path があれば遷移
         if ($request->redirect_path) {
-            return redirect($request->redirect_path);
+            if($request->flash_message){
+                // フラッシュメッセージの設定があればLaravelのフラッシュデータ保存に連携
+                return redirect($request->redirect_path)->with('flash_message', $request->flash_message);
+            }else{
+                return redirect($request->redirect_path);
+            }
         }
 
         // Page データがあれば、そのページに遷移

--- a/app/Http/Controllers/Core/DefaultController.php
+++ b/app/Http/Controllers/Core/DefaultController.php
@@ -141,12 +141,11 @@ class DefaultController extends ConnectController
         //echo $next_language;
 
        // permanent_link の編集
-       // 言語がデフォルト(next_language がnull)＆2nd以降がある場合は、language_or_1stdir はpermanent_link の一部なので、結合する。
         if (empty($next_language) && $link_or_after2nd) {
+            // 言語がデフォルト(next_language がnull)＆2nd以降がある場合は、language_or_1stdir はpermanent_link の一部なので、結合する。
             $permanent_link = $language_or_1stdir . '/' . $link_or_after2nd;
-        }
-       // 言語がデフォルト(next_language がnull)＆2nd以降がない場合は、language_or_1stdir がディレクトリ。
-        elseif (empty($next_language)) {
+        } elseif (empty($next_language)) {
+            // 言語がデフォルト(next_language がnull)＆2nd以降がない場合は、language_or_1stdir がディレクトリ。
             $permanent_link = $language_or_1stdir;
         } else {
             $permanent_link = $link_or_after2nd;
@@ -226,17 +225,15 @@ class DefaultController extends ConnectController
                 //if (is_dir(($finder->getPaths()[0].'/plugins/user/' . $action_core_frame->plugin_name . '/' . $file))) {
                 $template_dir = $finder->getPaths()[0].'/plugins/user/' . $action_core_frame->plugin_name . '/' . $file;
                 if (is_dir($template_dir)) {
-                    // テンプレート設定ファイルがある場合
                     if (File::exists($template_dir."/template.ini")) {
-                        // テンプレート設定ファイルからテンプレート名を探す。設定がなければディレクトリ名をテンプレート名とする。
+                        // テンプレート設定ファイルがある場合、テンプレート設定ファイルからテンプレート名を探す。設定がなければディレクトリ名をテンプレート名とする。
                         $template_inis = parse_ini_file($template_dir."/template.ini");
                         $template_name = $template_inis['template_name'];
                         if (empty($template_name)) {
                             $template_name = $file;
                         }
-                    }
-                    // テンプレート設定ファイルがない場合、テンプレートディレクトリ名をテンプレート名とする
-                    else {
+                    } else {
+                        // テンプレート設定ファイルがない場合、テンプレートディレクトリ名をテンプレート名とする
                         $template_name = $file;
                         $template_inis = array();
                     }
@@ -511,10 +508,10 @@ class DefaultController extends ConnectController
 
         // redirect_path があれば遷移
         if ($request->redirect_path) {
-            if($request->flash_message){
+            if ($request->flash_message) {
                 // フラッシュメッセージの設定があればLaravelのフラッシュデータ保存に連携
                 return redirect($request->redirect_path)->with('flash_message', $request->flash_message);
-            }else{
+            } else {
                 return redirect($request->redirect_path);
             }
         }


### PR DESCRIPTION
## 概要（Overview）
- Laravelの機能にセッションへフラッシュデータを保存する機能があります。
```
コード例 ※下記のwith()の部分
        return redirect("/plugin/rmaps/showResearchers/$page_id/$frame_id#frame-$frame_id")
            ->with('message', '研究者一覧を更新しました。');
```
- しかしながら、Connectで上記のコードを書くと、Connectのコア側のリクエスト制御処理の為、レスポンスヘッダが一瞬画面に表示されてしまいます。
![image](https://user-images.githubusercontent.com/13323806/89103332-f8cc5d80-d44b-11ea-8754-e313007997b8.png)
- Connectのお作法として下記のコードを書けばリダイレクトはされますが、今度はフラッシュデータの保存ができなくなります。
-- 更新画面のformのactionURLに`/redirect/plugin/~~`とredirectである旨のpathを設定
-- 同formのrequest内に`redirect_path`を設定
- Connect的なリダイレクト時にもLaravelの上記機能を使いたい為、コアのリダイレクト処理を改修しました。

## 関連Pull requests/Issues（Links to related pull requests or issues）
なし

## 参考（Reference）
https://readouble.com/laravel/5.5/ja/responses.html
![image](https://user-images.githubusercontent.com/13323806/89103193-e4d42c00-d44a-11ea-931a-8b51da15c11f.png)

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>
無し

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
