### PR TITLE
共通 Laravelのフラッシュデータにバリデータを追加

### DIFF
--- a/app/Http/Controllers/Core/DefaultController.php
+++ b/app/Http/Controllers/Core/DefaultController.php
@@ -508,12 +508,13 @@ class DefaultController extends ConnectController
 
         // redirect_path があれば遷移
         if ($request->redirect_path) {
+
+            $redirect_response = redirect($request->redirect_path);
             if ($request->flash_message) {
                 // フラッシュメッセージの設定があればLaravelのフラッシュデータ保存に連携
-                return redirect($request->redirect_path)->with('flash_message', $request->flash_message);
-            } else {
-                return redirect($request->redirect_path);
+                $redirect_response = $redirect_response->with('flash_message', $request->flash_message);
             }
+            return $redirect_response;
         }
 
         // Page データがあれば、そのページに遷移

--- a/app/Http/Controllers/Core/DefaultController.php
+++ b/app/Http/Controllers/Core/DefaultController.php
@@ -511,9 +511,16 @@ class DefaultController extends ConnectController
 
             $redirect_response = redirect($request->redirect_path);
             if ($request->flash_message) {
-                // フラッシュメッセージの設定があればLaravelのフラッシュデータ保存に連携
+                // フラッシュメッセージの設定があれば、Laravelのフラッシュデータ保存に連携
                 $redirect_response = $redirect_response->with('flash_message', $request->flash_message);
             }
+            if ($request->validator) {
+                // バリデーターの設定があれば（エラーチェックの結果、NGがあれば）、Laravelのバリデータ機能に連携
+                $redirect_response = $redirect_response->withErrors($request->validator->errors());
+                // フラッシュデータとして前画面の入力値を保存
+                $request->session()->flash('_old_input', $request->except('validator'));
+            }
+
             return $redirect_response;
         }
 


### PR DESCRIPTION
## 概要（Overview）
- Laravelでの手動バリデート時に画面へ戻す為、一般的にリダイレクトも設定しますが、この際、バリデート結果オブジェクトを渡す必要があります。
![image](https://user-images.githubusercontent.com/13323806/89408915-2707b100-d75c-11ea-856e-5c565b3e9d7a.png)
※withErrors()の部分
- Connect的なリダイレクト設定をした画面では現状、バリデートオブジェクトの受け渡しができない為、コアのリダイレクト機能を改修しました。
- これにより、POST後にGETへ戻すような作りの画面でバリデートが使えるようになります。
- 本対応に先立って、現状のままだとif/elseのネストが入れ子になってしまう為、フラッシュデータ保存のコードをリファクタリングしています。
※with()の部分

## 関連Pull requests/Issues（Links to related pull requests or issues）
無し

## 参考（Reference）
https://readouble.com/laravel/5.5/ja/validation.html
![image](https://user-images.githubusercontent.com/13323806/89408773-dd1ecb00-d75b-11ea-9e34-8f13c4d23b99.png)

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>
無し

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
