### PR TITLE
【管理機能】メッセージ管理を追加

### DIFF
--- a/app/Enums/PermissionType.php
+++ b/app/Enums/PermissionType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * 許可区分
+ */
+final class PermissionType
+{
+    // 定数メンバ
+    const not_allowed = 0;
+    const allowed = 1;
+
+    // key/valueの連想配列
+    const enum = [
+        self::not_allowed=>'許可しない',
+        self::allowed=>'許可する',
+    ];
+
+    /*
+    * 対応した和名を返す
+    */
+    public static function getDescription($key): string
+    {
+        return self::enum[$key];
+    }
+
+    /*
+    * key/valueの連想配列を返す
+    */
+    public static function getMembers()
+    {
+        return self::enum;
+    }
+}

--- a/app/Enums/ShowType.php
+++ b/app/Enums/ShowType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * 表示する・表示しない区分
+ */
+final class ShowType
+{
+    // 定数メンバ
+    const not_show = 0;
+    const show = 1;
+
+    // key/valueの連想配列
+    const enum = [
+        self::not_show=>'表示しない',
+        self::show=>'表示する',
+    ];
+
+    /*
+    * 対応した和名を返す
+    */
+    public static function getDescription($key): string
+    {
+        return self::enum[$key];
+    }
+
+    /*
+    * key/valueの連想配列を返す
+    */
+    public static function getMembers()
+    {
+        return self::enum;
+    }
+}

--- a/app/Http/Controllers/Core/CookieController.php
+++ b/app/Http/Controllers/Core/CookieController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Core;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\View;
+
+use DB;
+
+use App\Http\Controllers\Core\ConnectController;
+
+use App\Models\Common\Frame;
+use App\Models\Common\Page;
+use App\Models\Core\Configs;
+
+use App\Traits\ConnectCommonTrait;
+
+/**
+ * Cookie管理
+ *
+ * ルーティング処理から呼び出されるもの
+ *
+ * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category コア
+ * @package Contoroller
+ */
+class CookieController extends ConnectController
+{
+
+    use ConnectCommonTrait;
+
+    /**
+     *  コンストラクタ
+     */
+    public function __construct($page_id, $frame_id)
+    {
+        // ルートパラメータを取得する
+    }
+
+    /**
+     *  パスワードチェック処理
+     */
+    public function setCookieForMessageFirst($request, $page_id)
+    {
+        // Page データ
+        $page = Page::where('id', $page_id)->first();
+
+        // cookieをセット（cookie名、値、有効期間（分））して、元ページへリダイレクト
+        return redirect($page->permanent_link)->cookie('connect_cookie_message_first', 'agreed', 525600);;
+    }
+}

--- a/app/Plugins/Manage/MessageManage/MessageManage.php
+++ b/app/Plugins/Manage/MessageManage/MessageManage.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Plugins\Manage\MessageManage;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
+
+use File;
+use DB;
+
+use App\Models\Core\Configs;
+
+use App\Plugins\Manage\ManagePluginBase;
+
+/**
+ * メッセージ管理クラス
+ *
+ * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category メッセージ管理
+ * @package Contoroller
+ */
+class MessageManage extends ManagePluginBase
+{
+    /**
+     *  権限定義
+     */
+    public function declareRole()
+    {
+        // 権限チェックテーブル
+        $role_ckeck_table = array();
+        $role_ckeck_table["index"]  = array('admin_system');
+        $role_ckeck_table["update"] = array('admin_system');
+        return $role_ckeck_table;
+    }
+
+    /**
+     *  ページ初期表示
+     *
+     * @return view
+     */
+    public function index($request)
+    {
+        // Config データの取得
+        $configs = Configs::get();
+
+        // Config データの変換
+        $configs_array = array();
+        foreach ($configs as $config) {
+            $configs_array[$config->name] = $config->value;
+        }
+
+        // 管理画面プラグインの戻り値の返し方
+        // view 関数の第一引数に画面ファイルのパス、第二引数に画面に渡したいデータを名前付き配列で渡し、その結果のHTML。
+        return view('plugins.manage.message.message', [
+            "function" => __FUNCTION__,
+            "plugin_name" => "message",
+            "configs" => $configs_array,
+        ]);
+    }
+
+    /**
+     *  更新
+     */
+    public function update($request)
+    {
+        // httpメソッド確認
+        if (!$request->isMethod('post')) {
+            abort(403, '権限がありません。');
+        }
+
+        // --- 更新
+        // 初回確認メッセージ（利用有無）
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'message_first_show_type'],
+            ['category' => 'message',
+             'value'    => $request->message_first_show_type]
+        );
+
+        // 初回確認メッセージ（枠外クリック等の離脱許可）
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'message_first_permission_type'],
+            ['category' => 'message',
+             'value'    => $request->message_first_permission_type]
+        );
+
+        // 初回確認メッセージ（メッセージ内容）
+        $search = array('<script>','</script>');
+        $replace = array('','');
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'message_first_content'],
+            ['category' => 'message',
+             'value'    => str_replace($search, $replace, $request->message_first_content)]
+        );
+
+        // 初回確認メッセージ（ボタン名）
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'message_first_button_name'],
+            ['category' => 'message',
+             'value'    => $request->message_first_button_name]
+        );
+
+        // 初回確認メッセージ（除外URL）
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'message_first_exclued_url'],
+            ['category' => 'message',
+             'value'    => $request->message_first_exclued_url]
+        );
+
+        // ページ管理画面に戻る
+        return redirect("/manage/message");
+    }
+}

