### PR TITLE
bugfix: 【ウィジウィグ】 テーマなしだと、ウィジウィグの書式に、アイコン(PDF)等が表示されてないバグ修正 

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -9,9 +9,13 @@
     // テーマ固有書式
     $style_formats_file = '';
     $style_formats_path = public_path() . '/themes/' . $theme . '/wysiwyg/style_formats.txt';
-    $style_formats_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/style_formats.txt';
+    $style_formats_group_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/style_formats.txt';
+    $style_formats_default_path = public_path() . '/themes/Defaults/Default/wysiwyg/style_formats.txt';
     if (File::exists($style_formats_path)) {
         $style_formats_file = File::get($style_formats_path);
+    }
+    else if (File::exists($style_formats_group_default_path)) {
+        $style_formats_file = File::get($style_formats_group_default_path);
     }
     else if (File::exists($style_formats_default_path)) {
         $style_formats_file = File::get($style_formats_default_path);
@@ -20,9 +24,13 @@
     // テーマ固有スタイル
     $block_formats_file = '';
     $block_formats_path = public_path() . '/themes/' . $theme . '/wysiwyg/block_formats.txt';
-    $block_formats_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/block_formats.txt';
+    $block_formats_group_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/block_formats.txt';
+    $block_formats_default_path = public_path() . '/themes/Defaults/Default/wysiwyg/block_formats.txt';
     if (File::exists($block_formats_path)) {
         $block_formats_file = File::get($block_formats_path);
+    }
+    else if (File::exists($block_formats_group_default_path)) {
+        $block_formats_file = File::get($block_formats_group_default_path);
     }
     else if (File::exists($block_formats_default_path)) {
         $block_formats_file = File::get($block_formats_default_path);
@@ -31,9 +39,13 @@
     // CSS
     $content_css_file = '';
     $content_css_path = public_path() . '/themes/' . $theme . '/wysiwyg/content_css.txt';
-    $content_css_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/content_css.txt';
+    $content_css_group_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/content_css.txt';
+    $content_css_default_path = public_path() . '/themes/Defaults/Default/wysiwyg/content_css.txt';
     if (File::exists($content_css_path)) {
         $content_css_file = File::get($content_css_path);
+    }
+    else if (File::exists($content_css_group_default_path)) {
+        $content_css_file = File::get($content_css_group_default_path);
     }
     else if (File::exists($content_css_default_path)) {
         $content_css_file = File::get($content_css_default_path);
@@ -42,9 +54,13 @@
     // テーブル
     $table_class_list_file = '';
     $table_class_list_path = public_path() . '/themes/' . $theme . '/wysiwyg/table_class_list.txt';
-    $table_class_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/table_class_list.txt';
+    $table_class_group_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/table_class_list.txt';
+    $table_class_default_path = public_path() . '/themes/Defaults/Default/wysiwyg/table_class_list.txt';
     if (File::exists($table_class_list_path)) {
         $table_class_list_file = File::get($table_class_list_path);
+    }
+    else if (File::exists($table_class_group_default_path)) {
+        $table_class_list_file = File::get($table_class_group_default_path);
     }
     else if (File::exists($table_class_default_path)) {
         $table_class_list_file = File::get($table_class_default_path);
@@ -53,9 +69,13 @@
     // テーブルセル
     $table_cell_class_list_file = '';
     $table_cell_class_list_path = public_path() . '/themes/' . $theme . '/wysiwyg/table_cell_class_list.txt';
-    $table_cell_class_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/table_cell_class_list.txt';
+    $table_cell_class_group_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/table_cell_class_list.txt';
+    $table_cell_class_default_path = public_path() . '/themes/Defaults/Default/wysiwyg/table_cell_class_list.txt';
     if (File::exists($table_cell_class_list_path)) {
         $table_cell_class_list_file = File::get($table_cell_class_list_path);
+    }
+    else if (File::exists($table_cell_class_group_default_path)) {
+        $table_cell_class_list_file = File::get($table_cell_class_group_default_path);
     }
     else if (File::exists($table_cell_class_default_path)) {
         $table_cell_class_list_file = File::get($table_cell_class_default_path);
@@ -64,9 +84,13 @@
     // テーマ固有 箇条書きリスト（ULタグ）の表示設定
     $advlist_bullet_lists_file = '';
     $advlist_bullet_lists_path = public_path() . '/themes/' . $theme . '/wysiwyg/advlist_bullet_lists.txt';
-    $advlist_bullet_lists_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/advlist_bullet_lists.txt';
+    $advlist_bullet_lists_group_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/advlist_bullet_lists.txt';
+    $advlist_bullet_lists_default_path = public_path() . '/themes/Defaults/Default/wysiwyg/advlist_bullet_lists.txt';
     if (File::exists($advlist_bullet_lists_path)) {
         $advlist_bullet_lists_file = File::get($advlist_bullet_lists_path);
+    }
+    else if (File::exists($advlist_bullet_lists_group_default_path)) {
+        $advlist_bullet_lists_file = File::get($advlist_bullet_lists_group_default_path);
     }
     else if (File::exists($advlist_bullet_lists_default_path)) {
         $advlist_bullet_lists_file = File::get($advlist_bullet_lists_default_path);
@@ -75,9 +99,13 @@
     // テーマ固有 番号箇条書きリスト（OLタグ）の表示設定
     $advlist_number_lists_file = '';
     $advlist_number_lists_path = public_path() . '/themes/' . $theme . '/wysiwyg/advlist_number_lists.txt';
-    $advlist_number_lists_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/advlist_number_lists.txt';
+    $advlist_number_lists_group_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/advlist_number_lists.txt';
+    $advlist_number_lists_default_path = public_path() . '/themes/Defaults/Default/wysiwyg/advlist_number_lists.txt';
     if (File::exists($advlist_number_lists_path)) {
         $advlist_number_lists_file = File::get($advlist_number_lists_path);
+    }
+    else if (File::exists($advlist_number_lists_group_default_path)) {
+        $advlist_number_lists_file = File::get($advlist_number_lists_group_default_path);
     }
     else if (File::exists($advlist_number_lists_default_path)) {
         $advlist_number_lists_file = File::get($advlist_number_lists_default_path);


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

バグ修正のプルリクエストです。
多分この修正で問題ないと思っていますが、念のため社内で確認したあと、マージしようと思います。

いままで、ウィジウィグのオプション設定は、下記の読み込み順番でした。
1. テーマにウィジウィグのオプション設定あったら読み込む
2. テーマグループのDefaultテーマから、ウィジウィグのオプション設定あったら読み込む

修正後は、下記の読み込み順番になります。
1. テーマにウィジウィグのオプション設定あったら読み込む
2. テーマグループのDefaultテーマから、ウィジウィグのオプション設定あったら読み込む
3. **DefaultsグループのDefaultテーマから、ウィジウィグのオプション設定あったら読み込む**

### 推測

・テーマグループ毎にDefaultテーマがある想定で、テーマグループのDefaultテーマから、ウィジウィグのオプション設定が読み込まれていました。
・`テーマなし`の場合、`テーマ管理で作成したテーマ（Usersシリーズ）`の場合、Defaultテーマは存在しないため、ウィジウィグのオプションは読み込まれてませんでした。
→ 基本のウィジウィグのオプション設定は、DefaultsシリーズのDefaultテーマから読み込むで、問題ないかと思いました。


## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
https://github.com/opensource-workshop/connect-cms/issues/823
https://github.com/opensource-workshop/connect-cms/issues/701

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
