### PR TITLE
Extern auth：NC2外部認証連携部分修正

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -71,12 +71,13 @@ class LoginController extends Controller
      */
     public function login(Request $request)
     {
-        // 利用可能かチェック
-        if (!$this->checkUserStstus($request, $error_msg)) {
-            throw ValidationException::withMessages([
-                $this->username() => [$error_msg],
-            ]);
-        }
+// 外部認証を行う場合、先に利用可能かチェックをするとまだユーザー登録されていない場合エラーになる為、チェック処理は後にもっていく
+//        // 利用可能かチェック
+//        if (!$this->checkUserStstus($request, $error_msg)) {
+//            throw ValidationException::withMessages([
+//                $this->username() => [$error_msg],
+//            ]);
+//        }
 
         // 外部認証を使用
         $use_auth_method = Configs::where('name', 'use_auth_method')->first();
@@ -86,6 +87,13 @@ class LoginController extends Controller
             //
             // 以下はもともとのAuthenticatesUsers@login 処理
             //return $this->laravelLogin($request);
+
+            // 利用可能かチェック
+            if (!$this->checkUserStatus($request, $error_msg)) {
+                throw ValidationException::withMessages([
+                    $this->username() => [$error_msg],
+                ]);
+            }
 
             try {
                 return $this->laravelLogin($request);
@@ -113,6 +121,13 @@ class LoginController extends Controller
             $redirect = $this->authMethod($request);
             if (!empty($redirect)) {
                 return $redirect;
+            }
+
+            // 利用可能かチェック
+            if (!$this->checkUserStatus($request, $error_msg)) {
+                throw ValidationException::withMessages([
+                    $this->username() => [$error_msg],
+                ]);
             }
 
             // 外部認証と併せて、通常ログインも使用

--- a/app/Traits/ConnectCommonTrait.php
+++ b/app/Traits/ConnectCommonTrait.php
@@ -801,7 +801,7 @@ trait ConnectCommonTrait
      *  利用可能かチェック
      *  戻り値：true なら
      */
-    public function checkUserStstus($request, &$error_msg = "")
+    public function checkUserStatus($request, &$error_msg = "")
     {
         // userid は必要
         if (!$request->filled('userid')) {
@@ -873,7 +873,7 @@ trait ConnectCommonTrait
                     if (empty($user)) {
                         // ユーザが存在しない場合、ログインのみ権限でユーザを作成して、自動ログイン
                         $user = new User;
-                        $user->name = $request['userid'];
+                        $user->name = empty( $check_result['handle'] ) ? $request['userid'] : $check_result['handle'];
                         $user->userid = $request['userid'];
                         $user->password = Hash::make($request['password']);
                         $user->created_event = \AuthMethodType::netcommons2;
@@ -881,13 +881,41 @@ trait ConnectCommonTrait
 
                         // 追加権限設定があれば作成
                         if (!empty($auth_method['additional4'])) {
-                            $original_rols_options = explode(':', $auth_method['additional4']);
+                        
+                            // NC2側権限値取得
+                            $nc2_auth = "";
+                            if( array_key_exists( 'auth', $check_result ) == true )
+                            {
+                                $nc2_auth = $check_result['auth'];
+                            }
+                            
+                            // |で区切る（|は複数権限の設定がある場合に区切り文字として利用される）
+                            $set_rols = "";
+                            $rols_options_list = explode('|', $auth_method['additional4']);
+                            foreach( $rols_options_list as $value )
+                            {
+                                // :で区切る（:は、NC2側権限とConnectCMS側権限の区切り文字として利用される）
+                                $original_rols_options = explode(':', $value);
+                                
+                                // 一致した権限を設定する
+                                if( $original_rols_options[0] == $nc2_auth ) {
+                                    $set_rols = $original_rols_options[1];
+                                    break;
+                                }
+                            }
+                            
                             UsersRoles::create([
                                 'users_id'   => $user->id,
                                 'target'     => 'original_role',
-                                'role_name'  => $original_rols_options[1],
+                                'role_name'  => $set_rols,
                                 'role_value' => 1
                             ]);
+                        }
+                    }
+                    else {
+                        // ユーザ登録が既にある場合、そのユーザが利用可能になっているかどうかをチェックし、利用不可になっている場合は処理を戻す
+                        if ($user->status == 0) {
+                            return;
                         }
                     }
 

--- a/app/Traits/ConnectCommonTrait.php
+++ b/app/Traits/ConnectCommonTrait.php
@@ -914,7 +914,7 @@ trait ConnectCommonTrait
                     }
                     else {
                         // ユーザ登録が既にある場合、そのユーザが利用可能になっているかどうかをチェックし、利用不可になっている場合は処理を戻す
-                        if ($user->status == 0) {
+                        if( $user->status != UserStatus::active ) {
                             return;
                         }
                     }


### PR DESCRIPTION
## 概要
・外部認証チェックする前にアカウント利用可能チェックをしていたところを修正
・NC2外部認証後アカウント作成時、ハンドルが渡ってきている場合はハンドル名を登録するように修正
・NC2外部認証時、NC2側権限によって役割設定を振り分けられるような機能を追加
・外部認証処理時、既にアカウントがある時にそのアカウントが利用停止中なのかどうかチェックする部分にEnum設定を反映

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
