### PR TITLE
テーマ 基本／追加テーマのCSS／JSファイルにキャッシュバスティング用のクエリストリング追加

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -111,22 +111,22 @@
 
     <!-- Themes CSS（基本） -->
 @if (isset($themes['css']) && $themes['css'] != '')
-    <link href="{{url('/')}}/themes/{{$themes['css']}}/themes.css" rel="stylesheet">
+    <link href="{{url('/')}}/themes/{{$themes['css']}}/themes.css?version={{ filemtime($_SERVER['DOCUMENT_ROOT'] . "/themes/{$themes['css']}/themes.css") }}" rel="stylesheet">
 @endif
 
     <!-- Themes JS（基本） -->
 @if (isset($themes['js']) && $themes['js'] != '')
-    <script src="{{url('/')}}/themes/{{$themes['js']}}/themes.js"></script>
+    <script src="{{url('/')}}/themes/{{$themes['js']}}/themes.js?version={{ filemtime($_SERVER['DOCUMENT_ROOT'] . "/themes/{$themes['js']}/themes.js") }}"></script>
 @endif
 
     <!-- Themes CSS（追加） -->
 @if (isset($themes['additional_css']) && $themes['additional_css'] != '')
-    <link href="{{url('/')}}/themes/{{$themes['additional_css']}}/themes.css" rel="stylesheet">
+    <link href="{{url('/')}}/themes/{{$themes['additional_css']}}/themes.css?version={{ filemtime($_SERVER['DOCUMENT_ROOT'] . "/themes/{$themes['additional_css']}/themes.js") }}" rel="stylesheet">
 @endif
 
     <!-- Themes JS（追加） -->
 @if (isset($themes['additional_js']) && $themes['additional_js'] != '')
-    <script src="{{url('/')}}/themes/{{$themes['additional_js']}}/themes.js"></script>
+    <script src="{{url('/')}}/themes/{{$themes['additional_js']}}/themes.js?version={{ filemtime($_SERVER['DOCUMENT_ROOT'] . "/themes/{$themes['additional_js']}/themes.js") }}"></script>
 @endif
 
     <!-- Connect-CMS Page CSS -->


### PR DESCRIPTION
## 概要
### 背景
- とあるプロダクション環境でテーマファイル内CSSから設定している画像の差し替え要求があった。
- CSS内から画像ファイルを参照している箇所にクエリストリングを設定したが、そもそも大元のHTML→CSS読み込み部でブラウザキャッシュが効いてしまい、旧いCSSが読み込まれ、結果、画像も変わらないケースが発生
- 各クライアント端末側ブラウザのスーパーリロードを行えば解消はされるが、すべての閲覧者に対してリロードを要求するのは現実的ではない為、機能化に至りました。
### 対応内容
- サイト管理で設定できる基本テーマ／追加テーマに紐づくCSSファイル／JSファイルに対して、ファイルの更新時間を取得してクエリストリングを付与するようにしました。
- これにより、ファイル更新までは各クライアントのキャッシュが維持されます。
- （一応）テーマ設定はあるが、ファイルがないケースでシステムエラーが発生しないことは確認しています。

## 関連Pull requests/Issues
なし

## 参考
http://blog.ko-atrandom.com/?p=266

## DB変更の有無
なし

## チェックリスト
- bladeファイルなのでPHP_CodeSnifferは対象外
- マニュアルは下記ページのテーマ言及部を更新
	- https://connect-cms.jp/manual/manager/site


- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
