### PR TITLE
【コード管理】インポート・ダウンロード機能対応 他３件

### DIFF
--- a/app/Enums/CodeColumn.php
+++ b/app/Enums/CodeColumn.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * コード管理のカラム
+ */
+final class CodeColumn extends EnumsBase
+{
+    // 定数メンバ
+    const codes_help_messages_name = 'codes_help_messages_name';
+    const plugin_name = 'plugin_name';
+    const buckets_name = 'buckets_name';
+    const buckets_id = 'buckets_id';
+    const prefix = 'prefix';
+    const type_name = 'type_name';
+    const type_code1 = 'type_code1';
+    const type_code2 = 'type_code2';
+    const type_code3 = 'type_code3';
+    const type_code4 = 'type_code4';
+    const type_code5 = 'type_code5';
+    const code = 'code';
+    const value = 'value';
+    const additional1 = 'additional1';
+    const additional2 = 'additional2';
+    const additional3 = 'additional3';
+    const additional4 = 'additional4';
+    const additional5 = 'additional5';
+    const display_sequence = 'display_sequence';
+
+    // key/valueの連想配列
+    const enum = [
+        self::codes_help_messages_name => '注釈名',
+        self::plugin_name => 'プラグイン',
+        self::buckets_name => 'buckets_name',
+        self::buckets_id => 'buckets_id',
+        self::prefix => 'prefix',
+        self::type_name => 'type_name',
+        self::type_code1 => 'type_code1',
+        self::type_code2 => 'type_code2',
+        self::type_code3 => 'type_code3',
+        self::type_code4 => 'type_code4',
+        self::type_code5 => 'type_code5',
+        self::code => 'コード',
+        self::value => '値',
+        self::additional1 => 'additional1',
+        self::additional2 => 'additional2',
+        self::additional3 => 'additional3',
+        self::additional4 => 'additional4',
+        self::additional5 => 'additional5',
+        self::display_sequence => '表示順',
+    ];
+
+    /**
+     * 一覧表示 のkey/valueの連想配列を返す
+     */
+    public static function getIndexColumn()
+    {
+        $sort_flags = static::enum;
+        // plugin_nameは 一覧に必ず表示する項目 のため、取り除く
+        unset($sort_flags[self::plugin_name]);
+        return $sort_flags;
+    }
+}

