### PR TITLE
add: 【フォーム】申し込み可能期間の設定（開始～終了）機能追加

### DIFF
--- a/app/Models/User/Forms/Forms.php
+++ b/app/Models/User/Forms/Forms.php
@@ -15,6 +15,8 @@ class Forms extends Model
     protected $dates = [
         'display_from',
         'display_to',
+        'regist_from',
+        'regist_to',
     ];
 
     // 更新する項目の定義
@@ -26,6 +28,9 @@ class Forms extends Model
         'display_control_flag',
         'display_from',
         'display_to',
+        'regist_control_flag',
+        'regist_from',
+        'regist_to',
         'mail_send_flag',
         'mail_send_address',
         'user_mail_send_flag',

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -261,10 +261,21 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
                 return false;
             }
 
+            // 登録期間外か
+            if ($this->isOutOfTermRegist($form)) {
+                // エラー画面へ
+                return $this->view('forms_error_messages', [
+                    'error_messages' => ['登録期間外のため、登録出来ません。'],
+                ]);
+            }
+
             // 登録制限数オーバーか
             if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
                 // $setting_error_messages[] = '制限数に達したため登録を終了しました。';
-                $setting_error_messages[] = $form->entry_limit_over_message;
+                // エラー画面へ
+                return $this->view('forms_error_messages', [
+                    'error_messages' => [$form->entry_limit_over_message],
+                ]);
             }
         } else {
             // フレームに紐づくフォーム親データがない場合
@@ -327,6 +338,32 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
 
         // 値あり & 今日から見てToが過去か
         if ($form->display_to && $form->display_to->isPast()) {
+            // 期間外
+            return true;
+        }
+
+        // 期間内
+        return false;
+    }
+
+    /**
+     * 登録期間外か
+     */
+    private function isOutOfTermRegist($form)
+    {
+        if (! $form->regist_control_flag) {
+            // 制御フラグOFFなら、登録期間内として扱う
+            return false;
+        }
+
+        // 値あり & 今から見てFromが未来か
+        if ($form->regist_from && $form->regist_from->isFuture()) {
+            // 期間外
+            return true;
+        }
+
+        // 値あり & 今日から見てToが過去か
+        if ($form->regist_to && $form->regist_to->isPast()) {
             // 期間外
             return true;
         }
@@ -454,10 +491,20 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
             return false;
         }
 
+        // 登録期間外か
+        if ($this->isOutOfTermRegist($form)) {
+            // エラー画面へ
+            return $this->view('forms_error_messages', [
+                'error_messages' => ['登録期間外のため、登録出来ません。'],
+            ]);
+        }
+
         // 登録制限数オーバーか
         if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
-            // 初期画面へ遷移にして、それで同じ登録制限数オーバーチェックしてエラーメッセージ表示
-            return $this->index($request, $page_id, $frame_id);
+            // エラー画面へ
+            return $this->view('forms_error_messages', [
+                'error_messages' => [$form->entry_limit_over_message],
+            ]);
         }
 
         // フォームのカラムデータ
@@ -516,10 +563,20 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
             return false;
         }
 
+        // 登録期間外か
+        if ($this->isOutOfTermRegist($form)) {
+            // エラー画面へ
+            return $this->view('forms_error_messages', [
+                'error_messages' => ['登録期間外のため、登録出来ません。'],
+            ]);
+        }
+
         // 登録制限数オーバーか
         if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
-            // 初期画面へ遷移にして、それで同じ登録制限数オーバーチェックしてエラーメッセージ表示
-            return $this->index($request, $page_id, $frame_id);
+            // エラー画面へ
+            return $this->view('forms_error_messages', [
+                'error_messages' => [$form->entry_limit_over_message],
+            ]);
         }
 
         // forms_inputs 登録
@@ -673,10 +730,20 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
             return false;
         }
 
+        // 登録期間外か
+        if ($this->isOutOfTermRegist($form)) {
+            // エラー画面へ
+            return $this->view('forms_error_messages', [
+                'error_messages' => ['登録期間外のため、登録出来ません。'],
+            ]);
+        }
+
         // 登録制限数オーバーか
         if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
