### PR TITLE
【フォーム】ファイル型の追加、登録一覧画面の追加等

### DIFF
--- a/app/Enums/FormColumnType.php
+++ b/app/Enums/FormColumnType.php
@@ -19,7 +19,7 @@ final class FormColumnType
     const date = 'date';
     const time = 'time';
     const time_from_to = 'time_from_to';
-    // const file = 'file';
+    const file = 'file';
     const group = 'group';
 
     // key/valueの連想配列
@@ -35,7 +35,7 @@ final class FormColumnType
         self::date=>'日付型',
         self::time=>'時間型',
         self::time_from_to=>'時間型(FromTo)',
-        // self::file=>'ファイル型',
+        self::file=>'ファイル型',
         self::group=>'まとめ行',
     ];
 

--- a/app/Enums/FormColumnType.php
+++ b/app/Enums/FormColumnType.php
@@ -5,7 +5,7 @@ namespace App\Enums;
 /**
  * フォーム項目区分
  */
-final class FormColumnType
+final class FormColumnType extends EnumsBase
 {
     // 定数メンバ
     const text = 'text';
@@ -38,20 +38,4 @@ final class FormColumnType
         self::file=>'ファイル型',
         self::group=>'まとめ行',
     ];
-
-    /*
-    * 対応した和名を返す
-    */
-    public static function getDescription($key): string
-    {
-        return self::enum[$key];
-    }
-
-    /*
-    * key/valueの連想配列を返す
-    */
-    public static function getMembers()
-    {
-        return self::enum;
-    }
 }

--- a/app/Enums/FormStatusType.php
+++ b/app/Enums/FormStatusType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * フォームのステータス関係
+ */
+final class FormStatusType extends EnumsBase
+{
+    // 定数メンバ
+    const active = 0;
+    const temporary = 1;
+    const delete = 9;
+
+    // key/valueの連想配列
+    const enum = [
+        self::active => '本登録',
+        self::temporary => '仮登録',
+        self::delete => '削除',
+    ];
+}

--- a/app/Mail/ConnectMail.php
+++ b/app/Mail/ConnectMail.php
@@ -5,8 +5,8 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Support\Facades\Log;
+
+// use Illuminate\Contracts\Queue\ShouldQueue;
 
 class ConnectMail extends Mailable
 {
@@ -31,7 +31,19 @@ class ConnectMail extends Mailable
      */
     public function build()
     {
-         return $this->subject($this->options['subject'])
-             ->text($this->options['template'], $this->data);
+        $mail = $this->subject($this->options['subject'])
+                        ->text($this->options['template'], $this->data);
+
+        // 添付ファイル
+        if (isset($this->options['attachs'])) {
+            foreach ($this->options['attachs'] as $attach) {
+                $mail->attach($attach['file_path'], [
+                    'as' => $attach['file_name'],
+                    'mime' => $attach['mime'],
+                ]);
+            }
+        }
+
+        return $mail;
     }
 }

--- a/app/Models/User/Forms/FormsColumns.php
+++ b/app/Models/User/Forms/FormsColumns.php
@@ -13,4 +13,16 @@ class FormsColumns extends Model
 
     // 更新する項目の定義
     protected $fillable = ['forms_id', 'column_type', 'column_name', 'required', 'frame_col', 'caption', 'caption_color', 'place_holder', 'minutes_increments', 'minutes_increments_from', 'minutes_increments_to', 'rule_allowed_numeric', 'rule_allowed_alpha_numeric', 'rule_digits_or_less', 'rule_max', 'rule_min', 'rule_word_count', 'rule_date_after_equal', 'display_sequence'];
+
+    /**
+     * ファイルタイプのカラム型か
+     */
+    public static function isFileColumnType($column_type)
+    {
+        // ファイルタイプ
+        if ($column_type == \FormColumnType::file) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -249,6 +249,7 @@ return [
         'PermissionType' => \App\Enums\PermissionType::class,
         'StatusType' => \App\Enums\StatusType::class,
         'DisplayNumberType' => \App\Enums\DisplayNumberType::class,
+        'FormStatusType' => \App\Enums\FormStatusType::class,
 
         // utils
         'DateUtils' => \App\Utilities\Date\DateUtils::class,

--- a/database/migrations/2020_10_27_161242_add_mail_attach_flag_to_forms.php
+++ b/database/migrations/2020_10_27_161242_add_mail_attach_flag_to_forms.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddMailAttachFlagToForms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->integer('mail_attach_flag')->default(0)->comment('メールにファイルを添付するフラグ')->after('user_mail_send_flag');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('mail_attach_flag');
+        });
+    }
+}

