### PR TITLE
【フォーム】getパラメータ指定による初期入力値の設定 他1件

### DIFF
--- a/resources/views/plugins/user/forms/default/forms_input_checkbox.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_checkbox.blade.php
@@ -20,22 +20,25 @@
             // チェック用変数
             $column_checkbox_checked = "";
 
-            // old でチェックされていたもの
-            if (!empty(old('forms_columns_value.'.$form_obj->id))) {
-                foreach(old('forms_columns_value.'.$form_obj->id) as $old_value) {
-                    if ( $old_value == $select['value'] ) {
-                        $column_checkbox_checked = " checked";
+            // リクエストした自フレームのみ処理
+            if ($frame_id == $request->frame_id) {
+                // old でチェックされていたもの
+                if (!empty(old('forms_columns_value.'.$form_obj->id))) {
+                    foreach(old('forms_columns_value.'.$form_obj->id) as $old_value) {
+                        if ( $old_value == $select['value'] ) {
+                            $column_checkbox_checked = " checked";
+                        }
                     }
                 }
-            }
 
-            // 画面が戻ってきたもの
-            if (isset($request->forms_columns_value) &&
-                array_key_exists($form_obj->id, $request->forms_columns_value)) {
+                // 画面が戻ってきたもの
+                if (isset($request->forms_columns_value) &&
+                    array_key_exists($form_obj->id, $request->forms_columns_value)) {
 
-                foreach($request->forms_columns_value[$form_obj->id] as $request_value) {
-                    if ( $request_value == $select['value'] ) {
-                        $column_checkbox_checked = " checked";
+                    foreach($request->forms_columns_value[$form_obj->id] as $request_value) {
+                        if ( $request_value == $select['value'] ) {
+                            $column_checkbox_checked = " checked";
+                        }
                     }
                 }
             }

--- a/resources/views/plugins/user/forms/default/forms_input_date.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_date.blade.php
@@ -4,12 +4,12 @@
  * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
- --}}
+--}}
 <script>
     /**
      * カレンダーボタン押下
      */
-     $(function () {
+    $(function () {
         $('#{{ $form_obj->id }}').datetimepicker({
             @if (App::getLocale() == ConnectLocale::ja)
                 dayViewHeaderFormat: 'YYYY年 M月',
@@ -25,7 +25,7 @@
         <input 
             type="text" 
             name="forms_columns_value[{{ $form_obj->id }}]" 
-            value="{{old('forms_columns_value.'.$form_obj->id)}}"
+            value="@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif"
             class="form-control datetimepicker-input" 
             data-target="#{{ $form_obj->id }}"
         >

--- a/resources/views/plugins/user/forms/default/forms_input_mail.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_mail.blade.php
@@ -4,8 +4,8 @@
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
- --}}
- <input 
+--}}
+<input 
     name="forms_columns_value[{{$form_obj->id}}]" 
     class="form-control" 
     type="{{$form_obj->column_type}}" 

--- a/resources/views/plugins/user/forms/default/forms_input_radio.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_radio.blade.php
@@ -4,7 +4,7 @@
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
- --}}
+--}}
 @if (array_key_exists($form_obj->id, $forms_columns_id_select))
     @php
         // グループカラムの幅の計算
@@ -17,15 +17,23 @@
         @foreach($forms_columns_id_select[$form_obj->id] as $select)
 
             <div class="custom-control custom-radio custom-control-inline">