-            // 初期画面へ遷移にして、それで同じ登録制限数オーバーチェックしてエラーメッセージ表示
-            return $this->index($request, $page_id, $frame_id);
+            // エラー画面へ
+            return $this->view('forms_error_messages', [
+                'error_messages' => [$form->entry_limit_over_message],
+            ]);
         }
 
         // $id がなかったら、エラー画面へ
@@ -721,10 +788,20 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
             return false;
         }
 
+        // 登録期間外か
+        if ($this->isOutOfTermRegist($form)) {
+            // エラー画面へ
+            return $this->view('forms_error_messages', [
+                'error_messages' => ['登録期間外のため、登録出来ません。'],
+            ]);
+        }
+
         // 登録制限数オーバーか
         if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
-            // 初期画面へ遷移にして、それで同じ登録制限数オーバーチェックしてエラーメッセージ表示
-            return $this->index($request, $page_id, $frame_id);
+            // エラー画面へ
+            return $this->view('forms_error_messages', [
+                'error_messages' => [$form->entry_limit_over_message],
+            ]);
         }
 
         // $id がなかったら、エラー画面へ
@@ -994,6 +1071,8 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
         $validator_attributes['temporary_regist_mail_format'] = '仮登録メールフォーマット';
         $validator_attributes['display_from'] = '表示開始日時';
         $validator_attributes['display_to'] = '表示終了日時';
+        $validator_attributes['regist_from'] = '登録開始日時';
+        $validator_attributes['regist_to'] = '登録終了日時';
 
         $messages = [
             'data_save_flag.accepted' => '仮登録メールを送信する場合、:attributeにチェックを付けてください。',
@@ -1022,6 +1101,11 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
         $validator->sometimes("display_from", 'before:display_to', function ($input) {
             // 表示期間のFrom Toが両方入力ありなら、上記の 表示期間のFrom が To より前であること
             return $input->display_from && $input->display_to;
+        });
+
+        $validator->sometimes("regist_from", 'before:regist_to', function ($input) {
+            // 登録期間のFrom Toが両方入力ありなら、上記の 登録期間のFrom が To より前であること
+            return $input->regist_from && $input->regist_to;
         });
 
         // エラーがあった場合は入力画面に戻る。
@@ -1083,6 +1167,9 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
         $forms->display_control_flag = empty($request->display_control_flag) ? 0 : $request->display_control_flag;
         $forms->display_from        = empty($request->display_from) ? null : new \Carbon($request->display_from);
         $forms->display_to          = empty($request->display_to) ? null : new \Carbon($request->display_to);
+        $forms->regist_control_flag = empty($request->regist_control_flag) ? 0 : $request->regist_control_flag;
+        $forms->regist_from         = empty($request->regist_from) ? null : new \Carbon($request->regist_from);
+        $forms->regist_to           = empty($request->regist_to) ? null : new \Carbon($request->regist_to);
         $forms->mail_send_flag      = (empty($request->mail_send_flag))      ? 0 : $request->mail_send_flag;
         $forms->mail_send_address   = $request->mail_send_address;
         $forms->user_mail_send_flag = (empty($request->user_mail_send_flag)) ? 0 : $request->user_mail_send_flag;

--- a/database/migrations/2020_09_28_165505_add_regist_control_to_forms.php
+++ b/database/migrations/2020_09_28_165505_add_regist_control_to_forms.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddRegistControlToForms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->integer('regist_control_flag')->default(0)->comment('登録期間の制御')->after('display_to');
+            $table->dateTime('regist_from')->nullable()->comment('登録期間開始日時')->after('regist_control_flag');
+            $table->dateTime('regist_to')->nullable()->comment('登録期間終了日時')->after('regist_from');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('regist_control_flag');
+            $table->dropColumn('regist_from');
+            $table->dropColumn('regist_to');
+        });
+    }
+}

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -31,6 +31,16 @@
             dayViewHeaderFormat: 'YYYY MMM',
             sideBySide: true,
         });
