### PR TITLE
【メニュー】デザイン用に階層の深さを表現するclassを追加

### DIFF
--- a/resources/views/plugins/user/menus/default/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/default/menu_children.blade.php
@@ -10,9 +10,9 @@
 @if ($children->isView(Auth::user(), false, true, $page_roles))
 
     @if ($children->id == $page_id)
-    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item active">
+    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $children->depth }} active">
     @else
-    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item">
+    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $children->depth }}">
     @endif
         {{-- 各ページの深さをもとにインデントの表現 --}}
         @for ($i = 0; $i < $children->depth; $i++)

--- a/resources/views/plugins/user/menus/default/menus.blade.php
+++ b/resources/views/plugins/user/menus/default/menus.blade.php
@@ -22,9 +22,9 @@
 
                 {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
                 @if ($page->id == $page_id)
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item active">
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }} active">
                 @else
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item">
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }}">
                 @endif
                     {{-- 各ページの深さをもとにインデントの表現 --}}
                     @for ($i = 0; $i < $page->depth; $i++)

--- a/resources/views/plugins/user/menus/dropdown/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/dropdown/menu_children.blade.php
@@ -9,9 +9,9 @@
 
 @if ($children->isView(Auth::user(), false, true, $page_roles))
     @if ($children->id == $page_id)
-    <a class="dropdown-item active" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
+    <a class="dropdown-item {{ 'depth-' . $children->depth }} active" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
     @else
-    <a class="dropdown-item" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
+    <a class="dropdown-item {{ 'depth-' . $children->depth }}" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
     @endif
 
         {{-- 各ページの深さをもとにインデントの表現 --}}

--- a/resources/views/plugins/user/menus/dropdown/menus.blade.php
+++ b/resources/views/plugins/user/menus/dropdown/menus.blade.php
@@ -25,9 +25,9 @@
                     <li class="nav-item dropdown {{$page_obj->getClass()}}">
                     {{-- カレント --}}
                     @if ($ancestors->contains('id', $page_obj->id))
-                        <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                        <a class="nav-link active dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
                     @else