--- a/app/Enums/CodeColumn.php
+++ b/app/Enums/CodeColumn.php
@@ -10,8 +10,10 @@ use App\Enums\EnumsBase;
 final class CodeColumn extends EnumsBase
 {
     // 定数メンバ
-    const codes_help_messages_name = 'codes_help_messages_name';
+    const id = 'id';
     const plugin_name = 'plugin_name';
+    const codes_help_messages_name = 'codes_help_messages_name';
+    const codes_help_messages_alias_key = 'codes_help_messages_alias_key';
     const buckets_name = 'buckets_name';
     const buckets_id = 'buckets_id';
     const prefix = 'prefix';
@@ -32,8 +34,10 @@ final class CodeColumn extends EnumsBase
 
     // key/valueの連想配列
     const enum = [
-        self::codes_help_messages_name => '注釈名',
+        self::id => 'id',
         self::plugin_name => 'プラグイン',
+        self::codes_help_messages_name => '注釈名',
+        self::codes_help_messages_alias_key => '注釈キー',
         self::buckets_name => 'buckets_name',
         self::buckets_id => 'buckets_id',
         self::prefix => 'prefix',
@@ -58,9 +62,23 @@ final class CodeColumn extends EnumsBase
      */
     public static function getIndexColumn()
     {
-        $sort_flags = static::enum;
+        $code_columns = static::enum;
+
         // plugin_nameは 一覧に必ず表示する項目 のため、取り除く
-        unset($sort_flags[self::plugin_name]);
-        return $sort_flags;
+        unset($code_columns[self::plugin_name]);
+        return $code_columns;
+    }
+
+    /**
+     * インポート のkey/valueの連想配列を返す
+     */
+    public static function getImportColumn()
+    {
+        $code_columns = static::enum;
+
+        // エクスポートに不要な項目 を取り除く
+        unset($code_columns[self::buckets_name]);
+        unset($code_columns[self::codes_help_messages_name]);
+        return $code_columns;
     }
 }

--- a/app/Plugins/Manage/CodeManage/CodeManage.php
+++ b/app/Plugins/Manage/CodeManage/CodeManage.php
@@ -3,6 +3,7 @@
 namespace App\Plugins\Manage\CodeManage;
 
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
 
 use App\Models\Common\Codes;
@@ -15,7 +16,8 @@ use App\Plugins\Manage\ManagePluginBase;
 
 use Log;
 
-//use DB;
+use App\Utilities\Csv\CsvUtils;
+use App\Utilities\String\StringUtils;
 
 /**
  * コード管理クラス
@@ -62,6 +64,15 @@ class CodeManage extends ManagePluginBase
         $role_ckeck_table["helpMessageEdit"]    = array('admin_site');
         $role_ckeck_table["helpMessageUpdate"]  = array('admin_site');
         $role_ckeck_table["helpMessageDestroy"] = array('admin_site');
+
+        // インポート
+        $role_ckeck_table["import"]             = array('admin_site');
+        $role_ckeck_table["uploadCsv"]          = array('admin_site');
+
+        // ダウンロード（エクスポート）
+        $role_ckeck_table["download"]           = array('admin_site');
+        $role_ckeck_table["downloadCsv"]        = array('admin_site');
+        $role_ckeck_table["downloadCsvFormat"]  = array('admin_site');
 
         return $role_ckeck_table;
     }
@@ -767,4 +778,383 @@ class CodeManage extends ManagePluginBase
         $page = $request->get('page', 1);
         return redirect("/manage/code/helpMessages?page=$page");
     }
+
+    /**
+     * インポート画面表示
+     */
+    public function import($request, $page_id = null)
+    {
+        // 管理画面プラグインの戻り値の返し方
+        return view('plugins.manage.code.code_import', [
+            "function"      => __FUNCTION__,
+            "plugin_name"   => "code",
+        ]);
+    }
+
+    /**
+     * インポート
+     */
+    public function uploadCsv($request, $page_id = null)
+    {
+        // csv
+        $rules = [
+            'codes_csv'  => [
+                'required',
+                'file',
+                'mimes:csv,txt', // mimesの都合上text/csvなのでtxtも許可が必要
+                'mimetypes:text/plain',
+            ],
+        ];
+
+        // 画面エラーチェック
+        $validator = Validator::make($request->all(), $rules);
+        $validator->setAttributeNames([
+            'codes_csv'  => 'CSVファイル',
+        ]);
+
+        if ($validator->fails()) {
+            // Log::debug(var_export($validator->errors(), true));
+            // エラーと共に編集画面を呼び出す
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+
+        // CSVファイル一時保存
+        $path = $request->file('codes_csv')->store('tmp');
+        // Log::debug(var_export(storage_path('app/') . $path, true));
+        $csv_full_path = storage_path('app/') . $path;
+
+        // ファイル拡張子取得
+        $file_extension = $request->file('codes_csv')->getClientOriginalExtension();
+        // 小文字に変換
+        $file_extension = strtolower($file_extension);
+        // Log::debug(var_export($file_extension, true));
+
+        // 文字コード
+        $character_code = $request->character_code;
+
+        // 文字コード自動検出
+        if ($character_code == \CsvCharacterCode::auto) {
+            // 文字コードの自動検出(文字エンコーディングをsjis-win, UTF-8の順番で自動検出. 対象文字コード外の場合、false戻る)
+            $character_code = CsvUtils::getCharacterCodeAuto($csv_full_path);
+            if (!$character_code) {
+                // 一時ファイルの削除
+                $this->rmImportTmpFile($path);
+
+                $error_msgs = "文字コードを自動検出できませんでした。CSVファイルの文字コードを " . \CsvCharacterCode::getSelectMembersDescription(\CsvCharacterCode::sjis_win) .
+                            ", " . \CsvCharacterCode::getSelectMembersDescription(\CsvCharacterCode::utf_8) . " のいずれかに変更してください。";
+
+                return redirect()->back()->withErrors(['codes_csv' => $error_msgs])->withInput();
+            }
+        }
+
+        // 読み込み
+        $fp = fopen($csv_full_path, 'r');
+        // CSVファイル：Shift-JIS -> UTF-8変換時のみ
+        if ($character_code == \CsvCharacterCode::sjis_win) {
+            // ストリームフィルタ内で、Shift-JIS -> UTF-8変換
+            $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
+        }
+
+        // 一行目（ヘッダ）
+        $header_columns = fgetcsv($fp, 0, ',');
+        // CSVファイル：UTF-8のみ
+        if ($character_code == \CsvCharacterCode::utf_8) {
+            // UTF-8のみBOMコードを取り除く
+            $header_columns = CsvUtils::removeUtf8Bom($header_columns);
+        }
+        // dd($csv_full_path);
+        // \Log::debug('$header_columns:'. var_export($header_columns, true));
+
+        // カラムの取得
+        $code_columns = \CodeColumn::getImportColumn();
+
+        // ヘッダー項目のエラーチェック
+        $error_msgs = $this->checkCsvHeader($header_columns, $code_columns);
+        if (!empty($error_msgs)) {
+            // 一時ファイルの削除
+            fclose($fp);
+            $this->rmImportTmpFile($path);
+
+            return redirect()->back()->withErrors(['codes_csv' => $error_msgs])->withInput();
+        }
+
+        // データ項目のエラーチェック
+        $error_msgs = $this->checkCvslines($fp, $code_columns);
+        if (!empty($error_msgs)) {
+            // 一時ファイルの削除
+            fclose($fp);
+            $this->rmImportTmpFile($path);
+
+            return redirect()->back()->withErrors(['codes_csv' => $error_msgs])->withInput();
+        }
+
+        // // 一時ファイルの削除
+        // fclose($fp);
+        // $this->rmImportTmpFile($path);
+        // dd('ここまで');
+
+        // ファイルポインタの位置を先頭に戻す
+        rewind($fp);
+
+        // ヘッダー
+        $header_columns = fgetcsv($fp, 0, ',');
+        // CSVファイル：UTF-8のみ
+        if ($character_code == \CsvCharacterCode::utf_8) {
+            // UTF-8のみBOMコードを取り除く
+            $header_columns = CsvUtils::removeUtf8Bom($header_columns);
+        }
+
+        // データ
+        while (($csv_columns = fgetcsv($fp, 0, ',')) !== false) {
+            // --- 入力値変換
+            // Log::debug(var_export($csv_columns, true));
+
+            // 入力値をトリム(preg_replace(/u)で置換. /u = UTF-8 として処理)
+            $csv_columns = StringUtils::trimInput($csv_columns);
+
+            // 配列の頭から要素(id)を取り除いて取得
+            // CSVのデータ行の頭は、必ず固定項目のidの想定
+            $codes_id = array_shift($csv_columns);
+            // 空文字をnullに変換
+            $codes_id = StringUtils::convertEmptyStringsToNull($codes_id);
+
+            foreach ($csv_columns as $col => &$csv_column) {
+                // 空文字をnullに変換
+                $csv_column = StringUtils::convertEmptyStringsToNull($csv_column);
+            }
+            // Log::debug('$csv_columns:'. var_export($csv_columns, true));
+
+            // 一時ファイルの削除
+            // fclose($fp);
+            // Storage::delete($path);
+            // dd('ここまで' . $posted_at);
+
+            if (empty($codes_id)) {
+                // 登録
+                $codes = new Codes();
+            } else {
+                // 更新
+                // codes_idはバリデートでCodes存在チェック済みなので、必ずデータある想定
+                $codes = Codes::where('id', $codes_id)->first();
+            }
+
+            $codes->plugin_name          = $csv_columns[0];
+            $codes->codes_help_messages_alias_key = $csv_columns[1];
+            $codes->buckets_id           = $csv_columns[2];
+            $codes->prefix               = $csv_columns[3];
+            $codes->type_name            = $csv_columns[4];
+            $codes->type_code1           = $csv_columns[5];
+            $codes->type_code2           = $csv_columns[6];
+            $codes->type_code3           = $csv_columns[7];
+            $codes->type_code4           = $csv_columns[8];
+            $codes->type_code5           = $csv_columns[9];
+            $codes->code                 = $csv_columns[10];
+            $codes->value                = $csv_columns[11];
+            $codes->additional1          = $csv_columns[12];
+            $codes->additional2          = $csv_columns[13];
+            $codes->additional3          = $csv_columns[14];
+            $codes->additional4          = $csv_columns[15];
+            $codes->additional5          = $csv_columns[16];
+            $codes->display_sequence     = isset($csv_columns[17]) ? (int)$csv_columns[17] : 0;
+            $codes->save();
+        }
+
+        // 一時ファイルの削除
+        fclose($fp);
+        $this->rmImportTmpFile($path);
+
+        // インポート画面に戻る
+        return redirect("/manage/code/import")->with('flash_message', 'インポートしました。');
+    }
+
+    /**
+     * CSVヘッダーチェック
+     */
+    private function checkCsvHeader($header_columns, $header_column_format)
+    {
+        if (empty($header_columns)) {
+            return array("CSVファイルが空です。");
+        }
+
+        // 項目の不足チェック
+        $shortness = array_diff($header_column_format, $header_columns);
+        if (!empty($shortness)) {
+            // Log::debug(var_export($header_column_format, true));
+            // Log::debug(var_export($header_columns, true));
+            return array("1行目に " . implode(",", $shortness) . " が不足しています。");
+        }
+        // 項目の不要チェック
+        $excess = array_diff($header_columns, $header_column_format);
+        if (!empty($excess)) {
+            return array("1行目に " . implode(",", $excess) . " は不要です。");
+        }
+
+        return array();
+    }
+
+    /**
+     * インポート時の一時ファイル削除
+     */
+    private function rmImportTmpFile($path)
+    {
+        // 一時ファイルの削除
+        Storage::delete($path);
+    }
+
+    /**
+     * CSVデータ行チェック
+     */
+    private function checkCvslines($fp, $code_columns)
+    {
+        $rules = [
+            0 => ['nullable', 'numeric', 'exists:codes,id,deleted_at,NULL'],    // id
+            1 => ['nullable', 'exists:plugins,plugin_name'],                    // プラグイン(英語)
+            2 => ['nullable', 'exists:codes_help_messages,alias_key,deleted_at,NULL'],    // 注釈キー
+            3 => [],
+            4 => [],
+            5 => [],
+            6 => [],
+            7 => [],
+            8 => [],
+            9 => [],
+            10 => [],
+            11 => ['required'],     // コード
+            12 => ['required'],     // 値
+        ];
+
+        // ヘッダー行が1行目なので、2行目からデータ始まる
+        $line_count = 2;
+        $errors = [];
+
+        while (($csv_columns = fgetcsv($fp, 0, ',')) !== false) {
+            // 入力値をトリム (preg_replace(/u)で置換. /u = UTF-8 として処理)
+            $csv_columns = StringUtils::trimInput($csv_columns);
+
+            // バリデーション
+            $validator = Validator::make($csv_columns, $rules);
+            // Log::debug($line_count . '行目の$csv_columns:' . var_export($csv_columns, true));
+            // Log::debug(var_export($rules, true));
+
+            $attribute_names = [];
+
+            $col = 0;
+            foreach ($code_columns as $code_column) {
+                // 行数＋項目名
+                $attribute_names[$col] = $line_count . '行目の' . $code_column;
+                $col++;
+            }
+
+            $validator->setAttributeNames($attribute_names);
+            // Log::debug(var_export($attribute_names, true));
+
+            if ($validator->fails()) {
+                $errors = array_merge($errors, $validator->errors()->all());
+            }
+
+            $line_count++;
+        }
+
+        return $errors;
+    }
+
+    /**
+     * ダウンロード画面表示
+     */
+    public function download($request, $page_id = null)
+    {
+        // 管理画面プラグインの戻り値の返し方
+        return view('plugins.manage.code.code_download', [
+            "function" => __FUNCTION__,
+            "plugin_name" => "code",
+        ]);
+    }
+
+    /**
+     * CSVインポートのフォーマットダウンロード
+     */
+    public function downloadCsvFormat($request, $page_id = null)
+    {
+        // データ出力しない（フォーマットのみ出力）
+        $data_output_flag = false;
+        return $this->downloadCsv($request, $page_id, $sub_id = null, $data_output_flag);
+    }
+
+    /**
+     * データベースデータダウンロード
+     */
+    public function downloadCsv($request, $page_id = null, $sub_id = null, $data_output_flag = true)
+    {
+        // カラムの取得
+        $columns = \CodeColumn::getImportColumn();
+
+        // 返却用配列
+        $csv_array = array();
+
+        // 見出し行
+        foreach ($columns as $columnKey => $column) {
+            $csv_array[0][$columnKey] = $column;
+        }
+
+        // $data_output_flag = falseは、CSVフォーマットダウンロード処理
+        if ($data_output_flag) {
+            // 登録データの取得
+            $codes = Codes::orderBy('plugin_name')
+                    ->orderBy('buckets_id')
+                    ->orderBy('prefix')
+                    ->orderBy('type_code1')
+                    ->orderBy('type_code2')
+                    ->orderBy('type_code3')
+                    ->orderBy('type_code4')
+                    ->orderBy('type_code5')
+                    ->orderBy('display_sequence')
+                    ->get();
+
+            // 行数
+            $csv_line_no = 1;
+
+            // データ
+            foreach ($codes as $code) {
+                $csv_line = [];
+                foreach ($columns as $columnKey => $column) {
+                    $csv_line[$columnKey] = $code->$columnKey;
+                }
+
+                $csv_array[$csv_line_no] = $csv_line;
+                $csv_line_no++;
+            }
+        }
+
+        // レスポンス版
+        $filename = 'codes.csv';
+        $headers = [
+            'Content-Type' => 'text/csv',
+            'content-Disposition' => 'attachment; filename="'.$filename.'"',
+        ];
+
+        // データ
+        $csv_data = '';
+        foreach ($csv_array as $csv_line) {
+            foreach ($csv_line as $csv_col) {
+                $csv_data .= '"' . $csv_col . '",';
+            }
+            // 末尾カンマを削除
+            $csv_data = substr($csv_data, 0, -1);
+            $csv_data .= "\n";
+        }
+
+        // Log::debug(var_export($request->character_code, true));
+
+        // 文字コード変換
+        if ($request->character_code == \CsvCharacterCode::utf_8) {
+            $csv_data = mb_convert_encoding($csv_data, \CsvCharacterCode::utf_8);
+            // UTF-8のBOMコードを追加する(UTF-8 BOM付きにするとExcelで文字化けしない)
+            $csv_data = CsvUtils::addUtf8Bom($csv_data);
+        } else {
+            $csv_data = mb_convert_encoding($csv_data, \CsvCharacterCode::sjis_win);
+        }
+
+        return response()->make($csv_data, 200, $headers);
+    }
+
 }

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3197,8 +3197,6 @@ class DatabasesPlugin extends UserPluginBase
         // $rules[0] = ['nullable', 'numeric', 'exists:databases_inputs,id'];
         $rules[0] = ['nullable', 'numeric'];
 
-        $attribute_names = [];
-
         // エラーチェック配列
         $validator_array = array('column' => array(), 'message' => array());
 

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -2804,17 +2804,8 @@ class DatabasesPlugin extends UserPluginBase
         $fp = fopen($csv_full_path, 'r');
         // CSVファイル：Shift-JIS -> UTF-8変換時のみ
         if ($character_code == \CsvCharacterCode::sjis_win) {
-            // ストリームフィルタとして登録.
-            // 5C問題対応：https://qiita.com/suin/items/3edfb9cb15e26bffba11
-            // 5C問題 詳細：https://qiita.com/Kohei-Sato-1221/items/c050bb23436f35666165
-            stream_filter_register(
-                'sjis_to_utf8_encoding_filter',
-                SjisToUtf8EncodingFilter::class
-            );
-
-            // ファイル読み込み時に使うストリームフィルタを指定.
-            // ストリームフィルタ内で、Shift-JIS -> UTF-8変換してる。UTF-8変換で5C問題対応になる
-            stream_filter_append($fp, 'sjis_to_utf8_encoding_filter');
+            // ストリームフィルタ内で、Shift-JIS -> UTF-8変換
+            $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
         }
 
         // 一行目（ヘッダ）
@@ -2825,7 +2816,7 @@ class DatabasesPlugin extends UserPluginBase
             $header_columns = CsvUtils::removeUtf8Bom($header_columns);
         }
         // dd($csv_full_path);
