### PR TITLE
bugfix: 【サイト管理・バグ】サイト名が サイト管理＞サイト基本設定 以外適用されない

### DIFF
--- a/app/Http/Middleware/ConnectInit.php
+++ b/app/Http/Middleware/ConnectInit.php
@@ -39,7 +39,21 @@ class ConnectInit
         /* --- 共通で使用するDB --- */
 
         // Connect-CMS の各種設定
-        $request->attributes->add(['configs' => Configs::get()]);
+        // bugfix:【サイト管理・バグ】サイト名が サイト管理＞サイト基本設定 以外適用されない対応
+        // $request->attributes->add(['configs' => Configs::get()]);
+        $configs = Configs::get();
+        if (isset($configs)) {
+            $base_site_name = $configs->firstWhere('name', 'base_site_name');
+            $configs_base_site_name = $base_site_name->value;
+        } else {
+            $configs_base_site_name = config('app.name', 'Connect-CMS');
+        }
+        // requestにセット
+        $request->attributes->add(['configs' => $configs]);
+
+        // *** 全ビュー間のデータ共有
+        // サイト名
+        \View::share('configs_base_site_name', $configs_base_site_name);
 
         return $next($request);
     }

--- a/app/Http/Middleware/ConnectInit.php
+++ b/app/Http/Middleware/ConnectInit.php
@@ -42,17 +42,18 @@ class ConnectInit
         // bugfix:【サイト管理・バグ】サイト名が サイト管理＞サイト基本設定 以外適用されない対応
         // $request->attributes->add(['configs' => Configs::get()]);
         $configs = Configs::get();
+
+        // requestにセット
+        $request->attributes->add(['configs' => $configs]);
+
+        // *** 全ビュー間のデータ共有
+        // サイト名
         if (isset($configs)) {
             $base_site_name = $configs->firstWhere('name', 'base_site_name');
             $configs_base_site_name = $base_site_name->value;
         } else {
             $configs_base_site_name = config('app.name', 'Connect-CMS');
         }
-        // requestにセット
-        $request->attributes->add(['configs' => $configs]);
-
-        // *** 全ビュー間のデータ共有
-        // サイト名
         \View::share('configs_base_site_name', $configs_base_site_name);
 
         return $next($request);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,7 +8,6 @@ use Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider;
 
 use App\Traits\ConnectCommonTrait;
-use App\Models\Core\Configs;
 
 //class AppServiceProvider extends ServiceProvider
 class AppServiceProvider extends AuthServiceProvider
@@ -51,12 +50,6 @@ class AppServiceProvider extends AuthServiceProvider
      */
     public function boot()
     {
-        // *** 全ビュー間のデータ共有
-        // サイト名
-        $base_site_name = Configs::where('name', 'base_site_name')->first();
-        $configs_base_site_name = isset($base_site_name) ? $base_site_name->value : config('app.name', 'Connect-CMS');
-        \View::share('configs_base_site_name', $configs_base_site_name);
-
         // 認可サービス(Gate)利用の準備
         $this->registerPolicies();
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider;
 
 use App\Traits\ConnectCommonTrait;
+use App\Models\Core\Configs;
 
 //class AppServiceProvider extends ServiceProvider
 class AppServiceProvider extends AuthServiceProvider
@@ -50,6 +51,12 @@ class AppServiceProvider extends AuthServiceProvider
      */
     public function boot()
     {
+        // *** 全ビュー間のデータ共有
+        // サイト名
+        $base_site_name = Configs::where('name', 'base_site_name')->first();
+        $configs_base_site_name = isset($base_site_name) ? $base_site_name->value : config('app.name', 'Connect-CMS');
+        \View::share('configs_base_site_name', $configs_base_site_name);
+
         // 認可サービス(Gate)利用の準備
         $this->registerPolicies();
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -58,11 +58,7 @@
 @endif
     {{-- CSRF Token --}}
     <meta name="csrf-token" content="{{csrf_token()}}">
-@if(isset($configs))
-    <title>@if(isset($page)){{$page->page_name}} | @endif{{$configs['base_site_name']}}</title>
-@else
-    <title>@if(isset($page)){{$page->page_name}} | @endif{{config('app.name', 'Connect-CMS')}}</title>
-@endif
+    <title>@if(isset($page)){{$page->page_name}} | @endif{{ $configs_base_site_name }}</title>
 
     <!-- Styles -->
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
@@ -138,11 +134,7 @@ if(isset($configs_array['body_optional_class'])){
 <nav class="navbar navbar-expand-md navbar-dark bg-dark @if (isset($configs) && ($configs['base_header_fix'] == '1')) sticky-top @endif" aria-label="ヘッダー">
     <!-- Branding Image -->
     <a class="navbar-brand" href="{{ url('/') }}">
-        @if(isset($configs))
-            {{$configs['base_site_name']}}
-        @else
-            {{ config('app.name', 'Connect-CMS') }}
-        @endif
+        {{ $configs_base_site_name }}
     </a>
 
     <!-- SmartPhone Button -->
@@ -158,7 +150,7 @@ if(isset($configs_array['body_optional_class'])){
                 @foreach($page_list as $page_obj)
 
                     {{-- スマホメニューテンプレート(default) --}}
-                    @if (isset($configs) && 
+                    @if (isset($configs) &&
                             (!isset($configs['smartphone_menu_template']) ||
                                 (isset($configs['smartphone_menu_template']) && ($configs['smartphone_menu_template'] == ''))
                             )


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

バグ修正のプルリクエストです。
・マイページでサイト名が表示される事を確認
・管理画面でサイト名が表示される事を確認
・通常画面でサイト名が表示される事、タイトルが表示される事を確認

resources/views/layouts/app.blade.php　で表示していた下記ロジックを
```php
        @if(isset($configs))
            {{$configs['base_site_name']}}
        @else
            {{ config('app.name', 'Connect-CMS') }}
        @endif
```

~~app/Providers/AppServiceProvider.php　の　bootメソッドに移植して、全ビュー間のデータ共有する `\View::share()` 
でセットしました。~~


app/Http/Middleware/ConnectInit.phpの　handleメソッドに移植して、全ビュー間のデータ共有する `\View::share()` 
でセットしました。

[app/Http/Middleware/ConnectInit.php](https://github.com/opensource-workshop/connect-cms/blob/master/app/Http/Middleware/ConnectInit.php#L42)
```php
        /* --- 共通で使用するDB --- */

        // Connect-CMS の各種設定
        // bugfix:【サイト管理・バグ】サイト名が サイト管理＞サイト基本設定 以外適用されない対応
        // $request->attributes->add(['configs' => Configs::get()]);
        $configs = Configs::get();

        // requestにセット
        $request->attributes->add(['configs' => $configs]);

        // *** 全ビュー間のデータ共有
        // サイト名
        if (isset($configs)) {
            $base_site_name = $configs->firstWhere('name', 'base_site_name');
            $configs_base_site_name = $base_site_name->value;
        } else {
            $configs_base_site_name = config('app.name', 'Connect-CMS');
        }
        \View::share('configs_base_site_name', $configs_base_site_name);
```

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/409

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

全ビュー間のデータ共有 - ビュー 5.5 Laravel
https://readouble.com/laravel/5.5/ja/views.html#sharing-data-with-all-views

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