-                        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                        <a class="nav-link dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
                     @endif
 
                             {{$page_obj->page_name}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown/menu_children.blade.php
@@ -10,9 +10,9 @@
 @if ($children->isView(Auth::user(), false, true, $page_roles))
 
     @if ($children->id == $page_id)
-    <a class="dropdown-item active" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
+    <a class="dropdown-item {{ 'depth-' . $children->depth }} active" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
     @else
-    <a class="dropdown-item" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
+    <a class="dropdown-item {{ 'depth-' . $children->depth }}" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
     @endif
 
         {{-- 各ページの深さをもとにインデントの表現 --}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown/menus.blade.php
@@ -22,9 +22,9 @@
                 <li class="nav-item dropdown {{$page_obj->getClass()}}" onmouseleave="$(this).find('a.nav-link').click();$(this).find('a.nav-link').blur();">
                 {{-- カレント --}}
                 @if ($ancestors->contains('id', $page_obj->id))
-                    <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
+                    <a class="nav-link active dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
                 @else
-                    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
+                    <a class="nav-link dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
                 @endif
 
                         {{$page_obj->page_name}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_root/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_root/menu_children.blade.php
@@ -10,9 +10,9 @@
 @if ($children->display_flag == 1)
 
     @if ($children->id == $page_id)
-    <a class="dropdown-item active" href="{{ url("$children->permanent_link") }}">
+    <a class="dropdown-item {{ 'depth-' . $children->depth }} active" href="{{ url("$children->permanent_link") }}">
     @else
-    <a class="dropdown-item" href="{{ url("$children->permanent_link") }}">
+    <a class="dropdown-item {{ 'depth-' . $children->depth }}" href="{{ url("$children->permanent_link") }}">
     @endif
 
         {{-- 各ページの深さをもとにインデントの表現 --}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_root/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_root/menus.blade.php
@@ -20,9 +20,9 @@
                     <li class="nav-item dropdown {{$page_obj->getClass()}}">
                     {{-- カレント --}}
                     @if ($ancestors->contains('id', $page_obj->id))
-                        <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
+                        <a class="nav-link active dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
                     @else
-                        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
+                        <a class="nav-link dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
                     @endif
 
                             {{$page_obj->page_name}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink/menu_children.blade.php
@@ -10,9 +10,9 @@
 @if ($children->isView(Auth::user(), false, true, $page_roles))
 
     @if ($children->id == $page_id)
-    <a class="dropdown-item active" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
+    <a class="dropdown-item {{ 'depth-' . $children->depth }} active" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
     @else
-    <a class="dropdown-item" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
+    <a class="dropdown-item {{ 'depth-' . $children->depth }}" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
     @endif
 
         {{-- 各ページの深さをもとにインデントの表現 --}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink/menus.blade.php
@@ -22,9 +22,9 @@
                 <li class="nav-item dropdown {{$page_obj->getClass()}}" onmouseleave="$(this).find('a.nav-link').click();$(this).find('a.nav-link').blur();">
                 {{-- カレント --}}
                 @if ($ancestors->contains('id', $page_obj->id))
-                    <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
+                    <a class="nav-link active dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
                 @else
-                    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
+                    <a class="nav-link dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
                 @endif
 
                         {{$page_obj->page_name}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_design/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_design/menu_children.blade.php
@@ -10,9 +10,9 @@
 @if ($children->isView(Auth::user(), false, true, $page_roles))
 <li>
     @if ($children->id == $page_id)
-    <a class="dropdown-item active" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
+    <a class="dropdown-item {{ 'depth-' . $children->depth }} active" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
     @else
-    <a class="dropdown-item" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
+    <a class="dropdown-item {{ 'depth-' . $children->depth }}" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
     @endif
 
         {{-- 各ページの深さをもとにインデントの表現 --}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_design/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_design/menus.blade.php
@@ -22,9 +22,9 @@
                 <li class="nav-item dropdown {{$page_obj->getClass()}}" onmouseleave="$(this).find('a.nav-link').click();$(this).find('a.nav-link').blur();">
                 {{-- カレント --}}
                 @if ($page_obj->id == $page_id)
-                    <a class="nav-link active dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
+                    <a class="nav-link active dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
                 @else
-                    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
+                    <a class="nav-link dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
                 @endif
 
                         {{$page_obj->page_name}}

--- a/resources/views/plugins/user/menus/opencurrenttree/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree/menu_children.blade.php
@@ -28,9 +28,9 @@
 @if ($children->isView(Auth::user(), false, true, $page_roles))
 
     @if ($children->id == $page_id)
-    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item active">
+    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $children->depth }} active">
     @else
-    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item">
+    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $children->depth }}">
     @endif
 
         {{-- 各ページの深さをもとにインデントの表現 --}}

--- a/resources/views/plugins/user/menus/opencurrenttree/menus.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree/menus.blade.php
@@ -22,9 +22,9 @@
 
                 {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
                 @if ($page->id == $page_id)
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item active">
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }} active">
                 @else
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item">
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }}">
                 @endif
                     {{-- 各ページの深さをもとにインデントの表現 --}}
                     @for ($i = 0; $i < $page->depth; $i++)

--- a/resources/views/plugins/user/menus/opencurrenttree_for_design/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree_for_design/menu_children.blade.php
@@ -43,9 +43,9 @@
 
             {{-- カレントもしくは自分のルート筋なら表示する --}}
             @if ($children->isAncestorOf($current_page) || $current_page->id == $children->id)
-                {{$children->page_name}} {!!$menu->getFolderCloseFont()!!}
+                {{$children->page_name}} @if ($menu) {!!$menu->getFolderCloseFont()!!} @endif
             @else
-                {{$children->page_name}} {!!$menu->getFolderOpenFont()!!}
+                {{$children->page_name}} @if ($menu) {!!$menu->getFolderOpenFont()!!} @endif
             @endif
 
         @else

--- a/resources/views/plugins/user/menus/opencurrenttree_for_design/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree_for_design/menu_children.blade.php
@@ -28,9 +28,9 @@
 @if ($children->isView(Auth::user(), false, true, $page_roles))
     <li>
         @if ($children->id == $page_id)
-        <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item active">
+        <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $children->depth }} active">
         @else
-        <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item">
+        <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $children->depth }}">
         @endif
 
             {{-- 各ページの深さをもとにインデントの表現 --}}

--- a/resources/views/plugins/user/menus/opencurrenttree_for_design/menus.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree_for_design/menus.blade.php
@@ -24,9 +24,9 @@
                         <li>
                             {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
                             @if ($page->id == $page_id)
-                            <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item active">
+                            <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }} active">
                             @else
-                            <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item">
+                            <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }}">
                             @endif
                                 {{-- 各ページの深さをもとにインデントの表現 --}}
                                 @for ($i = 0; $i < $page->depth; $i++)

--- a/resources/views/plugins/user/menus/opencurrenttree_for_design/menus.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree_for_design/menus.blade.php
@@ -35,10 +35,12 @@
                                 {{$page->page_name}}
 
                                 {{-- カレントもしくは自分のルート筋なら＋、違えば－を表示する --}}
