### PR TITLE
add: whatsnews and database plugin, データベースプラグインの新着対応

### DIFF
--- a/app/Enums/WhatsnewsTargetPlugin.php
+++ b/app/Enums/WhatsnewsTargetPlugin.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * 新着対象プラグイン
+ */
+final class WhatsnewsTargetPlugin extends EnumsBase
+{
+    // 定数メンバ
+    const blogs = 'blogs';
+    const databases = 'databases';
+
+    // key/valueの連想配列
+    const enum = [
+        self::blogs => 'ブログ',
+        self::databases => 'データベース',
+    ];
+}

--- a/app/Models/User/Databases/DatabasesColumns.php
+++ b/app/Models/User/Databases/DatabasesColumns.php
@@ -7,7 +7,22 @@ use Illuminate\Database\Eloquent\Model;
 class DatabasesColumns extends Model
 {
     // 更新する項目の定義
-    protected $fillable = ['databases_id', 'column_type', 'column_name', 'required', 'frame_col', 'list_hide_flag', 'detail_hide_flag', 'sort_flag', 'search_flag', 'select_flag', 'display_sequence', 'row_group', 'column_group'];
+    protected $fillable = [
+        'databases_id',
+        'column_type',
+        'column_name',
+        'required',
+        'frame_col',
+        'list_hide_flag',
+        'detail_hide_flag',
+        'sort_flag',
+        'search_flag',
+        'select_flag',
+        'title_flag',
+        'display_sequence',
+        'row_group',
+        'column_group'
+    ];
 
     /**
      * DBカラムの権限を取得

--- a/app/Models/User/Whatsnews/Whatsnews.php
+++ b/app/Models/User/Whatsnews/Whatsnews.php
@@ -18,7 +18,15 @@ class Whatsnews extends Model
     public function getTargetPlugins()
     {
         // 新着情報として対象としているプラグインの定義
-        $target_plugins = array("blogs" => false);
+        // $target_plugins = array(
+        //     "blogs" => false,
+        //     "databases" => false,
+        // );
+        $target_plugins = array();
+        $target_plugin_keys = \WhatsnewsTargetPlugin::getMemberKeys();
+        foreach ($target_plugin_keys as $target_plugin_key) {
+            $target_plugins[$target_plugin_key] = false;
+        }
 
         // 表示ON になっているプラグインの情報を付与して返却
         if (!empty($this->target_plugins)) {

--- a/config/app.php
+++ b/config/app.php
@@ -242,6 +242,7 @@ return [
         'MinutesIncrements' => \App\Enums\MinutesIncrements::class,
         'ConnectLocale' => \App\Enums\ConnectLocale::class,
         'GroupType' => \App\Enums\GroupType::class,
+        'WhatsnewsTargetPlugin' => \App\Enums\WhatsnewsTargetPlugin::class,
 
         // Models
         'Plugins' => \App\Models\Core\Plugins::class,

--- a/database/migrations/2020_08_25_104542_add_title_flag_databases_columns_table.php
+++ b/database/migrations/2020_08_25_104542_add_title_flag_databases_columns_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddTitleFlagDatabasesColumnsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->integer('title_flag')->default(0)->comment('新着等のタイトル指定')->after('frame_col');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->dropColumn('title_flag');
+        });
+    }
+}

--- a/database/migrations/2020_08_26_113209_update_bucket_name_from_database_name_buckets_table.php
+++ b/database/migrations/2020_08_26_113209_update_bucket_name_from_database_name_buckets_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateBucketNameFromDatabaseNameBucketsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // bugfix:データベースでは「無題」でバケット名を登録して更新していない不具合があったため、バケット名をデータベース名で更新するパッチ
+        DB::statement('UPDATE buckets, `databases` SET buckets.bucket_name = `databases`.databases_name WHERE buckets.id = `databases`.bucket_id');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2020_08_26_125952_update_bucket_name_from_whatsnew_name_buckets_table.php
+++ b/database/migrations/2020_08_26_125952_update_bucket_name_from_whatsnew_name_buckets_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateBucketNameFromWhatsnewNameBucketsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // bugfix:新着では「無題」でバケット名を登録して更新していない不具合があったため、バケット名を新着設定名で更新するパッチ
+        DB::statement('UPDATE buckets, whatsnews SET buckets.bucket_name = whatsnews.whatsnew_name WHERE buckets.id = whatsnews.bucket_id');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2020_08_26_142624_add_whatsnews_index_to_databases.php
+++ b/database/migrations/2020_08_26_142624_add_whatsnews_index_to_databases.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * 新着情報に係るインデックスをデータベースプラグイン関係のテーブルに追加
+ */
+class AddWhatsnewsIndexToDatabases extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->index(['databases_id'], 'databases_id_index');
+        });
+
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->index(['databases_id', 'title_flag'], 'databases_id_and_title_flag_index');
+        });
+
+        Schema::table('databases_input_cols', function (Blueprint $table) {
+            $table->index(['databases_inputs_id', 'databases_columns_id'], 'databases_inputs_id_and_databases_columns_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->dropIndex('databases_id_index');
+        });
+
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->dropIndex('databases_id_and_title_flag_index');
+        });
+
+        Schema::table('databases_input_cols', function (Blueprint $table) {
+            $table->dropIndex('databases_inputs_id_and_databases_columns_id_index');
+        });
+    }
+}

