### PR TITLE
change: 【フォーム】申し込み人数制限オーバー時のメッセージを変更できるように対応

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -258,7 +258,8 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
 
             // 登録制限数オーバーか
             if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
-                $setting_error_messages[] = '制限数に達したため登録を終了しました。';
+                // $setting_error_messages[] = '制限数に達したため登録を終了しました。';
+                $setting_error_messages[] = $form->entry_limit_over_message;
             }
         } else {
             // フレームに紐づくフォーム親データがない場合
@@ -1016,6 +1017,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
         // フォーム設定
         $forms->forms_name          = $request->forms_name;
         $forms->entry_limit         = $request->entry_limit;
+        $forms->entry_limit_over_message = $request->entry_limit_over_message;
         $forms->mail_send_flag      = (empty($request->mail_send_flag))      ? 0 : $request->mail_send_flag;
         $forms->mail_send_address   = $request->mail_send_address;
         $forms->user_mail_send_flag = (empty($request->user_mail_send_flag)) ? 0 : $request->user_mail_send_flag;

--- a/database/migrations/2020_09_28_110707_add_entry_limit_over_message_to_forms.php
+++ b/database/migrations/2020_09_28_110707_add_entry_limit_over_message_to_forms.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEntryLimitOverMessageToForms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->text('entry_limit_over_message')->nullable()->comment('登録制限越えのメッセージ')->after('entry_limit');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('entry_limit_over_message');
+        });
+    }
+}

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -78,6 +78,14 @@
     </div>
 
     <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}"></label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <label class="control-label">登録制限越えのメッセージ</label>
+            <textarea name="entry_limit_over_message" class="form-control" rows=5 placeholder="（例）制限数に達したため登録を終了しました。">{{old('entry_limit_over_message', $form->entry_limit_over_message)}}</textarea>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">メール送信先</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-checkbox">

--- a/resources/views/plugins/user/forms/default/forms_error_messages.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_error_messages.blade.php
@@ -7,7 +7,7 @@
 <div class="card border-danger">
     <div class="card-body">
         @foreach ($error_messages as $error_message)
-            <p class="text-center cc_margin_bottom_0">{{ $error_message }}</p>
+            <p class="text-center cc_margin_bottom_0">{!! nl2br(e($error_message)) !!}</p>
         @endforeach
     </div>
 </div>


### PR DESCRIPTION
## 概要（Overview）
<!-- 変更するに至った背景や目的、及び、変更内容 -->

機能変更です。
詳細は https://github.com/opensource-workshop/connect-cms/issues/573 を参照してください。

## 画面
### フォーム設定画面
![image](https://user-images.githubusercontent.com/2756509/94384274-1fbdbc00-017d-11eb-9384-982a0b13e060.png)

### 登録制限越え時
![image](https://user-images.githubusercontent.com/2756509/94384295-3106c880-017d-11eb-9109-20b95d6f3d61.png)


## 主なcommits

* change: 【フォーム】申し込み人数制限オーバー時のメッセージを変更できるように対応

## 関連Pull requests/Issues（Links to related pull requests or issues）
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考（Reference）
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

有り 

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