-                                @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
-                                    {!!$menu->getFolderCloseFont()!!}
-                                @else
-                                    {!!$menu->getFolderOpenFont()!!}
+                                @if ($menu)
+                                    @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
+                                        {!!$menu->getFolderCloseFont()!!}
+                                    @else
+                                        {!!$menu->getFolderOpenFont()!!}
+                                    @endif
                                 @endif
                             </a>
                         </li>

--- a/resources/views/plugins/user/menus/parentsandchild/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/parentsandchild/menu_children.blade.php
@@ -10,9 +10,9 @@
         @if ($page_obj->isView(Auth::user(), false, true, $page_roles))
 
             @if ($page_obj->id == $page_id)
-            <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item active">
+            <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page_obj->depth }} active">
             @else
-            <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item">
+            <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page_obj->depth }}">
             @endif
 
             {{-- 各ページの深さをもとにインデントの表現 --}}

--- a/resources/views/plugins/user/menus/parentsandchild/menus.blade.php
+++ b/resources/views/plugins/user/menus/parentsandchild/menus.blade.php
@@ -33,9 +33,9 @@
                 {{-- 非表示のページは対象外 --}}
                 @if ($page_obj->isView(Auth::user(), false, true, $page_roles))
                     @if ($page_obj->id == $page_id)
-                    <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item active">{{$page_obj->page_name}}</a>
+                    <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page_obj->depth }} active">{{$page_obj->page_name}}</a>
                     @else
-                    <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item">{{$page_obj->page_name}}</a>
+                    <a href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page_obj->depth }}">{{$page_obj->page_name}}</a>
                     @endif
                     @if (isset($page_obj->children))
                         {{-- 子要素を再帰的に表示するため、別ファイルに分けてinclude --}}

--- a/resources/views/plugins/user/menus/sitemap/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/sitemap/menu_children.blade.php
@@ -11,9 +11,9 @@
 <ul>
 <li>
     @if ($children->id == $page_id)
-    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="active">
+    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="{{ 'depth-' . $children->depth }} active">
     @else
-    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="">
+    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="{{ 'depth-' . $children->depth }}">
     @endif
         {{-- 各ページの深さをもとにインデントの表現 --}}
 {{--

--- a/resources/views/plugins/user/menus/sitemap/menus.blade.php
+++ b/resources/views/plugins/user/menus/sitemap/menus.blade.php
@@ -21,9 +21,9 @@
 <li>
                 {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
                 @if ($page->id == $page_id)
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="active">
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="{{ 'depth-' . $page->depth }} active">
                 @else
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="">
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="{{ 'depth-' . $page->depth }}">
                 @endif
                     {{-- 各ページの深さをもとにインデントの表現 --}}
                     @for ($i = 0; $i < $page->depth; $i++)

--- a/resources/views/plugins/user/menus/sitemap_no_rootlink/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/sitemap_no_rootlink/menu_children.blade.php
@@ -11,9 +11,9 @@
 <ul>
 <li>
     @if ($children->id == $page_id)
-    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="active">
+    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="{{ 'depth-' . $children->depth }} active">
     @else
-    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="">
+    <a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="{{ 'depth-' . $children->depth }}">
     @endif
         {{-- 各ページの深さをもとにインデントの表現 --}}
 {{--

--- a/resources/views/plugins/user/menus/tab/menus.blade.php
+++ b/resources/views/plugins/user/menus/tab/menus.blade.php
@@ -17,9 +17,9 @@
     {{-- 非表示のページは対象外 --}}
     @if ($page->isView(Auth::user(), false, true, $page_roles))
         @if ($ancestors->contains('id', $page->id))
-            <li role="presentation" class="nav-item {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link active">{{$page->page_name}}</a></li>
+            <li role="presentation" class="nav-item {{ 'depth-' . $page->depth }} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link active">{{$page->page_name}}</a></li>
         @else
-            <li role="presentation" class="nav-item {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link">{{$page->page_name}}</a></li>
+            <li role="presentation" class="nav-item {{ 'depth-' . $page->depth }} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link">{{$page->page_name}}</a></li>
         @endif
     @endif
 @endforeach


### PR DESCRIPTION
## 概要
- 一部テンプレートは`<ul><li>`タグを使用せず、paddingによるインデントで見た目のみの表現しかされていなかった為、CSSからフックできる階層表現用のclassを追加（depth-0～X）
- 「ディレクトリ展開式（デザイン用）」テンプレートのバグ対応（ヌルポで落ちる）

## 関連Pull requests/Issues
なし

## 参考
なし

## DB変更の有無
なし

## チェックリスト
bladeファイルなので対象外
- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
