### PR TITLE
【フォーム】申し込みフォーム表示期間の設定（開始～終了）機能追加

### DIFF
--- a/app/Models/User/Forms/Forms.php
+++ b/app/Models/User/Forms/Forms.php
@@ -11,11 +11,21 @@ class Forms extends Model
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
 
+    // Carbonインスタンス（日付）に自動的に変換
+    protected $dates = [
+        'display_from',
+        'display_to',
+    ];
+
     // 更新する項目の定義
     protected $fillable = [
         'bucket_id',
         'forms_name',
         'entry_limit',
+        'entry_limit_over_message',
+        'display_control_flag',
+        'display_from',
+        'display_to',
         'mail_send_flag',
         'mail_send_address',
         'user_mail_send_flag',

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -992,6 +992,8 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
         $validator_attributes['data_save_flag'] = 'データを保存する';
         $validator_attributes['user_mail_send_flag'] = '登録者にメール送信する';
         $validator_attributes['temporary_regist_mail_format'] = '仮登録メールフォーマット';
+        $validator_attributes['display_from'] = '表示開始日時';
+        $validator_attributes['display_to'] = '表示終了日時';
 
         $messages = [
             'data_save_flag.accepted' => '仮登録メールを送信する場合、:attributeにチェックを付けてください。',
@@ -1015,6 +1017,11 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
         $validator->sometimes("temporary_regist_mail_format", 'regex:/\[\[entry_url\]\]/', function ($input) {
             // 仮登録メールがONなら、上記の 登録者にメール送信する ONであること
             return $input->use_temporary_regist_mail_flag;
+        });
+
+        $validator->sometimes("display_from", 'before:display_to', function ($input) {
+            // 表示期間のFrom Toが両方入力ありなら、上記の 表示期間のFrom が To より前であること
+            return $input->display_from && $input->display_to;
         });
 
         // エラーがあった場合は入力画面に戻る。

--- a/database/migrations/2020_09_28_143806_add_display_control_to_forms.php
+++ b/database/migrations/2020_09_28_143806_add_display_control_to_forms.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDisplayControlToForms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->integer('display_control_flag')->default(0)->comment('表示期間の制御')->after('entry_limit_over_message');
+            $table->dateTime('display_from')->nullable()->comment('表示期間開始日時')->after('display_control_flag');
+            $table->dateTime('display_to')->nullable()->comment('表示期間終了日時')->after('display_from');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('display_control_flag');
+            $table->dropColumn('display_from');
+            $table->dropColumn('display_to');
+        });
+    }
+}

--- a/resources/views/common/errors_form_line.blade.php
+++ b/resources/views/common/errors_form_line.blade.php
@@ -1,4 +1,4 @@
-@if (count($errors) > 0)
+@if ($errors && count($errors) > 0)
     <!-- Form Error List -->
     <div class="alert alert-danger">
         <strong>エラーがあります。</strong>

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -14,6 +14,8 @@
 
 @section("plugin_setting_$frame->id")
 
+@include('common.errors_form_line')
+
 <script>
     $(function () {
         /**
@@ -125,7 +127,7 @@
         <label class="{{$frame->getSettingLabelClass(true)}} pt-0"></label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
-                <label>開始日時</label>
+                <label>表示開始日時</label>
 
                 <div class="input-group" id="display_from{{$frame_id}}" data-target-input="nearest">
                     <input class="form-control datetimepicker-input" type="text" name="display_from" value="{{old('display_from', $form->display_from)}}" data-target="#display_from{{$frame_id}}">
@@ -143,7 +145,7 @@
                 @endif
             </div>
             <div class="col pl-0">
-                <label>終了日時</label>
+                <label>表示終了日時</label>
 
                 <div class="input-group" id="display_to{{$frame_id}}" data-target-input="nearest">
                     <input class="form-control datetimepicker-input" type="text" name="display_to" value="{{old('display_to', $form->display_to)}}" data-target="#display_to{{$frame_id}}">

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -138,7 +138,7 @@
 
                 <small class="text-muted">
                     ※ 未入力の場合、開始日時で表示制限しません。<br>
-                    ※ 開始日時になった瞬間に表示開始します。例えば14:00の場合、14:00に公開します。
+                    ※ 開始日時になった瞬間に公開します。例えば14:00の場合、14:00に公開します。
                 </small>
                 @if ($errors && $errors->has('display_from'))
                     <div class="text-danger">{{$errors->first('display_from')}}</div>

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -13,6 +13,25 @@
 @endsection
 
 @section("plugin_setting_$frame->id")
+
+<script>
+    $(function () {
+        /**
+         * カレンダーボタン押下
+         */
+        $('#display_from{{$frame_id}}').datetimepicker({
+            format: 'YYYY-MM-DD HH:mm',
+            dayViewHeaderFormat: 'YYYY MMM',
+            sideBySide: true,
+        });
+        $('#display_to{{$frame_id}}').datetimepicker({
+            format: 'YYYY-MM-DD HH:mm',
+            dayViewHeaderFormat: 'YYYY MMM',
+            sideBySide: true,
+        });
+    });
+</script>
+
 @if (!$form->id && !$create_flag)
     <div class="alert alert-warning mt-2">
         <i class="fas fa-exclamation-circle"></i>