--- a/resources/views/plugins/user/forms/default/forms.blade.php
+++ b/resources/views/plugins/user/forms/default/forms.blade.php
@@ -11,7 +11,7 @@
 
 @include('common.errors_form_line')
 
-<form action="{{URL::to('/')}}/plugin/forms/publicConfirm/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" name="form_add_column{{$frame_id}}" method="POST" class="form-horizontal" aria-label="{{$form->forms_name}}">
+<form action="{{URL::to('/')}}/plugin/forms/publicConfirm/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" name="form_add_column{{$frame_id}}" method="POST" class="form-horizontal" aria-label="{{$form->forms_name}}" enctype="multipart/form-data">
     {{ csrf_field() }}
 
 {{--

--- a/resources/views/plugins/user/forms/default/forms_confirm.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm.blade.php
@@ -101,6 +101,20 @@
             {{$request->forms_columns_value[$form_column->id]}}
             <input name="forms_columns_value[{{$form_column->id}}]" class="form-control" type="hidden" value="{{$request->forms_columns_value[$form_column->id]}}">
             @break
+        @case(FormColumnType::file)
+            @php
+                // value 値の取得
+                if ($uploads && $uploads->where('columns_id', $form_column->id)) {
+                    $value_obj = $uploads->where('columns_id', $form_column->id)->first();
+                }
+            @endphp
+            @if(isset($value_obj)) {{-- ファイルがアップロードされた or もともとアップロードされていて変更がない時 --}}
+                <input name="forms_columns_value[{{$form_column->id}}]" class="form-control" type="hidden" value="{{$value_obj->id}}">
+                <a href="{{url('/')}}/file/{{$value_obj->id}}" target="_blank">{{$value_obj->client_original_name}}</a>
+            @else
+                <input name="forms_columns_value[{{$form_column->id}}]" class="form-control" type="hidden" value="">
+            @endif
+            @break
         @endswitch
         </div>
     </div>

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -278,6 +278,28 @@
     </div>
 
     <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}} pt-0"></label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="col pl-0">
+                <label>メールの添付ファイル制御</label><br>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="1" id="mail_attach_flag_1" name="mail_attach_flag" class="custom-control-input" @if(old('mail_attach_flag', $form->mail_attach_flag) == 1) checked="checked" @endif>
+                    <label class="custom-control-label" for="mail_attach_flag_1">メールにファイルを添付する</label>
+                </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="0" id="mail_attach_flag_0" name="mail_attach_flag" class="custom-control-input" @if(old('mail_attach_flag', $form->mail_attach_flag) == 0) checked="checked" @endif>
+                    <label class="custom-control-label" for="mail_attach_flag_0">メールにファイルを添付しない</label>
+                </div>
+                <div>
+                    <small class="text-muted">
+                        ※ フォームにファイル型の項目があれば、メールにファイルを添付できます。<br>
+                    </small>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}} pt-0">仮登録メール</label>
         <div class="{{$frame->getSettingInputClass()}}">
             <div class="custom-control custom-checkbox">

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -45,10 +45,7 @@
 </script>
 
 @if (!$form->id && !$create_flag)
-    <div class="alert alert-warning mt-2">
-        <i class="fas fa-exclamation-circle"></i>
-        フォーム選択画面から選択するか、フォーム新規作成で作成してください。
-    </div>
+    @include('plugins.user.forms.default.forms_warning_messages_line', ['warning_messages' => ['フォーム選択から選択するか、フォーム作成で作成してください。']])
 @else
 
     <div class="alert alert-info mt-2"><i class="fas fa-exclamation-circle"></i>

