### PR TITLE
bugfix: データベース, カンマを含むチェックボックス選択肢をインポートできないため、チェックボックスの区切り文字を,→|に見直しするパッチ

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -218,19 +218,19 @@ class DatabasesPlugin extends UserPluginBase
         // Frame データ
         $frame = DB::table('frames')
                  ->select(
-                    'frames.*', 
-                    'databases.id as databases_id', 
-                    'databases_frames.id as databases_frames_id', 
-                    'databases_name', 
-                    'use_search_flag', 
-                    'placeholder_search', 
-                    'use_select_flag', 
-                    'use_sort_flag', 
-                    'view_count', 
-                    'default_hide', 
-                    'view_page_id', 
-                    'view_frame_id'
-                )
+                     'frames.*',
+                     'databases.id as databases_id',
+                     'databases_frames.id as databases_frames_id',
+                     'databases_name',
+                     'use_search_flag',
+                     'placeholder_search',
+                     'use_select_flag',
+                     'use_sort_flag',
+                     'view_count',
+                     'default_hide',
+                     'view_page_id',
+                     'view_frame_id'
+                 )
                  ->leftJoin('databases', 'databases.bucket_id', '=', 'frames.bucket_id')
                  ->leftJoin('databases_frames', 'databases_frames.frames_id', '=', 'frames.id')
                  ->where('frames.id', $frame_id)
