### PR TITLE
【データベース】CSVダウンロード・CVSインポートで文字コードを指定する機能追加 ＆ CVSインポート時、全角文字が消える不具合修正

### DIFF
--- a/app/Enums/CsvCharacterCode.php
+++ b/app/Enums/CsvCharacterCode.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * CSVの文字コード種類
+ */
+final class CsvCharacterCode extends EnumsBase
+{
+    // 定数メンバ
+    const auto = 'auto';
+    const sjis_win = 'SJIS-win';
+    const utf_8 = 'UTF-8';
+
+    // key/valueの連想配列
+    const enum = [
+        self::auto => '自動検出',
+        self::sjis_win => 'Shift-JIS',
+        self::utf_8 => 'UTF-8 BOM付',
+    ];
+}

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -2946,7 +2946,6 @@ class DatabasesPlugin extends UserPluginBase
             }
         }
         return $header_columns;
-
     }
 
     /**

--- a/app/Utilities/csv/SjisToUtf8EncodingFilter.php
+++ b/app/Utilities/csv/SjisToUtf8EncodingFilter.php
@@ -2,6 +2,8 @@
 
 namespace App\Utilities\csv;
 
+use Illuminate\Support\Facades\Log;
+
 /**
  * Shift-JIS から UTF-8 変換するストリームフィルタ
  * CSV読み込み時に使用して、5C問題対応
@@ -51,6 +53,8 @@ final class SjisToUtf8EncodingFilter extends \php_user_filter
 
             if ($data) { // ここに来た段階で $data は区切りが良いSJIS文字列になっている
                 $bucket->data = $this->encode($data);
+                // Log::debug(var_export($data, true));
+                // Log::debug(var_export($bucket->data, true));
                 \stream_bucket_append($out, $bucket);
                 $isBucketAppended = true;
             }
@@ -68,12 +72,14 @@ final class SjisToUtf8EncodingFilter extends \php_user_filter
 
     private function isValidEncoding(string $string): bool
     {
-        return \mb_check_encoding($string, 'SJIS-win');
+        // return \mb_check_encoding($string, 'SJIS-win');
+        return \mb_check_encoding($string, \CsvCharacterCode::sjis_win);
     }
 
     private function encode(string $string): string
     {
-        return \mb_convert_encoding($string, 'UTF-8', 'SJIS-win');
+        // return \mb_convert_encoding($string, 'UTF-8', 'SJIS-win');
+        return \mb_convert_encoding($string, \CsvCharacterCode::utf_8, \CsvCharacterCode::sjis_win);
     }
 
     private function assertBufferSizeIsSmallEnough(): void

--- a/config/app.php
+++ b/config/app.php
@@ -243,6 +243,7 @@ return [
         'ConnectLocale' => \App\Enums\ConnectLocale::class,
         'GroupType' => \App\Enums\GroupType::class,
         'WhatsnewsTargetPlugin' => \App\Enums\WhatsnewsTargetPlugin::class,
+        'CsvCharacterCode' => \App\Enums\CsvCharacterCode::class,
 
         // Models
         'Plugins' => \App\Models\Core\Plugins::class,

--- a/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
@@ -180,7 +180,7 @@
         <div class="row">
             <div class="col-3"></div>
             <div class="col-6">
-                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}'">
+                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}#frame-{{$frame_id}}'">
                     <i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass('md')}}"> キャンセル</span>
                 </button>
                 <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> 

--- a/resources/views/plugins/user/databases/default/databases_import.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_import.blade.php
@@ -14,11 +14,6 @@
 
 @section("plugin_setting_$frame->id")
 
-{{-- ダウンロード用フォーム --}}
-<form action="{{url('/')}}/download/plugin/databases/downloadCsvFormat/{{$page->id}}/{{$frame_id}}/{{$database->id}}" method="post" name="database_download_csv_format">
-    {{ csrf_field() }}
-</form>
-
 @if (session('flash_message'))
     <div class="alert alert-success">
         {{ session('flash_message') }}
@@ -31,6 +26,24 @@
     </ul>
 </div>
 
+{{-- ダウンロード用フォーム --}}
+<form action="{{url('/')}}/download/plugin/databases/downloadCsvFormat/{{$page->id}}/{{$frame_id}}/{{$database->id}}" method="post" name="database_download_csv_format">
+    {{ csrf_field() }}
+    <input type="hidden" name="character_code" value="">
+</form>
+
+<script type="text/javascript">
+    {{-- ダウンロードのsubmit JavaScript --}}
+    function submit_download_csv_format_shift_jis() {
+        database_download_csv_format.character_code.value = '{{CsvCharacterCode::sjis_win}}';
+        database_download_csv_format.submit();
+    }
+    function submit_download_csv_format_utf_8() {
+        database_download_csv_format.character_code.value = '{{CsvCharacterCode::utf_8}}';
+        database_download_csv_format.submit();
+    }
+</script>
+
 {{-- post先 --}}
 <form action="{{url('/')}}/redirect/plugin/databases/uploadCsv/{{$page->id}}/{{$frame_id}}/{{$database->id}}#frame-{{$frame_id}}" method="POST" class="form-horizontal" enctype="multipart/form-data">
     {{ csrf_field() }}
@@ -39,9 +52,18 @@
 
     <div class="form-group row">
         <div class="col text-right">
-            <a href="#frame-{{$frame_id}}" onclick="database_download_csv_format.submit();">
-                CSVファイルのフォーマット
-            </a>
+            <div class="btn-group">
+                <a href="#" onclick="submit_download_csv_format_shift_jis(); return false;">
+                    CSVファイルのフォーマット
+                </a>
+                <button type="button" class="btn btn-sm btn-link dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="sr-only">ドロップダウンボタン</span>
+                </button>
+                <div class="dropdown-menu">
+                    <a class="dropdown-item" href="#" onclick="submit_download_csv_format_shift_jis(); return false;">CSVファイルのフォーマット（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                    <a class="dropdown-item" href="#" onclick="submit_download_csv_format_utf_8(); return false;">CSVファイルのフォーマット（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -64,12 +86,24 @@
         </div>
     </div>
 
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">文字コード</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <select name="character_code" class="form-control">
+                @foreach (CsvCharacterCode::getMembers() as $character_code => $character_code_display)
+                    <option value="{{$character_code}}"@if(old('character_code') == $character_code) selected @endif>{{$character_code_display}}</option>
+                @endforeach
+            </select>
+            @if ($errors && $errors->has('character_code')) <div class="text-danger">{{$errors->first('character_code')}}</div> @endif
+        </div>
+    </div>
+
     {{-- Submitボタン --}}
     <div class="form-group text-center">
         <div class="row">
             <div class="col-3"></div>
             <div class="col-6">
-                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}'">
+                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}#frame-{{$frame_id}}'">
                     <i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass('md')}}"> キャンセル</span>
                 </button>
                 <button type="submit" class="btn btn-primary">

--- a/resources/views/plugins/user/databases/default/databases_list_buckets.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_list_buckets.blade.php
@@ -37,15 +37,25 @@
     {{-- ダウンロード用フォーム --}}
     <form action="" method="post" name="database_download" class="d-inline">
         {{ csrf_field() }}
+        <input type="hidden" name="character_code" value="">
     </form>
 
     <script type="text/javascript">
         {{-- ダウンロードのsubmit JavaScript --}}
-        function submit_download(id) {
-            if( !confirm('登録データをダウンロードします。\nよろしいですか？') ) {
+        function submit_download_shift_jis(id) {
+            if( !confirm('Shift-JISで登録データをダウンロードします。\nよろしいですか？') ) {
                 return;
             }
             database_download.action = "{{url('/')}}/download/plugin/databases/downloadCsv/{{$page->id}}/{{$frame_id}}/" + id;
+            database_download.character_code.value = '{{CsvCharacterCode::sjis_win}}';
+            database_download.submit();
+        }
+        function submit_download_utf_8(id) {
+            if( !confirm('UTF-8 BOM付きで登録データをダウンロードします。\nよろしいですか？') ) {
+                return;
+            }
+            database_download.action = "{{url('/')}}/download/plugin/databases/downloadCsv/{{$page->id}}/{{$frame_id}}/" + id;
+            database_download.character_code.value = '{{CsvCharacterCode::utf_8}}';
             database_download.submit();
         }
     </script>
@@ -71,9 +81,22 @@
                         <button class="btn btn-success btn-sm mr-1" type="button" onclick="location.href='{{url('/')}}/plugin/databases/editBuckets/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}'">
                             <i class="far fa-edit"></i> 設定変更
                         </button>
-                        <button type="button" class="btn btn-primary btn-sm" onclick="submit_download({{$plugin->id}});">
-                            <i class="fas fa-file-download"></i> ダウンロード
-                        </button>
+
+                        <div class="btn-group mr-1">
+                            <!-- <button type="button" class="btn btn-danger">Action</button> -->
+                            <button type="button" class="btn btn-primary btn-sm" onclick="submit_download_shift_jis({{$plugin->id}});">
+                                <i class="fas fa-file-download"></i> ダウンロード
+                            </button>
+
+                            <button type="button" class="btn btn-primary btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="sr-only">ドロップダウンボタン</span>
+                            </button>
+                            <div class="dropdown-menu">
+                                <a class="dropdown-item" href="#" onclick="submit_download_shift_jis({{$plugin->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                                <a class="dropdown-item" href="#" onclick="submit_download_utf_8({{$plugin->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+                            </div>
+                        </div>
+
                         <button type="button" class="btn btn-success btn-sm" onclick="location.href='{{url('/')}}/plugin/databases/import/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}'">
                             <i class="fas fa-file-upload"></i> インポート
                         </button>
@@ -90,7 +113,7 @@
         </div>
 
         <div class="form-group text-center mt-3">
-            <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}'"><i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass()}}"> キャンセル</span></button>
+            <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}#frame-{{$frame_id}}'"><i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass()}}"> キャンセル</span></button>
             <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> 表示{{$frame->plugin_name_full}}変更</button>
         </div>
     </form>

--- a/resources/views/plugins/user/databases/default/databases_list_buckets.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_list_buckets.blade.php
@@ -43,7 +43,7 @@
     <script type="text/javascript">
         {{-- ダウンロードのsubmit JavaScript --}}
         function submit_download_shift_jis(id) {
-            if( !confirm('Shift-JISで登録データをダウンロードします。\nよろしいですか？') ) {
+            if( !confirm('{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}で登録データをダウンロードします。\nよろしいですか？') ) {
                 return;
             }
             database_download.action = "{{url('/')}}/download/plugin/databases/downloadCsv/{{$page->id}}/{{$frame_id}}/" + id;
@@ -51,7 +51,7 @@
             database_download.submit();
         }
         function submit_download_utf_8(id) {
-            if( !confirm('UTF-8 BOM付きで登録データをダウンロードします。\nよろしいですか？') ) {
+            if( !confirm('{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}で登録データをダウンロードします。\nよろしいですか？') ) {
                 return;
             }
             database_download.action = "{{url('/')}}/download/plugin/databases/downloadCsv/{{$page->id}}/{{$frame_id}}/" + id;


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

【データベースプラグイン】にCSVダウンロード・CVSインポートで文字コードを指定する機能追加 です。

## 対応内容

* add: database plugin, CSVダウンロード・CVSインポートで文字コードを指定する機能追加
* bugfix: database plugin, CVSインポート時、全角文字が消える不具合修正
* change: database plugin, DB設定画面のキャンセルボタンに、#frame-XXX アンカー追加
* change: database plugin, インポート画面のキャンセルボタンに、#frame-XXX アンカー追加
* change: database plugin, DB選択画面のキャンセルボタンに、#frame-XXX アンカー追加

## 画面

### DB選択画面（ダウンロード）
![image](https://user-images.githubusercontent.com/2756509/92077804-1a788600-edf8-11ea-8800-9db153a65072.png)

### CVSインポート（フォーマットダウンロード）
![image](https://user-images.githubusercontent.com/2756509/92077900-47c53400-edf8-11ea-9c04-26f9c8e214af.png)

### CVSインポート（対応する文字コード）
![image](https://user-images.githubusercontent.com/2756509/92078005-80fda400-edf8-11ea-9302-8b9ba18522f8.png)

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/522

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

無し

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
