### PR TITLE
追加テーマ（CSS/JS/画像）を設定できるよう改修

### DIFF
--- a/app/Http/Controllers/Core/ConnectController.php
+++ b/app/Http/Controllers/Core/ConnectController.php
@@ -649,7 +649,8 @@ class ConnectController extends Controller
     }
 
     /**
-     *  指定されたテーマにCSS、JS があるか確認
+     *  ・指定された基本テーマにCSS、JS があるか確認
+     *  ・追加テーマにCSS、JS があれば設定
      */
     private function checkAsset($theme, $theme_setting_array)
     {
@@ -663,6 +664,20 @@ class ConnectController extends Controller
             $theme_setting_array['js'] = $theme;
         }
 
+        // 追加テーマが設定されていれば設定する
+        $configs = Configs::where('name', 'additional_theme')->first();
+        if($configs){
+            // CSS 存在チェック
+            if (File::exists(public_path().'/themes/'.$configs->value.'/themes.css')) {
+                $theme_setting_array['additional_css'] = $configs->value;
+            }
+
+            // JS 存在チェック
+            if (File::exists(public_path().'/themes/'.$configs->value.'/themes.js')) {
+                $theme_setting_array['additional_js'] = $configs->value;
+            }
+        }
+
         return $theme_setting_array;
     }
 
@@ -674,7 +689,12 @@ class ConnectController extends Controller
     protected function getThemes($request = null)
     {
         // 戻り値
-        $return_array = array('css' => '', 'js' => '');
+        $return_array = array(
+            'css' => '', 
+            'js' => '',
+            'css_additional' => '', 
+            'js_additional' => ''
+        );
 
         // セッションにテーマの選択がある場合（テーマ・チェンジャーで選択時の動き）
         if ($request && $request->session()->get('session_theme')) {

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -74,12 +74,15 @@ class SiteManage extends ManagePluginBase
         //     $configs_array[$config->name] = $config->value;
         // }
 
-        // 設定済みのテーマ
+        // 設定済みの基本テーマ
         $base_theme_obj = $configs->where('name', 'base_theme')->first();
         $current_base_theme = '';
         if (!empty($base_theme_obj)) {
             $current_base_theme = $base_theme_obj->value;
         }
+
+        // 設定済みの追加テーマ
+        $current_additional_theme = $configs->where('name', 'additional_theme')->first() ? $configs->where('name', 'additional_theme')->first()->value : '';
 
         // テーマの取得
         $themes = $this->getThemes();
@@ -96,6 +99,7 @@ class SiteManage extends ManagePluginBase
             // "configs"            => $configs_array,
             "configs"            => $configs,
             "current_base_theme" => $current_base_theme,
+            "current_additional_theme" => $current_additional_theme,
             "themes"             => $themes,
             "pages_select" => $pages_select,
         ]);
@@ -139,11 +143,18 @@ class SiteManage extends ManagePluginBase
              'value'    => $request->base_site_name]
         );
 
-        // 画面の基本のテーマ
+        // 基本テーマ
         $configs = Configs::updateOrCreate(
             ['name'     => 'base_theme'],
             ['category' => 'general',
              'value'    => $request->base_theme]
+        );
+
+        // 追加テーマ
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'additional_theme'],
+            ['category' => 'general',
+             'value'    => $request->additional_theme]
         );
 
         // 画面の基本の背景色

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -88,14 +88,24 @@
     <!-- Connect-CMS Global CSS -->
     <link href="{{ asset('css/connect.css') }}" rel="stylesheet">
 
-    <!-- Themes CSS -->
+    <!-- Themes CSS（基本） -->
 @if (isset($themes['css']) && $themes['css'] != '')
     <link href="{{url('/')}}/themes/{{$themes['css']}}/themes.css" rel="stylesheet">
 @endif
 
-    <!-- Themes JS -->
+    <!-- Themes JS（基本） -->
 @if (isset($themes['js']) && $themes['js'] != '')
     <script src="{{url('/')}}/themes/{{$themes['js']}}/themes.js"></script>
+@endif
+
+    <!-- Themes CSS（追加） -->
+@if (isset($themes['additional_css']) && $themes['additional_css'] != '')
+    <link href="{{url('/')}}/themes/{{$themes['additional_css']}}/themes.css" rel="stylesheet">
+@endif
+
+    <!-- Themes JS（追加） -->
+@if (isset($themes['additional_js']) && $themes['additional_js'] != '')
+    <script src="{{url('/')}}/themes/{{$themes['additional_js']}}/themes.js"></script>
 @endif
 
     <!-- Connect-CMS Page CSS -->

--- a/resources/views/plugins/manage/site/site.blade.php
+++ b/resources/views/plugins/manage/site/site.blade.php
@@ -35,9 +35,9 @@ use App\Models\Core\Configs;
             <small class="form-text text-muted">サイト名（各ページで上書き可能 ※予定）</small>
         </div>
 