@@ -502,24 +502,24 @@ class DatabasesPlugin extends UserPluginBase
                 }
 
                 foreach ($merge_search_options as $col_id => $search_vals) {
-                        // 検索方法
-                        $inputs_query->whereIn('databases_inputs.id', function ($query) use ($col_id, $search_vals) {
-                            $query->select('databases_inputs_id')
-                            ->from('databases_input_cols')
-                            ->join('databases_columns', 'databases_columns.id', '=', 'databases_input_cols.databases_columns_id')
-                            ->where('databases_input_cols.databases_columns_id', $col_id);
+                    // 検索方法
+                    $inputs_query->whereIn('databases_inputs.id', function ($query) use ($col_id, $search_vals) {
+                        $query->select('databases_inputs_id')
+                        ->from('databases_input_cols')
+                        ->join('databases_columns', 'databases_columns.id', '=', 'databases_input_cols.databases_columns_id')
+                        ->where('databases_input_cols.databases_columns_id', $col_id);
 
-                            $query->where(function($query) use($search_vals){
-                                foreach ($search_vals as $vals){
-                                    $reg_txt = $vals['reg_txt'];
-                                    $val = $vals['val'];
-                                    if ($reg_txt == 'ALL') {
-                                        $query->orwhere('value', $val);
-                                    } elseif ($reg_txt == 'PART') {
-                                        $query->orwhere('value', 'like', '%' . $val . '%');
-                                    }
+                        $query->where(function ($query) use ($search_vals) {
+                            foreach ($search_vals as $vals) {
+                                $reg_txt = $vals['reg_txt'];
+                                $val = $vals['val'];
+                                if ($reg_txt == 'ALL') {
+                                    $query->orwhere('value', $val);
+                                } elseif ($reg_txt == 'PART') {
+                                    $query->orwhere('value', 'like', '%' . $val . '%');
                                 }
-                            });
+                            }
+                        });
                         $query->groupBy('databases_inputs_id');
                     });
                 }
@@ -547,21 +547,21 @@ class DatabasesPlugin extends UserPluginBase
                             $search_vals = [];
                             $term_value_from = "";
                             $term_value_to = "";
-                            foreach($tmp_request_search_term as $key => $val){
-                                $search_vals[$key] = str_replace( "/", "", $val);
-                                if ($key == "term_value_from"){
+                            foreach ($tmp_request_search_term as $key => $val) {
+                                $search_vals[$key] = str_replace("/", "", $val);
+                                if ($key == "term_value_from") {
                                     $term_value_from = $val;
                                 }
-                                if ($key == "term_value_to"){
+                                if ($key == "term_value_to") {
                                     $term_value_to = $val;
                                 }
                             }
-                            if(!empty($term_value_from) && empty($term_value_to)) {
+                            if (!empty($term_value_from) && empty($term_value_to)) {
                                 //検索前が入力　後が未入力
                                 $target_day = date("Y-m-1", strtotime($term_value_from. "/01"));
-                                for($i = 0; $i < $term_month; $i++){
+                                for ($i = 0; $i < $term_month; $i++) {
                                     // $term_value_to に12ヶ月分入れる
-                                    $month = date("Ym",strtotime($target_day . "+$i month"));
+                                    $month = date("Ym", strtotime($target_day . "+$i month"));
                                     $search_vals["term_value_to_".$i] = $month;
                                     unset($search_vals["term_value_from"]);
                                     unset($search_vals["term_value_to"]);
@@ -569,9 +569,9 @@ class DatabasesPlugin extends UserPluginBase
                             } elseif (empty($term_value_from) && !empty($term_value_to)) {
                                 //検索前が未入力　後が入力
                                 $target_day = date("Y-m-1", strtotime($term_value_from. "/01"));
-                                for($i = 0; $i < $term_month; $i++){
+                                for ($i = 0; $i < $term_month; $i++) {
                                     // $term_value_from に前12ヶ月分入れる
-                                            $month = date("Ym",strtotime($target_day . "-$i month"));
+                                            $month = date("Ym", strtotime($target_day . "-$i month"));
                                     $search_vals["term_value_from_".$i] = $month;
                                     unset($search_vals["term_value_from"]);
                                     unset($search_vals["term_value_to"]);
@@ -596,15 +596,15 @@ class DatabasesPlugin extends UserPluginBase
                                     $search_vals["term_value_".$i] = date("Ym", $strtime_term_value_from);
                                 }
                             }
-                            
+
                             // テンプレートでsearch_term[XXXX]をセットすることで、ORの値を任意に増やすことができる（*や通年）等期間外のデータ
                             $inputs_query->whereIn('databases_inputs.id', function ($query) use ($col_id, $search_vals) {
                                 $query->select('databases_inputs_id')
                                 ->from('databases_input_cols')
                                 ->join('databases_columns', 'databases_columns.id', '=', 'databases_input_cols.databases_columns_id')
                                 ->where('databases_input_cols.databases_columns_id', $col_id);
-                                $query->where(function($query) use($search_vals){
-                                    foreach ($search_vals as $val){
+                                $query->where(function ($query) use ($search_vals) {
+                                    foreach ($search_vals as $val) {
                                         $query->orwhere('value', 'like', '%' . $val . '%');
                                     }
                                 });

--- a/database/migrations/2020_11_16_161136_update_checkbox_separator_to_databases_input_cols.php
+++ b/database/migrations/2020_11_16_161136_update_checkbox_separator_to_databases_input_cols.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateCheckboxSeparatorToDatabasesInputCols extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // bugfix: カンマを含むチェックボックス選択肢をインポートできないため、チェックボックスの区切り文字を,→|に見直しするパッチ
+        \DB::statement('UPDATE databases_input_cols cols, databases_columns colums ' .
+                ' SET cols.value = REPLACE(cols.value, ",", "|") ' .
+                ' WHERE cols.value like "%,%" AND cols.databases_columns_id = colums.id  AND colums.column_type = "checkbox"');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -209,6 +209,7 @@
                                     {{-- 選択肢名 --}}
                                     <td>
                                         <input class="form-control" type="text" name="select_name" value="{{ old('select_name') }}" placeholder="選択肢名">
+                                        <small class="text-muted">※ 選択肢名に | を含める事はできません。</small>
                                     </td>
 
                                     {{-- ＋ボタン --}}


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

カンマを含むチェックボックス選択肢をインポートできるようにする修正のパッチです。
複数選択肢の区切り文字 , → |に修正します。
また、既に登録された複数選択肢の値を修正するパッチも含んでいます。

## 画面
### 項目詳細-選択肢の設定

![image](https://user-images.githubusercontent.com/2756509/99226094-8762c000-282c-11eb-8348-901f24050e95.png)


## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