--- a/database/migrations/2020_08_26_144809_add_whatsnews_index_to_blogs_and_frames.php
+++ b/database/migrations/2020_08_26_144809_add_whatsnews_index_to_blogs_and_frames.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * 新着情報に係るインデックスをブログとフレーム関係のテーブルに追加
+ */
+class AddWhatsnewsIndexToBlogsAndFrames extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('blogs_posts', function (Blueprint $table) {
+            $table->index(['blogs_id'], 'blogs_id_index');
+        });
+
+        Schema::table('frames', function (Blueprint $table) {
+            $table->index(['bucket_id'], 'bucket_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('blogs_posts', function (Blueprint $table) {
+            $table->dropIndex('blogs_id_index');
+        });
+
+        Schema::table('frames', function (Blueprint $table) {
+            $table->dropIndex('bucket_id_index');
+        });
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_edit.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit.blade.php
@@ -23,18 +23,17 @@
             </div>
         @else
             <script type="text/javascript">
-
                 /**
-                * 項目の追加ボタン押下
-                */
+                 * 項目の追加ボタン押下
+                 */
                 function submit_add_column() {
                     database_columns.action = "{{url('/')}}/plugin/databases/addColumn/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
                     database_columns.submit();
                 }
 
                 /**
-                * 項目の削除ボタン押下
-                */
+                 * 項目の削除ボタン押下
+                 */
                 function submit_delete_column(column_id) {
                     if(confirm('項目を削除します。\nよろしいですか？')){
                         database_columns.action = "{{url('/')}}/plugin/databases/deleteColumn/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
@@ -45,8 +44,8 @@
                 }
 
                 /**
-                * 項目の更新ボタン押下
-                */
+                 * 項目の更新ボタン押下
+                 */
                 function submit_update_column(column_id) {
                     database_columns.action = "{{url('/')}}/plugin/databases/updateColumn/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
                     database_columns.column_id.value = column_id;
@@ -54,8 +53,8 @@
                 }
 
                 /**
-                * 項目の表示順操作ボタン押下
-                */
+                 * 項目の表示順操作ボタン押下
+                 */
                 function submit_display_sequence(column_id, display_sequence, display_sequence_operation) {
                     database_columns.action = "{{url('/')}}/plugin/databases/updateColumnSequence/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
                     database_columns.column_id.value = column_id;
@@ -65,8 +64,8 @@
                 }
 
                 /**
-                * ツールチップ
-                */
+                 * ツールチップ
+                 */
                 $(function () {
                     // 有効化
                     $('[data-toggle="tooltip"]').tooltip()
@@ -97,6 +96,14 @@
                         {{ $message ? $message : 'ユーザが登録時の項目を設定します。' }}
                     </div>
 
+                    {{-- ワーニングメッセージエリア --}}
+                    @if (! $title_flag)
+                        <div class="alert alert-warning mt-2">
+                            <i class="fas fa-exclamation-circle"></i>
+                            新着情報等でタイトル表示する項目が未設定です。いずれかの項目の「詳細」よりタイトル設定をしてください。
+                        </div>
+                    @endif
+
                     {{-- エラーメッセージエリア --}}
                     @if ($errors && $errors->any())
                         <div class="alert alert-danger mt-2">
@@ -116,8 +123,8 @@
                                     <th class="text-center text-nowrap" style="min-width: 165px;">項目名</th>
                                     <th class="text-center text-nowrap" style="min-width: 165px;">型</th>
                                     <th class="text-center text-nowrap">必須</th>
-                                    <th class="text-center">行<a href="#" data-toggle="tooltip" data-placement="top" title="行グループ">...</a></th>
-                                    <th class="text-center">列<a href="#" data-toggle="tooltip" data-placement="top" title="列グループ">...</a></th>
+                                    <th class="text-center">行<a href="#frame-{{$frame_id}}" data-toggle="tooltip" data-placement="top" title="行グループ">...</a></th>
+                                    <th class="text-center">列<a href="#frame-{{$frame_id}}" data-toggle="tooltip" data-placement="top" title="列グループ">...</a></th>
                                     <th class="text-center text-nowrap">詳細
                                         <a href="https://connect-cms.jp/manual/user/database#frame-125" target="_brank">
                                             <i class="fas fa-info-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></i>

--- a/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
@@ -101,7 +101,8 @@
     $column->column_type == DatabaseColumnType::radio ||
     $column->column_type == DatabaseColumnType::checkbox ||
     $column->column_type == DatabaseColumnType::select ||
-    $column->caption
+    $column->caption ||
+    $column->title_flag
     )
     <tr>
         <td class="pt-2 border border-0"></td>
@@ -122,6 +123,13 @@
                 <div class="small {{ $column->caption_color }}">
                     <i class="fas fa-pen"></i>
                     {{ mb_strimwidth($column->caption, 0, 60, '...', 'UTF-8') }}
+                </div>
+            @endif
+
+            @if ($column->title_flag)
+                {{-- タイトル指定が設定されている場合、タイトル指定を表示する --}}
+                <div class="small text-primary">
+                    <i class="fas fa-toggle-on"></i> タイトル指定
                 </div>
             @endif
         </td>

--- a/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row.blade.php
@@ -115,7 +115,8 @@
                 </div>
             @elseif(!$column->caption && $column->select_count == 0)
                 {{-- 選択肢データがなく、キャプションの設定もない場合はツールチップ分、余白として改行する --}}
-                <br>
+                {{-- change: <td>タグ内に表示するもがなければ<td>タグ自体が無視されるので、改行不要 --}}
+                {{--<br>--}}
             @endif
 
             @if ($column->caption)

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -93,6 +93,35 @@
             {{ $message ? $message : '項目【' . $column->column_name . ' 】の詳細設定を行います。' }}
         </div>
 
+        {{-- タイトル設定 --}}
+        <div class="card mb-4">
+            <h5 class="card-header">タイトルの設定</h5>
+            <div class="card-body">
+                {{-- タイトル指定 --}}
+                <div class="form-group row">
+                    <label class="{{$frame->getSettingLabelClass()}} pt-0">タイトル指定 </label>
+                    <div class="{{$frame->getSettingInputClass()}}">
+                        <div class="custom-control custom-checkbox">
+                            <input name="title_flag" value="1" type="checkbox" class="custom-control-input" id="list_detail_hide_role_article"
+                                        @if(old('title_flag', $column->title_flag)) checked @endif >
+
+                            <label class="custom-control-label" for="list_detail_hide_role_article">新着情報等のタイトルに指定する</label>
+                        </div>
+                        <small class="text-muted">
+                            ※ タイトル指定できる項目は、データベース毎に１つです。既に他項目でタイトル指定している場合、自動的に解除されます。<br>
+                        </small>
+                    </div>
+                </div>
+
+                {{-- ボタンエリア --}}
+                <div class="form-group text-center">
+                    <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary database-horizontal">
+                        <i class="fas fa-check"></i> 更新
+                    </button>
+                </div>
+            </div>
+        </div>
+
         @if ($column->column_type == DatabaseColumnType::radio || $column->column_type == DatabaseColumnType::checkbox || $column->column_type == DatabaseColumnType::select)
             {{-- 選択肢の設定 --}}
             <div class="card mb-4">

--- a/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
@@ -28,8 +28,12 @@
         @endif
         <dd>
             @if ($link_pattern[$whatsnew->plugin_name] == 'show_page_frame_post')
-            <a href="{{url('/')}}{{$link_base[$whatsnew->plugin_name]}}/{{$whatsnew->page_id}}/{{$whatsnew->frame_id}}/{{$whatsnew->post_id}}">
-                {{$whatsnew->post_title}}
+            <a href="{{url('/')}}{{$link_base[$whatsnew->plugin_name]}}/{{$whatsnew->page_id}}/{{$whatsnew->frame_id}}/{{$whatsnew->post_id}}#frame-{{$whatsnew->frame_id}}">
+                @if ($whatsnew->post_title)
+                    {{$whatsnew->post_title}}
+                @else
+                    (無題)
+                @endif
             </a>
             @endif
         </dd>

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
@@ -2,9 +2,10 @@
  * 新着情報編集画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 新着情報プラグイン
- --}}
+--}}
 @extends('core.cms_frame_base_setting')
 
 @section("core.cms_frame_edit_tab_$frame->id")
