### PR TITLE
【データベース】過去のデータベースを使って新たなデータベースを作る機能追加 

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -1676,7 +1676,6 @@ class DatabasesPlugin extends UserPluginBase
      */
     public function saveBuckets($request, $page_id, $frame_id, $databases_id = null)
     {
-
         // デフォルトで必須
         $validator_values['databases_name'] = ['required'];
         $validator_attributes['databases_name'] = 'データベース名';
@@ -1717,8 +1716,19 @@ class DatabasesPlugin extends UserPluginBase
             $bucket->plugin_name = 'databases';
             $bucket->save();
 
-            // ブログデータ新規オブジェクト
-            $databases = new Databases();
+            if (empty($request->copy_databases_id)) {
+                // 登録
+
+                // データベース新規オブジェクト
+                $databases = new Databases();
+            } else {
+                // コピー
+
+                // コピー元IDで、データベースデータ取得
+                $copy_databases = Databases::where('id', $request->copy_databases_id)->first();
+                // ID消して複製
+                $databases = $copy_databases->replicate();
+            }
             $databases->bucket_id = $bucket->id;
 
             // Frame のBuckets を見て、Buckets が設定されていなければ、作成したものに紐づける。
@@ -1762,6 +1772,47 @@ class DatabasesPlugin extends UserPluginBase
 
         // データ保存
         $databases->save();
+
+        // 登録
+        if (empty($request->databases_id)) {
+            // コピーIDあり
+            if ($request->copy_databases_id) {
+                // 【DBカラムコピー】
+                $copy_databases_columns = DatabasesColumns::where('databases_id', $request->copy_databases_id)->get();
+                foreach ($copy_databases_columns as $copy_databases_column) {
+                    // ID消して複製
+                    $databases_column = $copy_databases_column->replicate();
+                    $databases_column->databases_id = $databases->id;
+                    $databases_column->save();
+
+                    // 【DBカラムの権限表示指定コピー】
+                    $copy_databases_columns_roles = DatabasesColumnsRole::where('databases_id', $request->copy_databases_id)
+                                                                        ->where('databases_columns_id', $copy_databases_column->id)
+                                                                        ->get();
+                    foreach ($copy_databases_columns_roles as $copy_databases_columns_role) {
+                        // ID消して複製
+                        $databases_columns_role = $copy_databases_columns_role->replicate();
+                        $databases_columns_role->databases_id = $databases->id;
+                        $databases_columns_role->databases_columns_id = $databases_column->id;
+                        $databases_columns_role->save();
+                    }
+
+                    // 選択肢カラム
+                    if ($copy_databases_column->column_type == \DatabaseColumnType::radio ||
+                            $copy_databases_column->column_type == \DatabaseColumnType::checkbox ||
+                            $copy_databases_column->column_type == \DatabaseColumnType::select) {
+                        // 【DBカラム選択肢コピー】
+                        $copy_databases_columns_selects = DatabasesColumnsSelects::where('databases_columns_id', $copy_databases_column->id)->get();
+                        foreach ($copy_databases_columns_selects as $copy_databases_columns_select) {
+                            // ID消して複製
+                            $databases_columns_select = $copy_databases_columns_select->replicate();
+                            $databases_columns_select->databases_columns_id = $databases_column->id;
+                            $databases_columns_select->save();
+                        }
+                    }
+                }
+            }
+        }
 
         // 新規作成フラグを付けてデータベース設定変更画面を呼ぶ
         $create_flag = false;

--- a/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
@@ -41,14 +41,16 @@
 
 @if (!$database->id && !$create_flag)
 @else
-<form action="{{url('/')}}/plugin/databases/saveBuckets/{{$page->id}}/{{$frame_id}}" method="POST" class="">
+<form action="{{url('/')}}/plugin/databases/saveBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" class="">
     {{ csrf_field() }}
 
     {{-- create_flag がtrue の場合、新規作成するためにdatabases_id を空にする --}}
     @if ($create_flag)
         <input type="hidden" name="databases_id" value="">
+        <input type="hidden" name="copy_databases_id" value="{{old('copy_databases_id', $database->id)}}">
     @else
         <input type="hidden" name="databases_id" value="{{$database->id}}">
+        <input type="hidden" name="copy_databases_id" value="">
     @endif
 
     <div class="form-group row">

--- a/resources/views/plugins/user/databases/default/databases_list_buckets.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_list_buckets.blade.php
@@ -60,7 +60,7 @@
         }
     </script>
 
-    <form action="{{url('/')}}/plugin/{{$frame->plugin_name}}/changeBuckets/{{$page->id}}/{{$frame_id}}" method="POST" class="">
+    <form action="{{url('/')}}/plugin/{{$frame->plugin_name}}/changeBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" class="">
         {{ csrf_field() }}
         <div class="form-group">
             <table class="table table-hover table-responsive">
@@ -78,9 +78,17 @@
                     <td nowrap><input type="radio" value="{{$plugin->bucket_id}}" name="select_bucket"@if ($plugin_frame->bucket_id == $plugin->bucket_id) checked @endif></td>
                     <td nowrap>{{$plugin->plugin_bucket_name}}</td>
                     <td nowrap>
-                        <button class="btn btn-success btn-sm mr-1" type="button" onclick="location.href='{{url('/')}}/plugin/databases/editBuckets/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}'">
-                            <i class="far fa-edit"></i> 設定変更
-                        </button>
+                        <div class="btn-group mr-1">
+                            <button class="btn btn-success btn-sm" type="button" onclick="location.href='{{url('/')}}/plugin/databases/editBuckets/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}'">
+                                <i class="far fa-edit"></i> 設定変更
+                            </button>
+                            <button type="button" class="btn btn-success btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="sr-only">ドロップダウンボタン</span>
+                            </button>
+                            <div class="dropdown-menu">
+                                <a class="dropdown-item" href="{{url('/')}}/plugin/databases/createBuckets/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}">コピーしてDB作成へ</a>
+                            </div>
+                        </div>
 
                         <div class="btn-group mr-1">
                             <button type="button" class="btn btn-primary btn-sm" onclick="submit_download_shift_jis({{$plugin->id}});">


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

機能追加です。

## 画面
### DB選択画面
![image](https://user-images.githubusercontent.com/2756509/92575120-ebb05300-f2c2-11ea-8841-c0b7218f52a0.png)

## 対応内容

* add: database plugin, 過去のデータベースを使って新たなデータベースを作る機能追加
* change: database plugin, DB選択画面の表示データベース変更ボタンに、#frame-XXX アンカー追加
* change: database plugin, DB作成・DB設定画面の決定ボタンに、#frame-XXX アンカー追加


## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/541

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

無し

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
