### PR TITLE
add: wysiwyg, テーマ毎にwysiwygの簡易テンプレート挿入機能追加 

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -83,6 +83,21 @@
         $advlist_number_lists_file = File::get($advlist_number_lists_default_path);
     }
 
+    // テーマ固有 簡易テンプレート
+    $templates_file = '';
+    $templates_path = public_path() . '/themes/' . $theme . '/wysiwyg/templates.txt';
+    $templates_group_default_path = public_path() . '/themes/' . $theme_group_default . '/wysiwyg/templates.txt';
+    $templates_default_path = public_path() . '/themes/Defaults/Default/wysiwyg/templates.txt';
+    if (File::exists($templates_path)) {
+        $templates_file = File::get($templates_path);
+    }
+    else if (File::exists($templates_group_default_path)) {
+        $templates_file = File::get($templates_group_default_path);
+    }
+    else if (File::exists($templates_default_path)) {
+        $templates_file = File::get($templates_default_path);
+    }
+
     // TinyMCE Body クラス
     $body_class = '';
     if ($frame->area_id == 0) {
@@ -102,7 +117,7 @@
     }
 
     // plugins
-    $plugins = 'file image imagetools media link autolink preview textcolor code table lists advlist';
+    $plugins = 'file image imagetools media link autolink preview textcolor code table lists advlist template ';
     if (config('connect.OSWS_TRANSLATE_AGREEMENT') === true) {
         $plugins .= ' translate';
     }
@@ -110,6 +125,10 @@
 
     // toolbar
     $toolbar = 'undo redo | bold italic underline strikethrough subscript superscript | formatselect | styleselect | forecolor backcolor | removeformat | table | numlist bullist | blockquote | alignleft aligncenter alignright alignjustify | outdent indent | link jbimages | image file media | preview | code ';
+    // 簡易テンプレート設定がない場合、テンプレート挿入ボタン押下でエラー出るため、設定ない場合はボタン表示しない。
+    if (! empty($templates_file)) {
+        $toolbar .= '| template ';
+    }
     if (config('connect.OSWS_TRANSLATE_AGREEMENT') === true) {
         $toolbar .= '| translate ';
     }
@@ -154,6 +173,9 @@
 
         {{-- テーマ固有 番号箇条書きリスト（OLタグ）の表示設定 --}}
         {!!$advlist_number_lists_file!!}
+
+        {{-- テーマ固有 簡易テンプレート設定 --}}
+        {!!$templates_file!!}
 
         menubar  : '',
         relative_urls : false,


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

機能追加のプルリクエストです。
各テーマごとに、wysiwygの簡易テンプレートを挿入できるように機能追加 しました。

### wysiwygの簡易テンプレートサンプル

[templates.txt](https://github.com/opensource-workshop/connect-cms/files/6426934/templates.txt)　ファイルを
public\themes\Defaults\Default\wysiwyg\templates.txt に配置する事で、テンプレート挿入機能が動きます。

## 画像
### Wysiwyg（テンプレート挿入ボタン追加）
![image](https://user-images.githubusercontent.com/2756509/117138763-6eec5f00-ade6-11eb-8b3d-a6faad527df4.png)


## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
https://github.com/opensource-workshop/connect-cms-ideas/issues/5

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