-        // Log::debug('$header_columns:'. var_export($header_columns, true));
+        // \Log::debug('$header_columns:'. var_export($header_columns, true));
 
         // カラムの取得
         $databases_columns = DatabasesColumns::where('databases_id', $id)->orderBy('display_sequence', 'asc')->get();

--- a/app/Utilities/Csv/CsvUtils.php
+++ b/app/Utilities/Csv/CsvUtils.php
@@ -25,6 +25,8 @@ class CsvUtils
             // UTF-8 BOMありなしに関わらず、先頭3バイトのBOMコードを置換して取り除く
             // BOMなしは、置換対象がないのでそのまま値が返る
             $header_columns[0] = preg_replace('/^\xEF\xBB\xBF/', '', $header_columns[0]);
+            // UTF-8 BOMありの場合、先頭にBOMコードが邪魔して、両端のダブルクォーテーションが fgetcsv() で外れないため、ここで外す
+            $header_columns[0] = trim($header_columns[0], '"');
         }
         return $header_columns;
     }

--- a/app/Utilities/Csv/CsvUtils.php
+++ b/app/Utilities/Csv/CsvUtils.php
@@ -2,7 +2,7 @@
 
 namespace App\Utilities\Csv;
 
-use Illuminate\Support\Facades\Log;
+use App\Utilities\Csv\SjisToUtf8EncodingFilter;
 
 class CsvUtils
 {
@@ -41,8 +41,28 @@ class CsvUtils
 
         // 文字エンコーディングをsjis-win, UTF-8の順番で自動検出. 対象文字コード外の場合、false戻る
         $character_code = mb_detect_encoding($contents, \CsvCharacterCode::sjis_win.", ".\CsvCharacterCode::utf_8);
-        // Log::debug(var_export($character_code, true));
+        // \Log::debug(var_export($character_code, true));
 
         return $character_code;
+    }
+
+    /**
+     * ストリームフィルタ内で、Shift-JIS -> UTF-8変換
+     */
+    public static function setStreamFilterRegisterSjisToUtf8($fp)
+    {
+        // ストリームフィルタとして登録.
+        // 5C問題対応：https://qiita.com/suin/items/3edfb9cb15e26bffba11
+        // 5C問題 詳細：https://qiita.com/Kohei-Sato-1221/items/c050bb23436f35666165
+        stream_filter_register(
+            'sjis_to_utf8_encoding_filter',
+            SjisToUtf8EncodingFilter::class
+        );
+
+        // ファイル読み込み時に使うストリームフィルタを指定.
+        // ストリームフィルタ内で、Shift-JIS -> UTF-8変換してる。UTF-8変換で5C問題対応になる
+        stream_filter_append($fp, 'sjis_to_utf8_encoding_filter');
+
+        return $fp;
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -251,6 +251,7 @@ return [
         'DisplayNumberType' => \App\Enums\DisplayNumberType::class,
         'FormStatusType' => \App\Enums\FormStatusType::class,
         'AuthMethodType' => \App\Enums\AuthMethodType::class,
+        'CodeColumn' => \App\Enums\CodeColumn::class,
 
         // utils
         'DateUtils' => \App\Utilities\Date\DateUtils::class,

--- a/resources/views/plugins/manage/code/code.blade.php
+++ b/resources/views/plugins/manage/code/code.blade.php
@@ -68,31 +68,9 @@
 <tbody>
     <tr class="bg-light d-none d-sm-table-row">
         <th class="d-block d-sm-table-cell text-break">プラグイン</th>
-        @php
-        $colums = [
-            'codes_help_messages_name' => '注釈名',
-            'buckets_name' => 'buckets_name',
-            'buckets_id' => 'buckets_id',
-            'prefix' => 'prefix',
-            'type_name' => 'type_name',
-            'type_code1' => 'type_code1',
-            'type_code2' => 'type_code2',
-            'type_code3' => 'type_code3',
-            'type_code4' => 'type_code4',
-            'type_code5' => 'type_code5',
-            'code' => 'コード',
-            'value' => '値',
-            'additional1' => 'additional1',
-            'additional2' => 'additional2',
-            'additional3' => 'additional3',
-            'additional4' => 'additional4',
-            'additional5' => 'additional5',
-            'display_sequence' => '表示順',
-        ];
-        @endphp
-        @foreach($colums as $colum_key => $colum_value)
-            @if(in_array($colum_key, $config->value_array) == $colum_key)
-                <th class="d-block d-sm-table-cell text-break">{{$colum_value}}</th>
+        @foreach(CodeColumn::getIndexColumn() as $column_key => $column_value)
+            @if(in_array($column_key, $config->value_array) == $column_key)
+                <th class="d-block d-sm-table-cell text-break">{{$column_value}}</th>
             @endif
         @endforeach
     </tr>
@@ -103,12 +81,12 @@
             <a href="{{url('/')}}/manage/code/edit/{{$code->id}}?page={{$paginate_page}}&search_words={{$search_words}}"><i class="far fa-edit"></i></a>
             <span class="d-sm-none">プラグイン：</span>{{$code->plugin_name_full}}
         </th>
-        @foreach($colums as $colum_key => $colum_value)
-            @if(in_array($colum_key, $config->value_array) == $colum_key)
+        @foreach($colums as $column_key => $column_value)
+            @if(in_array($column_key, $config->value_array) == $column_key)
             {{-- 表示例
             <td class="d-block d-sm-table-cell"><span class="d-sm-none">buckets_id：</span>$code->buckets_id</td>
             --}}
-            <td class="d-block d-sm-table-cell"><span class="d-sm-none">{{$colum_value}}：</span>{{$code->$colum_key}}</td>
+            <td class="d-block d-sm-table-cell"><span class="d-sm-none">{{$column_value}}：</span>{{$code->$column_key}}</td>
             @endif
         @endforeach
     </tr>

--- a/resources/views/plugins/manage/code/code.blade.php
+++ b/resources/views/plugins/manage/code/code.blade.php
@@ -1,9 +1,5 @@
 {{--
  * コード管理のメインテンプレート
- *
- * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
- * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
- * @category コード管理
 --}}
 {{-- 管理画面ベース画面 --}}
 @extends('plugins.manage.manage')
@@ -12,91 +8,89 @@
 @section('manage_content')
 
 <div class="card">
-<div class="card-header p-0">
-
-{{-- 機能選択タブ --}}
-@include('plugins.manage.code.code_manage_tab')
-
-</div>
-<div class="card-body">
-
-{{-- 警告メッセージエリア --}}
-@if (! $config)
-    <div class="alert alert-warning" role="alert">
-        表示設定が未設定です。<a href="{{url('/')}}/manage/code/display" class="alert-link">表示設定</a>から設定してください。
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.code.code_manage_tab')
     </div>
-@endif
+    <div class="card-body">
 
-{{-- 検索エリア --}}
-<form action="{{url('/')}}/manage/code/index" method="GET" class="form-horizontal">
-    <div class="input-group">
-        <input type="text" name="search_words" value="{{$search_words}}" class="form-control">
-        <button type="button" class="btn text-muted" style="margin-left: -37px; z-index: 100;" onclick="location.href='{{url('/')}}/manage/code/index?page=1'">
-            <i class="fa fa-times"></i>
-        </button>
-        <div class="input-group-append">
-            <button class="btn btn-primary" type="submit"><i class="fas fa-search" aria-label="検索" role="presentation"></i></button>
-        </div>
-        <div class="ml-2">
-            <a data-toggle="collapse" href="#collapse-search-help">
-                <span class="btn btn-light"><i class="fas fa-question-circle"></i></span>
-            </a>
-        </div>
-    </div>
-</form>
+        {{-- 警告メッセージエリア --}}
+        @if (! $config)
+            <div class="alert alert-warning" role="alert">
+                表示設定が未設定です。<a href="{{url('/')}}/manage/code/display" class="alert-link">表示設定</a>から設定してください。
+            </div>
+        @endif
 
-{{-- 検索条件の補足 --}}
-@include('plugins.manage.code.search_help')
+        {{-- 検索エリア --}}
+        <form action="{{url('/')}}/manage/code/index" method="GET" class="form-horizontal">
+            <div class="input-group">
+                <input type="text" name="search_words" value="{{$search_words}}" class="form-control">
+                <button type="button" class="btn text-muted" style="margin-left: -37px; z-index: 100;" onclick="location.href='{{url('/')}}/manage/code/index?page=1'">
+                    <i class="fa fa-times"></i>
+                </button>
+                <div class="input-group-append">
+                    <button class="btn btn-primary" type="submit"><i class="fas fa-search" aria-label="検索" role="presentation"></i></button>
+                </div>
+                <div class="ml-2">
+                    <a data-toggle="collapse" href="#collapse-search-help">
+                        <span class="btn btn-light"><i class="fas fa-question-circle"></i></span>
+                    </a>
+                </div>
+            </div>
+        </form>
 
-{{-- ラベル検索エリア --}}
-<div class="mt-3">
-    {{--
-    <button type="button" class="btn btn-secondary btn-sm" onclick="location.href='{{url('/')}}/manage/code/index?page=1&search_words=type_code1=location'">
-        場所マスタ <span class="badge badge-light">3</span>
-    </button>
-    --}}
-    @foreach($codes_searches as $codes_search)
-    <button type="button" class="btn btn-outline-primary btn-sm" onclick="location.href='{{url('/')}}/manage/code/index?page=1&search_words={{$codes_search->search_words}}'">
-        <i class="fas fa-search" aria-label="検索" role="presentation"></i> {{$codes_search->name}}
-    </button>
-    @endforeach
-</div>
+        {{-- 検索条件の補足 --}}
+        @include('plugins.manage.code.search_help')
 
-{{-- 一覧エリア --}}
-<div class="text-right mt-3"><span class="badge badge-pill badge-light">{{ $codes->total() }} 件</span></div>
-<table class="table table-bordered table_border_radius table-hover cc-font-90">
-<tbody>
-    <tr class="bg-light d-none d-sm-table-row">
-        <th class="d-block d-sm-table-cell text-break">プラグイン</th>
-        @foreach(CodeColumn::getIndexColumn() as $column_key => $column_value)
-            @if(in_array($column_key, $config->value_array) == $column_key)
-                <th class="d-block d-sm-table-cell text-break">{{$column_value}}</th>
-            @endif
-        @endforeach
-    </tr>
-
-    @foreach($codes as $code)
-    <tr>
-        <th class="d-block d-sm-table-cell bg-light">
-            <a href="{{url('/')}}/manage/code/edit/{{$code->id}}?page={{$paginate_page}}&search_words={{$search_words}}"><i class="far fa-edit"></i></a>
-            <span class="d-sm-none">プラグイン：</span>{{$code->plugin_name_full}}
-        </th>
-        @foreach($colums as $column_key => $column_value)
-            @if(in_array($column_key, $config->value_array) == $column_key)
-            {{-- 表示例
-            <td class="d-block d-sm-table-cell"><span class="d-sm-none">buckets_id：</span>$code->buckets_id</td>
+        {{-- ラベル検索エリア --}}
+        <div class="mt-3">
+            {{--
+            <button type="button" class="btn btn-secondary btn-sm" onclick="location.href='{{url('/')}}/manage/code/index?page=1&search_words=type_code1=location'">
+                場所マスタ <span class="badge badge-light">3</span>
+            </button>
             --}}
-            <td class="d-block d-sm-table-cell"><span class="d-sm-none">{{$column_value}}：</span>{{$code->$column_key}}</td>
-            @endif
-        @endforeach
-    </tr>
-    @endforeach
-</tbody>
-</table>
+            @foreach($codes_searches as $codes_search)
+            <button type="button" class="btn btn-outline-primary btn-sm" onclick="location.href='{{url('/')}}/manage/code/index?page=1&search_words={{$codes_search->search_words}}'">
+                <i class="fas fa-search" aria-label="検索" role="presentation"></i> {{$codes_search->name}}
+            </button>
+            @endforeach
+        </div>
 
-{{ $codes->appends(['search_words' => $search_words])->links() }}
+        {{-- 一覧エリア --}}
+        <div class="text-right mt-3"><span class="badge badge-pill badge-light">{{ $codes->total() }} 件</span></div>
+        <table class="table table-bordered table_border_radius table-hover cc-font-90">
+            <tbody>
+                <tr class="bg-light d-none d-sm-table-row">
+                    <th class="d-block d-sm-table-cell text-break">プラグイン</th>
+                    @foreach(CodeColumn::getIndexColumn() as $column_key => $column_value)
+                        @if(in_array($column_key, $config->value_array) == $column_key)
+                            <th class="d-block d-sm-table-cell text-break">{{$column_value}}</th>
+                        @endif
+                    @endforeach
+                </tr>
 
-</div>
+                @foreach($codes as $code)
+                <tr>
+                    <th class="d-block d-sm-table-cell bg-light">
+                        <a href="{{url('/')}}/manage/code/edit/{{$code->id}}?page={{$paginate_page}}&search_words={{$search_words}}"><i class="far fa-edit"></i></a>
+                        <span class="d-sm-none">プラグイン：</span>{{$code->plugin_name_full}}
+                    </th>
+                    @foreach(CodeColumn::getIndexColumn() as $column_key => $column_value)
+                        @if(in_array($column_key, $config->value_array) == $column_key)
+                        {{-- 表示例
+                        <td class="d-block d-sm-table-cell"><span class="d-sm-none">buckets_id：</span>$code->buckets_id</td>
+                        --}}
+                        <td class="d-block d-sm-table-cell"><span class="d-sm-none">{{$column_value}}：</span>{{$code->$column_key}}</td>
+                        @endif
+                    @endforeach
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+
+        {{ $codes->appends(['search_words' => $search_words])->links() }}
+
+    </div>
 </div>
 
 @endsection

--- a/resources/views/plugins/manage/code/code_download.blade.php
+++ b/resources/views/plugins/manage/code/code_download.blade.php
@@ -1,0 +1,65 @@
+{{--
+ * CSVダウンロード画面テンプレート
+--}}
+
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.code.code_manage_tab')
+    </div>
+    <div class="card-body">
+        {{-- ダウンロード用フォーム --}}
+        <form action="{{url('/')}}/manage/code/downloadCsv" method="post" name="database_download_csv">
+            {{ csrf_field() }}
+            <input type="hidden" name="character_code" value="">
+        </form>
+
+        <script type="text/javascript">
+            {{-- ダウンロードのsubmit JavaScript --}}
+            function submit_download_shift_jis() {
+                database_download_csv.character_code.value = '{{CsvCharacterCode::sjis_win}}';
+                database_download_csv.submit();
+            }
+            function submit_download_utf_8() {
+                database_download_csv.character_code.value = '{{CsvCharacterCode::utf_8}}';
+                database_download_csv.submit();
+            }
+        </script>
+
+        {{-- post先 --}}
+        <form action="{{url('/')}}/manage/code/uploadCsv" method="POST" class="form-horizontal" enctype="multipart/form-data">
+            {{ csrf_field() }}
+            {{-- post後、再表示するURL --}}
+            <input type="hidden" name="redirect_path" value="{{url('/')}}/manage/code/import">
+
+            {{-- Submitボタン --}}
+            <div class="form-group text-center">
+                <div class="row">
+                    <div class="offset-sm-3 col-sm-6">
+
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-primary" onclick="submit_download_shift_jis({{$plugin->id}});">
+                                <i class="fas fa-file-download"></i> ダウンロード
+                            </button>
+                            <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="sr-only">ドロップダウンボタン</span>
+                            </button>
+                            <div class="dropdown-menu">
+                                <a class="dropdown-item" href="#" onclick="submit_download_shift_jis({{$plugin->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                                <a class="dropdown-item" href="#" onclick="submit_download_utf_8({{$plugin->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </form>
+
+    </div>
+</div>
+@endsection

--- a/resources/views/plugins/manage/code/code_import.blade.php
+++ b/resources/views/plugins/manage/code/code_import.blade.php
@@ -1,0 +1,116 @@
+{{--
+ * CSVインポート画面テンプレート
+--}}
+
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.code.code_manage_tab')
+    </div>
+    <div class="card-body">
+
+    @if (session('flash_message'))
+        <div class="alert alert-success">
+            {{ session('flash_message') }}
+        </div>
+    @endif
+
+{{--
+    <div class="alert alert-info" role="alert">
+        <ul class="pl-3">
+            CSVファイルを使って、コード管理へ一括登録できます。詳細は<a href="https://connect-cms.jp/manual/user/database#frame-178" target="_blank">こちら</a>を参照してください。
+        </ul>
+    </div>
+--}}
+
+    {{-- ダウンロード用フォーム --}}
+    <form action="{{url('/')}}/manage/code/downloadCsvFormat" method="post" name="database_download_csv_format">
+        {{ csrf_field() }}
+        <input type="hidden" name="character_code" value="">
+    </form>
+
+    <script type="text/javascript">
+        {{-- ダウンロードのsubmit JavaScript --}}
+        function submit_download_csv_format_shift_jis() {
+            database_download_csv_format.character_code.value = '{{CsvCharacterCode::sjis_win}}';
+            database_download_csv_format.submit();
+        }
+        function submit_download_csv_format_utf_8() {
+            database_download_csv_format.character_code.value = '{{CsvCharacterCode::utf_8}}';
+            database_download_csv_format.submit();
+        }
+    </script>
+
+    {{-- post先 --}}
+    <form action="{{url('/')}}/manage/code/uploadCsv" method="POST" class="form-horizontal" enctype="multipart/form-data">
+        {{ csrf_field() }}
+        {{-- post後、再表示するURL --}}
+        <input type="hidden" name="redirect_path" value="{{url('/')}}/manage/code/import">
+
+        <div class="form-group row">
+            <div class="col text-right">
+                <div class="btn-group">
+                    <a href="#" onclick="submit_download_csv_format_shift_jis(); return false;">
+                        CSVファイルのフォーマット
+                    </a>
+                    <button type="button" class="btn btn-sm btn-link dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span class="sr-only">ドロップダウンボタン</span>
+                    </button>
+                    <div class="dropdown-menu">
+                        <a class="dropdown-item" href="#" onclick="submit_download_csv_format_shift_jis(); return false;">CSVファイルのフォーマット（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                        <a class="dropdown-item" href="#" onclick="submit_download_csv_format_utf_8(); return false;">CSVファイルのフォーマット（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group form-row">
+            <label for="buckets_id" class="col-md-3 col-form-label text-md-right">CSVファイル <span class="badge badge-danger">必須</span></label>
+            <div class="col-md-9">
+                <input type="file" name="codes_csv" class="form-control-file">
+                @if ($errors && $errors->has('codes_csv'))
+                    @foreach ($errors->get('codes_csv') as $message)
+                        <div class="text-danger">{{$message}}</div>
+                    @endforeach
+                @endif
+            </div>
+        </div>
+
+        <div class="form-group form-row">
+            <label for="buckets_id" class="col-md-3 col-form-label text-md-right">文字コード</label>
+            <div class="col-md-9">
+                <select name="character_code" class="form-control">
+                    @foreach (CsvCharacterCode::getSelectMembers() as $character_code => $character_code_display)
+                        <option value="{{$character_code}}"@if(old('character_code') == $character_code) selected @endif>{{$character_code_display}}</option>
+                    @endforeach
+                </select>
+                <small class="text-muted">
+                    ※ UTF-8はBOM付・BOMなしどちらにも対応しています。
+                </small>
+                @if ($errors && $errors->has('character_code')) <div class="text-danger">{{$errors->first('character_code')}}</div> @endif
+            </div>
+        </div>
+
+        {{-- Submitボタン --}}
+        <div class="form-group text-center">
+            <div class="row">
+                <div class="offset-sm-3 col-sm-6">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-check"></i>
+                        <span class="" onclick="return confirm('インポートします。\nよろしいですか？')">
+                            インポート
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </form>
+
+</div>
+@endsection

--- a/resources/views/plugins/manage/code/code_manage_tab.blade.php
+++ b/resources/views/plugins/manage/code/code_manage_tab.blade.php
@@ -1,9 +1,5 @@
 {{--
  * 管理画面tabテンプレート
- *
- * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
- * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
- * @category コード管理
  --}}
 <div class="frame-setting-menu">
     <nav class="navbar navbar-expand-md navbar-light bg-light py-1">
@@ -17,7 +13,7 @@
                 @if ($function == "index")
                     <span class="nav-link"><span class="active">コード一覧</span></span>
                 @else
-                    <a href="{{url('/')}}/manage/code" class="nav-link">コード一覧</a></li>
+                    <a href="{{url('/')}}/manage/code" class="nav-link">コード一覧</a>
                 @endif
                 </li>
 
@@ -25,7 +21,7 @@
                 @if ($function == "regist")
                     <span class="nav-link"><span class="active">コード登録</span></span>
                 @else
-                    <a href="{{url('/')}}/manage/code/regist" class="nav-link">コード登録</a></li>
+                    <a href="{{url('/')}}/manage/code/regist" class="nav-link">コード登録</a>
                 @endif
                 </li>
 
@@ -39,7 +35,7 @@
                 @if ($function == "display")
                     <span class="nav-link"><span class="active">表示設定</span></span>
                 @else
-                    <a href="{{url('/')}}/manage/code/display" class="nav-link">表示設定</a></li>
+                    <a href="{{url('/')}}/manage/code/display" class="nav-link">表示設定</a>
                 @endif
                 </li>
 
@@ -47,7 +43,7 @@
                 @if ($function == "searches")
                     <span class="nav-link"><span class="active">検索条件一覧</span></span>
                 @else
-                    <a href="{{url('/')}}/manage/code/searches" class="nav-link">検索条件一覧</a></li>
+                    <a href="{{url('/')}}/manage/code/searches" class="nav-link">検索条件一覧</a>
                 @endif
                 </li>
 
@@ -55,7 +51,7 @@
                 @if ($function == "searchRegist")
                     <span class="nav-link"><span class="active">検索条件登録</span></span>
                 @else
-                    <a href="{{url('/')}}/manage/code/searchRegist" class="nav-link">検索条件登録</a></li>
+                    <a href="{{url('/')}}/manage/code/searchRegist" class="nav-link">検索条件登録</a>
                 @endif
                 </li>
 
@@ -65,27 +61,41 @@
                     </li>
                 @endif
 
-                <li role="presentation" class="nav-item">
-                @if ($function == "helpMessages")
-                    <span class="nav-link"><span class="active">注釈一覧</span></span>
-                @else
-                    <a href="{{url('/')}}/manage/code/helpMessages" class="nav-link">注釈一覧</a></li>
-                @endif
-                </li>
+                <li class="nav-item dropdown">
+                    <a href="#" class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                      その他設定
+                    </a>
+                    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
 
-                <li role="presentation" class="nav-item">
-                @if ($function == "helpMessageRegist")
-                    <span class="nav-link"><span class="active">注釈登録</span></span>
-                @else
-                    <a href="{{url('/')}}/manage/code/helpMessageRegist" class="nav-link">注釈登録</a></li>
-                @endif
-                </li>
+                        @if ($function == "helpMessages")
+                            <a href="{{url('/')}}/manage/code/helpMessages" class="dropdown-item active bg-light">注釈一覧</a>
+                        @else
+                            <a href="{{url('/')}}/manage/code/helpMessages" class="dropdown-item">注釈一覧</a>
+                        @endif
 
-                @if ($function == "helpMessageEdit")
-                    <li role="presentation" class="nav-item">
-                        <span class="nav-link"><span class="active">注釈変更</span></span>
-                    </li>
-                @endif
+                        @if ($function == "helpMessageRegist")
+                            <a href="{{url('/')}}/manage/code/helpMessageRegist" class="dropdown-item active bg-light">注釈登録</a>
+                        @else
+                            <a href="{{url('/')}}/manage/code/helpMessageRegist" class="dropdown-item">注釈登録</a>
+                        @endif
+
+                        @if ($function == "helpMessageEdit")
+                            <span class="dropdown-item active bg-light">注釈変更</span>
+                        @endif
+
+                        @if ($function == "import")
+                            <a href="{{url('/')}}/manage/code/import" class="dropdown-item active bg-light">インポート</a>
+                        @else
+                            <a href="{{url('/')}}/manage/code/import" class="dropdown-item">インポート</a>
+                        @endif
+
+                        @if ($function == "download")
+                            <a href="{{url('/')}}/manage/code/download" class="dropdown-item active bg-light">ダウンロード</a>
+                        @else
+                            <a href="{{url('/')}}/manage/code/download" class="dropdown-item">ダウンロード</a>
+                        @endif
+                    </div>
+                </li>
 
             </ul>
         </div>

--- a/resources/views/plugins/manage/code/display.blade.php
+++ b/resources/views/plugins/manage/code/display.blade.php
@@ -1,9 +1,5 @@
 {{--
  * (コード一覧)表示設定 画面のテンプレート
- *
- * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
- * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
- * @category コード管理
 --}}
 {{-- 管理画面ベース画面 --}}
 @extends('plugins.manage.manage')
@@ -12,238 +8,74 @@
 @section('manage_content')
 
 <div class="card">
-<div class="card-header p-0">
-
-{{-- 機能選択タブ --}}
-@include('plugins.manage.code.code_manage_tab')
-
-</div>
-<div class="card-body">
-
-    <div class="alert alert-info" role="alert">
-        コード一覧に表示する項目を設定します。
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.code.code_manage_tab')
     </div>
+    <div class="card-body">
 
-    <form action="" method="POST" class="form-horizontal">
-        {{ csrf_field() }}
-
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">プラグイン</div>
-            <div class="col-md-9">
-                表示する
-                <input type="hidden" name="code_list_display_colums[plugin_name]" value="plugin_name">
-                <div class="text-muted">
-                    プラグインは編集マークの表示に必要なため、必ず表示します。
-                </div>
-            </div>
+        <div class="alert alert-info" role="alert">
+            コード一覧に表示する項目を設定します。
         </div>
 
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">注釈名</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[codes_help_messages_name]" value="codes_help_messages_name"@if(in_array('codes_help_messages_name', $config->value_array)) == 'codes_help_messages_name') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
+        <form action="" method="POST" class="form-horizontal">
+            {{ csrf_field() }}
 
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">buckets_name</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[buckets_name]" value="buckets_name"@if(in_array('buckets_name', $config->value_array)) == 'buckets_name') checked @endif>表示する
-                    </label>
+            <div class="form-group row">
+                <div class="col-md-3 text-md-right">プラグイン</div>
+                <div class="col-md-9">
+                    表示する
+                    <input type="hidden" name="code_list_display_colums[plugin_name]" value="plugin_name">
+                    <div class="text-muted">
+                        プラグインは編集マークの表示に必要なため、必ず表示します。
+                    </div>
                 </div>
             </div>
-        </div>
 
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">buckets_id</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[buckets_id]" value="buckets_id"@if(in_array('buckets_id', $config->value_array)) == 'buckets_id') checked @endif>表示する
-                    </label>
+            {{--
+            <div class="form-group row">
+                <div class="col-md-3 text-md-right">注釈名</div>
+                <div class="col-md-9">
+                    <div class="form-check">
+                        <label class="form-check-label">
+                            <input class="form-check-input" type="checkbox" name="code_list_display_colums[codes_help_messages_name]" value="codes_help_messages_name"@if(in_array('codes_help_messages_name', $config->value_array)) == 'codes_help_messages_name') checked @endif>表示する
+                        </label>
+                    </div>
                 </div>
             </div>
-        </div>
+            --}}
 
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">prefix</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[prefix]" value="prefix"@if(in_array('prefix', $config->value_array)) == 'prefix') checked @endif>表示する
-                    </label>
+            @foreach(CodeColumn::getIndexColumn() as $column_key => $column_value)
+                <div class="form-group row">
+                    <div class="col-md-3 text-md-right">{{$column_value}}</div>
+                    <div class="col-md-9">
+                        <div class="form-check">
+                            <label class="form-check-label">
+                                <input class="form-check-input" type="checkbox" name="code_list_display_colums[{{$column_key}}]" value="{{$column_key}}"@if(in_array($column_key, $config->value_array)) == $column_key') checked @endif>表示する
+                            </label>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
+            @endforeach
 
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">type_name</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[type_name]" value="type_name"@if(in_array('type_name', $config->value_array)) == 'type_name') checked @endif>表示する
-                    </label>
+            <!-- Update code Button -->
+            <div class="form-group row">
+                <div class="offset-sm-3 col-sm-6">
+                    <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/')}}/manage/code?page={{$paginate_page}}'"><i class="fas fa-times"></i> キャンセル</button>
+                    @if ($config->id)
+                    <button type="button" class="btn btn-primary form-horizontal mr-2" onclick="this.form.action='{{url('/')}}/manage/code/displayUpdate/{{$config->id}}'; this.form.submit();">
+                        <i class="fas fa-check"></i> 更新
+                    </button>
+                    @else
+                    <button type="button" class="btn btn-primary form-horizontal mr-2" onclick="this.form.action='{{url('/')}}/manage/code/displayStore'; this.form.submit();">
+                        <i class="fas fa-check"></i> 登録
+                    </button>
+                    @endif
                 </div>
             </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">type_code1</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[type_code1]" value="type_code1"@if(in_array('type_code1', $config->value_array)) == 'type_code1') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">type_code2</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[type_code2]" value="type_code2"@if(in_array('type_code2', $config->value_array)) == 'type_code2') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">type_code3</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[type_code3]" value="type_code3"@if(in_array('type_code3', $config->value_array)) == 'type_code3') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">type_code4</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[type_code4]" value="type_code4"@if(in_array('type_code4', $config->value_array)) == 'type_code4') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">type_code5</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[type_code5]" value="type_code5"@if(in_array('type_code5', $config->value_array)) == 'type_code5') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
