### PR TITLE
add: forms plugin, フォーム選択画面にデータ保存状態を表示

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -574,14 +574,11 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
                             ->where('frames.id', $frame_id)->first();
 
         // データ取得（1ページの表示件数指定）
-        // $plugins = DB::table($plugin_name)
-        //                ->select($plugin_name . '.*', $plugin_name . '.' . $plugin_name . '_name as plugin_bucket_name')
-        //                ->orderBy('created_at', 'desc')
-        //                ->paginate(10, ["*"], "frame_{$frame_id}_page");
         $plugins = DB::table($plugin_name)
                         ->select(
                             $plugin_name . '.id',
                             $plugin_name . '.bucket_id',
+                            $plugin_name . '.data_save_flag',
                             $plugin_name . '.created_at',
                             $plugin_name . '.' . $plugin_name . '_name as plugin_bucket_name',
                             DB::raw('count(forms_inputs.forms_id) as entry_count')
@@ -590,6 +587,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
                         ->groupBy(
                             $plugin_name . '.id',
                             $plugin_name . '.bucket_id',
+                            $plugin_name . '.data_save_flag',
                             $plugin_name . '.created_at',
                             $plugin_name . '.' . $plugin_name . '_name',
                             'forms_inputs.forms_id'

--- a/resources/views/plugins/user/forms/default/forms_datalist.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_datalist.blade.php
@@ -69,6 +69,7 @@
                     <th></th>
                     <th>{{$frame->plugin_name_full}}名</th>
                     <th>件数</th>
+                    <th>データ保存</th>
                     <th>詳細</th>
                     <th>作成日</th>
                 </tr>
@@ -79,6 +80,7 @@
                     <td nowrap><input type="radio" value="{{$plugin->bucket_id}}" name="select_bucket"@if ($plugin_frame->bucket_id == $plugin->bucket_id) checked @endif></td>
                     <td nowrap>{{$plugin->plugin_bucket_name}}</td>
                     <td nowrap class="text-right">{{$plugin->entry_count}}</td>
+                    <td nowrap>@if ($plugin->data_save_flag) 保存する @else 保存しない @endif</td>
                     <td nowrap>
                         <button class="btn btn-success btn-sm mr-1" type="button" onclick="location.href='{{url('/')}}/plugin/forms/editBuckets/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}'">
                             <i class="far fa-edit"></i> 設定変更


### PR DESCRIPTION
## 概要（Overview）
変更するに至った背景や目的、及び、変更内容

機能追加です。
フォーム選択画面に件数を表示した事で、データが登録されてるか、されていないか不明瞭になったため、
データ保存状態を表示するようにしました。

## 画面
### フォーム選択画面
![image](https://user-images.githubusercontent.com/2756509/93308188-e90eaa00-f83c-11ea-946d-a1ef5a36c693.png)

## 関連Pull requests/Issues（Links to related pull requests or issues）
関連するPR、Issuseがあればそのリンク

https://github.com/opensource-workshop/connect-cms/issues/561

## 参考（Reference）
レビューするに当たって参考にできる情報があればそのリンク

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

無し

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
