### PR TITLE
bugfix: 【掲示板】メール設定で投稿通知の変更をOFFにしても変更確定時にメールが飛ぶバグ修正

### DIFF
--- a/app/Models/User/Bbses/BbsPost.php
+++ b/app/Models/User/Bbses/BbsPost.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Auth;
 
 use Kalnoy\Nestedset\NodeTrait;
 
-use App\Userable;
+use App\UserableNohistory;
 
 /**
  * 掲示板・記事
@@ -23,8 +23,8 @@ class BbsPost extends Model
     // 論理削除
     use SoftDeletes;
 
-    // 保存時のユーザー関連データの保持
-    use Userable;
+    // 保存時のユーザー関連データの保持（履歴なしUserable）
+    use UserableNohistory;
 
     // 更新する項目の定義
     protected $fillable = ['bbs_id', 'title', 'body', 'thread_root_id', 'thread_updated_at', 'status', '_lft', '_rgt', 'parent_id'];

--- a/database/migrations/2021_04_24_223934_add_first_committed_at_bbs_posts.php
+++ b/database/migrations/2021_04_24_223934_add_first_committed_at_bbs_posts.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFirstCommittedAtBbsPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('bbs_posts', function (Blueprint $table) {
+            $table->timestamp('first_committed_at')->nullable()->comment('初回確定日時')->after('thread_updated_at');
+        });
+
+        // 初期データ設定：初回確定日時が入っていないと、次回の更新時に新規とみなして、設定によっては登録通知メールが送られるため、初期値を設定
+        \DB::statement('UPDATE bbs_posts SET first_committed_at = created_at');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('bbs_posts', function (Blueprint $table) {
+            $table->dropColumn('first_committed_at');
+        });
+    }
+}


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

バグ修正のプルリクエストです。
https://github.com/opensource-workshop/connect-cms/issues/829 の不明点を確認してからマージしようと思ってます。

## 修正後テスト

* 投稿通知の変更をOFF
  *  編集時にメール飛ばない事を確認
  *  編集で一時保存してメール飛ばない事を確認
* 投稿通知の変更をON
  *  編集時にメール飛ぶ事を確認
  *  編集で一時保存してメール飛ばない事を確認（一時保存はメール飛ばない）
* 投稿通知の登録ON、変更OFF
  * 登録でメール飛ぶことを確認。
  * 登録で 一時保存→その後変更確定で、メール飛ぶことを確認。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

https://github.com/opensource-workshop/connect-cms/issues/829

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