--- a/resources/views/plugins/user/forms/default/forms_edit_input.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_input.blade.php
@@ -1,0 +1,81 @@
+{{--
+ * 登録一覧からの編集画面テンプレート。
+--}}
+@extends('core.cms_frame_base_setting')
+
+@section("core.cms_frame_edit_tab_$frame->id")
+    {{-- プラグイン側のフレームメニュー --}}
+    @include('plugins.user.forms.forms_frame_edit_tab')
+@endsection
+
+@section("plugin_setting_$frame->id")
+
+{{-- post先 --}}
+<form action="{{url('/')}}/redirect/plugin/forms/storeInput/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}" method="POST">
+    {{ csrf_field() }}
+    {{-- post後、再表示するURL --}}
+    <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/forms/listInputs/{{$page->id}}/{{$frame_id}}/{{$form->id}}#frame-{{$frame_id}}">
+
+    {{-- 固定項目：状態 --}}
+    <div class="form-group container-fluid row">
+
+        {{-- ラベル --}}
+        @if (isset($is_template_label_sm_4))
+            {{-- label-sm-4テンプレート --}}
+            <label class="col-sm-4 control-label text-nowrap" for="status{{$frame_id}}">状態</label>
+
+        @elseif (isset($is_template_label_sm_6))
+            {{-- label-sm-6テンプレート --}}
+            <label class="col-sm-6 control-label text-nowrap" for="status{{$frame_id}}">状態</label>
+
+        @else
+            {{-- defaultテンプレート --}}
+            <label class="col-sm-2 control-label text-nowrap" for="status{{$frame_id}}">状態</label>
+        @endif
+
+        {{-- 項目 --}}
+        <div class="col-sm">
+            <select id="status{{$frame_id}}" name="status" class="custom-select">
+                @foreach(FormStatusType::getMembers() as $status => $status_name)
+                    <option value="{{$status}}" @if ($status == $input->status) selected @endif>{{$status}} : {{$status_name}}</option>
+                @endforeach
+            </select>
+        </div>
+    </div>
+
+    <hr>
+
+    @foreach($forms_columns as $form_column)
+    <div class="form-group container-fluid row">
+
+        {{-- ラベル --}}
+        @if (isset($is_template_label_sm_4))
+            {{-- label-sm-4テンプレート --}}
+            <label class="col-sm-4 control-label text-nowrap">{{$form_column->column_name}}</label>
+
+        @elseif (isset($is_template_label_sm_6))
+            {{-- label-sm-6テンプレート --}}
+            <label class="col-sm-6 control-label text-nowrap">{{$form_column->column_name}}</label>
+
+        @else
+            {{-- defaultテンプレート --}}
+            <label class="col-sm-2 control-label text-nowrap">{{$form_column->column_name}}</label>
+        @endif
+
+        {{-- 項目 --}}
+        <div class="col-sm">
+            @include('plugins.user.forms.default.forms_include_value', ['column' => $form_column])
+        </div>
+    </div>
+    @endforeach
+
+    {{-- ボタンエリア --}}
+    <div class="form-group text-center">
+        <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/listInputs/{{$page->id}}/{{$frame->id}}/{{$form->id}}#frame-{{$frame->id}}" class="mr-2">
+            <span class="btn btn-info"><i class="fas fa-list"></i> <span class="hidden-xs">登録一覧へ</span></span>
+        </a>
+
+        <button type="submit" class="btn btn-primary" onclick="return confirm('変更を確定します。\nよろしいですか？')"><i class="fas fa-check"></i> 変更確定</button>
+    </div>
+</form>
+@endsection

--- a/resources/views/plugins/user/forms/default/forms_edit_warning_messages.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_warning_messages.blade.php
@@ -1,0 +1,17 @@
+{{--
+ * 設定画面のワーニングメッセージのテンプレート。
+--}}
+@extends('core.cms_frame_base_setting')
+
+@section("core.cms_frame_edit_tab_$frame->id")
+    {{-- プラグイン側のフレームメニュー --}}
+    @include('plugins.user.forms.forms_frame_edit_tab')
+@endsection
+
+@section("plugin_setting_$frame->id")
+<div class="alert alert-warning mt-2">
+    @foreach ($warning_messages as $warning_message)
+        <i class="fas fa-exclamation-circle"></i> {!! nl2br(e($warning_message)) !!}<br>
+    @endforeach
+</div>
+@endsection