+        $('#regist_from{{$frame_id}}').datetimepicker({
+            format: 'YYYY-MM-DD HH:mm',
+            dayViewHeaderFormat: 'YYYY MMM',
+            sideBySide: true,
+        });
+        $('#regist_to{{$frame_id}}').datetimepicker({
+            format: 'YYYY-MM-DD HH:mm',
+            dayViewHeaderFormat: 'YYYY MMM',
+            sideBySide: true,
+        });
     });
 </script>
 
@@ -160,6 +170,65 @@
                 </small>
                 @if ($errors && $errors->has('display_to'))
                     <div class="text-danger">{{$errors->first('display_to')}}</div>
+                @endif
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}} pt-0">登録期間</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="col pl-0">
+                <label>登録期間の制御</label><br>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="1" id="regist_control_flag_1" name="regist_control_flag" class="custom-control-input" @if(old('regist_control_flag', $form->regist_control_flag) == 1) checked="checked" @endif>
+                    <label class="custom-control-label" for="regist_control_flag_1">登録期間で制御する</label>
+                </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="0" id="regist_control_flag_0" name="regist_control_flag" class="custom-control-input" @if(old('regist_control_flag', $form->regist_control_flag) == 0) checked="checked" @endif>
+                    <label class="custom-control-label" for="regist_control_flag_0">登録期間で制御しない</label>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}} pt-0"></label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="col pl-0">
+                <label>登録開始日時</label>
+
+                <div class="input-group" id="regist_from{{$frame_id}}" data-target-input="nearest">
+                    <input class="form-control datetimepicker-input" type="text" name="regist_from" value="{{old('regist_from', $form->regist_from)}}" data-target="#regist_from{{$frame_id}}">
+                    <div class="input-group-append" data-target="#regist_from{{$frame_id}}" data-toggle="datetimepicker">
+                        <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                    </div>
+                </div>
+
+                <small class="text-muted">
+                    ※ 未入力の場合、開始日時で登録制限しません。<br>
+                    ※ 開始日時になった瞬間に登録開始します。例えば14:00の場合、14:00に登録開始します。
+                </small>
+                @if ($errors && $errors->has('regist_from'))
+                    <div class="text-danger">{{$errors->first('regist_from')}}</div>
+                @endif
+            </div>
+            <div class="col pl-0">
+                <label>登録終了日時</label>
+
+                <div class="input-group" id="regist_to{{$frame_id}}" data-target-input="nearest">
+                    <input class="form-control datetimepicker-input" type="text" name="regist_to" value="{{old('regist_to', $form->regist_to)}}" data-target="#regist_to{{$frame_id}}">
+                    <div class="input-group-append" data-target="#regist_to{{$frame_id}}" data-toggle="datetimepicker">
+                        <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                    </div>
+                </div>
+
+                <small class="text-muted">
+                    ※ 未入力の場合、終了日時で登録制限しません。<br>
+                    ※ 終了日時になった瞬間に登録終了します。例えば15:00の場合、14:59まで登録できます。
+                </small>
+                @if ($errors && $errors->has('regist_to'))
+                    <div class="text-danger">{{$errors->first('regist_to')}}</div>
                 @endif
             </div>
         </div>


### PR DESCRIPTION
## 概要（Overview）
<!-- 変更するに至った背景や目的、及び、変更内容 -->

機能追加です。
本登録・仮登録どちらでも、初期表示、確認画面、登録時に登録期間チェックを行い、期間外であれば登録できません。

## 画面
### フォーム設定画面
![image](https://user-images.githubusercontent.com/2756509/94409362-07679480-01b1-11eb-904e-b35655647b36.png)

### 登録期間外
![image](https://user-images.githubusercontent.com/2756509/94409401-13ebed00-01b1-11eb-9123-9a4e0e938342.png)


## 主なCommits

* add: 【フォーム】申し込み可能期間の設定（開始～終了）機能追加
* change: form, 登録制限数オーバーチェックは、indexに飛ばさず、直接エラー画面を表示するように見直し
* change: form, indexの登録制限数オーバーチェックは、エラーなら、すぐにエラー画面を表示するように修正

## 関連Pull requests/Issues（Links to related pull requests or issues）
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/596

## 参考（Reference）
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無（Whether DB is modified）
Pull requestsにマイグレーションの追加があるか<br>

有り

## チェックリスト（Checklist）
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
