### PR TITLE
【新着プラグイン】「もっと見る」機能を追加

### DIFF
--- a/app/Enums/Bs4Color.php
+++ b/app/Enums/Bs4Color.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * カラー（BootStrap4版）
+ */
+final class Bs4Color
+{
+    // 定数メンバ
+    const primary = 'primary';
+    const secondary = 'secondary';
+    const success = 'success';
+    const danger = 'danger';
+    const warning = 'warning';
+    const info = 'info';
+    const light = 'light';
+    const dark = 'dark';
+    const muted = 'muted';
+    const white = 'white';
+
+    // key/valueの連想配列
+    const enum = [
+        self::primary=>'青',
+        self::secondary=>'灰',
+        self::success=>'緑',
+        self::danger=>'赤',
+        self::warning=>'黄',
+        self::info=>'水色',
+        self::light=>'明色',
+        self::dark=>'黒',
+        self::muted=>'淡色',
+        self::white=>'白',
+    ];
+
+    /*
+    * 対応した和名を返す
+    */
+    public static function getDescription($key): string
+    {
+        return self::enum[$key];
+    }
+
+    /*
+    * key/valueの連想配列を返す
+    */
+    public static function getMembers()
+    {
+        return self::enum;
+    }
+}

--- a/app/Enums/RadiusType.php
+++ b/app/Enums/RadiusType.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * ボタンの形（BootStrap4版のBorder-radiusの一部を使用）
+ */
+final class RadiusType
+{
+    // 定数メンバ
+    const rounded = 'rounded';
+    const circle = 'rounded-circle';
+    const pill = 'rounded-pill';
+
+    // key/valueの連想配列
+    const enum = [
+        self::rounded=>'四角形',
+        self::circle=>'円形',
+        self::pill=>'楕円形',
+    ];
+
+    /*
+    * 対応した和名を返す
+    */
+    public static function getDescription($key): string
+    {
+        return self::enum[$key];
+    }
+
+    /*
+    * key/valueの連想配列を返す
+    */
+    public static function getMembers()
+    {
+        return self::enum;
+    }
+}

--- a/app/Enums/UseType.php
+++ b/app/Enums/UseType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * 使用する・使用しない区分
+ */
+final class UseType
+{
+    // 定数メンバ
+    const not_use = 0;
+    const use = 1;
+
+    // key/valueの連想配列
+    const enum = [
+        self::not_use=>'使用しない',
+        self::use=>'使用する',
+    ];
+
+    /*
+    * 対応した和名を返す
+    */
+    public static function getDescription($key): string
+    {
+        return self::enum[$key];
+    }
+
+    /*
+    * key/valueの連想配列を返す
+    */
+    public static function getMembers()
+    {
+        return self::enum;
+    }
+}

--- a/app/Http/Controllers/Core/DefaultController.php
+++ b/app/Http/Controllers/Core/DefaultController.php
@@ -397,6 +397,24 @@ class DefaultController extends ConnectController
     }
 
     /**
+     *  JSON-APIリクエスト（GET用）
+     *     - フレームに紐づくプラグインをインスタンス化して該当プラグインのinvoke()を呼び出します。
+     *     - Connect-CMSのview関連の処理を通さない為、returnにcollection渡してJSON返し等、Laravel的な処理が可能です。
+     */
+    public function invokeGetJson(Request $request, $plugin_name, $action = null, $page_id = null, $frame_id = null, $id = null)
+    {
+        // アプリのロケールを変更
+        $this->setAppLocale();
+
+        // プラグインのインスタンス生成
+        $frame = Frame::find($frame_id);
+        $class_name = $this->getClassname($frame->plugin_name);
+        $plugin_instance = new $class_name($this->page, $frame, $this->pages);
+
+        return $plugin_instance->invoke($plugin_instance, $request, $action, $page_id, $frame_id);
+    }
+
+    /**
      *  データがない場合にフレームも非表示にする。
      */
     private function setHiddenFrame($frames, $plugin_instances)

