### PR TITLE
【データベース検索】バグ修正 mysqlのバージョンによってはエラーになる為、不要なorderByを削除

### DIFF
--- a/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
+++ b/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
@@ -223,7 +223,7 @@ class DatabasesearchesPlugin extends UserPluginBase
                         ->groupBy('frames.page_id')
                         // bugfix: 入力データ1件の項目内で更新日がずれると重複を起こすため、updated_atのgroupBy不要。
                         //->groupBy('databases_input_cols.updated_at')
-                        ->orderBy('databases_input_cols.updated_at', 'desc');
+                        ;
 
             // データ取得
             //$inputs_ids_array[] = $inputs_query->get();
@@ -260,8 +260,7 @@ class DatabasesearchesPlugin extends UserPluginBase
         if ($databasesearches->frame_select == 1 && $databasesearches->target_frame_ids) {
             $inputs_ids->whereIn('frames.id', explode(',', $databasesearches->target_frame_ids));
         }
-        $inputs_ids = $inputs_ids->orderBy('databases_input_cols.updated_at', 'desc')
-                                ->paginate($databasesearches->view_count, ["*"], "frame_{$frame_id}_page");
+        $inputs_ids = $inputs_ids->paginate($databasesearches->view_count, ["*"], "frame_{$frame_id}_page");
         // Log::debug(var_export($inputs_ids->toArray(), true));
         // Log::debug(var_export($inputs_ids_marge, true));
 


### PR DESCRIPTION
## 概要
- 掲題の通り。
- 過去の修正でエラー対象のカラム（updated_at）をGroup Byから除外しているが、この際の修正漏れと思われる。
- ２つのクエリを修正。
- いずれも後続クエリ条件算出用で順序が求められる箇所ではない為、Order Byを除外

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/issues/627

## 参考
https://www.p-nt.com/technicblog/archives/204

## DB変更の有無
無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
