### PR TITLE
add: database plugin, 固定項目で公開日時追加

### DIFF
--- a/app/Enums/DatabaseColumnType.php
+++ b/app/Enums/DatabaseColumnType.php
@@ -27,8 +27,9 @@ final class DatabaseColumnType extends EnumsBase
     const wysiwyg = 'wysiwyg';
     // delete:「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止
     // const group = 'group';
-    const created    = 'created';
-    const updated    = 'updated';
+    const created = 'created';
+    const updated = 'updated';
+    const posted = 'posted';
 
     // key/valueの連想配列
     const enum = [
@@ -49,7 +50,8 @@ final class DatabaseColumnType extends EnumsBase
         self::wysiwyg=>'ウィジウィグ型',
         // delete:「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止
         // self::group=>'まとめ行',
-        self::created    => '登録日型（自動更新）',
-        self::updated    => '更新日型（自動更新）',
+        self::created => '登録日型（自動更新）',
+        self::updated => '更新日型（自動更新）',
+        self::posted => '公開日型（表示のみ）',
     ];
 }

--- a/app/Enums/DatabaseSortFlag.php
+++ b/app/Enums/DatabaseSortFlag.php
@@ -9,13 +9,34 @@ use App\Enums\EnumsBase;
  */
 final class DatabaseSortFlag extends EnumsBase
 {
+    // 定数メンバの'_'の前半. $sort_column_id
+    const created = 'created';
+    const updated = 'updated';
+    const posted  = 'posted';
+    const random  = 'random';
+
+    // 定数メンバの'_'の後半. $sort_column_order
+    const order_asc     = 'asc';
+    const order_desc    = 'desc';
+    const order_session = 'session';
+    const order_every   = 'every';
+
     // 定数メンバ
-    const created_asc    = 'created_asc';
-    const created_desc   = 'created_desc';
-    const updated_asc    = 'updated_asc';
-    const updated_desc   = 'updated_desc';
-    const random_session = 'random_session';
-    const random_every   = 'random_every';
+    // const created_asc    = 'created_asc';
+    // const created_desc   = 'created_desc';
+    // const updated_asc    = 'updated_asc';
+    // const updated_desc   = 'updated_desc';
+    // const random_session = 'random_session';
+    // const random_every   = 'random_every';
+    // PHP 5.6.0 以降はconstで文字連結可能 https://www.php.net/manual/ja/language.oop5.constants.php
+    const created_asc    = self::created . '_' . self::order_asc;
+    const created_desc   = self::created . '_' . self::order_desc;
+    const updated_asc    = self::updated . '_' . self::order_asc;
+    const updated_desc   = self::updated . '_' . self::order_desc;
+    const posted_asc     = self::posted . '_' . self::order_asc;
+    const posted_desc    = self::posted . '_' . self::order_desc;
+    const random_session = self::random . '_' . self::order_session;
+    const random_every   = self::random . '_' . self::order_every;
     const column         = 'column';
 
     // key/valueの連想配列
@@ -24,6 +45,8 @@ final class DatabaseSortFlag extends EnumsBase
         self::created_desc   => '登録日（新しい順）',
         self::updated_asc    => '更新日（古い順）',
         self::updated_desc   => '更新日（新しい順）',
+        self::posted_asc     => '公開日（古い順）',
+        self::posted_desc    => '公開日（新しい順）',
         self::random_session => 'ランダム（セッション）',
         self::random_every   => 'ランダム（毎回）',
         self::column         => '各カラム設定',

--- a/app/Models/User/Databases/DatabasesInputs.php
+++ b/app/Models/User/Databases/DatabasesInputs.php
@@ -11,16 +11,27 @@ class DatabasesInputs extends Model
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
 
+    // Carbonインスタンス（日付）に自動的に変換
+    protected $dates = ['posted_at'];
+
     // 更新する項目の定義
-    protected $fillable = ['databases_id', 'databases_inputs_id', 'databases_columns_id', 'value', 'created_at', 'updated_at'];
+    protected $fillable = [
+        'databases_id',
+        'databases_inputs_id',
+        'databases_columns_id',
+        'value',
+        'posted_at',
+        'created_at',
+        'updated_at'
+    ];
 
     /**
-    *  指定したタイプの項目があるか判定
-    */
+     *  指定したタイプの項目があるか判定
+     */
     public function hasType($columns, $_type)
     {
         $_types = array();
-        
+
         if ($_type && is_string($_type)) {
             //文字列で項目のタイプが指定されていたとき
             $_types = $this->getColumnTypeAry($_type);
@@ -43,32 +54,32 @@ class DatabasesInputs extends Model
     }
 
     /**
-    *  テキスト項目があるか判定
-    */
+     *  テキスト項目があるか判定
+     */
     public function hasTitleType($columns)
     {
         return $this->hasType($columns, 'title');
     }
 
     /**
-    *  画像項目があるか判定
-    */
+     *  画像項目があるか判定
+     */
     public function hasImageType($columns)
     {
         return $this->hasType($columns, 'image');
     }
 
     /**
-    *  文章の項目があるか判定
-    */
+     *  文章の項目があるか判定
+     */
     public function hasSentenceType($columns)
     {
         return $this->hasType($columns, 'sentence');
     }
 
     /**
-    *  n番目の画像型の値があるか判定
-    */
+     *  n番目の画像型の値があるか判定
+     */
     public function hasThImage($columns, $input_cols)
     {
         if ($this->getThImage($columns, $input_cols)) {
@@ -78,8 +89,8 @@ class DatabasesInputs extends Model
     }
 
     /**
-    *  タイプを指定して、表示するデータの番号を返す
-    */
+     *  タイプを指定して、表示するデータの番号を返す
+     */
     public function getNumType($columns, $type, $th_no = 1)
     {
         //コラムのデータを１行づつ確認する。
@@ -101,8 +112,8 @@ class DatabasesInputs extends Model
     }
 
     /**
-    *  コラムをソートして返す（オブジェクトのままソートした方がいい？）
-    */
+     *  コラムをソートして返す（オブジェクトのままソートした方がいい？）
+     */
     public function getColumns($columns, $_hide = null)
     {
         $_columns = json_decode(json_encode($columns, JSON_UNESCAPED_UNICODE, 10), true);
@@ -125,8 +136,8 @@ class DatabasesInputs extends Model
     }
 
     /**
-    *  コラムのデータを配置しやすいように整理する
-    */
+     *  コラムのデータを配置しやすいように整理する
+     */
     private function getColumnsSet($columns, $hide)
     {
         if ($hide != 'list' && $hide != 'detail') {
@@ -189,8 +200,8 @@ class DatabasesInputs extends Model
     }
 
     /**
-    *  指定した番号のコラムの値を返す
-    */
+     *  指定した番号のコラムの値を返す
+     */
     public function getVolue($input_cols, $column_id, $col = '')
     {
 
@@ -210,8 +221,8 @@ class DatabasesInputs extends Model
     }
 
     /**
-    *  グループ化された項目のタイプ
-    */
+     *  グループ化された項目のタイプ
+     */
     private function getColumnTypeAry($_type)
     {
         //入力値が文字列以外なら偽を返す。
@@ -233,8 +244,8 @@ class DatabasesInputs extends Model
     }
 
     /**
-    *  タイプに合わせた value をソースを返す
-    */
+     *  タイプに合わせた value をソースを返す
+     */
     public function getTagType($input_cols, $column, $notag = null)
     {
 
@@ -273,8 +284,8 @@ class DatabasesInputs extends Model
     }
 
     /**
-    * メニュー用のリンクを返す
-    */
+     * メニュー用のリンクを返す
+     */
     public function getPageFrameLink($frames, $pageid, $frameid)
     {
         //データベースが存在するフレーム設定を読み込む

--- a/database/migrations/2020_08_18_131841_add_posted_at_databases_inputs_table.php
+++ b/database/migrations/2020_08_18_131841_add_posted_at_databases_inputs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPostedAtDatabasesInputsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->dateTime('posted_at')->comment('公開日時')->after('status');
+        });
+
+        // 公開日時(投稿日時)のカラム追加時の初期値は、更新日時をセット
+        DB::statement('UPDATE databases_inputs SET posted_at = updated_at');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->dropColumn('posted_at');
+        });
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_confirm.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_confirm.blade.php
@@ -44,9 +44,10 @@
     {{ csrf_field() }}
     @foreach($databases_columns as $database_column)
 
-        {{-- 登録日型・更新日型は入力表示しない --}}
+        {{-- 登録日型・更新日型・公開日型は入力表示しない --}}
         @if($database_column->column_type == DatabaseColumnType::created ||
-            $database_column->column_type == DatabaseColumnType::updated)
+            $database_column->column_type == DatabaseColumnType::updated ||
+            $database_column->column_type == DatabaseColumnType::posted)
             @continue
         @endif
 
