### PR TITLE
メニューの「親子のみ」テンプレートの修正

### DIFF
--- a/resources/views/plugins/user/menus/parentsandchild/menus.blade.php
+++ b/resources/views/plugins/user/menus/parentsandchild/menus.blade.php
@@ -32,7 +32,11 @@
             @if($page_obj->parent_id == null)
                 {{-- 非表示のページは対象外 --}}
                 @if ($page_obj->isView(Auth::user(), false, true, $page_roles))
+                    @if ($page_obj->id == $page_id)
+                    <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item active">{{$page_obj->page_name}}</a>
+                    @else
                     <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item">{{$page_obj->page_name}}</a>
+                    @endif
                     @if (isset($page_obj->children))
                         {{-- 子要素を再帰的に表示するため、別ファイルに分けてinclude --}}
                         @include('plugins.user.menus.parentsandchild.menu_children',['children' => $page_obj->children])


### PR DESCRIPTION
親にActive クラスが抜けていた。

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>
無し