--- a/resources/views/plugins/user/forms/default/forms_include_value.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_include_value.blade.php
@@ -1,0 +1,34 @@
+{{--
+ * データ表示用テンプレート。
+--}}
+@php
+    use App\Models\Common\Uploads;
+
+    $obj = $input_cols->where('forms_inputs_id', $input->id)->where('forms_columns_id', $column->id)->first();
+
+    // ファイル型
+    if ($column->column_type == FormColumnType::file) {
+        if (empty($obj)) {
+            $value = '';
+        }
+        else {
+            $value = '<a href="' . url('/') . '/file/' . $obj->value . '" target="_blank">' . $obj->client_original_name . '</a>';
+        }
+    }
+    // その他の型
+    else {
+        $value = $obj ? $obj->value : "";
+    }
+
+    // 空の場合、なにか出力しないと「項目名<br>値」で出力してるテンプレートは高さがずれてしまうため対応
+    if (is_null($value) || $value === '') {
+        $value = "&nbsp;";
+    }
+@endphp
+
+{{-- ファイル型 --}}
+@if ($column->column_type == FormColumnType::file)
+    {!!$value!!}
+@else
+    {!!nl2br(e($value))!!}
+@endif

--- a/resources/views/plugins/user/forms/default/forms_input_file.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_input_file.blade.php
@@ -1,0 +1,7 @@
+{{--
+ * 登録画面(input file)テンプレート。
+--}}
+<input name="forms_columns_value[{{$form_obj->id}}]" type="{{$form_obj->column_type}}">
+@if ($errors && $errors->has("forms_columns_value.$form_obj->id"))
+    <div class="text-danger"><i class="fas fa-exclamation-circle"></i> {{$errors->first("forms_columns_value.$form_obj->id")}}</div>
+@endif

--- a/resources/views/plugins/user/forms/default/forms_list_buckets.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_buckets.blade.php
@@ -95,9 +95,13 @@
                     <td nowrap class="text-right">{{$plugin->active_entry_count}}</td>
                     <td nowrap>@if ($plugin->data_save_flag) 保存する @else 保存しない @endif</td>
                     <td nowrap>
-                        <button class="btn btn-success btn-sm mr-1" type="button" onclick="location.href='{{url('/')}}/plugin/forms/editBuckets/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}'">
+                        <a class="btn btn-success btn-sm mr-1" href="{{url('/')}}/plugin/forms/editBuckets/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}">
                             <i class="far fa-edit"></i> 設定変更
-                        </button>
+                        </a>
+
+                        <a class="btn btn-success btn-sm mr-1" href="{{url('/')}}/plugin/forms/listInputs/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}">
+                            <i class="fas fa-list"></i> 登録一覧
+                        </a>
 
                         <div class="btn-group">
                             <button type="button" class="btn btn-primary btn-sm" onclick="submit_download_shift_jis({{$plugin->id}});">

--- a/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
@@ -1,0 +1,89 @@
+{{--
+ * 登録一覧画面テンプレート
+--}}
+@extends('core.cms_frame_base_setting')
+
+@section("core.cms_frame_edit_tab_$frame->id")
+    {{-- プラグイン側のフレームメニュー --}}
+    @include('plugins.user.forms.forms_frame_edit_tab')
+@endsection
+
+@section("plugin_setting_$frame->id")
+
+@if (session('flash_message'))
+    <div class="alert alert-success">
+        {{ session('flash_message') }}
+    </div>
+@endif
+
+{{-- データのループ --}}
+<table class="table table-bordered table-responsive table-sm">
+    <thead class="thead-light">
+        <tr>
+            <th style="width:50px">状態</th>
+            @foreach($columns as $column)
+                <th>{{$column->column_name}}</th>
+            @endforeach
+        </tr>
+    </thead>
+
+    <tbody>
+    @foreach($inputs as $input)
+
+        @if ($input->status == FormStatusType::temporary)
+        {{-- 仮登録 --}}
+        <tr class="table-warning">
+        @elseif ($input->status == FormStatusType::delete)
+        {{-- 削除 --}}
+        <tr class="table-danger">
+        @else
+        {{-- 本登録 --}}
+        <tr>
+        @endif
+
+            <td>
+                <a href="{{url('/')}}/plugin/forms/editInput/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}" title="編集">
+                    <i class="far fa-edit"></i> {{$input->status}}
+                </a>
+            </td>
+
+            @foreach($columns as $column)
+                <td>
+                    @include('plugins.user.forms.default.forms_include_value')
+                </td>
+            @endforeach
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+
+<table class="table-bordered table-sm">
+    <tbody>
+    <tr>
+        <td>状態:0 = 本登録</td>
+        <td class="table-warning">状態:1 = 仮登録</td>
+        <td class="table-danger">状態:9 = 削除</td>
+    </tr>
+    </tbody>
+</table>
+
+{{-- ページング処理 --}}
+{{-- アクセシビリティ対応。1ページしかない時に、空navを表示するとスクリーンリーダーに不要な Navigation がひっかかるため表示させない。 --}}
+@if ($inputs->lastPage() > 1)
+    <nav class="text-center mt-3" aria-label="{{$form->forms_name}}のページ付け">
+        {{ $inputs->fragment('frame-' . $frame_id)->links() }}
+    </nav>
+@endif
+
+{{-- ボタン --}}
+<div class="form-group text-center mt-3">
+    <div class="row">
+        <div class="col">
+            <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/listBuckets/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}">
+                <span class="btn btn-info"><i class="fas fa-list"></i> <span class="hidden-xs">フォーム選択へ</span></span>
+            </a>
+        </div>
+    </div>
+</div>
+
+@endsection