@@ -133,14 +134,14 @@
         <label class="{{$frame->getSettingLabelClass()}}">ページ送りの表示</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-radio custom-control-inline">
-                <input 
-                    type="radio" value="1" id="page_method_1" name="page_method" 
+                <input
+                    type="radio" value="1" id="page_method_1" name="page_method"
                     class="custom-control-input" {{ $whatsnew->page_method == 1 ? 'checked' : '' }}
                 >
                 <label class="custom-control-label" for="page_method_1">表示する</label>
             </div>
             <div class="custom-control custom-radio custom-control-inline">
-                <input type="radio" value="0" id="page_method_0" name="page_method" 
+                <input type="radio" value="0" id="page_method_0" name="page_method"
                     class="custom-control-input" {{ $whatsnew->page_method == 0 ? 'checked' : '' }}
                 >
                 <label class="custom-control-label" for="page_method_0">表示しない</label>
@@ -239,40 +240,40 @@
     </div>
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">対象プラグイン <label class="badge badge-danger mb-0">必須</label></label>
-        <div class="{{$frame->getSettingInputClass(true)}}">
-        @foreach($whatsnew->getTargetPlugins() as $target_plugin => $use_flag)
-            <div class="custom-control custom-checkbox custom-control-inline">
-                <input type="checkbox" name="target_plugin[{{$target_plugin}}]" value="{{$target_plugin}}" class="custom-control-input" id="target_plugin_{{$target_plugin}}" @if(old("target_plugin.$target_plugin", $use_flag)) checked=checked @endif>
-                <label class="custom-control-label" for="target_plugin_{{$target_plugin}}">{{$target_plugin}}</label>
-            </div>
-        @endforeach
+        <label class="{{$frame->getSettingLabelClass()}} pt-0">対象プラグイン <label class="badge badge-danger mb-0">必須</label></label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            @foreach($whatsnew->getTargetPlugins() as $target_plugin => $use_flag)
+                <div class="custom-control custom-checkbox custom-control-inline">
+                    <input type="checkbox" name="target_plugin[{{$target_plugin}}]" value="{{$target_plugin}}" class="custom-control-input" id="target_plugin_{{$target_plugin}}" @if(old("target_plugin.$target_plugin", $use_flag)) checked=checked @endif>
+                    <label class="custom-control-label" for="target_plugin_{{$target_plugin}}">{{$target_plugin}}</label>
+                </div>
+            @endforeach
+            @if ($errors && $errors->has('target_plugin')) <div class="text-danger float-none">{{$errors->first('target_plugin')}}</div> @endif
         </div>
