### PR TITLE
【フォーム】メール件名、本文に[[form_name]]の埋め込みコード追加

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -727,6 +727,14 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
             $after_message = $form->temporary_regist_after_message;
 
             // メール送信
+            // メール件名の組み立て
+            $subject = $form->temporary_regist_mail_subject;
+
+            // メール件名内のサイト名文字列を置換
+            $subject = str_replace('[[site_name]]', Configs::where('name', 'base_site_name')->first()->value, $subject);
+            // メール件名内のフォーム名文字列を置換
+            $subject = str_replace('[[form_name]]', $form->forms_name, $subject);
+
             // メール本文の組み立て
             $mail_format = $form->temporary_regist_mail_format;
             $mail_text = str_replace('[[body]]', $contents_text, $mail_format);
@@ -734,14 +742,15 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
             // 本登録URL
             $entry_url = url('/') . "/plugin/forms/publicConfirmToken/{$page_id}/{$frame_id}/{$forms_inputs->id}?token={$user_token}#frame-{$frame_id}";
             $mail_text = str_replace('[[entry_url]]', $entry_url, $mail_text);
-
             // メール本文内のサイト名文字列を置換
             $mail_text = str_replace('[[site_name]]', Configs::where('name', 'base_site_name')->first()->value, $mail_text);
