### PR TITLE
add: データベース、入力エラー時に上部に共通エラーメッセージを表示する 他1件

### DIFF
--- a/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
@@ -13,6 +13,9 @@
 @endsection
 
 @section("plugin_setting_$frame->id")
+
+@include('common.errors_form_line')
+
 @if (!$database->id && !$create_flag)
     {{-- idなし & 変更 = DB未選択&変更:初期表示 --}}
     <div class="alert alert-warning mt-2">

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -15,6 +15,9 @@
 @endsection
 
 @section("plugin_setting_$frame->id")
+
+    @include('common.errors_form_line')
+
     <script type="text/javascript">
         /**
         * 選択肢の追加ボタン押下
@@ -307,7 +310,10 @@
                             <label class="{{$frame->getSettingLabelClass()}}">入力桁数</label>
                             <div class="{{$frame->getSettingInputClass()}}">
                                 <input type="text" name="rule_digits_or_less" value="{{old('rule_digits_or_less', $column->rule_digits_or_less)}}" class="form-control">
-                                <small class="text-muted">※ 入力桁数の指定時は「半角数値のみ許容」も適用されます。</small><br>
+                                <small class="text-muted">
+                                    ※ 数値で入力します。<br>
+                                    ※ 入力桁数の指定時は「半角数値のみ許容」も適用されます。
+                                </small><br>
                                 @if ($errors && $errors->has('rule_digits_or_less'))
                                     <div class="text-danger">{{$errors->first('rule_digits_or_less')}}</div>
                                 @endif
@@ -319,7 +325,10 @@
                             <label class="{{$frame->getSettingLabelClass()}}">入力最大文字数</label>
                             <div class="{{$frame->getSettingInputClass()}}">
                                 <input type="text" name="rule_word_count" value="{{old('rule_word_count', $column->rule_word_count)}}" class="form-control">
-                                <small class="text-muted">※ 全角は2文字、半角は1文字として換算します。</small><br>
+                                <small class="text-muted">
+                                    ※ 数値で入力します。<br>
+                                    ※ 全角は2文字、半角は1文字として換算します。
+                                </small>
                                 @if ($errors && $errors->has('rule_word_count'))
                                     <div class="text-danger">{{$errors->first('rule_word_count')}}</div>
                                 @endif
@@ -331,6 +340,7 @@
                             <label class="{{$frame->getSettingLabelClass()}}">最大値</label>
                             <div class="{{$frame->getSettingInputClass()}}">
                                 <input type="text" name="rule_max" value="{{old('rule_max', $column->rule_max)}}" class="form-control">
+                                <small class="text-muted">※ 数値で入力します。</small>
                                 @if ($errors && $errors->has('rule_max'))
                                     <div class="text-danger">{{$errors->first('rule_max')}}</div>
                                 @endif
@@ -342,6 +352,7 @@
                             <label class="{{$frame->getSettingLabelClass()}}">最小値</label>
                             <div class="{{$frame->getSettingInputClass()}}">
                                 <input type="text" name="rule_min" value="{{old('rule_min', $column->rule_min)}}" class="form-control">
+                                <small class="text-muted">※ 数値で入力します。</small>
                                 @if ($errors && $errors->has('rule_min'))
                                     <div class="text-danger">{{$errors->first('rule_min')}}</div>
                                 @endif

--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -15,13 +15,17 @@
 
 @section("plugin_setting_$frame->id")
 
+@include('common.errors_form_line')
+
 @if ($errors->any())
+    {{--
     <div class="alert alert-danger mt-2">
         @foreach ($errors->all() as $error)
             <i class="fas fa-exclamation-circle"></i>
             {{$error}}
         @endforeach
     </div>
+    --}}
 @else
     @if (!$database->id)
         <div class="alert alert-warning mt-2">

--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -14,6 +14,9 @@ use App\Models\User\Databases\DatabasesColumns;
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+
+@include('common.errors_form_line')
+
 @if (empty($setting_error_messages))
 
     <script type="text/javascript">


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

機能修正です。

## 画面
### 登録・編集画面

![image](https://user-images.githubusercontent.com/2756509/95642412-58498800-0ae3-11eb-820a-b76d2354d7d6.png)

### DB設定登録・編集画面
![image](https://user-images.githubusercontent.com/2756509/95642435-731bfc80-0ae3-11eb-8084-2a3b7affc656.png)

### DB項目詳細編集画面

#### 共通エラーメッセージを表示
![image](https://user-images.githubusercontent.com/2756509/95642455-9cd52380-0ae3-11eb-917a-c1098fa38fb6.png)

#### チェック処理の設定で数値入力設定の項目下に、「※ 数値で入力します。」コメントを追記
![image](https://user-images.githubusercontent.com/2756509/95642502-e7ef3680-0ae3-11eb-8fd6-113885063887.png)


### 表示設定画面

![image](https://user-images.githubusercontent.com/2756509/95642470-b0808a00-0ae3-11eb-93e2-161dd7f6b067.png)


## 主な対応

* add: データベース、入力エラー時に上部に共通エラーメッセージを表示する
* add: データベース項目設定詳細画面、チェック処理の設定で数値入力設定の項目下に、「※ 数値で入力します。」コメントを追記

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

無し

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

無し

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
