### PR TITLE
core修正 enums_optionをaliasesに動的に登録するよう改修

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,6 +1,6 @@
 <?php
 
-return [
+$app_array = [
 
     /*
     |--------------------------------------------------------------------------
@@ -262,3 +262,23 @@ return [
     ],
 
 ];
+
+/**
+ * 外部プラグイン用に定義したenumファイル（enums_optionディレクトリ）をaliasesに登録
+ */
+// configディレクトリを起点に「App\EnumsOption」ディレクトリを取得
+$path_enums_option = str_replace(DIRECTORY_SEPARATOR . 'config', '', dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'EnumsOption' . DIRECTORY_SEPARATOR;
+// 「App\EnumsOption」ディレクトリ配下のファイルをフルパスで取得
+$fullpaths = glob($path_enums_option . '*');
+foreach ($fullpaths as $fullpath) {
+    // 拡張子を除外
+    $fullpath_omit_extention = str_replace('.php', '', $fullpath);
+    // ディレクトリ部分を除外
+    $enums_option_name = str_replace($path_enums_option, '', $fullpath_omit_extention);
+    // ネームスペースを追加
+    $enums_option_name_with_namespace = '\\App\\EnumsOption\\' . $enums_option_name;
+    // Laravelのエイリアスに登録
+    $app_array['aliases'][$enums_option_name] = get_class(new $enums_option_name_with_namespace);
+}
+
+return $app_array;


### PR DESCRIPTION
## 概要
外部プラグイン用のenumファイル（EnumsOption配下）を動的に読み込むよう改修
- Connect-CMSでは各所でenumを多用しており、app.phpのaliasesに登録することでblade等で直接参照できるようにしています。
- しかしながら、外部プラグイン系のenumは独自性や非公開等の観点からapp.phpに直接登録することができませんでした。
- 故に外部プラグインでenumを利用する為にはblade等のファイルにuse文で直接ロード、又は、フルパスで参照する必要がありました。
- これを解消する為、app.phpの定義配列に動的にクラス登録を行うようにしたものが今回の改修です。
- 懸念点として画面ロード時の負荷増加がありましたが、30ファイルのenumに対して改修前後のContent Download（Request+Responseの秒数）をそれぞれ10回確認しましたが大きな差は見られませんでした。

## 関連Pull requests/Issues
なし

## 参考
なし

## DB変更の有無
なし

## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