+        </form>
 
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">コード</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[code]" value="code"@if(in_array('code', $config->value_array)) == 'code') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">値</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[value]" value="value"@if(in_array('value', $config->value_array)) == 'value') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">additional1</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[additional1]" value="additional1"@if(in_array('additional1', $config->value_array)) == 'additional1') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">additional2</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[additional2]" value="additional2"@if(in_array('additional2', $config->value_array)) == 'additional2') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">additional3</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[additional3]" value="additional3"@if(in_array('additional3', $config->value_array)) == 'additional3') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">additional4</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[additional4]" value="additional4"@if(in_array('additional4', $config->value_array)) == 'additional4') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">additional5</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[additional5]" value="additional5"@if(in_array('additional5', $config->value_array)) == 'additional5') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">表示順</div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="code_list_display_colums[display_sequence]" value="display_sequence"@if(in_array('display_sequence', $config->value_array)) == 'display_sequence') checked @endif>表示する
-                    </label>
-                </div>
-            </div>
-        </div>
-
-        <!-- Update code Button -->
-        <div class="form-group row">
-            <div class="offset-sm-3 col-sm-6">
-                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/')}}/manage/code?page={{$paginate_page}}'"><i class="fas fa-times"></i> キャンセル</button>
-                @if ($config->id)
-                <button type="button" class="btn btn-primary form-horizontal mr-2" onclick="this.form.action='{{url('/')}}/manage/code/displayUpdate/{{$config->id}}'; this.form.submit();">
-                    <i class="fas fa-check"></i> 更新
-                </button>
-                @else
-                <button type="button" class="btn btn-primary form-horizontal mr-2" onclick="this.form.action='{{url('/')}}/manage/code/displayStore'; this.form.submit();">
-                    <i class="fas fa-check"></i> 登録
-                </button>
-                @endif
-            </div>
-        </div>
-    </form>
-
-</div>
+    </div>
 </div>
 
 @endsection

