### PR TITLE
change: ユーザ管理一覧、ダウンロードボタン位置修正

### DIFF
--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -238,34 +238,12 @@ use App\Models\Core\UsersColumns;
 
                             {{-- ボタンエリア --}}
                             <div class="form-group text-center">
-                                <div class="row">
-                                    <div class="col-3"></div>
-                                    <div class="col-6">
-                                        <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/user/clearSearch')}}'">
-                                            <i class="fas fa-times"></i> クリア
-                                        </button>
-                                        <button type="submit" class="btn btn-primary form-horizontal">
-                                            <i class="fas fa-check"></i> 絞り込み
-                                        </button>
-                                    </div>
-                                    <div class="col-3 text-right">
-                                        <div class="btn-group dropup">
-                                            <button type="button" class="btn btn-primary" onclick="submit_download_shift_jis();">
-                                                <i class="fas fa-file-download"></i><span class="d-none d-md-inline"> ダウンロード</span>
-                                            </button>
-                                            <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                                <span class="sr-only">ドロップダウンボタン</span>
-                                            </button>
-                                            <div class="dropdown-menu">
-                                                <a class="dropdown-item" href="#" onclick="submit_download_shift_jis(); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
-                                                <a class="dropdown-item" href="#" onclick="submit_download_utf_8(); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
-                                                <a class="dropdown-item" href="https://connect-cms.jp/manual/manager/user#download-csv-help" target="_brank">
-                                                    <span class="btn btn-link"><i class="fas fa-question-circle"></i> オンラインマニュアル</span>
-                                                </a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
+                                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/user/clearSearch')}}'">
+                                    <i class="fas fa-times"></i> クリア
+                                </button>
+                                <button type="submit" class="btn btn-primary form-horizontal">
+                                    <i class="fas fa-check"></i> 絞り込み
+                                </button>
                             </div>
                         </form>
                     </div>
@@ -274,7 +252,28 @@ use App\Models\Core\UsersColumns;
         </div>
 
         <div class="form-group table-responsive">
-            <div class="text-right mt-3"><span class="badge badge-pill badge-light">{{ $users->total() }} 件</span></div>
+            {{-- ダウンロードボタン --}}
+            <div class="text-right mt-2">
+                <div class="btn-group">
+                    <button type="button" class="btn btn-link" onclick="submit_download_shift_jis();">
+                        <i class="fas fa-file-download"></i><span class=""> ダウンロード</span>
+                    </button>
+                    <button type="button" class="btn btn-link dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span class="sr-only">ドロップダウンボタン</span>
+                    </button>
+                    <div class="dropdown-menu">
+                        <a class="dropdown-item" href="#" onclick="submit_download_shift_jis(); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                        <a class="dropdown-item" href="#" onclick="submit_download_utf_8(); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+                        <a class="dropdown-item" href="https://connect-cms.jp/manual/manager/user#download-csv-help" target="_brank">
+                            <span class="btn btn-link"><i class="fas fa-question-circle"></i> オンラインマニュアル</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            {{-- 件数 --}}
+            <div class="text-right"><span class="badge badge-pill badge-light">{{ $users->total() }} 件</span></div>
+
             <table class="table table-hover cc-font-90">
             <thead>
                 <tr>

--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -251,9 +251,14 @@ use App\Models\Core\UsersColumns;
             </div>
         </div>
 
-        <div class="form-group table-responsive">
-            {{-- ダウンロードボタン --}}
-            <div class="text-right mt-2">
+        <div class="row mt-2">
+            <div class="col text-left d-flex align-items-end">
+                {{-- (左側)件数 --}}
+                <span class="badge badge-pill badge-light">{{ $users->total() }} 件</span>
+            </div>
+
+            <div class="col text-right">
+                {{-- (右側)ダウンロードボタン --}}
                 <div class="btn-group">
                     <button type="button" class="btn btn-link" onclick="submit_download_shift_jis();">
                         <i class="fas fa-file-download"></i><span class=""> ダウンロード</span>
@@ -270,10 +275,9 @@ use App\Models\Core\UsersColumns;
                     </div>
                 </div>
             </div>
+        </div>
 
-            {{-- 件数 --}}
-            <div class="text-right"><span class="badge badge-pill badge-light">{{ $users->total() }} 件</span></div>
-
+        <div class="form-group table-responsive">
             <table class="table table-hover cc-font-90">
             <thead>
                 <tr>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

ユーザ管理一覧、ダウンロードボタン位置修正のプルリクエストです。
要相談です。
⇒ 相談後修正しました。（左側に件数、右側にダウンロードボタン配置に見直し）

## 画面
### ユーザ管理一覧（ダウンロードボタン位置修正）

![image](https://user-images.githubusercontent.com/2756509/113812223-ac8aa780-97a8-11eb-81cd-2e190b46b587.png)


## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

issue https://github.com/opensource-workshop/connect-cms/issues/779
Pull request https://github.com/opensource-workshop/connect-cms/pull/784

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
