### PR TITLE
add: 共通のメール設定、メールアドレスの入力チェック追加。しかし入力エラー時に入力値が保持されない

### DIFF
--- a/resources/views/plugins/common/frame_edit_mails.blade.php
+++ b/resources/views/plugins/common/frame_edit_mails.blade.php
@@ -243,36 +243,36 @@
 </form>
 
 {{-- 初期状態で開くもの --}}
-@if ($bucket_mail->notice_on)
-<script>
-$('#collapse_notice').collapse({
-  toggle: true
-})
-</script>
+@if (old('notice_on', $bucket_mail->notice_on))
+    <script>
+    $('#collapse_notice').collapse({
+        toggle: true
+    })
+    </script>
 @endif
 
-@if ($bucket_mail->relate_on)
-<script>
-$('#collapse_relate').collapse({
-  toggle: true
-})
-</script>
+@if (old('relate_on', $bucket_mail->relate_on))
+    <script>
+    $('#collapse_relate').collapse({
+        toggle: true
+    })
+    </script>
 @endif
 
-@if ($bucket_mail->approval_on)
-<script>
-$('#collapse_approval').collapse({
-  toggle: true
-})
-</script>
+@if (old('approval_on', $bucket_mail->approval_on))
+    <script>
+    $('#collapse_approval').collapse({
+        toggle: true
+    })
+    </script>
 @endif
 
-@if ($bucket_mail->approved_on)
-<script>
-$('#collapse_approved').collapse({
-  toggle: true
-})
-</script>
+@if (old('approved_on', $bucket_mail->approved_on))
+    <script>
+    $('#collapse_approved').collapse({
+        toggle: true
+    })
+    </script>
 @endif
 
 {{-- 表示しない。 --}}


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

メール設定にメールアドレスの入力チェックを追加したけど、エラーメッセージは画面にわたるけど、
入力値が渡らななくハマりました。

原因思い当たる人いますか？

バリデートエラーでやってる事。

```php
        // redirect_path
        $redirect_path_array = [
            'redirect_path' => url('/') . "/plugin/" . $this->frame->plugin_name . "/editBucketsMails/" . $page_id . "/" . $frame_id . "/" . $bucket->id . "#frame-" . $frame_id
        ];

        // 項目のエラーチェック
        $validator = Validator::make($request->all(), [
            'notice_addresses' => ['nullable', 'email', Rule::requiredIf($request->notice_on)],
            'approval_addresses' => ['nullable', 'email', Rule::requiredIf($request->relate_on)],
            'approved_addresses' => ['nullable', 'email', Rule::requiredIf($request->approved_on)],

        ]);
        $validator->setAttributeNames([
            'notice_addresses' => '送信先メールアドレス',
            'approval_addresses' => '送信先メールアドレス',
            'approved_addresses' => '送信先メールアドレス',
        ]);

        // エラーがあった場合は入力画面に戻る。
        if ($validator->fails()) {
            // [debug]
            // セッション初期化などのLaravel 処理。
            // $request->flash();

            // 共通画面のため、redirect_pathが画面に書けないため、ここで設定
            $request->merge($redirect_path_array);

            // [debug]
            // dd(old('notice_on'), $request->notice_on);
            // $a = redirect()->back()->withErrors($validator)->withInput();
            // dd(old('notice_on'), $request->notice_on);                              // ←ここでold()の値が取れる事は確認。
            // return $a;

            return redirect()->back()->withErrors($validator)->withInput();    // ←リダイレクトの先のeditBucketsMails()では、old()とれず。
        }
```

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/803

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