@@ -82,6 +101,65 @@
         <div class="{{$frame->getSettingInputClass()}}">
             <label class="control-label">登録制限越えのメッセージ</label>
             <textarea name="entry_limit_over_message" class="form-control" rows=5 placeholder="（例）制限数に達したため登録を終了しました。">{{old('entry_limit_over_message', $form->entry_limit_over_message)}}</textarea>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}} pt-0">表示期間</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="col pl-0">
+                <label>表示期間の制御</label><br>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="1" id="display_control_flag_1" name="display_control_flag" class="custom-control-input" @if(old('display_control_flag', $form->display_control_flag) == 1) checked="checked" @endif>
+                    <label class="custom-control-label" for="display_control_flag_1">表示期間で制御する</label>
+                </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="0" id="display_control_flag_0" name="display_control_flag" class="custom-control-input" @if(old('display_control_flag', $form->display_control_flag) == 0) checked="checked" @endif>
+                    <label class="custom-control-label" for="display_control_flag_0">表示期間で制御しない</label>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}} pt-0"></label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="col pl-0">
+                <label>開始日時</label>
+
+                <div class="input-group" id="display_from{{$frame_id}}" data-target-input="nearest">
+                    <input class="form-control datetimepicker-input" type="text" name="display_from" value="{{old('display_from', $form->display_from)}}" data-target="#display_from{{$frame_id}}">
+                    <div class="input-group-append" data-target="#display_from{{$frame_id}}" data-toggle="datetimepicker">
+                        <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                    </div>
+                </div>
+
+                <small class="text-muted">
+                    ※ 未入力の場合、開始日時で表示制限しません。<br>
+                    ※ 開始日時になった瞬間に表示開始します。例えば14:00の場合、14:00に公開します。
+                </small>
+                @if ($errors && $errors->has('display_from'))
+                    <div class="text-danger">{{$errors->first('display_from')}}</div>
+                @endif
+            </div>
+            <div class="col pl-0">
+                <label>終了日時</label>
+
+                <div class="input-group" id="display_to{{$frame_id}}" data-target-input="nearest">
+                    <input class="form-control datetimepicker-input" type="text" name="display_to" value="{{old('display_to', $form->display_to)}}" data-target="#display_to{{$frame_id}}">
+                    <div class="input-group-append" data-target="#display_to{{$frame_id}}" data-toggle="datetimepicker">
+                        <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                    </div>
+                </div>
+
+                <small class="text-muted">
+                    ※ 未入力の場合、終了日時で表示制限しません。<br>
+                    ※ 終了日時になった瞬間に表示終了します。例えば15:00の場合、14:59まで表示します。
+                </small>
+                @if ($errors && $errors->has('display_to'))
+                    <div class="text-danger">{{$errors->first('display_to')}}</div>
+                @endif
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## 概要（Overview）
<!-- 変更するに至った背景や目的、及び、変更内容 -->

機能追加です。
本登録・仮登録どちらでも、初期表示、確認画面、登録時に表示期間チェックを行い、期間外であれば表示しません。
また、フォーム設定画面の設定が増え、エラーが目立たなくなってきたため、共通部品`@include('common.errors_form_line')`で画面上部にエラーがある旨を表示するようにしました。

## 画面
### フォーム設定画面
![image](https://user-images.githubusercontent.com/2756509/94402693-53154080-01a7-11eb-8690-d4936298e41d.png)

### フォーム設定画面 入力エラー時
![image](https://user-images.githubusercontent.com/2756509/94403121-ec445700-01a7-11eb-9f6a-99623ed5d74f.png)

### 登録期間外（登録不可）
![image](https://user-images.githubusercontent.com/2756509/94402883-940d5500-01a7-11eb-960c-5fec4357970d.png)

### 参考：登録期間内（登録可）
![image](https://user-images.githubusercontent.com/2756509/94402747-69bb9780-01a7-11eb-8c60-b87fafe32f69.png)


## 主なCommits

* add: 【フォーム】申し込みフォーム表示期間の設定（開始～終了）機能追加
* bugfix: core, errors_form_line.blade, エラー無い場合、例外がでるため修正
* add: form, 表示期間FromToでバリデーション追加（FromがToを越えたらエラー）

## 関連Pull requests/Issues（Links to related pull requests or issues）
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/591

## 参考（Reference）
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

有り

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
