### PR TITLE
【フォーム】プレースホルダーの設定機能の追加

### DIFF
--- a/app/Models/User/Forms/FormsColumns.php
+++ b/app/Models/User/Forms/FormsColumns.php
@@ -12,5 +12,5 @@ class FormsColumns extends Model
     use UserableNohistory;
 
     // 更新する項目の定義
-    protected $fillable = ['forms_id', 'column_type', 'column_name', 'required', 'frame_col', 'caption', 'caption_color', 'minutes_increments', 'minutes_increments_from', 'minutes_increments_to', 'rule_allowed_numeric', 'rule_allowed_alpha_numeric', 'rule_digits_or_less', 'rule_max', 'rule_min', 'rule_word_count', 'rule_date_after_equal', 'display_sequence'];
+    protected $fillable = ['forms_id', 'column_type', 'column_name', 'required', 'frame_col', 'caption', 'caption_color', 'place_holder', 'minutes_increments', 'minutes_increments_from', 'minutes_increments_to', 'rule_allowed_numeric', 'rule_allowed_alpha_numeric', 'rule_digits_or_less', 'rule_max', 'rule_min', 'rule_word_count', 'rule_date_after_equal', 'display_sequence'];
 }

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -1479,6 +1479,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
                 'forms_columns.frame_col',
                 'forms_columns.caption',
                 'forms_columns.caption_color',
+                'forms_columns.place_holder',
                 'forms_columns.display_sequence',
                 DB::raw('count(forms_columns_selects.id) as select_count'),
                 DB::raw('GROUP_CONCAT(forms_columns_selects.value order by forms_columns_selects.display_sequence SEPARATOR \',\') as select_names')
@@ -1497,6 +1498,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
                 'forms_columns.frame_col',
                 'forms_columns.caption',
                 'forms_columns.caption_color',
+                'forms_columns.place_holder',
                 'forms_columns.display_sequence'
             )
             ->orderby('forms_columns.display_sequence')
@@ -1701,6 +1703,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
         // 項目の更新処理
         $column->caption = $request->caption;
         $column->caption_color = $request->caption_color;
+        $column->place_holder = $request->place_holder;
         $column->frame_col = $request->frame_col;
         // 分刻み指定
         if ($column->column_type == \FormColumnType::time) {

--- a/database/migrations/2020_10_07_194550_add_placeholder_forms_columns_table.php
+++ b/database/migrations/2020_10_07_194550_add_placeholder_forms_columns_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPlaceholderFormsColumnsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms_columns', function (Blueprint $table) {
+            $table->string('place_holder', 255)->nullable()->comment('プレースホルダ―')->after('caption_color');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms_columns', function (Blueprint $table) {
+            $table->dropColumn('place_holder');
+        });
+    }
+}

--- a/resources/views/plugins/user/forms/default/forms_edit_row.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row.blade.php
@@ -88,7 +88,8 @@
     $column->column_type == FormColumnType::checkbox ||
     $column->column_type == FormColumnType::select ||
     $column->column_type == FormColumnType::group ||
-    $column->caption
+    $column->caption || 
+    $column->place_holder
     )
     <tr>
         <td class="pt-0 border border-0"></td>
@@ -97,13 +98,17 @@
         @if ($column->column_type != FormColumnType::group && $column->select_count > 0)
             {{-- 選択肢データがある場合、カンマ付で一覧表示する --}}
             <div class="small"><i class="far fa-list-alt"></i> {{ $column->select_names }}</div>
-        @elseif($column->column_type != FormColumnType::group && !$column->caption && $column->select_count == 0)
-            {{-- 選択肢データがなく、キャプションの設定もない場合はツールチップ分、余白として改行する --}}
+        @elseif($column->column_type != FormColumnType::group && !$column->caption && !$column->place_holder && $column->select_count == 0)
+            {{-- 選択肢データがなく、キャプション／プレースホルダーの設定もない場合はツールチップ分、余白として改行する --}}
             <br>
         @endif
         @if ($column->caption)
             {{-- キャプションが設定されている場合、キャプションを表示する --}}
             <div class="small {{ $column->caption_color }}"><i class="fas fa-pen"></i> {{ mb_strimwidth($column->caption, 0, 60, '...', 'UTF-8') }}</div>