@@ -160,6 +161,18 @@
     @foreach($delete_upload_column_ids as $delete_upload_column_id)
         <input name="delete_upload_column_ids[{{$delete_upload_column_id}}]" type="hidden" value="{{$delete_upload_column_id}}">
     @endforeach
+
+    {{-- 固定項目エリア --}}
+    <hr>
+    <div class="form-group container-fluid row">
+        {{-- ラベル --}}
+        <label class="col-sm-2 control-label text-nowrap">公開日時</label>
+        {{-- 項目 --}}
+        <div class="col-sm-10">
+            {{$request->posted_at}}
+            <input name="posted_at" class="form-control" type="hidden" value="{{$request->posted_at}}">
+        </div>
+    </div>
 
     {{-- ボタンエリア --}}
     <div class="form-group text-center">

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -355,9 +355,7 @@
                 <div class="form-group row">
                     <label class="{{$frame->getSettingLabelClass()}}">内容 </label>
                     <div class="{{$frame->getSettingInputClass()}}">
-                        <textarea name="caption" class="form-control" rows="3">
-                            {{old('caption', $column->caption)}}
-                        </textarea>
+                        <textarea name="caption" class="form-control" rows="3">{{old('caption', $column->caption)}}</textarea>
                     </div>
                 </div>
 

