### PR TITLE
add: database plugin, 複数年月型（テキスト入力）追加

### DIFF
--- a/app/Enums/DatabaseColumnType.php
+++ b/app/Enums/DatabaseColumnType.php
@@ -19,6 +19,7 @@ final class DatabaseColumnType extends EnumsBase
     // const birthday = 'birthday';
     // const datetime = 'datetime';
     const date = 'date';
+    const dates_ym = 'dates_ym';
     const time = 'time';
     const link = 'link';
     const file = 'file';
@@ -31,23 +32,27 @@ final class DatabaseColumnType extends EnumsBase
     const updated = 'updated';
     const posted = 'posted';
 
+    // 複数年月型（テキスト入力）のデフォルトキャプション
+    const dates_ym_caption = 'yyyy/mm形式で年月を入力してください。また複数入力したい場合は、カンマ「,」区切りで入力してください。';
+
     // key/valueの連想配列
     const enum = [
-        self::text=>'1行文字列型',
-        self::textarea=>'複数行文字列型',
-        self::radio=>'単一選択型',
-        self::checkbox=>'複数選択型',
-        self::select=>'リストボックス型',
-        self::mail=>'メールアドレス型',
+        self::text => '1行文字列型',
+        self::textarea => '複数行文字列型',
+        self::radio => '単一選択型',
+        self::checkbox => '複数選択型',
+        self::select => 'リストボックス型',
+        self::mail => 'メールアドレス型',
         // self::birthday=>'生年月日型',
         // self::datetime=>'日付＆時間型',
-        self::date=>'日付型',
-        self::time=>'時間型',
-        self::link=>'リンク型',
-        self::file=>'ファイル型',
-        self::image=>'画像型',
-        self::video=>'動画型',
-        self::wysiwyg=>'ウィジウィグ型',
+        self::date => '日付型',
+        self::dates_ym => '複数年月型（テキスト入力）',
+        self::time => '時間型',
+        self::link => 'リンク型',
+        self::file => 'ファイル型',
+        self::image => '画像型',
+        self::video => '動画型',
+        self::wysiwyg => 'ウィジウィグ型',
         // delete:「行グループ」「列グループ」追加に伴い、機能してない 項目の型「まとめ行」を廃止
         // self::group=>'まとめ行',
         self::created => '登録日型（自動更新）',

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -26,6 +26,7 @@ use App\Models\User\Databases\DatabasesInputCols;
 
 use App\Rules\CustomVali_AlphaNumForMultiByte;
 use App\Rules\CustomVali_CheckWidthForString;
+use App\Rules\CustomVali_DatesYm;
 
 use App\Mail\ConnectMail;
 use App\Plugins\User\UserPluginBase;
@@ -1006,6 +1007,11 @@ class DatabasesPlugin extends UserPluginBase
             $validator_rule[] = 'nullable';
             $validator_rule[] = 'date';
         }
