### PR TITLE
【データベース】表示順追加

### DIFF
--- a/app/Enums/DatabaseColumnType.php
+++ b/app/Enums/DatabaseColumnType.php
@@ -31,6 +31,7 @@ final class DatabaseColumnType extends EnumsBase
     const created = 'created';
     const updated = 'updated';
     const posted = 'posted';
+    const display = 'display';
 
     // 複数年月型（テキスト入力）のデフォルトキャプション
     const dates_ym_caption = 'yyyy/mm形式で年月を入力してください。また複数入力したい場合は、カンマ「,」区切りで入力してください。';
@@ -58,5 +59,6 @@ final class DatabaseColumnType extends EnumsBase
         self::created => '登録日型（自動更新）',
         self::updated => '更新日型（自動更新）',
         self::posted => '公開日型（表示のみ）',
+        self::display => '表示順型（表示のみ）',
     ];
 }

--- a/app/Enums/DatabaseSortFlag.php
+++ b/app/Enums/DatabaseSortFlag.php
@@ -10,9 +10,11 @@ use App\Enums\EnumsBase;
 final class DatabaseSortFlag extends EnumsBase
 {
     // 定数メンバの'_'の前半. $sort_column_id
+    // 注意：_ は区切り文字に使っているため、const内に _ を含めない事
     const created = 'created';
     const updated = 'updated';
     const posted  = 'posted';
+    const display = 'display';
     const random  = 'random';
 
     // 定数メンバの'_'の後半. $sort_column_order
@@ -35,6 +37,8 @@ final class DatabaseSortFlag extends EnumsBase
     const updated_desc   = self::updated . '_' . self::order_desc;
     const posted_asc     = self::posted . '_' . self::order_asc;
     const posted_desc    = self::posted . '_' . self::order_desc;
+    const display_asc    = self::display . '_' . self::order_asc;
+    const display_desc   = self::display . '_' . self::order_desc;
     const random_session = self::random . '_' . self::order_session;
     const random_every   = self::random . '_' . self::order_every;
     const column         = 'column';
@@ -47,6 +51,8 @@ final class DatabaseSortFlag extends EnumsBase
         self::updated_desc   => '更新日（新しい順）',
         self::posted_asc     => '公開日（古い順）',
         self::posted_desc    => '公開日（新しい順）',
+        self::display_asc    => '表示順（昇順）',
+        self::display_desc   => '表示順（降順）',
         self::random_session => 'ランダム（セッション）',
         self::random_every   => 'ランダム（毎回）',
         self::column         => '各カラム設定',

--- a/app/Models/User/Databases/DatabasesColumns.php
+++ b/app/Models/User/Databases/DatabasesColumns.php
@@ -33,4 +33,19 @@ class DatabasesColumns extends Model
         // 1対多
         return $this->hasMany('App\Models\User\Databases\DatabasesColumnsRole', 'databases_columns_id', 'id');
     }
+
+    /**
+     * 入力しないカラム型か
+     */
+    public static function isNotInputColumnType($column_type)
+    {
+        // 登録日型・更新日型・公開日型・表示順型は入力しない
+        if ($column_type == \DatabaseColumnType::created ||
+                    $column_type == \DatabaseColumnType::updated ||
+                    $column_type == \DatabaseColumnType::posted ||
+                    $column_type == \DatabaseColumnType::display) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/database/migrations/2020_09_11_100735_add_display_sequence_databases_inputs.php
+++ b/database/migrations/2020_09_11_100735_add_display_sequence_databases_inputs.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDisplaySequenceDatabasesInputs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->integer('display_sequence')->comment('表示順')->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->dropColumn('display_sequence');
+        });
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_confirm.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_confirm.blade.php
@@ -7,6 +7,10 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
 --}}
+@php
+use App\Models\User\Databases\DatabasesColumns;
+@endphp
+
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
@@ -44,10 +48,8 @@
     {{ csrf_field() }}
     @foreach($databases_columns as $database_column)
 
-        {{-- 登録日型・更新日型・公開日型は入力表示しない --}}
-        @if($database_column->column_type == DatabaseColumnType::created ||
-            $database_column->column_type == DatabaseColumnType::updated ||
-            $database_column->column_type == DatabaseColumnType::posted)
+        {{-- 入力しないカラム型は表示しない --}}
+        @if (DatabasesColumns::isNotInputColumnType($database_column->column_type))
             @continue
         @endif
 
@@ -169,12 +171,18 @@
     {{-- 固定項目エリア --}}
     <hr>
     <div class="form-group container-fluid row">
-        {{-- ラベル --}}
         <label class="col-sm-2 control-label text-nowrap">公開日時</label>
-        {{-- 項目 --}}
         <div class="col-sm-10">
             {{$request->posted_at}}
             <input name="posted_at" class="form-control" type="hidden" value="{{$request->posted_at}}">
+        </div>
+    </div>
+
+    <div class="form-group container-fluid row">
+        <label class="col-sm-2 control-label text-nowrap">表示順</label>
+        <div class="col-sm-10">
+            {{$request->display_sequence}}
+            <input name="display_sequence" class="form-control" type="hidden" value="{{$request->display_sequence}}">
         </div>
     </div>
 

--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -38,7 +38,7 @@
 
 @if (!$database->id)
 @else
-<form action="{{url('/')}}/plugin/databases/saveView/{{$page->id}}/{{$frame_id}}" method="POST" class="">
+<form action="{{url('/')}}/plugin/databases/saveView/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" class="">
     {{ csrf_field() }}
 
     {{-- 表示件数 --}}