--- a/app/Models/User/Whatsnews/Whatsnews.php
+++ b/app/Models/User/Whatsnews/Whatsnews.php
@@ -9,7 +9,25 @@ use Illuminate\Database\Eloquent\Model;
 class Whatsnews extends Model
 {
     // 更新する項目の定義
-    protected $fillable = ['bucket_id', 'whatsnew_name', 'view_pattern', 'count', 'days', 'rss', 'rss_count', 'view_posted_name', 'view_posted_at', 'target_plugins', 'frame_select'];
+    protected $fillable = [
+        'bucket_id', 
+        'whatsnew_name', 
+        'view_pattern', 
+        'count', 
+        'days', 
+        'rss', 
+        'rss_count', 
+        'view_posted_name', 
+        'view_posted_at', 
+        'target_plugins', 
+        'frame_select',
+        'read_more_use_flag',
+        'read_more_name',
+        'read_more_fetch_count',
+        'read_more_btn_color_type',
+        'read_more_btn_type',
+        'read_more_btn_transparent_flag'
+    ];
 
     /**
      *  表示するプラグインの配列を返却

--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -474,6 +474,12 @@ class WhatsnewsPlugin extends UserPluginBase
             'count'             => ['nullable', 'numeric'],
             'days'              => ['nullable', 'numeric'],
             'rss_count'         => ['nullable', 'numeric'],
+            'read_more_use_flag' => ['required', 'numeric'],
+            'read_more_name' => ['required'],
+            'read_more_fetch_count' => ['required', 'numeric'],
+            'read_more_btn_color_type' => ['required'],
+            'read_more_btn_type' => ['required'],
+            'read_more_btn_transparent_flag' => ['required', 'numeric'],
         ]);
         $validator->setAttributeNames([
             'whatsnew_name'     => '新着情報設定名称',
@@ -481,6 +487,12 @@ class WhatsnewsPlugin extends UserPluginBase
             'count'             => '表示件数',
             'days'              => '表示日数',
             'rss_count'         => '対象RSS件数',
+            'read_more_use_flag' => 'もっと見るボタンの表示',
+            'read_more_name' => 'ボタン名',
+            'read_more_fetch_count' => 'ボタン押下時の取得件数／回',
+            'read_more_btn_color_type' => 'もっと見るボタン色',
+            'read_more_btn_type' => 'もっと見るボタンの形',
+            'read_more_btn_transparent_flag' => 'ボタン透過の使用',
         ]);
 
         // エラーがあった場合は入力画面に戻る。
@@ -545,6 +557,12 @@ class WhatsnewsPlugin extends UserPluginBase
         $whatsnews->view_posted_name  = $request->view_posted_name;
         $whatsnews->view_posted_at    = $request->view_posted_at;
         $whatsnews->important         = $request->important;
+        $whatsnews->read_more_use_flag = $request->read_more_use_flag;
+        $whatsnews->read_more_name = $request->read_more_name;
+        $whatsnews->read_more_fetch_count = $request->read_more_fetch_count;
+        $whatsnews->read_more_btn_color_type = $request->read_more_btn_color_type;
+        $whatsnews->read_more_btn_type = $request->read_more_btn_type;
+        $whatsnews->read_more_btn_transparent_flag = $request->read_more_btn_transparent_flag;
         $whatsnews->target_plugins    = implode(',', $request->target_plugin);
         $whatsnews->frame_select      = intval($request->frame_select);
 //Log::debug($request->target_frame_ids);

--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -118,6 +118,12 @@ class WhatsnewsPlugin extends UserPluginBase
                      'whatsnews.view_posted_name',
                      'whatsnews.view_posted_at',
                      'whatsnews.important',
+                     'whatsnews.read_more_use_flag',
+                     'whatsnews.read_more_name',
+                     'whatsnews.read_more_fetch_count',
+                     'whatsnews.read_more_btn_color_type',
+                     'whatsnews.read_more_btn_type',
+                     'whatsnews.read_more_btn_transparent_flag',
                      'whatsnews.target_plugins',
                      'whatsnews.frame_select',
                      'whatsnews.target_frame_ids'

--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -355,10 +355,10 @@ class WhatsnewsPlugin extends UserPluginBase
         $whatsnews_query = $this->buildQueryGetWhatsnews($whatsnews_frame, $union_sqls);
 
         // limit/offset条件を付加
-        if($request->limit){
+        if ($request->limit) {
             $whatsnews_query->limit($request->limit);
         }
-        if($request->offset){
+        if ($request->offset) {
             $whatsnews_query->offset($request->offset);
         }
         // データ抽出

--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -40,6 +40,11 @@ class WhatsnewsPlugin extends UserPluginBase
     public $whatsnews_results = null;
 
     /**
+     *  新着の総件数
+     */
+    public $whatsnews_total_count = 0;
+
+    /**
      *  新着のフレーム情報
      */
     public $whatsnews_frame = null;
@@ -226,6 +231,9 @@ class WhatsnewsPlugin extends UserPluginBase
             $whatsnews = $whatsnews->where('important', null);
         }
 