--- a/app/Plugins/Manage/MessageManage/MessageManage.php
+++ b/app/Plugins/Manage/MessageManage/MessageManage.php
@@ -108,6 +108,13 @@ class MessageManage extends ManagePluginBase
              'value'    => $request->message_first_exclued_url]
         );
 
+        // 初回確認メッセージ（メッセージウィンドウ任意クラス）
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'message_first_optional_class'],
+            ['category' => 'message',
+             'value'    => $request->message_first_optional_class]
+        );
+
         // ページ管理画面に戻る
         return redirect("/manage/message");
     }

--- a/config/app.php
+++ b/config/app.php
@@ -244,6 +244,8 @@ return [
         'GroupType' => \App\Enums\GroupType::class,
         'WhatsnewsTargetPlugin' => \App\Enums\WhatsnewsTargetPlugin::class,
         'CsvCharacterCode' => \App\Enums\CsvCharacterCode::class,
+        'ShowType' => \App\Enums\ShowType::class,
+        'PermissionType' => \App\Enums\PermissionType::class,
 
         // Models
         'Plugins' => \App\Models\Core\Plugins::class,

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -344,12 +344,13 @@
         $message_first_show_type = isset($configs_array['message_first_show_type']) ? $configs_array['message_first_show_type']->value : 0;
         $message_first_permission_type = isset($configs_array['message_first_permission_type']) ? $configs_array['message_first_permission_type']->value : 0;
         $message_first_exclued_urls = isset($configs_array['message_first_exclued_url']) ? explode(',' ,$configs_array['message_first_exclued_url']->value) : array();
+        $message_first_optional_class = isset($configs_array['message_first_optional_class']) ? $configs_array['message_first_optional_class']->value : '';
     @endphp
     {{-- 管理画面で設定ON、且つ、本ページが初回確認メッセージ表示の除外URL以外、且つ、同意していない（Cookie未セット）場合にメッセージ表示 --}}
     @if($message_first_show_type == ShowType::show && !in_array($page->permanent_link ,$message_first_exclued_urls) && Cookie::get('connect_cookie_message_first') != 'agreed')
 
         <!-- 初回確認メッセージ表示用のモーダルウィンドウ -->
-        <div class="modal" id="first_message_modal" tabindex="-1" role="dialog" aria-labelledby="first_message_modal_label" aria-hidden="true" data-backdrop="{{ $message_first_permission_type == PermissionType::not_allowed ? 'static' : 'true' }}">
+        <div class="modal {{ $message_first_optional_class }}" id="first_message_modal" tabindex="-1" role="dialog" aria-labelledby="first_message_modal_label" aria-hidden="true" data-backdrop="{{ $message_first_permission_type == PermissionType::not_allowed ? 'static' : 'true' }}">
             <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
                 <div class="modal-content">
                     <div class="modal-body">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -345,8 +345,8 @@
         $message_first_permission_type = isset($configs_array['message_first_permission_type']) ? $configs_array['message_first_permission_type']->value : 0;
         $message_first_exclued_urls = isset($configs_array['message_first_exclued_url']) ? explode(',' ,$configs_array['message_first_exclued_url']->value) : array();
     @endphp
-    {{-- 管理画面で設定ON、且つ、本ページが初回確認メッセージ表示の除外URL以外の場合にメッセージ表示 --}}
-    @if($message_first_show_type == ShowType::show && !in_array($page->permanent_link ,$message_first_exclued_urls))
+    {{-- 管理画面で設定ON、且つ、本ページが初回確認メッセージ表示の除外URL以外、且つ、同意していない（Cookie未セット）場合にメッセージ表示 --}}
+    @if($message_first_show_type == ShowType::show && !in_array($page->permanent_link ,$message_first_exclued_urls) && Cookie::get('connect_cookie_message_first') != 'agreed')
 
         <!-- 初回確認メッセージ表示用のモーダルウィンドウ -->
         <div class="modal" id="first_message_modal" tabindex="-1" role="dialog" aria-labelledby="first_message_modal_label" aria-hidden="true" data-backdrop="{{ $message_first_permission_type == PermissionType::not_allowed ? 'static' : 'true' }}">
@@ -357,11 +357,11 @@
                         {!! $configs_array['message_first_content']->value !!}
                     </div>
                     <div class="modal-footer">
-                        <form action="{{url('/core/frame/addCookieForFirstMessage')}}/{{$page->id}}" name="form_add_cookie_first_message" method="POST">
+                        <form action="{{url('/core/cookie/setCookieForMessageFirst')}}/{{$page->id}}" name="form_set_cookie" id="form_set_cookie" method="POST">
                             {{ csrf_field() }}
 
                             {{-- ボタン --}}
-                            <button type="button" class="btn btn-primary" data-dismiss="modal">
+                            <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submit_form_set_cookie();">
                                 {{ $configs_array['message_first_button_name']->value }}
                             </button>
                         </form>
@@ -374,6 +374,10 @@
             window.onload = function() {
                 $('#first_message_modal').modal();
             };
+            // cookieセット処理リクエスト
+            function submit_form_set_cookie() {
+                form_set_cookie.submit();
+            }
         </script>
     @endif
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -338,5 +338,44 @@
     @endif
     @endauth
 
+    {{-- 初回確認メッセージの表示モーダル --}}
+    @php
+        // Configsテーブルから設定値を取得
+        $message_first_show_type = isset($configs_array['message_first_show_type']) ? $configs_array['message_first_show_type']->value : 0;
+        $message_first_permission_type = isset($configs_array['message_first_permission_type']) ? $configs_array['message_first_permission_type']->value : 0;
+        $message_first_exclued_urls = isset($configs_array['message_first_exclued_url']) ? explode(',' ,$configs_array['message_first_exclued_url']->value) : array();
+    @endphp
+    {{-- 管理画面で設定ON、且つ、本ページが初回確認メッセージ表示の除外URL以外の場合にメッセージ表示 --}}
+    @if($message_first_show_type == ShowType::show && !in_array($page->permanent_link ,$message_first_exclued_urls))
+
+        <!-- 初回確認メッセージ表示用のモーダルウィンドウ -->
+        <div class="modal" id="first_message_modal" tabindex="-1" role="dialog" aria-labelledby="first_message_modal_label" aria-hidden="true" data-backdrop="{{ $message_first_permission_type == PermissionType::not_allowed ? 'static' : 'true' }}">
+            <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
+                <div class="modal-content">
+                    <div class="modal-body">
+                        {{-- メッセージ内容 --}}
+                        {!! $configs_array['message_first_content']->value !!}
+                    </div>
+                    <div class="modal-footer">
+                        <form action="{{url('/core/frame/addCookieForFirstMessage')}}/{{$page->id}}" name="form_add_cookie_first_message" method="POST">
+                            {{ csrf_field() }}
+
+                            {{-- ボタン --}}
+                            <button type="button" class="btn btn-primary" data-dismiss="modal">
+                                {{ $configs_array['message_first_button_name']->value }}
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <script>
+            // 画面ロード時にモーダル表示
+            window.onload = function() {
+                $('#first_message_modal').modal();
+            };
+        </script>
+    @endif
+
 </body>
 </html>

--- a/resources/views/plugins/manage/menus_list.blade.php
+++ b/resources/views/plugins/manage/menus_list.blade.php
@@ -66,6 +66,13 @@
             <a href="{{url('/')}}/manage/api" class="list-group-item">API管理</a>
         @endif
     @endif
+    @if (Auth::user()->can('admin_system'))
+        @if (isset($plugin_name) && $plugin_name == 'message')
+            <a href="{{url('/')}}/manage/message" class="list-group-item active">メッセージ管理</a>
+        @else
+            <a href="{{url('/')}}/manage/message" class="list-group-item">メッセージ管理</a>
+        @endif
+    @endif
     <div class="list-group-item text-secondary bg-light">データ管理系</div>
     @if (Auth::user()->can('admin_site'))
         @if (isset($plugin_name) && $plugin_name == 'theme')

--- a/resources/views/plugins/manage/message/message.blade.php
+++ b/resources/views/plugins/manage/message/message.blade.php
@@ -1,0 +1,129 @@
+{{--
+ * 初回確認メッセージ管理のメインテンプレート
+ *
+ * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category メッセージ管理
+ --}}
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.message.message_tab')
+    </div>
+
+    <div class="card-body">
+        <form name="form_message_first" method="post" action="{{url('/')}}/manage/message/update">
+            {{ csrf_field() }}
+
+            {{-- 初回確認メッセージの利用有無 --}}
+            <div class="form-group">
+                <label class="col-form-label">表示の有無</label>
+                <div class="row">
+                    @foreach (ShowType::enum as $key => $value)
+                        {{-- ラジオのチェック判定 --}}
+                        @php
+                            $checked = null;
+                            if(!isset($configs["message_first_show_type"]) && $loop->first){
+                                // 未登録、且つ、ループ初回時はチェックON
+                                $checked = 'checked';
+                            }
+                            if(isset($configs["message_first_show_type"]) && $configs["message_first_show_type"] == $key){
+                                // 設定値があればそれに応じてチェックON
+                                $checked = 'checked';
+                            }
+                        @endphp
+                        {{-- ラジオ表示 --}}
+                        <div class="col-md-3">
+                            <div class="custom-control custom-radio custom-control-inline">
+                                <input 
+                                    type="radio" value="{{ $key }}" class="custom-control-input" id="message_first_show_type_{{ $key }}" 
+                                    name="message_first_show_type" {{ $checked }}
+                                >
+                                <label class="custom-control-label" for="{{ "message_first_show_type_${key}" }}">
+                                    {{ $value }}
+                                </label>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+                <small class="form-text text-muted">※サイト訪問者にポップアップメッセージを表示するか選択します。（用例：利用規約、プライバシーポリシーへの同意等）</small>
+                <small class="form-text text-muted">※本機能はCookieを使用します。Cookieの取り扱いについてはサイトポリシーで検討の上、ご利用ください。</small>
+                <small class="form-text text-muted">※メッセージ内のボタン押下で訪問者ブラウザにCookieをセットし、Cookieセット後はポップアップメッセージは表示されません。</small>
+            </div>
+
+            {{-- ウィンドウ外クリックによる離脱許可 --}}
+            <div class="form-group">
+                <label class="col-form-label">ウィンドウ外クリックによる離脱</label>
+                <div class="row">
+                    @foreach (PermissionType::enum as $key => $value)
+                        {{-- ラジオのチェック判定 --}}
+                        @php
+                            $checked = null;
+                            if(!isset($configs["message_first_permission_type"]) && $loop->first){
+                                // 未登録、且つ、ループ初回時はチェックON
+                                $checked = 'checked';
+                            }
+                            if(isset($configs["message_first_permission_type"]) && $configs["message_first_permission_type"] == $key){
+                                // 設定値があればそれに応じてチェックON
+                                $checked = 'checked';
+                            }
+                        @endphp
+                        {{-- ラジオ表示 --}}
+                        <div class="col-md-3">
+                            <div class="custom-control custom-radio custom-control-inline">
+                                <input 
+                                    type="radio" value="{{ $key }}" class="custom-control-input" id="message_first_permission_type_{{ $key }}" 
+                                    name="message_first_permission_type" {{ $checked }}
+                                >
+                                <label class="custom-control-label" for="{{ "message_first_permission_type_${key}" }}">
+                                    {{ $value }}
+                                </label>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+                <small class="form-text text-muted">※メッセージウィンドウ外クリックによる離脱を許可するか選択します。</small>
+            </div>
+
+            {{-- メッセージ内容 --}}
+            <div class="form-group">
+                <label class="control-label">メッセージ内容</label>
+                <textarea name="message_first_content" class="form-control" rows=5 placeholder="（例）当サイトではトラフィック分析を目的として、クッキー(Cookie)を利用しています。当サイトの閲覧を続けた場合、クッキーの利用に同意いただいたことになります。詳しくはプライバシーポリシーをご覧ください。">{{ $configs['message_first_content'] }}</textarea>
+                <small class="form-text text-muted">※ポップアップに表示するメッセージを設定します。HTML入力が可能です。scriptタグは使用できません。</small>
+            </div>
+
+            {{-- ボタン名 --}}
+            <div class="form-group">
+                <label class="col-form-label">ボタン名</label>
+                <input type="text" name="message_first_button_name" value="{{ $configs['message_first_button_name'] }}" class="form-control">
+                <small class="form-text text-muted">※ポップアップに表示するボタン名を設定します。</small>
+            </div>
+
+            {{-- 除外URL --}}
+            <div class="form-group">
+                <label class="col-form-label">除外URL</label>
+                <input type="text" name="message_first_exclued_url" value="{{ $configs['message_first_exclued_url'] }}" class="form-control" placeholder="（例）/about,/policy">
+                <small class="form-text text-muted">※メッセージ表示を除外するURLを設定します。「,」区切りで複数設定できます。</small>
+            </div>
+
+            {{-- メッセージエリア任意クラス --}}
+            <div class="form-group">
+                <label class="col-form-label">メッセージエリア任意クラス</label>
+                <input type="text" name="message_first_optional_class" value="{{ $configs['message_first_optional_class'] }}" class="form-control">
+                <small class="form-text text-muted">※メッセージウィンドウに任意のclass属性を設定します。</small>
+            </div>
+
+            {{-- 更新ボタン --}}
+            <div class="form-group text-center">
+                <button type="submit" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
+            </div>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/plugins/manage/message/message_tab.blade.php
+++ b/resources/views/plugins/manage/message/message_tab.blade.php
@@ -1,0 +1,26 @@
+{{--
+ * 編集画面tabテンプレート
+ *
+ * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category メッセージ管理
+ --}}
+<div class="frame-setting-menu">
+    <nav class="navbar navbar-expand-md navbar-light bg-light py-1">
+        <span class="d-md-none">処理選択 - メッセージ管理</span>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsingNavbarLg">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="navbar-collapse collapse" id="collapsingNavbarLg">
+            <ul class="navbar-nav">
+                <li role="presentation" class="nav-item">
+                @if ($function == "index")
+                    <span class="nav-link"><span class="active">初回確認メッセージ</span></span>
+                @else
+                    <a href="{{url('/manage/message')}}" class="nav-link">初回確認メッセージ</a></li>
+                @endif
+                </li>
+            </ul>
+        </div>
+    </nav>
+</div>


### PR DESCRIPTION
## 概要（Overview）
- 管理者メニューに「メッセージ管理」として初回確認メッセージの設定機能を追加

## 関連Pull requests/Issues（Links to related pull requests or issues）
https://github.com/opensource-workshop/connect-cms/issues/525

## 参考（Reference）
なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>
無し

## チェックリスト（Checklist）
- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
