### PR TITLE
modify: ファイル名をアップロードテーブルから取ってくるよう修正

### DIFF
--- a/app/Models/User/Cabinets/CabinetContent.php
+++ b/app/Models/User/Cabinets/CabinetContent.php
@@ -32,4 +32,20 @@ class CabinetContent extends Model
         // withDefault() を指定しておくことで、Uploads がないときに空のオブジェクトが返ってくるので、null po 防止。
         return $this->hasOne(Uploads::class, 'id', 'upload_id')->withDefault();
     }
+
+    /**
+     * 画面表示用のファイル名を取得する
+     *
+     * @return string  画面表示用のファイル名
+     */
+    public function getDisplayNameAttribute()
+    {
+        $displayName = $this->name;
+        // 管理機能のアップロードファイル管理で、ファイル名の変更ができるため、
+        // ファイルはアップロードテーブルから名称取得する
+        if ($this->is_folder === self::is_folder_off) {
+            $displayName = $this->upload->client_original_name;
+        }
+        return $displayName;
+    }
 }

--- a/app/Plugins/User/Cabinets/CabinetsPlugin.php
+++ b/app/Plugins/User/Cabinets/CabinetsPlugin.php
@@ -102,10 +102,16 @@ class CabinetsPlugin extends UserPluginBase
 
         // 表示テンプレートを呼び出す。
         return $this->view('index', [
-           'cabinet' => $cabinet,
-           'cabinet_contents' => $parent->children()->orderBy('is_folder', 'desc')->orderBy('name', 'asc')->get(),
-           'breadcrumbs' => $this->fetchBreadCrumbs($cabinet->id, $parent->id),
-           'parent_id' =>  $parent->id,
+            'cabinet' => $cabinet,
+            'cabinet_contents' => $parent->children()->get()->sort(function ($first, $second) {
+                // フォルダ>ファイル>名前順（昇順）
+                if ($first['is_folder'] == $second['is_folder']) {
+                    return $first['displayName'] < $second['displayName'] ? -1 : 1;
+                }
+                return $first['is_folder'] < $second['is_folder'] ? 1 : -1;
+            }),
+            'breadcrumbs' => $this->fetchBreadCrumbs($cabinet->id, $parent->id),
+            'parent_id' =>  $parent->id,
         ]);
     }
 

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -160,13 +160,13 @@
                 <tr>
                     <td>
                         <div class="custom-control custom-checkbox">
-                            <input type="checkbox" class="custom-control-input" id="customCheck{{$loop->index}}" name="cabinet_content_id[]" value="{{$cabinet_content->id}}" data-name="{{$cabinet_content->name}}">
+                            <input type="checkbox" class="custom-control-input" id="customCheck{{$loop->index}}" name="cabinet_content_id[]" value="{{$cabinet_content->id}}" data-name="{{$cabinet_content->displayName}}">
                             <label class="custom-control-label" for="customCheck{{$loop->index}}"></label>
                         </div>
                     </td>
                     @if ($cabinet_content->is_folder == true)
                         <td>
-                            <i class="fas fa-folder mr-1 text-warning"></i><a href="{{url('/')}}/plugin/cabinets/index/{{$page->id}}/{{$frame_id}}?parent_id={{$cabinet_content->id}}#frame-{{$frame->id}}">{{$cabinet_content->name}}</a>
+                            <i class="fas fa-folder mr-1 text-warning"></i><a href="{{url('/')}}/plugin/cabinets/index/{{$page->id}}/{{$frame_id}}?parent_id={{$cabinet_content->id}}#frame-{{$frame->id}}">{{$cabinet_content->displayName}}</a>
                             <small class="form-text text-muted d-block d-md-none">
                                 - | {{$cabinet_content->created_at}}
                             </small>
@@ -175,7 +175,7 @@
                         <td class="d-none d-md-table-cell">{{$cabinet_content->created_at}}</td>
                     @else
                         <td>
-                            <i class="far fa-file mr-1 text-secondary"></i><a href="{{url('/')}}/file/{{$cabinet_content->upload_id}}" target="_blank">{{$cabinet_content->name}}</a>
+                            <i class="far fa-file mr-1 text-secondary"></i><a href="{{url('/')}}/file/{{$cabinet_content->upload_id}}" target="_blank">{{$cabinet_content->displayName}}</a>
                             <small class="form-text text-muted d-block d-md-none">
                                 {{$cabinet_content->upload->getFormatSize()}} | {{$cabinet_content->created_at}}
                             </small>


### PR DESCRIPTION
## 概要
管理機能のアップロードファイル管理で、ファイル名の変更ができるため、
ファイルはアップロードテーブルから名称取得する。

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms-ideas/issues/58

## 参考


## DB変更の有無
無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