--- a/resources/views/plugins/manage/code/help_message.blade.php
+++ b/resources/views/plugins/manage/code/help_message.blade.php
@@ -1,9 +1,5 @@
 {{--
  * 注釈一覧画面のメインテンプレート
- *
- * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
- * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
- * @category コード管理
 --}}
 {{-- 管理画面ベース画面 --}}
 @extends('plugins.manage.manage')
@@ -12,38 +8,38 @@
 @section('manage_content')
 
 <div class="card">
-<div class="card-header p-0">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.code.code_manage_tab')
+    </div>
+    <div class="card-body">
 
-{{-- 機能選択タブ --}}
-@include('plugins.manage.code.code_manage_tab')
+        {{-- 一覧エリア --}}
+        <div class="text-right mt-3"><span class="badge badge-pill badge-light">{{ $codes_help_messages->total() }} 件</span></div>
+        <table class="table table-bordered table_border_radius table-hover cc-font-90">
+            <tbody>
+                <tr class="bg-light d-none d-sm-table-row">
+                    <th class="d-block d-sm-table-cell text-break">注釈名</th>
+                    <th class="d-block d-sm-table-cell text-break">注釈キー</th>
+                    <th class="d-block d-sm-table-cell text-break">表示順</th>
+                </tr>
 
-</div>
-<div class="card-body">
+                @foreach($codes_help_messages as $codes_help_message)
+                <tr>
+                    <th class="d-block d-sm-table-cell bg-light">
+                        <a href="{{url('/')}}/manage/code/helpMessageEdit/{{$codes_help_message->id}}?page={{$paginate_page}}&search_words={{$search_words}}"><i class="far fa-edit"></i></a>
+                        <span class="d-sm-none">注釈名：</span>{{$codes_help_message->name}}
+                    </th>
+                    <td class="d-block d-sm-table-cell"><span class="d-sm-none">注釈キー：</span>{{$codes_help_message->alias_key}}</td>
+                    <td class="d-block d-sm-table-cell"><span class="d-sm-none">表示順：</span>{{$codes_help_message->display_sequence}}</td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
 