--- a/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
@@ -54,6 +54,10 @@
     elseif ($column->column_type == DatabaseColumnType::updated) {
         $value = $inputs->updated_at;
     }
+    // 公開日型
+    elseif ($column->column_type == DatabaseColumnType::posted) {
+        $value = $inputs->posted_at;
+    }
     // その他の型
     else {
         $value = $obj ? $obj->value : "";

--- a/resources/views/plugins/user/databases/default/databases_include_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_value.blade.php
@@ -53,6 +53,10 @@
     elseif ($column->column_type == DatabaseColumnType::updated) {
         $value = $input->updated_at;
     }
+    // 公開日型
+    elseif ($column->column_type == DatabaseColumnType::posted) {
+        $value = $input->posted_at;
+    }
     // その他の型
     else {
         $value = $obj ? $obj->value : "";

--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -1,14 +1,32 @@
 {{--
  * 登録画面テンプレート。
  *
- * @author 永原　篤 <nagahara@opensource-workshop.jp>, 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
- --}}
+--}}
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
 @if (empty($setting_error_messages))
+
+    <script type="text/javascript">
+        /**
+         * 公開日時のカレンダーボタン押下
+         */
+        $(function () {
+            $('#posted_at{{$frame_id}}').datetimepicker({
+                @if (App::getLocale() == ConnectLocale::ja)
+                    dayViewHeaderFormat: 'YYYY年 M月',
+                @endif
+                locale: '{{ App::getLocale() }}',
+                sideBySide: true,
+                format: 'YYYY-MM-DD HH:mm'
+            });
+        });
+    </script>
 
     @if (isset($id))
     <form action="{{URL::to('/')}}/plugin/databases/publicConfirm/{{$page->id}}/{{$frame_id}}/{{$id}}#frame-{{$frame_id}}" name="database_add_column{{$frame_id}}" method="POST" class="form-horizontal" enctype="multipart/form-data">
@@ -27,6 +45,7 @@
             {{-- 登録日型・更新日型は入力表示しない --}}
             @case(DatabaseColumnType::created)
             @case(DatabaseColumnType::updated)
+            @case(DatabaseColumnType::posted)
                 @break
             {{-- 通常の項目 --}}
             @default
@@ -39,6 +58,22 @@
                 </div>
             @endswitch
         @endforeach