-        {{-- テーマ --}}
+        {{-- 基本テーマ --}}
         <div class="form-group">
-            <label class="col-form-label">テーマ</label>
+            <label class="col-form-label">基本テーマ</label>
             <select name="base_theme" class="form-control">
                 <option value="">テーマなし</option>
                 @foreach($themes as $theme)
@@ -49,6 +49,25 @@ use App\Models\Core\Configs;
                         </optgroup>
                     @else
                         <option value="{{$theme['dir']}}"@if(old('base_theme', $current_base_theme) == $theme['dir']) selected @endif>{{$theme['name']}}</option>
+                    @endisset
+                @endforeach
+            </select>
+        </div>
+
+        {{-- 追加テーマ --}}
+        <div class="form-group">
+            <label class="col-form-label">追加テーマ</label>
+            <select name="additional_theme" class="form-control">
+                <option value="">テーマなし</option>
+                @foreach($themes as $theme)
+                    @isset($theme['themes'])
+                        <optgroup label="{{$theme['name']}}">
+                        @foreach($theme['themes'] as $sub_theme)
+                            <option value="{{$sub_theme['dir']}}"@if(old('additional_theme', $current_additional_theme) == $sub_theme['dir']) selected @endif>{{$sub_theme['name']}}</option>
+                        @endforeach
+                        </optgroup>
+                    @else
+                        <option value="{{$theme['dir']}}"@if(old('additional_theme', $current_additional_theme) == $theme['dir']) selected @endif>{{$theme['name']}}</option>
                     @endisset
                 @endforeach
             </select>

--- a/resources/views/plugins/manage/site/site.blade.php
+++ b/resources/views/plugins/manage/site/site.blade.php
@@ -71,6 +71,7 @@ use App\Models\Core\Configs;
                     @endisset
                 @endforeach
             </select>
+            <small class="form-text text-muted">基本テーマとは別のテーマを追加で読み込みます。スタイルの読み込み順は追加テーマの方が後になる為、スタイル競合時は追加テーマのものが優先されます。</small>
         </div>
 
         <div id="app">

--- a/resources/views/plugins/manage/theme/theme.blade.php
+++ b/resources/views/plugins/manage/theme/theme.blade.php
@@ -108,6 +108,11 @@
                     <input type="text" name="theme_name" id="theme_name" value="" class="form-control">
                     @endif
                     @if ($errors && $errors->has('theme_name')) <div class="text-danger">{{$errors->first('theme_name')}}</div> @endif
+                    <small class="text-muted">
+                        <div>※ 独自テーマを作成できます。独自テーマではCSS、javascript、画像を独自に定義することができます。</div>
+                        <div>※ 作成した独自テーマは<a href="{{ url('/manage/site') }}" target="_blank">サイト管理</a>から設定することができます。</div>
+                        <div>※ テーマファイルはサーバ上の [ドキュメントルート]/public/themes/Users/[ディレクトリ名] に作成されます。</div>
+                    </small>
                 </div>
             </div>
             <div class="form-group row">

--- a/resources/views/plugins/manage/theme/theme_css_edit.blade.php
+++ b/resources/views/plugins/manage/theme/theme_css_edit.blade.php
@@ -21,8 +21,10 @@
         <form action="{{url('/')}}/manage/theme/saveCss" method="POST">
             {{csrf_field()}}
             <input name="dir_name" type="hidden" value="{{$dir_name}}" />
-            <textarea name="css" class="form-control" rows=20>{{$css}}</textarea>
-
+            <textarea name="css" class="form-control" rows=20 placeholder="（例）&#13;.navbar-dark .navbar-brand {&#13;    color: #ffff00; # デフォルトのヘッダーバー文字色を黄色にします。 &#13;}">{{$css}}</textarea>
+            <small class="text-muted">
+                <div>※ CSSを保存しても変更が反映されない時はブラウザのスーパーリロードを試行してください。</div>
+            </small>
             <div class="form-group mt-3">
                 <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/')}}/manage/theme/'"><i class="fas fa-times"></i> キャンセル</button>
                 <button type="submit" class="btn btn-primary form-horizontal">


### PR DESCRIPTION
## 概要
- 現状、サイト管理から設定できるテーマは１つのみの為、例えば下記のような要件時に対応できない問題がありました。
	- グループ毎に異なるサイトを構築した場合、個別サイトで共通スタイルは共有しつつも、個別にスタイルも保持したい場合に設定が出来ない。
	- デザイナ業者等に依頼したベースのスタイルを維持しつつ、運用期間中に発生した追加・修正スタイル等が取り込めない。
- これに対応する為、サイト管理に追加テーマと称して、もう１つテーマを設定できるように拡張する対応です。

## 関連Pull requests/Issues
なし

## 参考
https://connect-cms.jp/plugin/bbses/show/106/233/289#frame-233

## DB変更の有無
なし

## チェックリスト
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
