### PR TITLE
【データベース】新着、データベースプラグインの表示設定に絞り込み条件を考慮して、表示しないようにする対応

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -2093,8 +2093,6 @@ class DatabasesPlugin extends UserPluginBase
      */
     public function updateColumnDetail($request, $page_id, $frame_id)
     {
-        $column = DatabasesColumns::where('id', $request->column_id)->first();
-
         $validator_values = null;
         $validator_attributes = null;
 
@@ -2170,6 +2168,9 @@ class DatabasesPlugin extends UserPluginBase
                     ->where('title_flag', 1)
                     ->update(['title_flag' => 0]);
         }
+
+        // bugfix: 更新データは上記update後に取得しないと、title_flagが更新されない不具合対応
+        $column = DatabasesColumns::where('id', $request->column_id)->first();
 
         // タイトル指定
         $column->title_flag = $title_flag;

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3585,6 +3585,17 @@ class DatabasesPlugin extends UserPluginBase
         // 戻り値('sql_method'、link_pattern'、'link_base')
         // 新着側でユニオンしてるため、selectで指定する項目は全必須。プラグイン側にない項目はNULLで返す。
 
+        // 全ての「カラム」と「表示設定の絞り込み条件」の取得
+        $columns = DatabasesTool::getDatabasesColumnsAndFilterSearchAll();
+        $columns = $columns->get();
+
+        // 権限によって非表示columのdatabases_columns_id配列を取得する（各データベースの項目毎で権限によって非表示）
+        $hide_columns_ids = (new DatabasesTool())->getHideColumnsIds($columns, 'list_detail_display_flag');
+
+        // 各データベースのフレームの表示設定
+        $databases_frames_settings = DatabasesTool::getDatabasesFramesSettings($columns);
+
+
 /*
 SELECT
     frames.page_id                as page_id,
@@ -3614,7 +3625,7 @@ AND databases_inputs.posted_at <= NOW()
 ;
 */
         // データ詳細の取得
-        $return[] = DatabasesInputs::select(
+        $inputs_query = DatabasesInputs::select(
             'frames.page_id                as page_id',
             'frames.id                     as frame_id',
             'databases_inputs.id           as post_id,',
@@ -3628,9 +3639,11 @@ AND databases_inputs.posted_at <= NOW()
         )
                 ->join('databases', 'databases.id', '=', 'databases_inputs.databases_id')
                 ->join('frames', 'frames.bucket_id', '=', 'databases.bucket_id')
-                ->leftJoin('databases_columns', function ($leftJoin) {
+                ->leftJoin('databases_columns', function ($leftJoin) use ($hide_columns_ids) {
                     $leftJoin->on('databases_inputs.databases_id', '=', 'databases_columns.databases_id')
-                                ->where('databases_columns.title_flag', 1);
+                                ->where('databases_columns.title_flag', 1)
+                                // タイトル指定しても、権限によって非表示columだったらvalue表示しない（基本的に、タイトル指定したけど権限で非表示は、設定ミスと思う。その時は(無題)で表示される）
+                                ->whereNotIn('databases_columns.id', $hide_columns_ids);
                 })
                 ->leftJoin('databases_input_cols', function ($leftJoin) {
                     $leftJoin->on('databases_inputs.id', '=', 'databases_input_cols.databases_inputs_id')
@@ -3639,6 +3652,15 @@ AND databases_inputs.posted_at <= NOW()
                 ->where('databases_inputs.status', 0)
                 ->where('databases_inputs.posted_at', '<=', Carbon::now());
 
+        // 全データベースの検索キーワードの絞り込み と カラムの絞り込み
+        $inputs_query = DatabasesTool::appendSearchKeywordAndSearchColumnsAllDb(
+            'databases_inputs.id',
+            $inputs_query,
+            $databases_frames_settings,
+            $hide_columns_ids
+        );
+
+        $return[] = $inputs_query;
         $return[] = 'show_page_frame_post';
         $return[] = '/plugin/databases/detail';
 


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

[【データベース】表示設定に絞り込み条件を追加](https://github.com/opensource-workshop/connect-cms/issues/549) 対応に伴う 「新着」 対応です。

## 主なcommits

* add: database plugin, 新着でデータベースの表示設定による絞り込み設定に対応
* add: database plugin, 新着でタイトル指定しても、権限によって非表示columだったらvalue表示しない 
* change: database serches plugin, データベースの新着で使うメソッドの共通化（getDatabasesColumnsAndFilterSearchAll()、getDatabasesFramesSettings(), appendSearchKeywordAndSearchColumnsAllDb()）
* bugfix: database plugin, 設定でタイトル指定のチェックが更新時に外れる不具合修正

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/pull/554
https://github.com/opensource-workshop/connect-cms/pull/553

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

無し

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