-                @if (old('forms_columns_value.'.$form_obj->id) == $select['value'] ||
-                     (isset($request->forms_columns_value) &&
-                      array_key_exists($form_obj->id, $request->forms_columns_value) &&
-                      $request->forms_columns_value[$form_obj->id] == $select['value'])
-                )
-                <input type="radio" id="forms_columns_value[{{$form_obj->id}}]_{{$loop->iteration}}" name="forms_columns_value[{{$form_obj->id}}]" value="{{$select['value']}}" class="custom-control-input" checked>
-            @else
-                <input type="radio" id="forms_columns_value[{{$form_obj->id}}]_{{$loop->iteration}}" name="forms_columns_value[{{$form_obj->id}}]" value="{{$select['value']}}" class="custom-control-input">
-            @endif
+                @php
+                // ラジオ用変数
+                $column_radio_checked = "";
+
+                // リクエストした自フレームのみ処理
+                if ($frame_id == $request->frame_id) {
+                    if (old('forms_columns_value.'.$form_obj->id) == $select['value'] ||
+                        (isset($request->forms_columns_value) &&
+                        array_key_exists($form_obj->id, $request->forms_columns_value) &&
+                        $request->forms_columns_value[$form_obj->id] == $select['value'])
+                    ) {
+                        $column_radio_checked = " checked";
+                    }
+                }
+                @endphp
+
+                <input type="radio" id="forms_columns_value[{{$form_obj->id}}]_{{$loop->iteration}}" name="forms_columns_value[{{$form_obj->id}}]" value="{{$select['value']}}" class="custom-control-input" {{$column_radio_checked}}>
                 <label class="custom-control-label" for="forms_columns_value[{{$form_obj->id}}]_{{$loop->iteration}}">{{$select['value']}}</label>
             </div>
 

--- a/resources/views/plugins/user/forms/default/forms_input_select.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_select.blade.php
@@ -4,7 +4,7 @@
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
- --}}
+--}}
 @if (array_key_exists($form_obj->id, $forms_columns_id_select))
     @php
         // グループカラムの幅の計算
@@ -16,16 +16,23 @@
     <select id="forms_columns_value[{{$form_obj->id}}]_{{$loop->iteration}}" name="forms_columns_value[{{$form_obj->id}}]" class="custom-select">
         <option value=""></option>
         @foreach($forms_columns_id_select[$form_obj->id] as $select)
+            @php
+            // セレクトボックス用変数
+            $column_selected = "";
 
-            @if (old('forms_columns_value.'.$form_obj->id) == $select['value'] ||
-                 (isset($request->forms_columns_value) &&
-                  array_key_exists($form_obj->id, $request->forms_columns_value) &&
-                  $request->forms_columns_value[$form_obj->id] == $select['value'])
-            )
-                <option value="{{$select['value']}}" selected>{{$select['value']}}</option>
-            @else
-                <option value="{{$select['value']}}">{{$select['value']}}</option>
-            @endif
+            // リクエストした自フレームのみ処理
+            if ($frame_id == $request->frame_id) {
+                if (old('forms_columns_value.'.$form_obj->id) == $select['value'] ||
+                    (isset($request->forms_columns_value) &&
+                    array_key_exists($form_obj->id, $request->forms_columns_value) &&
+                    $request->forms_columns_value[$form_obj->id] == $select['value'])
+                ) {
+                    $column_selected = " selected";
+                }
+            }
+            @endphp
+
+            <option value="{{$select['value']}}" {{$column_selected}}>{{$select['value']}}</option>
         @endforeach
     </select>
     @if ($errors && $errors->has("forms_columns_value.$form_obj->id"))

--- a/resources/views/plugins/user/forms/default/forms_input_text.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_text.blade.php
@@ -4,7 +4,7 @@
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
- --}}
+--}}
 <input name="forms_columns_value[{{$form_obj->id}}]" class="form-control" type="{{$form_obj->column_type}}" value="@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif">
 @if ($errors && $errors->has("forms_columns_value.$form_obj->id"))
     <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first("forms_columns_value.$form_obj->id")}}</div>

--- a/resources/views/plugins/user/forms/default/forms_input_textarea.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_textarea.blade.php
@@ -5,7 +5,7 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
  --}}
-<textarea rows="4" name="forms_columns_value[{{$form_obj->id}}]" class="form-control">{{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}</textarea>
+<textarea rows="4" name="forms_columns_value[{{$form_obj->id}}]" class="form-control">@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif</textarea>
 @if ($errors && $errors->has("forms_columns_value.$form_obj->id"))
     <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first("forms_columns_value.$form_obj->id")}}</div>
 @endif