-        @if ($errors && $errors->has('target_plugin')) <div class="text-danger">{{$errors->first('target_plugin')}}</div> @endif
     </div>
 
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">フレームの選択</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-radio custom-control-inline">
-                <input 
-                    type="radio" 
-                    value="0" 
-                    id="frame_select_0" 
-                    name="frame_select" 
-                    class="custom-control-input" 
+                <input
+                    type="radio"
+                    value="0"
+                    id="frame_select_0"
+                    name="frame_select"
+                    class="custom-control-input"
                     {{ $whatsnew->frame_select == 0 ? 'checked' : '' }}
                     v-on:click="setDisabledTargetFrame(0)"
                 >
                 <label class="custom-control-label" for="frame_select_0">全て表示する</label>
             </div>
             <div class="custom-control custom-radio custom-control-inline">
-                <input 
-                    type="radio" 
-                    value="1" 
-                    id="frame_select_1" 
-                    name="frame_select" 
-                    class="custom-control-input" 
+                <input
+                    type="radio"
+                    value="1"
+                    id="frame_select_1"
+                    name="frame_select"
+                    class="custom-control-input"
                     {{ $whatsnew->frame_select == 1 ? 'checked' : '' }}
                     v-on:click="setDisabledTargetFrame(1)"
                 >
