### PR TITLE
データベース、項目毎に項目名の表示をOFFにできる機能追加

### DIFF
--- a/app/Models/User/Databases/DatabasesColumns.php
+++ b/app/Models/User/Databases/DatabasesColumns.php
@@ -20,6 +20,7 @@ class DatabasesColumns extends Model
         'frame_col',
         'list_hide_flag',
         'detail_hide_flag',
+        'label_hide_flag',
         'sort_flag',
         'search_flag',
         'select_flag',

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -2061,6 +2061,8 @@ class DatabasesPlugin extends UserPluginBase
         $column->list_hide_flag = (empty($request->list_hide_flag)) ? 0 : $request->list_hide_flag;
         // 詳細から非表示にする指定
         $column->detail_hide_flag = (empty($request->detail_hide_flag)) ? 0 : $request->detail_hide_flag;
+        // 項目名を非表示にする指定
+        $column->label_hide_flag = (empty($request->label_hide_flag)) ? 0 : $request->label_hide_flag;
         // 権限で表示カラムを制御
         $column->role_display_control_flag = (empty($request->role_display_control_flag)) ? 0 : $request->role_display_control_flag;
         // 並べ替え指定

--- a/database/migrations/2020_10_08_154013_add_label_hide_flag_to_databases_columns.php
+++ b/database/migrations/2020_10_08_154013_add_label_hide_flag_to_databases_columns.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLabelHideFlagToDatabasesColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->integer('label_hide_flag')->default(0)->comment('項目名を非表示にする指定')->after('detail_hide_flag');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->dropColumn('label_hide_flag');
+        });
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases.blade.php
+++ b/resources/views/plugins/user/databases/default/databases.blade.php
@@ -35,7 +35,10 @@
                         @foreach($group_col_columns as $column)
                             <div class="row pt-2 pb-2">
                                 <div class="col">
-                                    <small><b>{{$column->column_name}}</b></small><br>
+                                    @if ($column->label_hide_flag == '0')
+                                        <small><b>{{$column->column_name}}</b></small><br>
+                                    @endif
+
                                     <div class="{{$column->classname}}">
                                         @include('plugins.user.databases.default.databases_include_value')
                                     </div>

--- a/resources/views/plugins/user/databases/default/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_detail.blade.php
@@ -22,7 +22,10 @@
             @foreach($group_col_columns as $column)
                 <div class="row pt-2 pb-2">
                     <div class="col">
-                        <small><b>{{$column->column_name}}</b></small><br>
+                        @if ($column->label_hide_flag == '0')
+                            <small><b>{{$column->column_name}}</b></small><br>
+                        @endif
+
                         <div class="{{$column->classname}}">
                             @include('plugins.user.databases.default.databases_include_detail_value')
                         </div>

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -446,6 +446,21 @@
                     </div>
                 </div>
 
+                {{-- 項目名を非表示にする指定 --}}
+                <div class="form-group row">
+                    <label class="{{$frame->getSettingLabelClass(true)}}">項目名の表示指定</label>
+                    <div class="{{$frame->getSettingInputClass(true)}}">
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="0" id="label_hide_flag_0" name="label_hide_flag" class="custom-control-input" @if(old('label_hide_flag', $column->label_hide_flag) == 0) checked="checked" @endif>
+                            <label class="custom-control-label" for="label_hide_flag_0">項目名を表示する</label>
+                        </div>
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="1" id="label_hide_flag_1" name="label_hide_flag" class="custom-control-input" @if(old('label_hide_flag', $column->label_hide_flag) == 1) checked="checked" @endif>
+                            <label class="custom-control-label" for="label_hide_flag_1">項目名を表示しない</label>
+                        </div>
+                    </div>
+                </div>
+
                 {{-- 権限毎に一覧・詳細で非表示にする指定 --}}
                 <div class="form-group row">
                     <label class="{{$frame->getSettingLabelClass(true)}} pt-0">権限の表示指定</label>

--- a/resources/views/plugins/user/databases/table/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/table/databases_detail.blade.php
@@ -14,10 +14,16 @@
     @foreach($columns as $column)
     @if($column->detail_hide_flag == 0)
     <tr>
-        <th style="background-color: #e9ecef;" nowrap>{{$column->column_name}}</th>
-        <td class="{{$column->classname}}">
-            @include('plugins.user.databases.default.databases_include_detail_value')
-        </td>
+        @if ($column->label_hide_flag == '0')
+            <th style="background-color: #e9ecef;" nowrap>{{$column->column_name}}</th>
+            <td class="{{$column->classname}}">
+                @include('plugins.user.databases.default.databases_include_detail_value')
+            </td>
+        @else
+            <td class="{{$column->classname}}" colspan="2">
+                @include('plugins.user.databases.default.databases_include_detail_value')
+            </td>
+        @endif
     </tr>
     @endif
     @endforeach


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

機能追加です。
defaultテンプレート・default-left-col-3テンプレート・tableテンプレートに対応しました。
tebleテンプレートは詳細画面のみ、項目名の表示ON・OFFができます。

## 画面（defaultテンプレート）
### 一覧画面表示（カラム1の項目名を非表示）
![image](https://user-images.githubusercontent.com/2756509/95425882-f4f31500-097f-11eb-89cb-851a7a253117.png)

### 詳細画面表示（カラム1の項目名を非表示）
![image](https://user-images.githubusercontent.com/2756509/95425937-12c07a00-0980-11eb-811b-416cd533f723.png)

## 画面（default-left-col-3テンプレート）
### 一覧画面表示（カラム1の項目名を非表示）
![image](https://user-images.githubusercontent.com/2756509/95426035-3be10a80-0980-11eb-8e29-342ecc2e0108.png)
### 詳細画面表示（カラム1の項目名を非表示）
![image](https://user-images.githubusercontent.com/2756509/95426153-659a3180-0980-11eb-8e83-ade6d23f783b.png)

## 画面（tebleテンプレート）
### 一覧画面表示（カラム1の項目名は非表示設定だけど、表示）
![image](https://user-images.githubusercontent.com/2756509/95426302-9f6b3800-0980-11eb-8b55-c3768be614e2.png)

### 詳細画面表示（カラム1の項目名を非表示）
![image](https://user-images.githubusercontent.com/2756509/95426355-b6aa2580-0980-11eb-94b5-8d3b4bac9ff4.png)


## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/632

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