+            // メール本文内のフォーム名文字列を置換
+            $mail_text = str_replace('[[form_name]]', $form->forms_name, $mail_text);
 
             // メール送信（ユーザー側）
             foreach ($user_mailaddresses as $user_mailaddress) {
                 if (!empty($user_mailaddress)) {
-                    Mail::to(trim($user_mailaddress))->send(new ConnectMail(['subject' => $form->temporary_regist_mail_subject, 'template' => 'mail.send'], ['content' => $mail_text]));
+                    Mail::to(trim($user_mailaddress))->send(new ConnectMail(['subject' => $subject, 'template' => 'mail.send'], ['content' => $mail_text]));
                 }
             }
         } else {
@@ -756,21 +765,32 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
 
             // メール送信
             if ($form->mail_send_flag || $form->user_mail_send_flag) {
+                // メール件名の組み立て
+                $subject = $form->mail_subject;
+
+                // メール本文内の採番文字列を置換
+                $subject = str_replace('[[number]]', $number, $subject);
+                // メール件名内のサイト名文字列を置換
+                $subject = str_replace('[[site_name]]', Configs::where('name', 'base_site_name')->first()->value, $subject);
+                // メール件名内のフォーム名文字列を置換
+                $subject = str_replace('[[form_name]]', $form->forms_name, $subject);
+
                 // メール本文の組み立て
                 $mail_format = $form->mail_format;
                 $mail_text = str_replace('[[body]]', $contents_text, $mail_format);
 
                 // メール本文内の採番文字列を置換
                 $mail_text = str_replace('[[number]]', $number, $mail_text);
-
                 // メール本文内のサイト名文字列を置換
                 $mail_text = str_replace('[[site_name]]', Configs::where('name', 'base_site_name')->first()->value, $mail_text);
+                // メール本文内のフォーム名文字列を置換
+                $mail_text = str_replace('[[form_name]]', $form->forms_name, $mail_text);
 
                 // メール送信（管理者側）
                 if ($form->mail_send_flag) {
                     $mail_addresses = explode(',', $form->mail_send_address);
                     foreach ($mail_addresses as $mail_address) {
-                        Mail::to(trim($mail_address))->send(new ConnectMail(['subject' => $form->mail_subject, 'template' => 'mail.send'], ['content' => $mail_text]));
+                        Mail::to(trim($mail_address))->send(new ConnectMail(['subject' => $subject, 'template' => 'mail.send'], ['content' => $mail_text]));
                     }
                 }
 
@@ -778,7 +798,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
                 if ($form->user_mail_send_flag) {
                     foreach ($user_mailaddresses as $user_mailaddress) {
                         if (!empty($user_mailaddress)) {
-                            Mail::to(trim($user_mailaddress))->send(new ConnectMail(['subject' => $form->mail_subject, 'template' => 'mail.send'], ['content' => $mail_text]));
+                            Mail::to(trim($user_mailaddress))->send(new ConnectMail(['subject' => $subject, 'template' => 'mail.send'], ['content' => $mail_text]));
                         }
                     }
                 }
@@ -964,21 +984,32 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
 
         // メール送信
         if ($form->mail_send_flag || $form->user_mail_send_flag) {
+            // メール件名の組み立て
+            $subject = $form->mail_subject;
+
+            // メール本文内の採番文字列を置換
+            $subject = str_replace('[[number]]', $number, $subject);
+            // メール件名内のサイト名文字列を置換
+            $subject = str_replace('[[site_name]]', Configs::where('name', 'base_site_name')->first()->value, $subject);
+            // メール件名内のフォーム名文字列を置換
+            $subject = str_replace('[[form_name]]', $form->forms_name, $subject);
+
             // メール本文の組み立て
             $mail_format = $form->mail_format;
             $mail_text = str_replace('[[body]]', $contents_text, $mail_format);
 
             // メール本文内の採番文字列を置換
             $mail_text = str_replace('[[number]]', $number, $mail_text);
-
             // メール本文内のサイト名文字列を置換
             $mail_text = str_replace('[[site_name]]', Configs::where('name', 'base_site_name')->first()->value, $mail_text);
+            // メール本文内のフォーム名文字列を置換
+            $mail_text = str_replace('[[form_name]]', $form->forms_name, $mail_text);
 
             // メール送信（管理者側）
             if ($form->mail_send_flag) {
                 $mail_addresses = explode(',', $form->mail_send_address);
                 foreach ($mail_addresses as $mail_address) {
-                    Mail::to(trim($mail_address))->send(new ConnectMail(['subject' => $form->mail_subject, 'template' => 'mail.send'], ['content' => $mail_text]));
+                    Mail::to(trim($mail_address))->send(new ConnectMail(['subject' => $subject, 'template' => 'mail.send'], ['content' => $mail_text]));
                 }
             }
 
@@ -986,7 +1017,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
             if ($form->user_mail_send_flag) {
                 foreach ($user_mailaddresses as $user_mailaddress) {
                     if (!empty($user_mailaddress)) {
-                        Mail::to(trim($user_mailaddress))->send(new ConnectMail(['subject' => $form->mail_subject, 'template' => 'mail.send'], ['content' => $mail_text]));
+                        Mail::to(trim($user_mailaddress))->send(new ConnectMail(['subject' => $subject, 'template' => 'mail.send'], ['content' => $mail_text]));
                     }
                 }
             }

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -288,6 +288,10 @@
         <div class="{{$frame->getSettingInputClass()}}">
             <label class="control-label">仮登録メール件名</label>
             <input type="text" name="temporary_regist_mail_subject" value="{{old('temporary_regist_mail_subject', $form->temporary_regist_mail_subject)}}" class="form-control" placeholder="（例）仮登録のお知らせと本登録のお願い">
+            <small class="text-muted">
+                ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。
+            </small>
         </div>
     </div>
 
@@ -299,6 +303,7 @@
             <small class="text-muted">
                 ※ [[entry_url]] を記述すると本登録URLが入ります。本登録URLの有効期限は仮登録後60分です。<br>
                 ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
                 ※ [[body]] を記述すると該当部分に登録内容が入ります。
             </small>
             @if ($errors && $errors->has('temporary_regist_mail_format')) <div class="text-danger">{{$errors->first('temporary_regist_mail_format')}}</div> @endif
@@ -324,6 +329,11 @@
         <div class="{{$frame->getSettingInputClass()}}">
             <label class="control-label">本登録メール件名</label>
             <input type="text" name="mail_subject" value="{{old('mail_subject', $form->mail_subject)}}" class="form-control">
+            <small class="text-muted">
+                ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
+                ※ [[number]] を記述すると該当部分に採番した番号が入ります。（採番機能の使用時）
+            </small>
         </div>
     </div>
 
@@ -334,6 +344,7 @@
             <textarea name="mail_format" class="form-control" rows=5 placeholder="（例）受付内容をお知らせいたします。&#13;&#10;----------------------------------&#13;&#10;[[body]]&#13;&#10;----------------------------------">{{old('mail_format', $form->mail_format)}}</textarea>
             <small class="text-muted">
                 ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
                 ※ [[body]] を記述すると該当部分に登録内容が入ります。<br>
                 ※ [[number]] を記述すると該当部分に採番した番号が入ります。（採番機能の使用時）
             </small>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

機能追加です。

## 画面
### フォーム設定画面

![image](https://user-images.githubusercontent.com/2756509/95286867-7aeb5f00-089f-11eb-8e4c-2daa4015e31a.png)
![image](https://user-images.githubusercontent.com/2756509/95286906-935b7980-089f-11eb-9be8-4facaf1af853.png)


## 主なcommits

* メール件名、本文に[[form_name]]の埋め込みコード追加
* メール件名に[[site_name]]、[[number]]の追加

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/618

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
