### PR TITLE
change: フォーム, データベースに合わせて、複数選択肢の区切り文字を, → | に変更

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -44,6 +44,8 @@ use App\Utilities\Token\TokenUtils;
  */
 class FormsPlugin extends UserPluginBase
 {
+    const CHECKBOX_SEPARATOR = '|';
+
     /* オブジェクト変数 */
 
     /* コアから呼び出す関数 */
@@ -797,7 +799,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
 
             $value = "";
             if (is_array($request->forms_columns_value[$forms_column->id])) {
-                $value = implode(',', $request->forms_columns_value[$forms_column->id]);
+                $value = implode(self::CHECKBOX_SEPARATOR, $request->forms_columns_value[$forms_column->id]);
             } else {
                 $value = $request->forms_columns_value[$forms_column->id];
             }
@@ -1135,7 +1137,7 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
 
             $value = "";
             if (is_array($forms_input_cols[$forms_column->id])) {
-                $value = implode(',', $forms_input_cols[$forms_column->id]->value);
+                $value = implode(self::CHECKBOX_SEPARATOR, $forms_input_cols[$forms_column->id]->value);
             } else {
                 $value = $forms_input_cols[$forms_column->id]->value;
             }
@@ -1980,10 +1982,14 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
      */
     public function addSelect($request, $page_id, $frame_id)
     {
-        // エラーチェック
+        $messages = [
+            'select_name.regex' => ':attributeに | を含める事はできないため、取り除いてください。',
+        ];
+
+        // エラーチェック  regex（|を含まない）
         $validator = Validator::make($request->all(), [
-            'select_name'  => ['required'],
-        ]);
+            'select_name'  => ['required', 'regex:/^(?!.*\|).*$/'],
+        ], $messages);
         $validator->setAttributeNames([
             'select_name'  => '選択肢名',
         ]);
@@ -2024,10 +2030,14 @@ Mail::to('nagahara@osws.jp')->send(new ConnectMail($content));
             "select_name" => $request->$str_select_name,
         ]);
 
-        // エラーチェック
+        $messages = [
+            'select_name.regex' => ':attributeに | を含める事はできないため、取り除いてください。',
+        ];
+
+        // エラーチェック  regex（|を含まない）
         $validator = Validator::make($request->all(), [
-            'select_name'  => ['required'],
-        ]);
+            'select_name'  => ['required', 'regex:/^(?!.*\|).*$/'],
+        ], $messages);
         $validator->setAttributeNames([
             'select_name'  => '選択肢名',
         ]);

--- a/database/migrations/2020_11_16_171151_update_checkbox_separator_to_forms_input_cols.php
+++ b/database/migrations/2020_11_16_171151_update_checkbox_separator_to_forms_input_cols.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateCheckboxSeparatorToFormsInputCols extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // bugfix: カンマを含むチェックボックス選択肢をインポートできないため、チェックボックスの区切り文字を,→|に見直しするパッチ
+        \DB::statement('UPDATE forms_input_cols cols, forms_columns colums ' .
+                ' SET cols.value = REPLACE(cols.value, ",", "|") ' .
+                ' WHERE cols.value like "%,%" AND cols.forms_columns_id = colums.id  AND colums.column_type = "checkbox"');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
@@ -164,7 +164,10 @@
                             <td>
                                 {{-- 選択肢名 --}}
                                 <input class="form-control" type="text" name="select_name" value="{{ old('select_name') }}" placeholder="選択肢名">
-                                <small class="text-muted">※ 選択肢が１つの場合、選択状態で初期表示します。</small>
+                                <small class="text-muted">
+                                    ※ 選択肢が１つの場合、選択状態で初期表示します。<br>
+                                    ※ 選択肢名に | を含める事はできません<br>
+                                </small>
                             </td>
                             <td class="text-center">
                                 {{-- ＋ボタン --}}


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名の通りです。

## 画面
### 項目詳細-選択肢の設定

![image](https://user-images.githubusercontent.com/2756509/99228327-cd6d5300-282f-11eb-8df5-1ce2f7441960.png)


## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/pull/671

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