+        @endif
+        @if ($column->place_holder)
+            {{-- プレースホルダーが設定されている場合、プレースホルダーを表示する --}}
+            <div class="small"><i class="fas fa-pen-fancy"></i> {{ mb_strimwidth($column->place_holder, 0, 60, '...', 'UTF-8') }}</div>
         @endif
         @if ($column->column_type == FormColumnType::group && !isset($column->frame_col))
             {{-- まとめ行でまとめ数の設定がない場合はツールチップ分、余白として改行する --}}

--- a/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
@@ -381,6 +381,34 @@
 
     <br>
 
+    @if (
+        $column->column_type == FormColumnType::text || 
+        $column->column_type == FormColumnType::textarea || 
+        $column->column_type == FormColumnType::mail || 
+        $column->column_type == FormColumnType::date
+    )
+        {{-- プレースホルダ設定 --}}
+        <div class="card">
+            <h5 class="card-header">プレースホルダの設定</h5>
+            <div class="card-body">
+
+                {{-- プレースホルダ内容 --}}
+                <div class="form-group row">
+                    <label class="{{$frame->getSettingLabelClass()}}">内容 </label>
+                    <div class="{{$frame->getSettingInputClass()}}">
+                        <input type="text" name="place_holder" class="form-control" value="{{old('place_holder', $column->place_holder)}}">
+                    </div>
+                </div>
+
+                {{-- ボタンエリア --}}
+                <div class="form-group text-center">
+                    <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
+                </div>
+            </div>
+        </div>
+        <br>
+    @endif
+
     {{-- ボタンエリア --}}
     <div class="form-group text-center">
         {{-- キャンセルボタン --}}

--- a/resources/views/plugins/user/forms/default/forms_input_date.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_date.blade.php
@@ -28,6 +28,7 @@
             value="@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif"
             class="form-control datetimepicker-input" 
             data-target="#{{ $form_obj->id }}"
+            placeholder="{{ $form_obj->place_holder }}"
         >
         <div class="input-group-append" data-target="#{{ $form_obj->id }}" data-toggle="datetimepicker">
             <div class="input-group-text"><i class="fa fa-calendar"></i></div>

--- a/resources/views/plugins/user/forms/default/forms_input_mail.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_mail.blade.php
@@ -10,6 +10,7 @@
     class="form-control" 
     type="{{$form_obj->column_type}}" 
     value="@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif"
+    placeholder="{{ $form_obj->place_holder }}"
 >
 {{-- 確認用の項目 --}}
 <input 

--- a/resources/views/plugins/user/forms/default/forms_input_text.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_text.blade.php
@@ -5,7 +5,7 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
 --}}
-<input name="forms_columns_value[{{$form_obj->id}}]" class="form-control" type="{{$form_obj->column_type}}" value="@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif">
+<input name="forms_columns_value[{{$form_obj->id}}]" class="form-control" type="{{$form_obj->column_type}}" value="@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif" placeholder="{{ $form_obj->place_holder }}">
 @if ($errors && $errors->has("forms_columns_value.$form_obj->id"))
     <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first("forms_columns_value.$form_obj->id")}}</div>
 @endif

--- a/resources/views/plugins/user/forms/default/forms_input_textarea.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_textarea.blade.php
@@ -5,7 +5,7 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
  --}}
-<textarea rows="4" name="forms_columns_value[{{$form_obj->id}}]" class="form-control">@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif</textarea>
+<textarea rows="4" name="forms_columns_value[{{$form_obj->id}}]" class="form-control" placeholder="{{ $form_obj->place_holder }}">@if ($frame_id == $request->frame_id){{old('forms_columns_value.'.$form_obj->id, $request->forms_columns_value[$form_obj->id])}}@endif</textarea>
 @if ($errors && $errors->has("forms_columns_value.$form_obj->id"))
     <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first("forms_columns_value.$form_obj->id")}}</div>
 @endif


### PR DESCRIPTION
## 概要
- 項目毎にプレースホルダーを設定できるように改修
- 対象は1行文字列型、複数行文字列型、メールアドレス型、日付型の４つ

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/issues/215

## 参考
なし

## DB変更の有無
有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
