### PR TITLE
add: form plugin, 登録制限機能追加

### DIFF
--- a/app/Models/User/Forms/Forms.php
+++ b/app/Models/User/Forms/Forms.php
@@ -7,5 +7,18 @@ use Illuminate\Database\Eloquent\Model;
 class Forms extends Model
 {
     // 更新する項目の定義
-    protected $fillable = ['bucket_id', 'forms_name', 'mail_send_flag', 'mail_send_address', 'user_mail_send_flag', 'mail_subject', 'mail_format', 'data_save_flag', 'after_message', 'numbering_use_flag', 'numbering_prefix'];
+    protected $fillable = [
+        'bucket_id',
+        'forms_name',
+        'entry_limit',
+        'mail_send_flag',
+        'mail_send_address',
+        'user_mail_send_flag',
+        'mail_subject',
+        'mail_format',
+        'data_save_flag',
+        'after_message',
+        'numbering_use_flag',
+        'numbering_prefix'
+    ];
 }

--- a/database/migrations/2020_09_09_202328_add_entry_limit_forms.php
+++ b/database/migrations/2020_09_09_202328_add_entry_limit_forms.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEntryLimitForms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->integer('entry_limit')->nullable()->comment('登録制限数')->after('forms_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('entry_limit');
+        });
+    }
+}

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -36,21 +36,29 @@
 
 @if (!$form->id && !$create_flag)
 @else
-<form action="{{url('/')}}/plugin/forms/saveBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" class="">
-    {{ csrf_field() }}
 
-    {{-- create_flag がtrue の場合、新規作成するためにforms_id を空にする --}}
-    @if ($create_flag)
-        <input type="hidden" name="forms_id" value="">
-    @else
-        <input type="hidden" name="forms_id" value="{{$form->id}}">
-    @endif
+{{-- create_flag がtrue の場合、新規作成するためにforms_id を空にする --}}
+@if ($create_flag)
+<form action="{{url('/')}}/plugin/forms/saveBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" class="">
+@else
+<form action="{{url('/')}}/plugin/forms/saveBuckets/{{$page->id}}/{{$frame_id}}/{{$form->id}}#frame-{{$frame_id}}" method="POST" class="">
+@endif
+    {{ csrf_field() }}
 
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">フォーム名 <label class="badge badge-danger">必須</label></label>
         <div class="{{$frame->getSettingInputClass()}}">
             <input type="text" name="forms_name" value="{{old('forms_name', $form->forms_name)}}" class="form-control">
             @if ($errors && $errors->has('forms_name')) <div class="text-danger">{{$errors->first('forms_name')}}</div> @endif
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">登録制限数</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <input type="text" name="entry_limit" value="{{old('entry_limit', $form->entry_limit)}}" class="form-control">
+            <small class="text-muted">※ 未入力か 0 の場合、登録数を制限しません。</small><br>
+            @if ($errors && $errors->has('entry_limit')) <div class="text-danger">{{$errors->first('entry_limit')}}</div> @endif
         </div>
     </div>
 


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

機能追加です。

## 対応内容

* 登録制限数 設定
入力チェック：数値チェック、0以上入力、任意入力
自動入力値変換：数値入力なら小数点切り捨てて整数に変換。（例）1.9⇒1に変換
※ 未入力か 0 の場合、登録数を制限しません。

* 登録制限数チェック
登録画面、確認画面、登録確定時（送信ボタン押下時）にそれぞれチェック。
制限数オーバーなら登録させない。

## 画面

### フォーム設定画面

![image](https://user-images.githubusercontent.com/2756509/92611304-9ccee180-f2f3-11ea-986c-9aca1cff66c1.png)

### 登録制限数オーバーのメッセージ

![image](https://user-images.githubusercontent.com/2756509/92611077-5f6a5400-f2f3-11ea-8f18-a89d1ffe5a14.png)

## 主なcommits

* add: form plugin, 登録制限機能追加
* bugfix: form plugin, フォーム設定変更時に入力エラーがあると、フォーム作成画面に遷移する不具合修正

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/543

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

有り

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