+
+        {{-- 固定項目エリア --}}
+        <hr>
+        <div class="form-group row">
+            <label class="col-sm-3 control-label">公開日時 <label class="badge badge-danger">必須</label></label>
+            <div class="col-sm-9">
+                <div class="input-group date" id="posted_at{{$frame_id}}" data-target-input="nearest">
+                    <input type="text" name="posted_at" value="{{old('posted_at', $inputs->posted_at)}}" class="form-control datetimepicker-input" data-target="#posted_at{{$frame_id}}">
+                    <div class="input-group-append" data-target="#posted_at{{$frame_id}}" data-toggle="datetimepicker">
+                        <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                    </div>
+                </div>
+                @if ($errors && $errors->has('posted_at')) <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first('posted_at')}}</div> @endif
+            </div>
+        </div>
+
         {{-- ボタンエリア --}}
         <div class="form-group text-center">
             <div class="row">

--- a/resources/views/plugins/user/databases/default/databases_input_date.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input_date.blade.php
@@ -2,9 +2,10 @@
  * 登録画面(input date)テンプレート。
  *
  * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
- --}}
+--}}
 @php
     // value 値の取得
     $value_obj = (empty($input_cols)) ? null : $input_cols->where('databases_inputs_id', $id)->where('databases_columns_id', $database_obj->id)->first();
@@ -17,10 +18,12 @@
     /**
      * カレンダーボタン押下
      */
-     $(function () {
+    $(function () {
         $('#{{ $database_obj->id }}').datetimepicker({
-            dayViewHeaderDatabaseat: 'YYYY年 M月',
-            databaseat: 'YYYY/MM/DD',
+            @if (App::getLocale() == ConnectLocale::ja)
+                dayViewHeaderFormat: 'YYYY年 M月',
+            @endif
+            locale: '{{ App::getLocale() }}',
             format: 'YYYY/MM/DD',
             timepicker:false
         });
@@ -28,11 +31,11 @@
 </script>
     {{-- 日付 --}}
     <div class="input-group date" id="{{ $database_obj->id }}" data-target-input="nearest">
-        <input 
-            type="text" 
-            name="databases_columns_value[{{ $database_obj->id }}]" 
+        <input
+            type="text"
+            name="databases_columns_value[{{ $database_obj->id }}]"
             value="{{old('databases_columns_value.'.$database_obj->id, $value)}}"
-            class="form-control datetimepicker-input" 
+            class="form-control datetimepicker-input"
             data-target="#{{ $database_obj->id }}"
         >
         <div class="input-group-append" data-target="#{{ $database_obj->id }}" data-toggle="datetimepicker">


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

データベースプラグインに 固定項目で公開日時を追加します。

・固定項目として、入力時必須で「公開日時」を登録させる。初期値は今日日時。
・公開日時(投稿日時)のDBカラム追加時の初期値は、更新日時の値をセット
・「公開日時」の表示するには、「公開日型（表示のみ）」を追加して、任意でデータベースプラグインに設定する形。
・ソート順に「公開日（古い順）」「公開日（新しい順）」を追加

## commits

* add: database plugin, 固定項目で公開日時追加
* bugfix: database plugin, フォームプラグインの名残でFormColumnType::dateが使われていたため、DatabaseColumnType::dateに修正
* bugfix: database plugin, キャプション設定に不要な空白と改行が入る不具合修正
* bugfix: database plugin, 日付型入力時のカレンダー表示の年月表示がYYYY年 M月形式になっていなかったため修正, 念のためカレンダーの多言語対応
* bugfix: database plugin, 登録日型・更新日型・公開日型は入力表示しないため、バリデータチェックしない
* bugfix: database plugin, まとめ行削除漏れ対応（まとめ行以外の項目について、バリデータールールをセットの箇所）

## 画面

### 一覧・詳細画面（公開日表示）
![image](https://user-images.githubusercontent.com/2756509/90604789-5c220200-e238-11ea-82dd-a25b1c567ae7.png)

### 登録・編集画面イメージ（公開日）

![image](https://user-images.githubusercontent.com/2756509/90604920-8b387380-e238-11ea-9138-ce2326954c84.png)


### 設定画面-表示設定（公開日ソート順設定）
![image](https://user-images.githubusercontent.com/2756509/90604654-241abf00-e238-11ea-8f89-f18819c822d9.png)

### 設定画面-項目設定(公開日型)

![image](https://user-images.githubusercontent.com/2756509/90605044-c5a21080-e238-11ea-95a3-40dae8d6fb49.png)


## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/490

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

有り

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
