### PR TITLE
modify: codes.plugin_nameが全小文字で登録されるよう修正

### DIFF
--- a/database/migrations/2021_08_12_141439_update_plugin_name_codes_table.php
+++ b/database/migrations/2021_08_12_141439_update_plugin_name_codes_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Common\Codes;
+
+class UpdatePluginNameCodesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('codes', function (Blueprint $table) {
+            //
+        });
+
+        // プラグイン名をすべて小文字に更新
+        $codes = Codes::get();
+        foreach ($codes as $code) {
+            $code->update(['plugin_name' => strtolower($code->plugin_name)]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('codes', function (Blueprint $table) {
+            //
+        });
+
+        // プラグイン名を先頭大文字に更新
+        $codes = Codes::get();
+        foreach ($codes as $code) {
+            $code->update(['plugin_name' => ucfirst($code->plugin_name)]);
+        }
+    }
+}

--- a/resources/views/plugins/manage/code/edit.blade.php
+++ b/resources/views/plugins/manage/code/edit.blade.php
@@ -75,7 +75,7 @@
                 <select name="plugin_name" id="plugin_name" class="form-control">
                     <option value=""@if($code->plugin_name == "") selected @endif>設定なし</option>
                     @foreach ($plugins as $plugin)
-                        <option value="{{$plugin->plugin_name}}"@if(old('plugin_name', $code->plugin_name) == $plugin->plugin_name) selected @endif>{{$plugin->plugin_name_full}}</option>
+                        <option value="{{strtolower($plugin->plugin_name)}}"@if(old('plugin_name', $code->plugin_name) == strtolower($plugin->plugin_name)) selected @endif>{{$plugin->plugin_name_full}}</option>
                     @endforeach
                 </select>
                 <div class="text-muted">{{$codes_help_message->plugin_name_help_message}}</div>


### PR DESCRIPTION
## 概要
codes.plugin_nameが全小文字で登録されるよう修正
bucketsやframesでは全小文字であり、Connect-CMS内で平仄を取るため

## 関連Pull requests/Issues

#960

## 参考

## DB変更の有無

有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
