### PR TITLE
add: database plugin, 添付ファイル一括インポート対応

### DIFF
--- a/app/Rules/CustomVali_CsvExtensions.php
+++ b/app/Rules/CustomVali_CsvExtensions.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * CSV用 拡張子バリデーション
+ */
+class CustomVali_CsvExtensions implements Rule
+{
+    protected $allow_extension = null;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct(array $allow_extension)
+    {
+        $this->allow_extension = $allow_extension;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute 項目名
+     * @param  mixed  $value 画像のフルパスセットする
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        // ファイルが存在するか
+        if (! file_exists($value)) {
+            // ファイルなしはエラー
+            return false;
+        }
+
+        $filesystem = new Filesystem();
+        $extension = $filesystem->extension($value);
+        // 小文字に変換
+        $extension = strtolower($extension);
+
+        return in_array($extension, $this->allow_extension);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return ':attributeには ' . implode(',', $this->allow_extension) . ' のうちいずれかの形式のファイルを指定してください。';
+    }
+}

--- a/app/Rules/CustomVali_CsvImage.php
+++ b/app/Rules/CustomVali_CsvImage.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Rules;
+
+/**
+ * CSV用 画像バリデーション
+ */
+class CustomVali_CsvImage extends CustomVali_CsvExtensions
+{
+    protected $allow_extension = null;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct(array $allow_extension = ['jpeg', 'png', 'gif', 'bmp', 'svg'])
+    {
+        $this->allow_extension = $allow_extension;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute 項目名
+     * @param  mixed  $value 画像のフルパスセットする
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return parent::passes($attribute, $value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return ':attributeには画像ファイルを指定してください。';
+    }
+}

--- a/app/Utilities/csv/Csv.php
+++ b/app/Utilities/csv/Csv.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Utilities\csv;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Shift-JIS から UTF-8 変換するストリームフィルタ
+ * CSV読み込み時に使用して、5C問題対応
+ */
+class Csv
+{
+    /**
+     * UTF-8のBOMコードを追加する(UTF-8 BOM付きにするとExcelで文字化けしない)
+     */
+    public static function addUtf8Bom($csv_data)
+    {
+        //「UTF-8」の「BOM」であるコード「0xEF」「0xBB」「0xBF」をカンマ区切りにされた文字列の先頭に連結
+        $csv_data = pack('C*', 0xEF, 0xBB, 0xBF) . $csv_data;
+        return $csv_data;
+    }
+
+    /**
+     * UTF-8のBOMコードを取り除く
+     */
+    public static function removeUtf8Bom($header_columns)
+    {
+        if (isset($header_columns[0])) {
+            // UTF-8 BOMありなしに関わらず、先頭3バイトのBOMコードを置換して取り除く
+            // BOMなしは、置換対象がないのでそのまま値が返る
+            $header_columns[0] = preg_replace('/^\xEF\xBB\xBF/', '', $header_columns[0]);
+        }
+        return $header_columns;
+    }
+
+    /**
+     * 空文字をnullに変換
+     * Laravel公式のリクエストを自動トリムする処理と同じ処理
+     * copy by Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::transform()
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public static function convertEmptyStringsToNull($value)
+    {
+        return is_string($value) && $value === '' ? null : $value;
+    }
+
+    /**
+     * 文字コードの自動検出(文字エンコーディングをsjis-win, UTF-8の順番で自動検出. 対象文字コード外の場合、false戻る)
+     */
+    public static function getCharacterCodeAuto($csv_full_path)
+    {
+        // 全体ではなく0～1024までを取得
+        $contents = file_get_contents($csv_full_path, null, null, 0, 1024);
+
+        // 文字エンコーディングをsjis-win, UTF-8の順番で自動検出. 対象文字コード外の場合、false戻る
+        $character_code = mb_detect_encoding($contents, \CsvCharacterCode::sjis_win.", ".\CsvCharacterCode::utf_8);
+        // Log::debug(var_export($character_code, true));
+
+        return $character_code;
+    }
+}

--- a/app/Utilities/zip/UnZip.php
+++ b/app/Utilities/zip/UnZip.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Utilities\zip;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Shift-JIS から UTF-8 変換するストリームフィルタ
+ * CSV読み込み時に使用して、5C問題対応
+ *
+ * 参照：https://qiita.com/suin/items/3edfb9cb15e26bffba11
+ */
+class Unzip
+{
+    /**
+     * ZipArchiveクラスが使えるか
+     */
+    public static function useZipArchive(): bool
+    {
+        return class_exists('ZipArchive');
+    }
+
+    /**
+     * 一時的な解凍フォルダ名
+     */
+    public static function getTmpDir(): string
+    {
+        return uniqid('', true);
+    }
+
+    /**
+     * ZIP解凍
+     */
+    public static function unzip(string $zip_path, string $unzip_dir_full_path)
+    {
+        $zip = new \ZipArchive();
+        // $res = $zip->open(storage_path('app/') . $path);
+        $res = $zip->open($zip_path);
+        if ($res !== true) {
+            // ZIPファイルオープン失敗
+            $error_msg = "ZIPファイルを開く時にエラーが発生しました。（エラーコード：{$res}）ZIPファイルを確認して作り直してください。";
+            return $error_msg;
+        }
+
+        $index = 0;
+        while ($zipEntry = $zip->statIndex($index)) {
+            $zipEntryName = $zipEntry['name'];
+
+            // windowsでZIPファイルを作成でZIP内のファイル名が日本語の場合、ファイル名はsjis_winになるためエンコード必要
+            $zipEntry2 = $zip->statIndex($index, \ZipArchive::FL_ENC_RAW);
+            $zipEntry2Name = $zipEntry2['name'];
+            $destName = mb_convert_encoding($zipEntry2Name, \CsvCharacterCode::utf_8, \CsvCharacterCode::sjis_win.", ".\CsvCharacterCode::utf_8);
+            // 末尾.csv（大文字小文字区別しない）は.csv(小文字)にリネーム
+            // $destName = preg_replace('/\.csv$/i', '.csv', $destName);
+
+            // utf-8にリネーム
+            if ($zip->renameName($zipEntryName, $destName) === false) {
+                // zip内リネームエラー
+                $zip->close();
+                $error_msg = "ZIPファイル内のファイル名変更時にエラーが発生しました。";
+                return $error_msg;
+            }
+
+            // 1ファイルずつzipから取り出して解凍
+            if ($zip->extractTo($unzip_dir_full_path, $destName) === false) {
+                // zip解凍エラー
+                $zip->close();
+                $error_msg = "ZIPファイル解凍時にエラーが発生しました。";
+                return $error_msg;
+            }
+            $index++;
+        }
+        $zip->close();
+
+        return true;
+    }
+
+    /**
+     * 空でないディレクトリを削除
+     * copy by https://qiita.com/suin/items/b5445ff6fbc21e8d883a
+     */
+    public static function rmdirNotEmpty($dir)
+    {
+        if (!file_exists($dir)) {
+            // ディレクトリがなければ処理しない
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            if ($file->isDir() === true) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($dir);
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_import.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_import.blade.php
@@ -5,6 +5,10 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
 --}}
+@php
+use App\Utilities\zip\UnZip;
+@endphp
+
 @extends('core.cms_frame_base_setting')
 
 @section("core.cms_frame_edit_tab_$frame->id")
@@ -78,6 +82,11 @@
         <label class="{{$frame->getSettingLabelClass()}} pt-0">CSVファイル <label class="badge badge-danger">必須</label></label>
         <div class="{{$frame->getSettingInputClass()}}">
             <input type="file" name="databases_csv" class="form-control-file">
+            @if (UnZip::useZipArchive())
+                <small class="text-muted">
+                    ※ CSVファイル・ZIPファイルに対応しています。
+                </small>
+            @endif
             @if ($errors && $errors->has('databases_csv'))
                 @foreach ($errors->get('databases_csv') as $message)
                     <div class="text-danger">{{$message}}</div>
@@ -95,7 +104,7 @@
                 @endforeach
             </select>
             <small class="text-muted">
-                ※ UTF-8はBOM付・BOMなしどちらにも対応しています。<br>
+                ※ UTF-8はBOM付・BOMなしどちらにも対応しています。
             </small>
             @if ($errors && $errors->has('character_code')) <div class="text-danger">{{$errors->first('character_code')}}</div> @endif
         </div>


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

機能追加です。


### 対応状況

* phpのZipArchive有効時のみ、添付ファイル一括インポート可能
* 添付ファイルありで、登録・更新対応済み
* 添付ファイル一括インポート時の、添付ファイルバリデーション対応済み
* 添付ファイル一括インポート時の添付ファイルは、一度全てUploadsテーブルに`temporary_flag = 1（一時的）`でアップし、その後データ行から呼び出されたら、`temporary_flag = 0（利用）`に更新している。

### zip内フォルダ構成

#### 【添付なし】
xxxxxxx.csv

#### 【添付あり】
zip内/[database_folder]/[database_file].csv　　　
zip内/[database_folder]/uploads/xxxxx_01.jpg
zip内/[database_folder]/uploads/xxxxx_02.jpg
zip内/[database_folder]/uploads/xxxxx_yyyyyy.pdf

※ windowsでzip圧縮すると、zip内にフォルダが1個作られるため、このフォルダ構成にしました。
※ フォルダ名 `[database_folder]` は任意の名前でOKです。
※ CSVファイル名 `[database_file]`.csv は任意の名前でOKです。含めるCSVファイルは1ファイルのみにしてください。
※ `[database_folder]/uploads/` の `uploads` は固定のフォルダ名です。ここに添付ファイルを入れてください。

#### --- zip内/[database_file].csv のファイル書き方

"uploads/xxxxx_01.jpg"
"uploads/xxxxx_02.jpg"
"uploads/xxxxx_yyyyyy.pdf"

※ 対象ファイルが無いと入力チェックでエラーになります。

## 対応内容

* add: database plugin, 添付ファイル一括インポート対応
* add: database plugin, 画像型、動画型の拡張子バリデーション追加
* add: database plugin, 添付ファイル一括CSVインポート時専用の画像型、動画型の拡張子バリデーション追加
* add: database plugin, 添付ファイル一括CSVインポート時専用の画像型、動画型に指定したパスにファイルがなかった時のバリデーション追加
* change: database plugin, CSVのみでインポート時に添付ファイルのバリデーションをしないよう対応
* bugfix: database plugin, CSVインポート時に使うfgetcsv($fp, 0, ",");で","だと、うまくカンマ区切りして取得できない事があったため、','に変更

## 画面

### インポート画面（phpのZipArchive有効時）
CVSファイル選択の下に、「※ CSVファイル・ZIPファイルに対応しています。」メッセージが表示され、
ZIPファイルを使った,添付ファイル一括インポートが出来ます。
![image](https://user-images.githubusercontent.com/2756509/92471034-3d4cd500-f212-11ea-9a48-a55cb418690c.png)

### インポート画面（phpのZipArchive無効時）
CVSファイル選択の下に、メッセージを表示されず、
ZIPファイルを使った,添付ファイル一括インポートを利用できません。
![image](https://user-images.githubusercontent.com/2756509/92471254-96b50400-f212-11ea-8a67-9ed47047c44d.png)


## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/516

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

無し

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