+        // 複数年月型（テキスト入力）チェック
+        if ($databases_column->column_type == \DatabaseColumnType::dates_ym) {
+            $validator_rule[] = 'nullable';
+            $validator_rule[] = new CustomVali_DatesYm();
+        }
         // バリデータールールをセット
         if ($validator_rule) {
             $validator_array['column']['databases_columns_value.' . $databases_column->id] = $validator_rule;
@@ -1746,6 +1752,12 @@ class DatabasesPlugin extends UserPluginBase
         $column->required = $request->required ? \Required::on : \Required::off;
         $column->display_sequence = $max_display_sequence;
         $column->caption_color = \Bs4TextColor::dark;
+
+        // 複数年月型（テキスト入力）は、デフォルトでキャプションをセットする
+        if (\DatabaseColumnType::dates_ym == $request->column_type) {
+            $column->caption = \DatabaseColumnType::dates_ym_caption;
+        }
+
         $column->save();
         $message = '項目【 '. $request->column_name .' 】を追加しました。';
 
@@ -1940,6 +1952,13 @@ class DatabasesPlugin extends UserPluginBase
         $column->column_name = $request->column_name;
         $column->column_type = $request->column_type;
         $column->required = $request->required ? \Required::on : \Required::off;
+
+        // 複数年月型（テキスト入力）は、キャプションが空なら定型文をセットする
+        if (\DatabaseColumnType::dates_ym == $request->column_type &&
+                !$column->caption) {
+            $column->caption = \DatabaseColumnType::dates_ym_caption;
+        }
+
         $column->save();
         $message = '項目【 '. $request->column_name .' 】を更新しました。';
 

--- a/app/Rules/CustomVali_DatesYm.php
+++ b/app/Rules/CustomVali_DatesYm.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+use Illuminate\Validation\Concerns\ValidatesAttributes;
+
+/**
+ * 複数カンマ区切りの年月入力チェック
+ */
+class CustomVali_DatesYm implements Rule
+{
+    // Laravelのvalidateチェックメソッド
+    use ValidatesAttributes;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute 項目名
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        // カンマ区切り文字列を配列に
+        $dates_ym = explode(',', $value);
+
+        foreach ($dates_ym as $date_ym) {
+            // see) 年月の正規表現 https://regexper.com/#%2F%28%5B1-2%5D%5B0-9%5D%7B3%7D%29%5C%2F%28%5B0-1%5D%5B0-9%5D%29%2F
+            // if (preg_match('/([1-2][0-9]{3})\/([0-1][0-9])/', trim($date_ym))) {
+            //     echo '日付の形式が正しくありません。';
+            //     return false;
+            // }
+
+            // laravel validate to date_format 年月チェック
+            if (! $this->validateDateFormat($attribute, trim($date_ym), ['Y/m'])) {
+                // echo '日付の形式が正しくありません。';
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return ':attributeには正しい形式の日付を指定してください。';
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_confirm.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_confirm.blade.php
@@ -94,7 +94,11 @@
                 {{$request->databases_columns_value[$database_column->id]}}
                 <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
                 @break
-            @case("date")
+            @case(DatabaseColumnType::date)
+                {{$request->databases_columns_value[$database_column->id]}}
+                <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
+                @break
+            @case(DatabaseColumnType::dates_ym)
                 {{$request->databases_columns_value[$database_column->id]}}
                 <input name="databases_columns_value[{{$database_column->id}}]" class="form-control" type="hidden" value="{{$request->databases_columns_value[$database_column->id]}}">
                 @break

--- a/resources/views/plugins/user/databases/default/databases_input_dates_ym.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input_dates_ym.blade.php
@@ -1,0 +1,21 @@
+{{--
+ * 登録画面(input dates_ym)テンプレート。
+ * databases_input_text.blade.phpよりコピー
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category データベース・プラグイン
+--}}
+@php
+    // value 値の取得
+    $value_obj = (empty($input_cols)) ? null : $input_cols->where('databases_inputs_id', $id)->where('databases_columns_id', $database_obj->id)->first();
+    $value = '';
+    if (!empty($value_obj)) {
+        $value = $value_obj->value;
+    }
+@endphp
+<input name="databases_columns_value[{{$database_obj->id}}]" class="form-control" type="{{$database_obj->column_type}}" value="@if ($frame_id == $request->frame_id){{old('databases_columns_value.'.$database_obj->id, $value)}}@endif">
+@if ($errors && $errors->has("databases_columns_value.$database_obj->id"))
+    <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first("databases_columns_value.$database_obj->id")}}</div>
+@endif


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

データベースプラグインに複数年月型（テキスト入力）追加

・複数年月型（テキスト入力）の項目を追加した場合、キャプションが自動設定されます。
・複数年月型（テキスト入力）の項目を更新＆キャプション空の場合、キャプションが自動設定されます。

![image](https://user-images.githubusercontent.com/2756509/91007051-f5289280-e615-11ea-9a06-2a5265743348.png)

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/501

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

無し

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