@@ -283,18 +284,38 @@
 
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">対象ページ - フレーム</label>
-        <div class="card {{$frame->getSettingInputClass(false, true)}}">
-            <div class="card-body py-2 pl-0">
-            @foreach($target_plugins_frames as $target_plugins_frame)
-            <div class="custom-control custom-checkbox">
-                <input type="checkbox" name="target_frame_ids[{{$target_plugins_frame->id}}]" value="{{$target_plugins_frame->id}}" class="custom-control-input" id="target_plugins_frame_{{$target_plugins_frame->id}}" @if(old("target_frame_ids.$target_plugins_frame->id", $whatsnew->isTargetFrame($target_plugins_frame->id))) checked=checked @endif>
-                <label class="custom-control-label" for="target_plugins_frame_{{$target_plugins_frame->id}}">{{$target_plugins_frame->page_name}} - {{$target_plugins_frame->bucket_name}}</label>
-            </div>
-            @endforeach
-            @if ($errors && $errors->has('target_plugins_frames')) <div class="text-danger">{{$errors->first('target_plugins_frames')}}</div> @endif
-        </div>
-    </div>
+        <div class="{{$frame->getSettingInputClass(false, true)}}">
+            <ul class="nav nav-pills" role="tablist">
+                @foreach(WhatsnewsTargetPlugin::getMembers() as $target_plugin => $target_plugin_full)
+                    {{--
+                    <li class="nav-item">
+                        <a href="#blogs{{frame->id}}" class="nav-link active" data-toggle="tab" role="tab">ブログ</a>
+                    </li>
+                    --}}
+                    <li class="nav-item">
+                        <a href="#{{$target_plugin}}{{$frame->id}}" class="nav-link @if($loop->first) active @endif" data-toggle="tab" role="tab">{{$target_plugin_full}}</a>
+                    </li>
+                @endforeach
+            </ul>
 
