### PR TITLE
掲示板の修正（日付の表記の統一）

### DIFF
--- a/app/Models/User/Bbses/BbsPost.php
+++ b/app/Models/User/Bbses/BbsPost.php
@@ -94,4 +94,20 @@ class BbsPost extends Model
         }
         return true;
     }
+
+    /**
+     * 更新日時の取得
+     */
+    public function getUpdatedAt($wrong_only = true)
+    {
+        // 必ず返却
+        if ($wrong_only == false) {
+            return $this->updated_at->format('Y年n月j日 H時i分');
+        }
+
+        // 登録日時と更新日時が違う場合のみ返却
+        if ($this->updated_at && $this->created_at != $this->updated_at) {
+            return "（更新：" . $this->updated_at->format('Y年n月j日 H時i分') . "）";
+        }
+    }
 }

--- a/resources/views/plugins/user/bbses/default/index.blade.php
+++ b/resources/views/plugins/user/bbses/default/index.blade.php
@@ -46,10 +46,10 @@
                 {{-- 一覧での展開方法：すべて閉じるの場合は、card のボディに根記事を含めた記事のタイトル一覧を表示 --}}
                 <div class="card-body">
                     {{-- 根記事（スレッドの記事は古い順なので、根記事は最初） --}}
-                    @include('plugins.user.bbses.default.post_title_div', ['view_post' => $post, 'current_post' => null])
+                    @include('plugins.user.bbses.default.post_title_div', ['view_post' => $post, 'current_post' => null, 'list_class' => 'mb-2'])
                     {{-- スレッド記事 --}}
                     @foreach ($children_posts->where("thread_root_id", $post->id) as $children_post)
-                        @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => null])
+                        @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => null, 'list_class' => 'mb-2'])
                     @endforeach
                 </div>
             </div>
@@ -57,8 +57,8 @@
             {{-- 一覧での展開方法：すべて展開 or すべて閉じておく --}}
             <div class="card mb-3">
                 <div class="card-header">
-                    @include('plugins.user.bbses.default.post_title', ['view_post' => $post, 'current_post' => null])
-                    <span class="float-right">{{$post->updated_at->format('Y-m-d')}} [{{$post->created_name}}]</span>
+                    @include('plugins.user.bbses.default.post_title', ['view_post' => $post, 'current_post' => null, 'list_class' => ''])
+                    <span class="float-right">{{$post->created_at->format('Y-m-d')}} [{{$post->created_name}}]</span>
                 </div>
                 <div class="card-body">
                     {!!$post->body!!}
@@ -72,7 +72,7 @@
                                 @endif
                                 <div class="card-body">
                                     @foreach ($children_posts->where("thread_root_id", $post->id) as $children_post)
-                                        @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => null])
+                                        @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => null, 'list_class' => 'mb-2'])
                                     @endforeach
                                 </div>
                             </div>
@@ -81,8 +81,8 @@
                             @foreach ($children_posts->where("thread_root_id", $post->id) as $children_post)
                                 <div class="card mt-3">
                                     <div class="card-header">
-                                        @include('plugins.user.bbses.default.post_title', ['view_post' => $children_post, 'current_post' => null])
-                                        <span class="float-right">{{$children_post->updated_at->format('Y-m-d')}} [{{$children_post->created_name}}]</span>
+                                        @include('plugins.user.bbses.default.post_title', ['view_post' => $children_post, 'current_post' => null, 'list_class' => ''])
+                                        <span class="float-right">{{$children_post->created_at->format('Y-m-d')}} [{{$children_post->created_name}}]</span>
                                     </div>
                                     <div class="card-body">
                                         {!!$children_post->body!!}

--- a/resources/views/plugins/user/bbses/default/post_title_div.blade.php
+++ b/resources/views/plugins/user/bbses/default/post_title_div.blade.php
@@ -6,13 +6,13 @@
  * @category 掲示板プラグイン
 --}}
 @if ($plugin_frame->list_underline)
-<div class="border-bottom clearfix mb-2">
+<div class="border-bottom clearfix {{$list_class}}">
 @else
-<div class="clearfix mb-2">
+<div class="clearfix {{$list_class}}">
 @endif
     <div class="float-left">
         <i class="fas fa-chevron-circle-right"></i>
         @include('plugins.user.bbses.default.post_title', ['view_post' => $view_post, 'current_post' => $current_post])
     </div>
-    <div class="float-right">{{$view_post->updated_at->format('Y-m-d')}} [{{$view_post->created_name}}]</div>
+    <div class="float-right">{{$view_post->created_at->format('Y-m-d')}} [{{$view_post->created_name}}]</div>
 </div>

--- a/resources/views/plugins/user/bbses/default/show.blade.php
+++ b/resources/views/plugins/user/bbses/default/show.blade.php
@@ -47,7 +47,7 @@
         <h2>{{$post->title}}</h2>
 
         {{-- 投稿日時 --}}
-        <b>{{$post->created_at->format('Y年n月j日 H時i分')}}</b>
+        <b>{{$post->created_at->format('Y年n月j日 H時i分')}} [{{$post->created_name}}]</b>
     </header>
 
     {{-- 記事本文 --}}
@@ -55,6 +55,9 @@
 
     {{-- post データは以下のように2重配列で渡す（Laravelが配列の0番目のみ使用するので） --}}
     <footer class="row">