--- a/resources/views/plugins/user/forms/default/forms_warning_messages_line.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_warning_messages_line.blade.php
@@ -1,0 +1,8 @@
+{{--
+ * ワーニングメッセージのテンプレート。
+--}}
+<div class="alert alert-warning mt-2">
+    @foreach ($warning_messages as $warning_message)
+        <i class="fas fa-exclamation-circle"></i> {!! nl2br(e($warning_message)) !!}<br>
+    @endforeach
+</div>

--- a/resources/views/plugins/user/forms/forms_frame_edit_tab.blade.php
+++ b/resources/views/plugins/user/forms/forms_frame_edit_tab.blade.php
@@ -4,7 +4,7 @@
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォームプラグイン
- --}}
+--}}
 @if ($action == 'editColumn' || $action == 'editColumnDetail'  || $action == '')
     <li role="presentation" class="nav-item">
         <span class="nav-link"><span class="active">項目設定</span></span>
@@ -30,6 +30,15 @@
 @else
     <li role="presentation" class="nav-item">
         <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/createBuckets/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">フォーム作成</a>
+    </li>
+@endif
+@if ($action == 'listInputs')
+    <li role="presentation" class="nav-item">
+        <span class="nav-link"><span class="active">登録一覧</span></span>
+    </li>
+@else
+    <li role="presentation" class="nav-item">
+        <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/listInputs/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">登録一覧</a>
     </li>
 @endif
 @if ($action == 'listBuckets')


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

機能追加です。
・フォームにファイル型を追加しました。
・フォームにファイル型があり、メール通知する場合、メールにファイルを添付できます。
・フォーム設定で「データ登録しない」場合、登録したファイルは削除されます。
・フォーム設定の「メールの添付ファイル制御」で、ファイルを通知メールに添付するか制御できます。
・登録されたファイルを確認するため、登録一覧画面を追加しました。
・フォームに重複登録される事を想定して、登録一覧＞編集で登録データを削除扱いにできるようにしました。

## 画面

### 登録画面（ファイル型）

![image](https://user-images.githubusercontent.com/2756509/97278301-f3c94f80-187c-11eb-8698-56cd9beb29f8.png)

### 確認画面（ファイル型）

![image](https://user-images.githubusercontent.com/2756509/97278874-9da8dc00-187d-11eb-9afe-5174686737d3.png)

### 項目設定（ファイル型の追加）

![image](https://user-images.githubusercontent.com/2756509/97277875-5ff78380-187c-11eb-87ab-3c32545f72a4.png)

### フォーム設定（メールの添付ファイル制御）
![image](https://user-images.githubusercontent.com/2756509/97279056-d34dc500-187d-11eb-969e-1be852958d60.png)

### 登録一覧
![image](https://user-images.githubusercontent.com/2756509/97276219-405f5b80-187a-11eb-93a1-362e9f811f7b.png)

### 登録一覧＞編集画面
![image](https://user-images.githubusercontent.com/2756509/97276402-7997cb80-187a-11eb-9a7a-596a90ef51b4.png)



## 主なcommits

* add: フォーム、ファイル型追加
* add: フォーム、登録一覧画面、登録一覧からの編集画面の追加 
* add: フォーム設定、メールの添付ファイル制御を追加 …
* add: フォーム、ファイル型でメール添付できる機能追加
* change: フォームのenum, FormColumnTypeをEnumsBaseを継承するように修正
* change: フォームのCSVダウンロード、基本ないが、forms_input_colsにデータが無い場合にも対応(登録一覧の表示は、forms_input_colsがない場合にも対応していた)
* change: フォーム、フォーム未選択時のメッセージの共通化

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/489

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