--- a/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
@@ -58,6 +58,10 @@
     elseif ($column->column_type == DatabaseColumnType::posted) {
         $value = $inputs->posted_at;
     }
+    // 表示順型
+    elseif ($column->column_type == DatabaseColumnType::display) {
+        $value = $inputs->display_sequence;
+    }
     // その他の型
     else {
         $value = $obj ? $obj->value : "";

--- a/resources/views/plugins/user/databases/default/databases_include_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_value.blade.php
@@ -57,6 +57,10 @@
     elseif ($column->column_type == DatabaseColumnType::posted) {
         $value = $input->posted_at;
     }
+    // 表示順型
+    elseif ($column->column_type == DatabaseColumnType::display) {
+        $value = $input->display_sequence;
+    }
     // その他の型
     else {
         $value = $obj ? $obj->value : "";

--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -7,6 +7,10 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
 --}}
+@php
+use App\Models\User\Databases\DatabasesColumns;
+@endphp
+
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
@@ -41,22 +45,19 @@
 --}}
 
         @foreach($databases_columns as $database_column)
-            @switch($database_column->column_type)
-            {{-- 登録日型・更新日型は入力表示しない --}}
-            @case(DatabaseColumnType::created)
-            @case(DatabaseColumnType::updated)
-            @case(DatabaseColumnType::posted)
-                @break
+            {{-- 入力しないカラム型は表示しない --}}
+            @if (DatabasesColumns::isNotInputColumnType($database_column->column_type))
+                @continue
+            @endif
+
             {{-- 通常の項目 --}}
-            @default
-                <div class="form-group row">
-                    <label class="col-sm-3 control-label">{{$database_column->column_name}} @if ($database_column->required)<label class="badge badge-danger">必須</label> @endif</label>
-                    <div class="col-sm-9">
-                        @include('plugins.user.databases.default.databases_input_' . $database_column->column_type,['database_obj' => $database_column])
-                        <div class="small {{ $database_column->caption_color }}">{!! nl2br($database_column->caption) !!}</div>
-                    </div>
+            <div class="form-group row">
+                <label class="col-sm-3 control-label">{{$database_column->column_name}} @if ($database_column->required)<label class="badge badge-danger">必須</label> @endif</label>
+                <div class="col-sm-9">
+                    @include('plugins.user.databases.default.databases_input_' . $database_column->column_type,['database_obj' => $database_column])
+                    <div class="small {{ $database_column->caption_color }}">{!! nl2br($database_column->caption) !!}</div>
                 </div>
-            @endswitch
+            </div>
         @endforeach
 
         {{-- 固定項目エリア --}}
@@ -71,6 +72,15 @@
                     </div>
                 </div>
                 @if ($errors && $errors->has('posted_at')) <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first('posted_at')}}</div> @endif
+            </div>
+        </div>
+
+        <div class="form-group row">
+            <label class="col-sm-3 control-label">表示順</label>
+            <div class="col-sm-9">
+                <input type="text" name="display_sequence" value="{{old('display_sequence', $inputs->display_sequence)}}" class="form-control">
+                <small class="text-muted">※ 未指定時は最後に表示されるように自動登録します。</small>
+                @if ($errors && $errors->has('display_sequence')) <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first('display_sequence')}}</div> @endif
             </div>
         </div>
 

--- a/resources/views/plugins/user/linklists/default/edit.blade.php
+++ b/resources/views/plugins/user/linklists/default/edit.blade.php
@@ -60,7 +60,7 @@
         <label class="col-md-2 control-label text-md-right">表示順</label>
         <div class="col-md-10">
             <input type="text" name="display_sequence" value="{{old('display_sequence', $post->display_sequence)}}" class="form-control">
-            <small class="text-muted">※ 未指定時は最後に追加されます。</small>
+            <small class="text-muted">※ 未指定時は最後に表示されるように自動登録します。</small>
             @if ($errors && $errors->has('display_sequence')) <div class="text-danger">{{$errors->first('display_sequence')}}</div> @endif
         </div>
     </div>


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

機能追加です。

## 対応内容

* DBカラムに表示順型（表示のみ）追加
* ソート条件に表示順（昇順・降順）追加
* CSVダウンロードに表示順追加
* CSVインポートに表示順対応

## 画面
### 一覧表示の並べ替えに表示順（昇順・降順）追加
![image](https://user-images.githubusercontent.com/2756509/92865572-7450ff80-f439-11ea-9da5-86921ac600b5.png)

### 表示設定に表示順（昇順・降順）追加

![image](https://user-images.githubusercontent.com/2756509/92865994-f7725580-f439-11ea-81c3-c1b00ff5f4d0.png)

### 項目設定に表示順型（表示のみ）を追加
![image](https://user-images.githubusercontent.com/2756509/92865825-c6922080-f439-11ea-927e-6b75cc5c1a3c.png)

## 主なcommits

* database plugin
  * add: database plugin, 表示順追加
  * add: database plugin, DBカラムに表示順型（表示のみ）追加
  * add: database plugin, ソート条件に表示順（昇順・降順）追加
  * add: database plugin, CSVダウンロードに表示順追加
  * add: database plugin, CSVインポートに表示順追加
  * change: database plugin, 表示設定の決定ボタンに、#frame-XXX アンカー追加
  * bugfix: database plugin, CSVのみでインポート時、ファイル型に値があると入力エラーになっていたのを無視するように修正
* link plugin
  * change: links plugin, 表示順のヘルプメッセージ修正

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/547

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

有り

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