+        <div class="col-12 text-right mb-1">
+            {{$post->getUpdatedAt()}}
+        </div>
         <div class="col-12 text-right mb-1">
         {{-- 一時保存 --}}
         @if ($post->status == 1)
@@ -121,15 +124,15 @@
         <div class="card mb-3">
             {{-- 詳細でのスレッド記事の展開方法：すべて閉じるの場合は、card のヘッダに根記事のタイトルを表示 --}}
             <div class="card-header">
-                {{$thread_root_post->title}}@if ($thread_root_post->status == 1) <span class="badge badge-warning align-bottom">一時保存</span>@elseif ($thread_root_post->status == 2) <span class="badge badge-warning align-bottom">承認待ち</span>@endif<span class="float-right">{{$thread_root_post->created_at->format('Y-m-d')}} [{{$thread_root_post->created_name}}]</span>
+                {{$thread_root_post->title}}@if ($thread_root_post->status == 1) <span class="badge badge-warning align-bottom">一時保存</span>@elseif ($thread_root_post->status == 2) <span class="badge badge-warning align-bottom">承認待ち</span>@endif<span class="float-right">{{$thread_root_post->created_at->format('Y年n月j日')}} [{{$thread_root_post->created_name}}]</span>
             </div>
             {{-- 詳細でのスレッド記事の展開方法：すべて閉じるの場合は、card のボディに根記事を含めた記事のタイトル一覧を表示 --}}
             <div class="card-body">
                 {{-- 根記事（スレッドの記事は古い順なので、根記事は最初） --}}
-                @include('plugins.user.bbses.default.post_title_div', ['view_post' => $thread_root_post, 'current_post' => $post])
+                @include('plugins.user.bbses.default.post_title_div', ['view_post' => $thread_root_post, 'current_post' => $post, 'list_class' => ''])
                 {{-- スレッド記事 --}}
                 @foreach ($children_posts->where("thread_root_id", $thread_root_post->id) as $children_post)
-                    @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => $post])
+                    @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => $post, 'list_class' => ''])
                 @endforeach
             </div>
         </div>
@@ -141,7 +144,7 @@
             @if ($plugin_frame->thread_format != 0)
                 {{-- 詳細でのスレッド記事の展開方法が詳細表示している記事のみ展開の場合 --}}
                 <div class="card-header">
-                    @include('plugins.user.bbses.default.post_title', ['view_post' => $thread_root_post, 'current_post' => $post])
+                    @include('plugins.user.bbses.default.post_title', ['view_post' => $thread_root_post, 'current_post' => $post, 'list_class' => ''])
                 </div>
                 {{-- 詳細でのスレッド記事の展開方法：すべて閉じるの場合は、card のボディに根記事を含めた記事のタイトル一覧を表示 --}}
                 <div class="card-body">
@@ -149,14 +152,14 @@
                     @if ($thread_root_post->id == $post->id)
                         <div class="card mb-2">
                             <div class="card-header">
-                                @include('plugins.user.bbses.default.post_title_div', ['view_post' => $thread_root_post, 'current_post' => $post])
+                                @include('plugins.user.bbses.default.post_title_div', ['view_post' => $thread_root_post, 'current_post' => $post, 'list_class' => ''])
                             </div>
                             <div class="card-body">
                                 {!!$thread_root_post->body!!}
                             </div>
                         </div>
                     @else
-                        @include('plugins.user.bbses.default.post_title_div', ['view_post' => $thread_root_post, 'current_post' => $post])
+                        @include('plugins.user.bbses.default.post_title_div', ['view_post' => $thread_root_post, 'current_post' => $post, 'list_class' => ''])
                     @endif
 
                     {{-- スレッド記事 --}}
@@ -164,40 +167,37 @@
                         @if ($children_post->id == $post->id)
                             <div class="card mb-2">
                                 <div class="card-header">
-                                    @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => $post])
+                                    @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => $post, 'list_class' => ''])
                                 </div>
                                 <div class="card-body">
                                     {!!$children_post->body!!}
                                 </div>
                             </div>
                         @else
-                            @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => $post])
+                            @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => $post, 'list_class' => ''])
                         @endif
                     @endforeach
                 </div>
             @else
                 <div class="card-header">
-                    @include('plugins.user.bbses.default.post_title', ['view_post' => $thread_root_post, 'current_post' => $post])
+                    @include('plugins.user.bbses.default.post_title_div', ['view_post' => $thread_root_post, 'current_post' => $post, 'list_class' => ''])
                 </div>
                 <div class="card-body">
                     {!!$thread_root_post->body!!}
                     @foreach ($children_posts as $children_post)
                         <div class="card mt-3">
                             <div class="card-header">
-                                @include('plugins.user.bbses.default.post_title', ['view_post' => $children_post, 'current_post' => $post])
+                                @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => $post, 'list_class' => ''])
                             </div>
                             <div class="card-body">
                                 {!!$children_post->body!!}
                             </div>
                         </div>
                     @endforeach
-            </div>
+                </div>
             @endif
         </div>
     @endif
-
-
-
 @endif
 
 {{-- / post がある想定の処理 --}}


### PR DESCRIPTION
日付は登録日の表示を基本として、詳細画面では、登録日時と更新日時が違うときのみ、更新日時を表示

## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
日付は登録日の表示を基本として、詳細画面では、登録日時と更新日時が違うときのみ、更新日時を表示

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
無し

## チェックリスト
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
