### PR TITLE
Fix bug 2 utf8mb4

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -18,7 +18,7 @@ class CreateUsersTable extends Migration
             $table->increments('id');
             $table->string('name');
             //$table->string('email')->unique();
-            $table->string('email')->unique()->nullable();
+            $table->string('email', 191)->unique()->nullable();
             //$table->timestamp('email_verified_at')->nullable();  // change laravel6. create migration 2021_01_27_154006_change_users_table_in_laravel6.
             $table->string('password');
             $table->rememberToken();

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -14,7 +14,7 @@ class CreatePasswordResetsTable extends Migration
     public function up()
     {
         Schema::create('password_resets', function (Blueprint $table) {
-            $table->string('email')->index();
+            $table->string('email', 191)->index();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });

--- a/database/migrations/2019_02_25_090524_add_user_id_to_users.php
+++ b/database/migrations/2019_02_25_090524_add_user_id_to_users.php
@@ -15,7 +15,7 @@ class AddUserIdToUsers extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             //
-            $table->string('userid')->unique()->after('email');
+            $table->string('userid', 191)->unique()->after('email');
         });
     }
 

--- a/database/migrations/2019_08_21_165015_add_status_etc_to_contents.php
+++ b/database/migrations/2019_08_21_165015_add_status_etc_to_contents.php
@@ -16,8 +16,8 @@ class AddStatusEtcToContents extends Migration
         Schema::table('contents', function (Blueprint $table) {
             //
             $table->text('content2_text')->nullable()->after('content_text');
-            $table->string('view_more')->unique()->nullable()->after('content2_text');
-            $table->string('hide_more')->unique()->nullable()->after('view_more');
+            $table->string('view_more', 191)->unique()->nullable()->after('content2_text');
+            $table->string('hide_more', 191)->unique()->nullable()->after('view_more');
             $table->integer('status')->default('0')->after('hide_more');
         });
     }

--- a/database/migrations/2020_04_02_232011_create_sessions_table.php
+++ b/database/migrations/2020_04_02_232011_create_sessions_table.php
@@ -14,7 +14,7 @@ class CreateSessionsTable extends Migration
     public function up()
     {
         Schema::create('sessions', function (Blueprint $table) {
-            $table->string('id')->unique();
+            $table->string('id', 191)->unique();
             $table->unsignedInteger('user_id')->nullable();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();

--- a/database/migrations/2020_05_14_155953_add_codes_help_messages_alias_key_to_codes_table.php
+++ b/database/migrations/2020_05_14_155953_add_codes_help_messages_alias_key_to_codes_table.php
@@ -22,7 +22,7 @@ class AddCodesHelpMessagesAliasKeyToCodesTable extends Migration
     public function up()
     {
         Schema::table('codes', function (Blueprint $table) {
-            $table->string('codes_help_messages_alias_key', 255)->comment('注釈キー')->nullable()->after('id');
+            $table->string('codes_help_messages_alias_key', 191)->comment('注釈キー')->nullable()->after('id');
         });
     }
 

--- a/database/migrations/2020_05_14_160224_create_codes_help_messages_table.php
+++ b/database/migrations/2020_05_14_160224_create_codes_help_messages_table.php
@@ -23,7 +23,7 @@ class CreateCodesHelpMessagesTable extends Migration
     {
         Schema::create('codes_help_messages', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('alias_key', 255)->comment('注釈キー');      // 必須
+            $table->string('alias_key', 191)->comment('注釈キー');      // 必須
             $table->string('name', 255)->comment('注釈名');             // 必須
 
             $table->string('codes_help_messages_alias_key_help_message', 255)->nullable();

--- a/database/migrations/2021_01_30_130730_create_jobs_table.php
+++ b/database/migrations/2021_01_30_130730_create_jobs_table.php
@@ -15,7 +15,7 @@ class CreateJobsTable extends Migration
     {
         Schema::create('jobs', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('queue')->index();
+            $table->string('queue', 191)->index();
             $table->longText('payload');
             $table->unsignedTinyInteger('attempts');
             $table->unsignedInteger('reserved_at')->nullable();

--- a/database/migrations/2021_05_11_162339_alter_database_charset_to_utf8mb4.php
+++ b/database/migrations/2021_05_11_162339_alter_database_charset_to_utf8mb4.php
@@ -105,12 +105,9 @@ class AlterDatabaseCharsetToUtf8mb4 extends Migration
          * テーブルへのマイグレーション
          */
         $table_names = $schema_manager->listTableNames();
-        // 「sessions」テーブルのみ除外する
-        $table_names_omit_session = array_diff($table_names, array('sessions'));
-        $table_names_omit_session = array_values($table_names_omit_session);
 
         // 既存テーブルの文字コード、照合順序の変更
-        foreach($table_names_omit_session as $table_name){
+        foreach($table_names as $table_name){
             $convert_statement = "ALTER TABLE `$table_name` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
             DB::connection()->getpdo()->exec($convert_statement);
             Log::info("execute table convert statement:$convert_statement");


### PR DESCRIPTION
## 概要
- 先日マージしたutf8mb4化対応の対応漏れに対する対応です。
- 現状、新規インストール時のマイグレーション実行時にINDEXサイズエラーでコケます。（↓一例）
`Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes`
- 原因は先日のマージでDB接続設定もutf8mb4としている為、テーブル新規作成時にutf8mb4でテーブル作成されますが、各個別マイグレーションファイルのユニークKEY設定しているカラムのサイズ変更対応が漏れていた為、データ長255のまま実行され、上記エラーに繋がります。
- これを解消する為、新規マイグレーション時も考慮して各項目の初期サイズに明示的に191を指定しています。
https://github.com/opensource-workshop/connect-cms/commit/9bcf6eab5a613a5a7377d385faf954633764e102
- また、当初対応ではデータ長を191としていいか未調査だった為、sessionsテーブル（Laravelのセッション管理テーブル）をutf8mb4対応から除外していましたが、これを加える変更を行っています。これはその後の調査で、実際のデータ長が40だったこと、一般的にセッションIDの長さは入れ物サイズ的に191あれば十分であろうと推定しているからです。対応が平易だった為、平伏合わす観点で本対応に加えています。
https://github.com/opensource-workshop/connect-cms/commit/69a043e7048fba5d8b15950cbd3d2037585dc32b
- 既に既存サイトでマイグレーション実行済みサイトのsessionsテーブルをutf8mb4化するマイグレーションは含んでいませんが、該当テーブルはそもそもutf8mb4化する必要性がないと想定される為、これについては対応を省略しています。

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/pull/728

## 参考
【PHP】セッションIDの長さを変える
https://qiita.com/rukihena/items/5c1470e1bcff0558c225

## DB変更の有無
あり

## チェックリスト
該当なし
- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
