### PR TITLE
BBS→BBSのNC2移行を対応しました

### DIFF
--- a/app/Models/Migration/Nc2/Nc2Block.php
+++ b/app/Models/Migration/Nc2/Nc2Block.php
@@ -109,7 +109,7 @@ class Nc2Block extends Model
     protected $plugin_name = [
         'announcement'  => 'contents',     // お知らせ
         'assignment'    => 'Development',  // レポート
-        'bbs'           => 'blogs',        // 掲示板     ※ 2020-09時点では掲示板はブログに移行
+        'bbs'           => 'bbses',        // 掲示板
         'cabinet'       => 'cabinets',  // キャビネット
         'calendar'      => 'Development',  // カレンダー
         'chat'          => 'Development',  // チャット

--- a/app/Models/User/Bbses/BbsPost.php
+++ b/app/Models/User/Bbses/BbsPost.php
@@ -27,7 +27,7 @@ class BbsPost extends Model
     use UserableNohistory;
 
     // 更新する項目の定義
-    protected $fillable = ['bbs_id', 'title', 'body', 'thread_root_id', 'thread_updated_at', 'status', '_lft', '_rgt', 'parent_id'];
+    protected $fillable = ['bbs_id', 'title', 'body', 'thread_root_id', 'thread_updated_at', 'first_committed_at', 'status', '_lft', '_rgt', 'parent_id', 'created_name'];
 
     // 入れ子集合モデル
     use NodeTrait;

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -5214,14 +5214,20 @@ trait MigrationTrait
                 $journals_ini .= "post_title[" . $nc2_bbs_post->post_id . "] = \"" . str_replace('"', '', $nc2_bbs_post->subject) . "\"\n";
             }
 
+            // bbs->blog移行の場合は、blog用のフォルダに吐き出す
+            $export_path = 'bbses/bbs_';
+            if ($this->plugin_name['bbs'] === 'blogs') {
+                $export_path = 'blogs/blog_bbs_';
+            }
+
             // blog の設定
             //Storage::put($this->getImportPath('blogs/blog_bbs_') . $this->zeroSuppress($nc2_bbs_post->bbs_id) . '.ini', $journals_ini);
-            $this->storagePut($this->getImportPath('blogs/blog_bbs_') . $this->zeroSuppress($nc2_bbs->bbs_id) . '.ini', $journals_ini);
+            $this->storagePut($this->getImportPath($export_path) . $this->zeroSuppress($nc2_bbs->bbs_id) . '.ini', $journals_ini);
 
             // blog の記事
             //Storage::put($this->getImportPath('blogs/blog_bbs_') . $this->zeroSuppress($nc2_bbs_post->bbs_id) . '.tsv', $journals_tsv);
             $journals_tsv = $this->exportStrReplace($journals_tsv, 'bbses');
-            $this->storagePut($this->getImportPath('blogs/blog_bbs_') . $this->zeroSuppress($nc2_bbs->bbs_id) . '.tsv', $journals_tsv);
+            $this->storagePut($this->getImportPath($export_path) . $this->zeroSuppress($nc2_bbs->bbs_id) . '.tsv', $journals_tsv);
         }
     }
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -22,6 +22,8 @@ use App\Models\Common\Permalink;
 use App\Models\Common\Uploads;
 use App\Models\Core\Configs;
 use App\Models\Core\UsersRoles;
+use App\Models\User\Bbses\Bbs;
+use App\Models\User\Bbses\BbsPost;
 use App\Models\User\Blogs\Blogs;
 use App\Models\User\Blogs\BlogsPosts;
 use App\Models\User\Cabinets\Cabinet;
@@ -367,6 +369,14 @@ trait MigrationTrait
             CabinetContent::truncate();
             Buckets::where('plugin_name', 'cabinets')->delete();
             MigrationMapping::where('target_source_table', 'cabinets')->delete();
+        }
+
+        if ($target == 'bbses' || $target == 'all') {
+            Bbs::truncate();
+            BbsPost::truncate();
+            Buckets::where('plugin_name', 'bbses')->delete();
+            MigrationMapping::where('target_source_table', 'bbses')->delete();
+            MigrationMapping::where('target_source_table', 'bbs_posts')->delete();
         }
     }
 
@@ -5106,10 +5116,10 @@ trait MigrationTrait
         $this->putMonitor(3, "Start nc2ExportBbs.");
 
         // データクリア
-        //if ($redo === true) {
-        //    // 移行用ファイルの削除
-        //    Storage::deleteDirectory($this->getImportPath('blogs/'));
-        //}
+        if ($redo === true) {
+            // 移行用ファイルの削除
+            Storage::deleteDirectory($this->getImportPath('bbses/'));
+        }
 
         // NC2掲示板（Bbs）を移行する。
         $nc2_bbses = Nc2Bbs::orderBy('bbs_id')->get();

--- a/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
@@ -105,6 +105,7 @@ cc_import_plugins[] = "forms"
 cc_import_plugins[] = "linklists"
 cc_import_plugins[] = "whatsnews"
 cc_import_plugins[] = "cabinets"
+cc_import_plugins[] = "bbses"
 
 ;------------------------------------------------
 ;- ページ関係
@@ -169,6 +170,7 @@ import_frame_plugins[] = "forms"
 import_frame_plugins[] = "linklists"
 import_frame_plugins[] = "whatsnews"
 import_frame_plugins[] = "cabinets"
+import_frame_plugins[] = "bbses"
 
 ; 強制的にフレームデザインを適用する（none は対象外）
 ;cc_import_force_frame_design = "primary"


### PR DESCRIPTION
## 概要
掲示板→掲示板のNC2移行処理を追加しました。
もともと掲示板→ブログへ移行していましたが、
Connect-CMSに掲示板プラグインが追加されたため、対応しました。

## 関連Pull requests/Issues

## 参考

## DB変更の有無
無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