-{{-- 一覧エリア --}}
-<div class="text-right mt-3"><span class="badge badge-pill badge-light">{{ $codes_help_messages->total() }} 件</span></div>
-<table class="table table-bordered table_border_radius table-hover cc-font-90">
-<tbody>
-    <tr class="bg-light d-none d-sm-table-row">
-        <th class="d-block d-sm-table-cell text-break">注釈名</th>
-        <th class="d-block d-sm-table-cell text-break">表示順</th>
-    </tr>
+        {{ $codes_help_messages->links() }}
 
-    @foreach($codes_help_messages as $codes_help_message)
-    <tr>
-        <th class="d-block d-sm-table-cell bg-light">
-            <a href="{{url('/')}}/manage/code/helpMessageEdit/{{$codes_help_message->id}}?page={{$paginate_page}}&search_words={{$search_words}}"><i class="far fa-edit"></i></a>
-            <span class="d-sm-none">注釈名：</span>{{$codes_help_message->name}}
-        </th>
-        <td class="d-block d-sm-table-cell"><span class="d-sm-none">表示順：</span>{{$codes_help_message->display_sequence}}</td>
-    </tr>
-    @endforeach
-</tbody>
-</table>
-
-{{ $codes_help_messages->links() }}
-
-</div>
+    </div>
 </div>
 
 @endsection


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