+            <div class="tab-content">
+                @foreach(WhatsnewsTargetPlugin::getMembers() as $target_plugin => $target_plugin_full)
+                    <div id="{{$target_plugin}}{{$frame->id}}" class="tab-pane card @if($loop->first) active @endif" role="tabpanel">
+                        <div class="card-body py-2 pl-3">
+                            @foreach($target_plugins_frames as $target_plugins_frame)
+                                @if ($target_plugins_frame->plugin_name == $target_plugin)
+                                    <div class="custom-control custom-checkbox">
+                                        <input type="checkbox" name="target_frame_ids[{{$target_plugins_frame->id}}]" value="{{$target_plugins_frame->id}}" class="custom-control-input" id="target_plugins_frame_{{$target_plugins_frame->id}}" @if(old("target_frame_ids.$target_plugins_frame->id", $whatsnew->isTargetFrame($target_plugins_frame->id))) checked=checked @endif>
+                                        <label class="custom-control-label" for="target_plugins_frame_{{$target_plugins_frame->id}}">{{$target_plugins_frame->page_name}} - {{$target_plugins_frame->bucket_name}}</label>
+                                    </div>
+                                @endif
+                            @endforeach
+                        </div>
+                    </div>
+                @endforeach
+                @if ($errors && $errors->has('target_plugins_frames')) <div class="text-danger">{{$errors->first('target_plugins_frames')}}</div> @endif
+            </div>
+        </div>
     </div>
 
     {{-- Submitボタン --}}


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

データベースプラグインの新着対応です。
* 新着表示させるには、新着に表示するタイトルが必要になるため、データベースプラグインの項目に、タイトル表示フラグを追加しました。（データベース毎で１つ、タイトル表示用の項目を設定します）
    * 既に他項目でタイトル表示設定済みの場合、自動解除されます。
* タイトル表示未設定のデータベースは、設定画面で注意メッセージを表示します。

## 画面

### 新着設定画面
![image](https://user-images.githubusercontent.com/2756509/91281995-b6383f80-e7c3-11ea-843e-ad9496f531a9.png)

### データベース設定ー項目詳細
![image](https://user-images.githubusercontent.com/2756509/91282133-e7187480-e7c3-11ea-8c33-be7de848d935.png)

### データベース設定ー項目一覧（タイトル指定の場合）

![image](https://user-images.githubusercontent.com/2756509/91302583-aaf40c80-e7e1-11ea-846f-79ae3e2582b7.png)

### データベース設定ー項目一覧（タイトル無指定の場合）

![image](https://user-images.githubusercontent.com/2756509/91302471-86983000-e7e1-11ea-8495-a6e00c3b99d6.png)



## commits

* add: whatsnews and database plugin, データベースプラグインの新着対応
* add: whatsnews plugin, 新着対象プラグインのEnum対応
* add: database plugin, 新着に表示するため、DB項目にタイトル指定フラグを追加
* add: database plugin, タイトル指定未設定の場合、設定画面にワーニングメッセージ追加
* add: database plugin, データベースプラグイン関連のテーブルに新着対応のインデックスを追加
* add: blogs plugin, ブログとフレーム関連のテーブルに新着対応のインデックスを追加
* change: whatsnews plugin, 重要な記事（importantカラム）がないプラグインもあるため、重要な記事判定は、結果取得後に行う
* change: whatsnews plugin, 重要な記事判定を、結果取得後に移動したため、件数制限もあわせて結果取得後に行う様見直し
* change: whatsnews plugin, 記事タイトルが空の場合、リンクが表示されなかったので、「(無題)」でリンク表示する
* change: database plugin, 設定項目一覧で<td>タグ内に表示するもがなければ<td>タグ自体が無視されるので、`<br>`改行不要
* bugfix: database plugin, バケット名を「無題」で登録して更新してい不具合があったため、不具合修正
* bugfix: database plugin, データベース名でバケット名をアップデートするマイグレーションを作成
* bugfix: database plugin, 設定画面の行グループ、列グループのツールチップリンクをクリックすると、画面上部に移動する不具合修正
* bugfix: whatsnews plugin, バケット名を「無題」で登録して更新してい不具合があったため、不具合修正
* bugfix: whatsnews plugin, 新着設定名でバケット名をアップデートするマイグレーションを作成
* bugfix: whatsnews plugin, 新着設定の新規登録時、フレーム更新に必要なフレーム検索処理が抜けていたので追加


## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/503

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

有り

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
