### PR TITLE
データベース, default-left-col-3テンプレート追加（初期表示画面のみ左側col-3にするテンプレート、左にサムネイル画像を配置する場合に利用する事を想定）

### DIFF
--- a/resources/views/plugins/user/databases/default-left-col-3/databases.blade.php
+++ b/resources/views/plugins/user/databases/default-left-col-3/databases.blade.php
@@ -1,0 +1,6 @@
+{{--
+ * 初期表示画面テンプレート。
+--}}
+
+{{-- defaultの初期表示blade --}}
+@include('plugins.user.databases.default.databases', ['use_left_col_3' => true])

--- a/resources/views/plugins/user/databases/default-left-col-3/template.ini
+++ b/resources/views/plugins/user/databases/default-left-col-3/template.ini
@@ -1,0 +1,3 @@
+[base]
+template_name = default-left-col-3
+display_sequence = 2

--- a/resources/views/plugins/user/databases/default/databases.blade.php
+++ b/resources/views/plugins/user/databases/default/databases.blade.php
@@ -24,7 +24,13 @@
                     <div class="row border-left border-right border-bottom @if($loop->first) border-top @endif">
                     {{-- 列グループ ループ --}}
                     @foreach($group_row_cols_columns as $group_col_columns)
+                        {{-- 最初の繰り返し & left-col-3を使う（default-left-col-3テンプレートより指定） --}}
+                        @if ($loop->first && isset($use_left_col_3))
+                        <div class="col-sm-3">
+                        @else
                         <div class="col-sm">
+                        @endif
+
                         {{-- カラム ループ --}}
                         @foreach($group_col_columns as $column)
                             <div class="row pt-2 pb-2">


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

機能追加です。

## 画面
### 初期表示（一覧）画面
![image](https://user-images.githubusercontent.com/2756509/95422755-db030380-097a-11eb-9543-b37a59064734.png)

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/630

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