下記の機能追加プルリクエストです。

* コード管理のインポート機能追加
* コード管理のダウンロード機能追加
* コード管理の一覧表示設定に、id, 注釈キー を追加
* コード管理、上部メニューが多くなってきたため、その他設定としてまとめる
* データベースプラグイン、UTF-8 BOM付でCSVインポートすると、必ずエラーになる（初めのカラムがないエラー）不具合を修正

### 画面
#### 表示設定 （id, 注釈キー を追加）
![image](https://user-images.githubusercontent.com/2756509/104414196-30226700-55b3-11eb-9742-8388193f647e.png)

#### 上部メニューが多くなってきたため、その他設定としてまとめる
![image](https://user-images.githubusercontent.com/2756509/104414255-50eabc80-55b3-11eb-91ba-e4a1e1b11b28.png)

#### インポート画面
![image](https://user-images.githubusercontent.com/2756509/104414323-6bbd3100-55b3-11eb-87c5-c1f8e540cb3b.png)

#### ダウンロード画面
![image](https://user-images.githubusercontent.com/2756509/104414392-868fa580-55b3-11eb-924d-7a91b7a5ce14.png)


### commits

* add: コード管理、インポート追加
* add: コード管理、ダウンロード追加
* add: コード管理、表示設定にid, 注釈キーを追加
* add: コード管理、注釈一覧に注釈キー項目を追加
* add: コード管理, コード管理のカラムのenum追加
* change: コード管理、表示設定の表示をenumsを参照するよう見直し
* change: コード管理、一覧表示をenumsを参照するよう見直し
* change: コード管理、上部メニューが多くなってきたため、その他設定としてまとめる
* change: コード管理, 変数の誤字修正 colum -> column
* change: データベースプラグイン、インポート時のストリームフィルタ内で、Shift-JIS -> UTF-8変換を、外部メソッド化対応
* delete: データベースプラグイン, 不要な変数の初期化削除
* bugfix: データベースプラグイン、UTF-8 BOM付だと初めのカラムがないと必ずエラーになる不具合を修正

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/697

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