--- a/resources/views/plugins/user/forms/default/forms_input_time.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_time.blade.php
@@ -4,12 +4,12 @@
  * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
- --}}
+--}}
 <script>
     /**
      * 時間カレンダーボタン押下
      */
-     $(function () {
+    $(function () {
         $('#{{ $form_obj->id }}').datetimepicker({
             tooltips: {
                 close: '閉じる',
@@ -35,7 +35,7 @@
         <input 
             type="text" 
             name="forms_columns_value[{{ $form_obj->id }}]" 
-            value="{{old('forms_columns_value.'.$form_obj->id)}}"
+            value="@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif"
             class="form-control datetimepicker-input" 
             data-target="#{{ $form_obj->id }}"
         >

--- a/resources/views/plugins/user/forms/default/forms_input_time_from_to.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_time_from_to.blade.php
@@ -4,12 +4,12 @@
  * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
- --}}
- <script>
+--}}
+<script>
     /**
      * 時間Fromカレンダーボタン押下
      */
-     $(function () {
+    $(function () {
         $('#{{ $form_obj->id }}_from').datetimepicker({
             tooltips: {
                 close: '閉じる',
@@ -33,7 +33,7 @@
     /**
      * 時間Toカレンダーボタン押下
      */
-     $(function () {
+    $(function () {
         $('#{{ $form_obj->id }}_to').datetimepicker({
             tooltips: {
                 close: '閉じる',
@@ -61,7 +61,7 @@
             <input 
                 type="text" 
                 name="forms_columns_value_for_time_from[{{ $form_obj->id }}]" 
-                value="{{old('forms_columns_value_for_time_from.'.$form_obj->id)}}"
+                value="@if ($frame_id == $request->frame_id){{old('forms_columns_value_for_time_from.'.$form_obj->id, $request->forms_columns_value_for_time_from[$form_obj->id])}}@endif"
                 class="form-control datetimepicker-input" 
                 data-target="#{{ $form_obj->id }}_from"
             >
@@ -77,7 +77,7 @@
             <input 
                 type="text" 
                 name="forms_columns_value_for_time_to[{{ $form_obj->id }}]" 
-                value="{{old('forms_columns_value_for_time_to.'.$form_obj->id)}}"
+                value="@if ($frame_id == $request->frame_id){{old('forms_columns_value_for_time_to.'.$form_obj->id, $request->forms_columns_value_for_time_to[$form_obj->id])}}@endif"
                 class="form-control datetimepicker-input" 
                 data-target="#{{ $form_obj->id }}_to"
             >


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

URLにフォームの項目名のgetパラメータを追加すると、フォームの初期値に値が設定される機能追加です。

### URL例

http://example.com/plugin/forms/index/2712/9509?日付=2020/09/29&数値=1&メール=xxxx&複数行=zzzz&単一=単１&複数選択=赤,青&リスト=B&時間=11:00&時間FromTo=11:50~12:00#frame-9509

※ 同一名の項目があったら、同じ値が設定されます。
※ 複数選択は、(,)カンマ区切りで複数指定できます。
※ 時間型FromToは、(～又は~)区切りでFromTo指定できます。
※ getパラメータで日付の時の/入力、問題なしです。（上記URLだと`日付=2020/09/29`の部分）

### そのURLのフォーム初期画面
![image](https://user-images.githubusercontent.com/2756509/94881657-fb295300-04a0-11eb-844f-4fb624807f48.png)


## 主なcommits

* add: form, getパラメータ指定による初期入力値の設定 https://github.com/opensource-workshop/connect-cms/issues/599
* bugfix: form, 1ページに複数フォームを配置し、1個のフォームで登録を行うと、リクエストが1個目しかなく、他フォームでリクエス https://github.com/opensource-workshop/connect-cms/issues/603

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
