### PR TITLE
bugfix: データベースのdefault, tableテンプレート, 各項目のcss class指定がきくように対応（入力値のみにclassを反映させる）

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -293,9 +293,9 @@ class DatabasesPlugin extends UserPluginBase
 
         $setting_error_messages = null;
         $databases_columns = null;
-        $databases_columns_id_select = null;
+        // $databases_columns_id_select = null;
         if ($database) {
-            $databases_columns_id_select = $this->getDatabasesColumnsSelects($database->id);
+            // $databases_columns_id_select = $this->getDatabasesColumnsSelects($database->id);
 
             /**
              * データベースのカラムデータを取得
@@ -330,7 +330,7 @@ class DatabasesPlugin extends UserPluginBase
         //--- 初期表示データ
 
         if (empty($database)) {
-            $databases = null;
+            // $databases = null;
             $columns = null;
             $select_columns = null;
             $sort_columns = null;
@@ -340,7 +340,7 @@ class DatabasesPlugin extends UserPluginBase
             $input_cols = null;
         } else {
             // データベースの取得
-            $databases = Databases::where('id', $database->id)->first();
+            // $databases = Databases::where('id', $database->id)->first();
 
             // フレーム毎のデータベース設定の取得
             $databases_frames = DatabasesFrames::where('frames_id', $frame_id)->where('databases_id', $database->id)->first();
@@ -547,15 +547,15 @@ class DatabasesPlugin extends UserPluginBase
         return $this->view(
             'databases',
             [
-                'request'  => $request,
-                'frame_id' => $frame_id,
-                'database' => $database,
-                'databases_columns' => $databases_columns,
-                'databases_columns_id_select' => $databases_columns_id_select,
+                // 'request'  => $request,
+                // 'frame_id' => $frame_id,
+                // 'database' => $database,
+                // 'databases_columns' => $databases_columns,
+                // 'databases_columns_id_select' => $databases_columns_id_select,
                 'errors' => $errors,
                 'setting_error_messages' => $setting_error_messages,
 
-                'databases'        => $databases,
+                // 'databases'        => $databases,
                 'database_frame'   => $database_frame,
                 'databases_frames' => empty($databases_frames) ? new DatabasesFrames() : $databases_frames,
                 'columns'          => $columns,

--- a/resources/views/plugins/user/databases/default/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_detail.blade.php
@@ -23,7 +23,9 @@
                 <div class="row pt-2 pb-2">
                     <div class="col">
                         <small><b>{{$column->column_name}}</b></small><br>
-                        @include('plugins.user.databases.default.databases_include_detail_value')
+                        <div class="{{$column->classname}}">
+                            @include('plugins.user.databases.default.databases_include_detail_value')
+                        </div>
                     </div>
                 </div>
             @endforeach

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -39,7 +39,7 @@
             @foreach($columns as $column)
                 @if($column->list_hide_flag == 0)
                     @if($is_first)
-                        <td>
+                        <td class="{{$column->classname}}">
                             <a href="{{url('/')}}/plugin/databases/detail/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}">
                                 @include('plugins.user.databases.default.databases_include_value')
                             </a>
@@ -48,7 +48,7 @@
                         $is_first = false;
                         @endphp
                     @else
-                        <td>
+                        <td class="{{$column->classname}}">
                             @include('plugins.user.databases.default.databases_include_value')
                         </td>
                     @endif

--- a/resources/views/plugins/user/databases/table/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/table/databases_detail.blade.php
@@ -15,7 +15,7 @@
     @if($column->detail_hide_flag == 0)
     <tr>
         <th style="background-color: #e9ecef;" nowrap>{{$column->column_name}}</th>
-        <td>
+        <td class="{{$column->classname}}">
             @include('plugins.user.databases.default.databases_include_detail_value')
         </td>
     </tr>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

https://github.com/opensource-workshop/connect-cms/pull/626 のバグ修正、詳細画面の対応もれです。
また、tableテンプレートも、一覧・詳細画面対応しました。

## 主なcommits

* bugfix: データベースのdefault, tableテンプレート, 各項目のcss class指定がきくように対応（入力値のみにclassを反映させる）
* データベース, indexのリファクタリング（bladeで使ってない変数をコメントアウト）

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

issue
https://github.com/opensource-workshop/connect-cms/issues/625

pull requests
https://github.com/opensource-workshop/connect-cms/pull/626

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