+        // 新着の「もっと見る」処理判定用に総件数を保持
+        $this->whatsnews_total_count = $whatsnews->count();
+
         // 件数制限
         if ($method == 'rss') {
             // 「RSS件数」で制限
@@ -375,6 +383,7 @@ class WhatsnewsPlugin extends UserPluginBase
             'whatsnews', [
             'whatsnews'       => $whatsnews,
             'whatsnews_frame' => $whatsnews_frame,
+            'whatsnews_total_count' => $this->whatsnews_total_count,
             'link_pattern'    => $link_pattern,
             'link_base'       => $link_base,
             ]

--- a/config/app.php
+++ b/config/app.php
@@ -246,6 +246,7 @@ $app_array = [
         'DayOfWeek' => \App\Enums\DayOfWeek::class,
         'Bs4TextColor' => \App\Enums\Bs4TextColor::class,
         'Bs4Color' => \App\Enums\Bs4Color::class,
+        'RadiusType' => \App\Enums\RadiusType::class,
         'MinutesIncrements' => \App\Enums\MinutesIncrements::class,
         'ConnectLocale' => \App\Enums\ConnectLocale::class,
         'GroupType' => \App\Enums\GroupType::class,

--- a/config/app.php
+++ b/config/app.php
@@ -251,6 +251,7 @@ $app_array = [
         'WhatsnewsTargetPlugin' => \App\Enums\WhatsnewsTargetPlugin::class,
         'CsvCharacterCode' => \App\Enums\CsvCharacterCode::class,
         'ShowType' => \App\Enums\ShowType::class,
+        'UseType' => \App\Enums\UseType::class,
         'PermissionType' => \App\Enums\PermissionType::class,
         'StatusType' => \App\Enums\StatusType::class,
         'DisplayNumberType' => \App\Enums\DisplayNumberType::class,

--- a/config/app.php
+++ b/config/app.php
@@ -245,6 +245,7 @@ $app_array = [
         'DatabaseRoleName' => \App\Enums\DatabaseRoleName::class,
         'DayOfWeek' => \App\Enums\DayOfWeek::class,
         'Bs4TextColor' => \App\Enums\Bs4TextColor::class,
+        'Bs4Color' => \App\Enums\Bs4Color::class,
         'MinutesIncrements' => \App\Enums\MinutesIncrements::class,
         'ConnectLocale' => \App\Enums\ConnectLocale::class,
         'GroupType' => \App\Enums\GroupType::class,

--- a/database/migrations/2021_06_01_155251_add_column_whatsnews_table.php
+++ b/database/migrations/2021_06_01_155251_add_column_whatsnews_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Enums
+use App\Enums\Bs4Color;
+use App\Enums\RadiusType;
+
+class AddColumnWhatsnewsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('whatsnews', function (Blueprint $table) {
+            $table->integer('read_more_use_flag')->default(0)->comment('もっと見る使用フラグ')->after('important');
+            $table->string('read_more_name', 191)->default('もっと見る')->comment('もっと見るボタン名')->after('read_more_use_flag');
+            $table->integer('read_more_fetch_count')->default(5)->comment('もっと見る取得件数／回')->after('read_more_name');
+            $table->string('read_more_btn_color_type', 191)->default(Bs4Color::primary)->comment('（ボタンデザイン）ボタンの色区分')->after('read_more_fetch_count');
+            $table->string('read_more_btn_type', 191)->default(RadiusType::rounded)->comment('（ボタンデザイン）ボタンの形区分')->after('read_more_btn_color_type');
+            $table->integer('read_more_btn_transparent_flag')->default(0)->comment('（ボタンデザイン）透過使用フラグ')->after('read_more_btn_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('whatsnews', function (Blueprint $table) {
+            $table->dropColumn('read_more_use_flag');
+            $table->dropColumn('read_more_name');
+            $table->dropColumn('read_more_fetch_count');
+            $table->dropColumn('read_more_btn_color_type');
+            $table->dropColumn('read_more_btn_type');
+            $table->dropColumn('read_more_btn_transparent_flag');
+        });
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -129,6 +129,23 @@
     @if (isset($configs_array) && isset($configs_array['favicon']))
         <link href="{{url('/')}}/uploads/favicon/favicon.ico" rel="SHORTCUT ICON" />
     @endif
+
+    <!-- Polyfill -->
+    {{-- ※IEが公式に消えたら（2022年6月16日）消したい。 --}}
+    @php
+        $is_exist_whatsnews = false;
+        if(isset($plugin_instances)){
+            foreach($plugin_instances as $plugin_instance){
+                if($plugin_instance instanceof \App\Plugins\User\Whatsnews\WhatsnewsPlugin){
+                    $is_exist_whatsnews = true;
+                }
+            }
+        }
+    @endphp
+    @if ($is_exist_whatsnews)
+        {{-- IEで発生する「Promiseは定義されていません。」エラー回避＠新着プラグインの非同期処理 --}}
+        <script>window.Promise || document.write('<script src="//www.promisejs.org/polyfills/promise-7.0.4.min.js"><\/script>');</script>
+    @endif
 </head>
 @php
 // body任意クラスを抽出（カンマ設定時はランダムで１つ設定）

--- a/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
@@ -87,16 +87,18 @@
 <script>
     const app_{{ $frame->id }} = new Vue({
         el: "#app_{{ $frame->id }}",
-        data: {
-            url: '{{ url('/') }}',
-            link_pattern: @json($link_pattern),
-            link_base: @json($link_base),
-            whatsnewses: [],
-            whatsnews_total_count: {{ $whatsnews_total_count }}, // 総件数
-            view_posted_at: {{ $whatsnews_frame->view_posted_at }},
-            view_posted_name: {{ $whatsnews_frame->view_posted_name }},
-            limit: 5, // 何件ずつ取得するか ※リリース版は5にする
-            offset: {{ $whatsnews->count() }} // 何件目から取得するか（＝現時点の取得件数）※初期値はサーバから返された一覧件数
+        data: function() {
+            return {
+                url: '{{ url('/') }}',
+                link_pattern: @json($link_pattern),
+                link_base: @json($link_base),
+                whatsnewses: [],
+                whatsnews_total_count: {{ $whatsnews_total_count }}, // 総件数
+                view_posted_at: {{ $whatsnews_frame->view_posted_at }},
+                view_posted_name: {{ $whatsnews_frame->view_posted_name }},
+                limit: 5, // 何件ずつ取得するか ※リリース版は5にする
+                offset: {{ $whatsnews->count() }} // 何件目から取得するか（＝現時点の取得件数）※初期値はサーバから返された一覧件数
+            }
         },
         methods: {
             searchWhatsnewses: function () {

--- a/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
@@ -92,46 +92,7 @@
 </div>
 
     @if ($whatsnews_frame->read_more_use_flag == UseType::use)
-        <script>
-            const app_{{ $frame->id }} = new Vue({
-                el: "#app_{{ $frame->id }}",
-                data: function() {
-                    return {
-                        url: '{{ url('/') }}',
-                        link_pattern: @json($link_pattern),
-                        link_base: @json($link_base),
-                        whatsnewses: [],
-                        whatsnews_total_count: {{ $whatsnews_total_count }}, // 総件数
-                        view_posted_at: {{ $whatsnews_frame->view_posted_at }},
-                        view_posted_name: {{ $whatsnews_frame->view_posted_name }},
-                        limit: {{ $whatsnews_frame->read_more_fetch_count }},
-                        offset: {{ $whatsnews->count() }} // 何件目から取得するか（＝現時点の取得件数）※初期値はサーバから返された一覧件数
-                    }
-                },
-                methods: {
-                    searchWhatsnewses: function () {
-                        let self = this;
-                        // 非同期通信で追加の一覧を取得
-                        axios.get("{{url('/')}}/json/whatsnews/indexJson/{{$page->id}}/{{$frame_id}}/?limit=" + this.limit + "&offset=" + this.offset)
-                            .then(function(res){
-                                // foreach内ではthisでvueインスタンスのwhatsnewsesが参照できない為、tmp_arrに一時的に代入
-                                tmp_arr = self.whatsnewses;
-                                res.data.forEach(function(obj) {
-                                    // 取得した差分をループしてtmp_arrに格納
-                                    tmp_arr.push(obj);
-                                });
-                                // vueインスタンスのwhatsnewsesに代入
-                                this.whatsnewses = tmp_arr;
-                            })
-                            .catch(function (error) {
-                                console.log(error)
-                            });
-                        // offset値をカウントアップ
-                        this.offset += this.limit;
-                    }
-                },
-            });
-        </script>
+        @include('plugins.user.whatsnews.whatsnews_script')
     @endif
 @endif
 @endsection

--- a/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
@@ -110,11 +110,12 @@
                 },
                 methods: {
                     searchWhatsnewses: function () {
+                        let self = this;
                         // 非同期通信で追加の一覧を取得
                         axios.get("{{url('/')}}/json/whatsnews/indexJson/{{$page->id}}/{{$frame_id}}/?limit=" + this.limit + "&offset=" + this.offset)
-                            .then((res)=>{
+                            .then(function(res){
                                 // foreach内ではthisでvueインスタンスのwhatsnewsesが参照できない為、tmp_arrに一時的に代入
-                                tmp_arr = this.whatsnewses;
+                                tmp_arr = self.whatsnewses;
                                 res.data.forEach(function(obj) {
                                     // 取得した差分をループしてtmp_arrに格納
                                     tmp_arr.push(obj);

--- a/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
@@ -1,7 +1,7 @@
 {{--
  * 新着情報表示画面
  *
- * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>, 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 新着情報プラグイン
 --}}
@@ -18,7 +18,7 @@
 <div>
     <dl>
     @foreach($whatsnews as $whatsnew)
-        {{-- view_posted_at: 登録日時の表示 --}}
+        {{-- 登録日時、カテゴリ --}}
         @if ($whatsnews_frame->view_posted_at)
         <dt>
             {{(new Carbon($whatsnew->posted_at))->format('Y/m/d')}}
@@ -27,6 +27,7 @@
             @endif
         </dt>
         @endif
+        {{-- タイトル＋リンク --}}
         <dd>
             @if ($link_pattern[$whatsnew->plugin_name] == 'show_page_frame_post')
             <a href="{{url('/')}}{{$link_base[$whatsnew->plugin_name]}}/{{$whatsnew->page_id}}/{{$whatsnew->frame_id}}/{{$whatsnew->post_id}}#frame-{{$whatsnew->frame_id}}">
@@ -38,6 +39,7 @@
             </a>
             @endif
         </dd>
+        {{-- 投稿者 --}}
         @if ($whatsnews_frame->view_posted_name)
         <dd>
             {{$whatsnew->posted_name}}

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
@@ -227,6 +227,98 @@
         </div>
     </div>
 
+    <h5><span class="badge badge-secondary">もっと見る機能</span></h5>
+
+    {{-- もっと見るボタンの表示 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">ボタンの表示</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            @foreach (ShowType::enum as $key => $value)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input 
+                        type="radio" 
+                        value="{{ $key }}" 
+                        id="{{ "read_more_use_flag_${key}" }}"
+                        name="read_more_use_flag" 
+                        class="custom-control-input" 
+                        {{ $whatsnew->read_more_use_flag == $key ? 'checked' : '' }}
+                    >
+                    <label class="custom-control-label" for="{{ "read_more_use_flag_${key}" }}">
+                        {{ $value }}
+                    </label>
+                </div>
+            @endforeach
+        </div>
+    </div>
+    
+    {{-- もっと見る取得件数／回 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">ボタン押下時の<br>取得件数／回</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <input type="text" name="read_more_fetch_count" value="{{old('read_more_fetch_count', $whatsnew->read_more_fetch_count ? $whatsnew->read_more_fetch_count : 5)}}" class="form-control col-sm-3">
+            @if ($errors && $errors->has('read_more_fetch_count')) <div class="text-danger">{{$errors->first('read_more_fetch_count')}}</div> @endif
+        </div>
+    </div>
+
+    {{-- もっと見るボタン名 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">ボタン名</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <input type="text" name="read_more_name" value="{{old('read_more_name', $whatsnew->read_more_name ? $whatsnew->read_more_name : 'もっと見る')}}" class="form-control">
+            @if ($errors && $errors->has('read_more_name')) <div class="text-danger">{{$errors->first('read_more_name')}}</div> @endif
+        </div>
+    </div>
+
+    {{-- もっと見るボタン色 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">ボタン色</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <select class="form-control" name="read_more_btn_color_type">
+                @foreach (Bs4Color::getMembers() as $key=>$value)
+                    <option value="{{$key}}" class="{{ 'text-' . $key }}" @if($key == old('read_more_btn_color_type', $whatsnew->read_more_btn_color_type)) selected @endif>
+                        {{ $value }}
+                    </option>
+                @endforeach
+            </select>
+        </div>
+    </div>
+
+    {{-- もっと見るボタンの形 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">ボタンの形</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <select class="form-control" name="read_more_btn_type">
+                @foreach (RadiusType::getMembers() as $key=>$value)
+                    <option value="{{$key}}" @if($key == old('read_more_btn_type', $whatsnew->read_more_btn_type)) selected @endif>
+                        {{ $value }}
+                    </option>
+                @endforeach
+            </select>
+        </div>
+    </div>
+
+    {{-- もっと見るボタン透過設定 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">ボタン透過の使用</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            @foreach (UseType::enum as $key => $value)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input 
+                        type="radio" 
+                        value="{{ $key }}" 
+                        id="{{ "read_more_btn_transparent_flag_${key}" }}"
+                        name="read_more_btn_transparent_flag" 
+                        class="custom-control-input" 
+                        {{ $whatsnew->read_more_btn_transparent_flag == $key ? 'checked' : '' }}
+                    >
+                    <label class="custom-control-label" for="{{ "read_more_btn_transparent_flag_${key}" }}">
+                        {{ $value }}
+                    </label>
+                </div>
+            @endforeach
+        </div>
+    </div>
+    
     <h5><span class="badge badge-secondary">表示対象プラグイン・フレーム</span></h5>
 
     {{-- 対象プラグイン --}}

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
@@ -64,9 +64,11 @@
         </div>
     </div>
 
+    <h5><span class="badge badge-secondary">新着の取得方式・表示件数</span></h5>
+
     {{-- 新着の取得方式 --}}
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">新着の取得方式</label>
+        <label class="{{$frame->getSettingLabelClass()}}">取得方式</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-radio custom-control-inline">
                 @if($whatsnew->view_pattern == 0)
@@ -105,6 +107,8 @@
         </div>
     </div>
 
+    <h5><span class="badge badge-secondary">RSS</span></h5>
+
     {{-- RSS --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass(true)}}">RSS</label>
@@ -135,6 +139,8 @@
             @if ($errors && $errors->has('rss_count')) <div class="text-danger">{{$errors->first('rss_count')}}</div> @endif
         </div>
     </div>
+
+    <h5><span class="badge badge-secondary">その他情報の表示</span></h5>
 
     {{-- 登録者の表示 --}}
     <div class="form-group row">
@@ -180,6 +186,8 @@
         </div>
     </div>
 
+    <h5><span class="badge badge-secondary">重要記事の扱い</span></h5>
+
     {{-- 重要記事の扱い --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}} @if(!$frame->isExpandNarrow()) pt-sm-0 @endif">重要記事の扱い</label><br />
@@ -218,6 +226,8 @@
             </div>
         </div>
     </div>
+
+    <h5><span class="badge badge-secondary">表示対象プラグイン・フレーム</span></h5>
 
     {{-- 対象プラグイン --}}
     <div class="form-group row">

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
@@ -3,6 +3,7 @@
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 新着情報プラグイン
 --}}
@@ -54,6 +55,7 @@
         <input type="hidden" name="whatsnews_id" value="{{$whatsnew->id}}">
     @endif
 
+    {{-- バケツ名 --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">新着情報名 <label class="badge badge-danger">必須</label></label>
         <div class="{{$frame->getSettingInputClass()}}">
@@ -62,6 +64,7 @@
         </div>
     </div>
 
+    {{-- 新着の取得方式 --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">新着の取得方式</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
@@ -84,6 +87,7 @@
         </div>
     </div>
 
+    {{-- 表示件数 --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">表示件数</label>
         <div class="{{$frame->getSettingInputClass()}}">
@@ -92,6 +96,7 @@
         </div>
     </div>
 
+    {{-- 表示日数 --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">表示日数</label>
         <div class="{{$frame->getSettingInputClass()}}">
@@ -100,28 +105,29 @@
         </div>
     </div>
 
+    {{-- RSS --}}
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">RSS</label>
+        <label class="{{$frame->getSettingLabelClass(true)}}">RSS</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
-            <div class="custom-control custom-radio custom-control-inline">
-                @if($whatsnew->rss == 1)
-                    <input type="radio" value="1" id="rss_1" name="rss" class="custom-control-input" checked="checked">
-                @else
-                    <input type="radio" value="1" id="rss_1" name="rss" class="custom-control-input">
-                @endif
-                <label class="custom-control-label" for="rss_1">表示する</label>
-            </div>
-            <div class="custom-control custom-radio custom-control-inline">
-                @if($whatsnew->rss == 0)
-                    <input type="radio" value="0" id="rss_0" name="rss" class="custom-control-input" checked="checked">
-                @else
-                    <input type="radio" value="0" id="rss_0" name="rss" class="custom-control-input">
-                @endif
-                <label class="custom-control-label" for="rss_0">表示しない</label>
-            </div>
+            @foreach (ShowType::enum as $key => $value)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input 
+                        type="radio" 
+                        value="{{ $key }}" 
+                        id="{{ "rss_${key}" }}"
+                        name="rss" 
+                        class="custom-control-input" 
+                        {{ $whatsnew->rss == $key ? 'checked' : '' }}
+                    >
+                    <label class="custom-control-label" for="{{ "rss_${key}" }}">
+                        {{ $value }}
+                    </label>
+                </div>
+            @endforeach
         </div>
     </div>
 
+    {{-- RSS件数 --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">RSS件数</label>
         <div class="{{$frame->getSettingInputClass()}}">
@@ -130,77 +136,51 @@
         </div>
     </div>
 
-    {{-- <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">ページ送りの表示</label>
+    {{-- 登録者の表示 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">登録者の表示</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
-            <div class="custom-control custom-radio custom-control-inline">
-                <input
-                    type="radio" value="1" id="page_method_1" name="page_method"
-                    class="custom-control-input" {{ $whatsnew->page_method == 1 ? 'checked' : '' }}
-                >
-                <label class="custom-control-label" for="page_method_1">表示する</label>
-            </div>
-            <div class="custom-control custom-radio custom-control-inline">
-                <input type="radio" value="0" id="page_method_0" name="page_method"
-                    class="custom-control-input" {{ $whatsnew->page_method == 0 ? 'checked' : '' }}
-                >
-                <label class="custom-control-label" for="page_method_0">表示しない</label>
-            </div>
+            @foreach (ShowType::enum as $key => $value)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input 
+                        type="radio" 
+                        value="{{ $key }}" 
+                        id="{{ "view_posted_name_${key}" }}"
+                        name="view_posted_name" 
+                        class="custom-control-input" 
+                        {{ $whatsnew->view_posted_name == $key ? 'checked' : '' }}
+                    >
+                    <label class="custom-control-label" for="{{ "view_posted_name_${key}" }}">
+                        {{ $value }}
+                    </label>
+                </div>
+            @endforeach
         </div>
     </div>
 
+    {{-- 登録日時の表示 --}}
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">ページ送り件数</label>
-        <div class="{{$frame->getSettingInputClass()}}">
-            <input type="text" name="page_count" value="{{old('page_count', $whatsnew->page_count)}}" class="form-control col-sm-3">
-            @if ($errors && $errors->has('page_count')) <div class="text-danger">{{$errors->first('page_count')}}</div> @endif
-        </div>
-    </div> --}}
-
-    <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">登録者の表示</label><br />
+        <label class="{{$frame->getSettingLabelClass(true)}}">登録日時の表示</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
-            <div class="custom-control custom-radio custom-control-inline">
-                @if($whatsnew->view_posted_name == 1)
-                    <input type="radio" value="1" id="view_posted_name_1" name="view_posted_name" class="custom-control-input" checked="checked">
-                @else
-                    <input type="radio" value="1" id="view_posted_name_1" name="view_posted_name" class="custom-control-input">
-                @endif
-                <label class="custom-control-label" for="view_posted_name_1">表示する</label>
-            </div>
-            <div class="custom-control custom-radio custom-control-inline">
-                @if($whatsnew->view_posted_name == 0)
-                    <input type="radio" value="0" id="view_posted_name_0" name="view_posted_name" class="custom-control-input" checked="checked">
-                @else
-                    <input type="radio" value="0" id="view_posted_name_0" name="view_posted_name" class="custom-control-input">
-                @endif
-                <label class="custom-control-label" for="view_posted_name_0">表示しない</label>
-            </div>
+            @foreach (ShowType::enum as $key => $value)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input 
+                        type="radio" 
+                        value="{{ $key }}" 
+                        id="{{ "view_posted_at_${key}" }}"
+                        name="view_posted_at" 
+                        class="custom-control-input" 
+                        {{ $whatsnew->view_posted_at == $key ? 'checked' : '' }}
+                    >
+                    <label class="custom-control-label" for="{{ "view_posted_at_${key}" }}">
+                        {{ $value }}
+                    </label>
+                </div>
+            @endforeach
         </div>
     </div>
 
-    <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">登録日時の表示</label><br />
-        <div class="{{$frame->getSettingInputClass(true)}}">
-            <div class="custom-control custom-radio custom-control-inline">
-                @if($whatsnew->view_posted_at == 1)
-                    <input type="radio" value="1" id="view_posted_at_1" name="view_posted_at" class="custom-control-input" checked="checked">
-                @else
-                    <input type="radio" value="1" id="view_posted_at_1" name="view_posted_at" class="custom-control-input">
-                @endif
-                <label class="custom-control-label" for="view_posted_at_1">表示する</label>
-            </div>
-            <div class="custom-control custom-radio custom-control-inline">
-                @if($whatsnew->view_posted_at == 0)
-                    <input type="radio" value="0" id="view_posted_at_0" name="view_posted_at" class="custom-control-input" checked="checked">
-                @else
-                    <input type="radio" value="0" id="view_posted_at_0" name="view_posted_at" class="custom-control-input">
-                @endif
-                <label class="custom-control-label" for="view_posted_at_0">表示しない</label>
-            </div>
-        </div>
-    </div>
-
+    {{-- 重要記事の扱い --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}} @if(!$frame->isExpandNarrow()) pt-sm-0 @endif">重要記事の扱い</label><br />
         <div class="{{$frame->getSettingInputClass()}}">
@@ -239,6 +219,7 @@
         </div>
     </div>
 
+    {{-- 対象プラグイン --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}} pt-0">対象プラグイン <label class="badge badge-danger mb-0">必須</label></label>
         <div class="{{$frame->getSettingInputClass()}}">
@@ -252,6 +233,7 @@
         </div>
     </div>
 
+    {{-- フレームの選択 --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">フレームの選択</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
@@ -282,6 +264,7 @@
         </div>
     </div>
 
+    {{-- 対象ページ - フレーム --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">対象ページ - フレーム</label>
         <div class="{{$frame->getSettingInputClass(false, true)}}">

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
@@ -332,7 +332,8 @@
         </div>
     </div>
     
-    <div class="form-group row border">
+    {{-- もっと見るボタンプレビュー --}}
+    <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass(true)}}">ボタンプレビュー</label>
         <div class="text-center {{$frame->getSettingInputClass(true)}}">
             <p :class="[readMoreBtnClass]">
@@ -482,7 +483,7 @@
         data: function() {
             return {
                 read_more_use_flag : {{ $whatsnew->read_more_use_flag ? $whatsnew->read_more_use_flag : "0" }},
-                read_more_name : '{{ $whatsnew->read_more_name ? $whatsnew->read_more_name : '' }}',
+                read_more_name : '{{ $whatsnew->read_more_name ? $whatsnew->read_more_name : 'もっと見る' }}',
                 read_more_btn_color_type : '{{ $whatsnew->read_more_btn_color_type ? $whatsnew->read_more_btn_color_type : Bs4Color::primary }}',
                 read_more_btn_type : '{{ $whatsnew->read_more_btn_type ? $whatsnew->read_more_btn_type : RadiusType::rounded }}',
                 read_more_btn_transparent_flag : {{ $whatsnew->read_more_btn_transparent_flag ? $whatsnew->read_more_btn_transparent_flag : "0" }}

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
@@ -242,6 +242,7 @@
                         name="read_more_use_flag" 
                         class="custom-control-input" 
                         {{ $whatsnew->read_more_use_flag == $key ? 'checked' : '' }}
+                        v-model="read_more_use_flag"
                     >
                     <label class="custom-control-label" for="{{ "read_more_use_flag_${key}" }}">
                         {{ $value }}
@@ -255,7 +256,12 @@
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">ボタン押下時の<br>取得件数／回</label>
         <div class="{{$frame->getSettingInputClass()}}">
-            <input type="text" name="read_more_fetch_count" value="{{old('read_more_fetch_count', $whatsnew->read_more_fetch_count ? $whatsnew->read_more_fetch_count : 5)}}" class="form-control col-sm-3">
+            <input 
+                type="text" 
+                name="read_more_fetch_count" 
+                value="{{old('read_more_fetch_count', $whatsnew->read_more_fetch_count ? $whatsnew->read_more_fetch_count : 5)}}" 
+                class="form-control col-sm-3"
+            >
             @if ($errors && $errors->has('read_more_fetch_count')) <div class="text-danger">{{$errors->first('read_more_fetch_count')}}</div> @endif
         </div>
     </div>
@@ -264,7 +270,13 @@
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">ボタン名</label>
         <div class="{{$frame->getSettingInputClass()}}">
-            <input type="text" name="read_more_name" value="{{old('read_more_name', $whatsnew->read_more_name ? $whatsnew->read_more_name : 'もっと見る')}}" class="form-control">
+            <input 
+                type="text" 
+                name="read_more_name" 
+                value="{{old('read_more_name', $whatsnew->read_more_name ? $whatsnew->read_more_name : 'もっと見る')}}" 
+                class="form-control"
+                v-model="read_more_name"
+            >
             @if ($errors && $errors->has('read_more_name')) <div class="text-danger">{{$errors->first('read_more_name')}}</div> @endif
         </div>
     </div>
@@ -273,7 +285,7 @@
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">ボタン色</label>
         <div class="{{$frame->getSettingInputClass()}}">
-            <select class="form-control" name="read_more_btn_color_type">
+            <select class="form-control" name="read_more_btn_color_type" v-model="read_more_btn_color_type">
                 @foreach (Bs4Color::getMembers() as $key=>$value)
                     <option value="{{$key}}" class="{{ 'text-' . $key }}" @if($key == old('read_more_btn_color_type', $whatsnew->read_more_btn_color_type)) selected @endif>
                         {{ $value }}
@@ -287,7 +299,7 @@
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">ボタンの形</label>
         <div class="{{$frame->getSettingInputClass()}}">
-            <select class="form-control" name="read_more_btn_type">
+            <select class="form-control" name="read_more_btn_type" v-model="read_more_btn_type">
                 @foreach (RadiusType::getMembers() as $key=>$value)
                     <option value="{{$key}}" @if($key == old('read_more_btn_type', $whatsnew->read_more_btn_type)) selected @endif>
                         {{ $value }}
@@ -310,6 +322,7 @@
                         name="read_more_btn_transparent_flag" 
                         class="custom-control-input" 
                         {{ $whatsnew->read_more_btn_transparent_flag == $key ? 'checked' : '' }}
+                        v-model="read_more_btn_transparent_flag"
                     >
                     <label class="custom-control-label" for="{{ "read_more_btn_transparent_flag_${key}" }}">
                         {{ $value }}
@@ -319,6 +332,15 @@
         </div>
     </div>
     
+    <div class="form-group row border">
+        <label class="{{$frame->getSettingLabelClass(true)}}">ボタンプレビュー</label>
+        <div class="text-center {{$frame->getSettingInputClass(true)}}">
+            <p :class="[readMoreBtnClass]">
+                @{{ read_more_name }}
+            </p>
+        </div>
+    </div>
+
     <h5><span class="badge badge-secondary">表示対象プラグイン・フレーム</span></h5>
 
     {{-- 対象プラグイン --}}
@@ -457,6 +479,15 @@
 <script>
     new Vue({
         el: "#app_{{ $frame->id }}",
+        data: function() {
+            return {
+                read_more_use_flag : {{ $whatsnew->read_more_use_flag ? $whatsnew->read_more_use_flag : "0" }},
+                read_more_name : '{{ $whatsnew->read_more_name ? $whatsnew->read_more_name : '' }}',
+                read_more_btn_color_type : '{{ $whatsnew->read_more_btn_color_type ? $whatsnew->read_more_btn_color_type : Bs4Color::primary }}',
+                read_more_btn_type : '{{ $whatsnew->read_more_btn_type ? $whatsnew->read_more_btn_type : RadiusType::rounded }}',
+                read_more_btn_transparent_flag : {{ $whatsnew->read_more_btn_transparent_flag ? $whatsnew->read_more_btn_transparent_flag : "0" }}
+            }
+        },
         methods: {
             // 対象フレームのチェックボックスdisabled制御
             setDisabledTargetFrame:function(frame_select_value){
@@ -465,6 +496,14 @@
                     // disabledでチェックボックスの選択状態がクリアされてしまうが、再選択時に意識的に選択してもらう
                     elms[i].disabled = frame_select_value == '0' ? true : false;
                 }
+            }
+        },
+        computed: {
+            readMoreBtnClass : function() {
+                let btn_class = 'btn-';
+                btn_class += this.read_more_btn_transparent_flag == 1 ? 'outline-' : '';
+                btn_class += this.read_more_btn_color_type;
+                return ['btn', btn_class, this.read_more_btn_type]
             }
         },
         // 初期表示にvueメソッドをcallする

--- a/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
@@ -1,7 +1,7 @@
 {{--
  * 新着情報表示画面（１行表示）
  *
- * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>, 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 新着情報プラグイン
 --}}
@@ -15,7 +15,7 @@
     @endif
 </p>
 
-<div class="container">
+<div class="container" id="{{ $whatsnews_frame->read_more_use_flag == UseType::use ? 'app_' . $frame->id : '' }}">
 @foreach($whatsnews as $whatsnew)
     <div class="mb-2 row">
         {{-- 投稿日 --}}
@@ -55,7 +55,30 @@
         @endif
     </div>
 @endforeach
-    
+    {{-- 「もっと見る」ボタン押下時、非同期で新着一覧をレンダリング ※templateタグはタグとして出力されないタグです。 --}}
+    <div v-for="whatsnews in whatsnewses" class="mb-2 row">
+        {{-- 登録日時 --}}
+        <div v-if="view_posted_at == 1" class="p-0 col-md-2 col-lg text-nowrap" style="display: contents;">
+            <span class="mr-2">@{{ moment(whatsnews.posted_at).format('YYYY/MM/DD')}}</span>
+        </div>
+        {{-- カテゴリ --}}
+        <div v-if="whatsnews.category != null && whatsnews.category != ''" class="p-0 col-md-2 col-lg" style="display: contents;">
+            <div>
+                <span :class="'mr-2 badge cc_category_' + whatsnews.classname">@{{ whatsnews.category }}</span>
+            </div>
+        </div>
+        {{-- タイトル＋リンク --}}
+        <div v-if="link_pattern[whatsnews.plugin_name] == 'show_page_frame_post'" class="p-0 col-12 col-sm-12 col-md col-lg mr-2 text-truncate">
+            <a :href="url + link_base[whatsnews.plugin_name] + '/' + whatsnews.page_id + '/' + whatsnews.frame_id + '/' + whatsnews.post_id + '#frame-' + whatsnews.frame_id">
+                <template v-if="whatsnews.post_title == null || whatsnews.post_title == ''">（無題）</template>
+                <template v-else>@{{ whatsnews.post_title }}</template>
+            </a>
+        </div>
+        {{-- 投稿者 --}}
+        <div v-if="view_posted_name == 1" class="p-0 col-12 col-sm-12 col-md-3 col-lg-2 text-right text-nowrap">
+            @{{ whatsnews.posted_name }}
+        </div>
+    </div>
     
     {{-- ページング処理 --}}
     {{-- @if ($whatsnews_frame->page_method == 1)
@@ -63,6 +86,23 @@
             {{ $whatsnews->links() }}
         </div>
     @endif --}}
+    {{-- もっと見るボタン ※取得件数が総件数以下で表示 --}}
+    @if ($whatsnews_frame->read_more_use_flag == UseType::use)
+        @php
+            $btn_color = 'btn-';
+            $btn_color .= $whatsnews_frame->read_more_btn_transparent_flag == UseType::use ? 'outline-' : '';
+            $btn_color .= $whatsnews_frame->read_more_btn_color_type;
+        @endphp
+        <div v-if="whatsnews_total_count >= offset" class="text-center">
+            <button class="btn {{ $btn_color }} {{ $whatsnews_frame->read_more_btn_type }}" v-on:click="searchWhatsnewses">
+                {{ $whatsnews_frame->read_more_name }}
+            </button>
+        </div>
+    @endif
 </div>
+
+    @if ($whatsnews_frame->read_more_use_flag == UseType::use)
+        @include('plugins.user.whatsnews.whatsnews_script')
+    @endif
 @endif
 @endsection

--- a/resources/views/plugins/user/whatsnews/whatsnews_script.blade.php
+++ b/resources/views/plugins/user/whatsnews/whatsnews_script.blade.php
@@ -1,0 +1,47 @@
+{{--
+ * 新着情報のscriptテンプレート ※app.jsがコンパイル利用できるようになったらVueコンポーネント化する
+ *
+ * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category 新着情報プラグイン
+--}}
+<script>
+    const app_{{ $frame->id }} = new Vue({
+        el: "#app_{{ $frame->id }}",
+        data: function() {
+            return {
+                url: '{{ url('/') }}',
+                link_pattern: @json($link_pattern),
+                link_base: @json($link_base),
+                whatsnewses: [],
+                whatsnews_total_count: {{ $whatsnews_total_count }}, // 総件数
+                view_posted_at: {{ $whatsnews_frame->view_posted_at }},
+                view_posted_name: {{ $whatsnews_frame->view_posted_name }},
+                limit: {{ $whatsnews_frame->read_more_fetch_count }},
+                offset: {{ $whatsnews->count() }} // 何件目から取得するか（＝現時点の取得件数）※初期値はサーバから返された一覧件数
+            }
+        },
+        methods: {
+            searchWhatsnewses: function () {
+                let self = this;
+                // 非同期通信で追加の一覧を取得
+                axios.get("{{url('/')}}/json/whatsnews/indexJson/{{$page->id}}/{{$frame_id}}/?limit=" + this.limit + "&offset=" + this.offset)
+                    .then(function(res){
+                        // foreach内ではthisでvueインスタンスのwhatsnewsesが参照できない為、tmp_arrに一時的に代入
+                        tmp_arr = self.whatsnewses;
+                        res.data.forEach(function(obj) {
+                            // 取得した差分をループしてtmp_arrに格納
+                            tmp_arr.push(obj);
+                        });
+                        // vueインスタンスのwhatsnewsesに代入
+                        this.whatsnewses = tmp_arr;
+                    })
+                    .catch(function (error) {
+                        console.log(error)
+                    });
+                // offset値をカウントアップ
+                this.offset += this.limit;
+            }
+        },
+    });
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,6 +78,9 @@ Route::get('/plugin/{plugin_name}/{action}/{page_id?}/{frame_id?}/{id?}', 'Core\
 // 一般プラグインの更新系アクション（画面がある場合）
 Route::post('/plugin/{plugin_name}/{action}/{page_id?}/{frame_id?}/{id?}', 'Core\DefaultController@invokePost')->name('post_plugin');
 
+// 一般プラグインのJSONレスポンスアクション
+Route::get('/json/{plugin_name}/{action}/{page_id?}/{frame_id?}', 'Core\DefaultController@invokeGetJson')->name('get_json');
+
 // 一般プラグインの更新系アクション（リダイレクトする場合）
 Route::post('/redirect/plugin/{plugin_name}/{action}/{page_id?}/{frame_id?}/{id?}', 'Core\DefaultController@invokePostRedirect')->name('post_redirect');
 Route::get('/redirect/plugin/{plugin_name}/{action}/{page_id?}/{frame_id?}/{id?}', 'Core\DefaultController@invokePostRedirect')->name('get_redirect');


### PR DESCRIPTION
## 概要
- 新着プラグインに「もっと見る」ボタン機能を付与できる機能追加です。
- 新着は利用頻度が比較的高いプラグインの為、既存サイトへの影響を考慮して、該当ボタンの表示可否等は設定画面から変更できるようにしています。（設定項目：表示可否、ボタン表示名、押下時の取得件数等）※デフォルトは非表示です。
- 追加の新着一覧は非同期で取得する為、コア側にAPIコールできるI/F機能を追加しています。
- （検討中＠6/2）初動開発ではIEで動作できなかった為、ポリフィル対応を検討中です。なるべくIEでの動作も目指したいですが、調査結果次第ではIEでは本機能を無効化する可能性もあります。（追記＠6/4）ポリフィル対応を入れてIE動作OKです。
- （ポリフィルについて）app.blade.phpで表示ページに新着プラグインが存在したら、CDN経由で必要なJSライブラリをversion固定で読み込むようにしています。いずれ消す可能性のあるライブラリの為、CDN経由にしています。

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms-ideas/issues/33

## 参考
なし

## DB変更の有無
有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認した。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
