### PR TITLE
fix: viewに対してのcabinet変数の設定漏れを追加

### DIFF
--- a/app/Plugins/User/Cabinets/CabinetsPlugin.php
+++ b/app/Plugins/User/Cabinets/CabinetsPlugin.php
@@ -101,6 +101,7 @@ class CabinetsPlugin extends UserPluginBase
 
         // 表示テンプレートを呼び出す。
         return $this->view('index', [
+           'cabinet' => $cabinet,
            'cabinet_contents' => $parent->children()->orderBy('is_folder', 'desc')->orderBy('name', 'asc')->get(),
            'breadcrumbs' => $this->fetchBreadCrumbs($cabinet->id, $parent->id),
            'parent_id' =>  $parent->id,


### PR DESCRIPTION
## 概要
コミット漏れがあり、500エラーとなってしまっていました。

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/pull/910

## 参考

## DB変更の有無
 無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
