### PR TITLE
Fix キャビネットのファイル削除でエラー

### DIFF
--- a/app/Plugins/User/Cabinets/CabinetsPlugin.php
+++ b/app/Plugins/User/Cabinets/CabinetsPlugin.php
@@ -374,7 +374,7 @@ class CabinetsPlugin extends UserPluginBase
     {
         $validator = $this->getContentsControlValidator($request);
         if ($validator->fails()) {
-            return back()->withErrors($validator)->withInput()->with('parent_id', $request->parent_id);
+            return back()->withErrors($validator)->withInput();
         }
 
         foreach ($request->cabinet_content_id as $cabinet_content_id) {
@@ -387,7 +387,7 @@ class CabinetsPlugin extends UserPluginBase
         }
 
         // 登録後はリダイレクトして初期表示。
-        return new Collection(['redirect_path' => url('/') . "/plugin/cabinets/index/" . $page_id . "/" . $frame_id . "/" . $this->frame->bucket_id . '?parent_id=' . $request->parent_id . "#frame-" . $frame_id ]);
+        return new Collection(['redirect_path' => url('/') . "/plugin/cabinets/changeDirectory/" . $page_id . "/" . $frame_id . "/" . $request->parent_id . "/#frame-" . $frame_id ]);
     }
 
     /**

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -13,7 +13,7 @@
     $(function () {
         @can('posts.create', [[null, $frame->plugin_name, $buckets]])
         $('#collapse_mkdir{{$frame->id}}').on('hidden.bs.collapse', function () {
-            $('#folder_name').val('');
+            $('#folder_name{{$frame_id}}').val('');
         });
 
         $('#collapse_mkdir{{$frame->id}}').on('show.bs.collapse', function () {
@@ -25,7 +25,8 @@
         });
 
         $('#collapse_upload{{$frame->id}}').on('hidden.bs.collapse', function () {
-            $('#upload-file').val('');
+            $('#upload_file{{$frame_id}}').val('');
+            $('#upload_file{{$frame_id}}').next('.custom-file-label').html('ファイル選択...');
         });
 
         $('.custom-file-input').on('change',function(){
@@ -35,43 +36,46 @@
 
         @endcan
 
-        $('input[type="checkbox"][name="cabinet_content_id[]"]').on('change', function(){
+        $('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]').on('change', function(){
 
-            $('#selected-contents').html('');
+            $('#selected-contents{{$frame_id}}').html('');
 
-            if ($('input[type="checkbox"][name="cabinet_content_id[]"]:checked').length > 0){
-                $('.btn-download').prop('disabled', false);
-                $('input[type="checkbox"][name="cabinet_content_id[]"]:checked').each(function(){
-                    $('#selected-contents').append('<li>' + $(this).data('name') + '</li>');
+            if ($('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:checked').length > 0){
+                $('#app_{{$frame_id}} .btn-download').prop('disabled', false);
+                $('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:checked').each(function(){
+                    $('#selected-contents{{$frame_id}}').append('<li>' + $(this).data('name') + '</li>');
                 })
                 @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
-                $('.btn-delete').prop('disabled', false);
+                $('#app_{{$frame_id}} .btn-delete').prop('disabled', false);
                 @endcan
             } else {
-                $('.btn-download').prop('disabled', true);
+                $('#app_{{$frame_id}} .btn-download').prop('disabled', true);
                 @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
-                $('.btn-delete').prop('disabled', true);
+                $('#app_{{$frame_id}} .btn-delete').prop('disabled', true);
                 @endcan
             }
         });
 
-        $('.btn-download').on('click', function(){
-            $('#form-cabinet-contents').attr('action', '{{url('/')}}/download/plugin/cabinets/download/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}');
-            $('#form-cabinet-contents').submit();
+        $('#app_{{$frame_id}} .btn-download').on('click', function(){
+            $('#form-cabinet-contents{{$frame_id}}').attr('action', '{{url('/')}}/download/plugin/cabinets/download/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}');
+            $('#form-cabinet-contents{{$frame_id}}').submit();
         });
 
     });
 
     @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
-    function deleteContents() {
+    function deleteContents{{$frame_id}}() {
         if (window.confirm('データを削除します。\nよろしいですか？')) {
-            $('#form-cabinet-contents').attr('action', '{{url('/')}}/redirect/plugin/cabinets/deleteContents/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}');
-            $('#form-cabinet-contents').attr('method', 'POST');
-            $('#form-cabinet-contents').submit();
+            $('#form-cabinet-contents{{$frame_id}}').attr('action', '{{url('/')}}/redirect/plugin/cabinets/deleteContents/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}');
+            $('#form-cabinet-contents{{$frame_id}}').attr('method', 'POST');
+            $('#form-cabinet-contents{{$frame_id}}').append('<input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/cabinets/changeDirectory/{{$page->id}}/{{$frame_id}}/{{$parent_id}}/#frame-{{$frame->id}}">');
+
+            $('#form-cabinet-contents{{$frame_id}}').submit();
         }
     }
     @endcan
 </script>
+<div id="app_{{$frame_id}}">
 @can('posts.create', [[null, $frame->plugin_name, $buckets]])
 <div class="p-2 text-right mb-2">
     <button class="btn btn-primary" data-toggle="collapse" data-target="#collapse_mkdir{{$frame->id}}"><i class="fas fa-folder-plus"></i><span class="d-none d-sm-inline"> フォルダ作成</span></button>
@@ -86,7 +90,7 @@
         <div class="form-group row">
             <label class="{{$frame->getSettingLabelClass()}}" for="folder_name">フォルダ名</label>
             <div class="{{$frame->getSettingInputClass()}}">
-                <input type="text" name="folder_name[{{$frame_id}}]" value="{{old("folder_name.$frame_id")}}" class="form-control @if ($errors && $errors->has("folder_name.$frame_id")) border-danger @endif" id="folder_name">
+                <input type="text" name="folder_name[{{$frame_id}}]" value="{{old("folder_name.$frame_id")}}" class="form-control @if ($errors && $errors->has("folder_name.$frame_id")) border-danger @endif" id="folder_name{{$frame_id}}">
                 @if ($errors && $errors->has("folder_name.$frame_id")) 
                     <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("folder_name.*")}}</div>
                 @endif
@@ -106,7 +110,7 @@
         <div class="form-group">
             <div class="custom-file">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file">
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
                 <label class="custom-file-label" for="upload_file" data-browse="参照">ファイル選択...</label>
             </div>
             @if ($errors && $errors->has("upload_file.$frame_id")) 
@@ -129,14 +133,14 @@
     @endif
 @endforeach
 </ul>
-<form id="form-cabinet-contents" method="GET">
+<form id="form-cabinet-contents{{$frame_id}}" method="GET">
 {{csrf_field()}}
 <input type="hidden" name="parent_id" value="{{$parent_id}}">
 @include('plugins.common.errors_inline', ['name' => 'cabinet_content_id'])
 <div class="bg-light p-2 text-right">
     <span class="mr-2">チェックした項目を</span>
     @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
-    <button class="btn btn-danger btn-sm btn-delete" type="button" data-toggle="modal" data-target="#delete-confirm" disabled><i class="fas fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span></button>
+    <button class="btn btn-danger btn-sm btn-delete" type="button" data-toggle="modal" data-target="#delete-confirm{{$frame->id}}" disabled><i class="fas fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span></button>
     @endcan
     <button class="btn btn-primary btn-sm btn-download" type="button" disabled><i class="fas fa-download"></i><span class="d-none d-sm-inline"> ダウンロード</span></button>
 </div>
@@ -166,8 +170,8 @@
                 <tr>
                     <td>
                         <div class="custom-control custom-checkbox">
-                            <input type="checkbox" class="custom-control-input" id="customCheck{{$loop->index}}" name="cabinet_content_id[]" value="{{$cabinet_content->id}}" data-name="{{$cabinet_content->displayName}}">
-                            <label class="custom-control-label" for="customCheck{{$loop->index}}"></label>
+                            <input type="checkbox" class="custom-control-input" id="customCheck{{$cabinet_content->id}}" name="cabinet_content_id[]" value="{{$cabinet_content->id}}" data-name="{{$cabinet_content->displayName}}">
+                            <label class="custom-control-label" for="customCheck{{$cabinet_content->id}}"></label>
                         </div>
                     </td>
                     @if ($cabinet_content->is_folder == true)
@@ -197,14 +201,14 @@
 <div class="bg-light p-2 text-right">
     <span class="mr-2">チェックした項目を</span>
     @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
-    <button class="btn btn-danger btn-sm btn-delete" type="button" data-toggle="modal" data-target="#delete-confirm" disabled><i class="fas fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span></button>
+    <button class="btn btn-danger btn-sm btn-delete" type="button" data-toggle="modal" data-target="#delete-confirm{{$frame_id}}" disabled><i class="fas fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span></button>
     @endcan
     <button class="btn btn-primary btn-sm btn-download" type="button" disabled><i class="fas fa-download"></i><span class="d-none d-sm-inline"> ダウンロード</span></button>
 </div>
 </form>
 @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
 {{-- 削除確認モーダルウィンドウ --}}
-<div class="modal" id="delete-confirm" tabindex="-1" role="dialog" aria-labelledby="delete-title" aria-hidden="true">
+<div class="modal" id="delete-confirm{{$frame_id}}" tabindex="-1" role="dialog" aria-labelledby="delete-title" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             {{-- ヘッダー --}}
@@ -219,7 +223,7 @@
                 <div class="card border-danger">
                     <div class="card-body">
                         <div class="text-danger">以下のデータを削除します。<br>元に戻すことはできないため、よく確認して実行してください。</div>
-                        <ul class="text-danger" id="selected-contents"></ul>
+                        <ul class="text-danger" id="selected-contents{{$frame_id}}"></ul>
                     </div>
                     <div class="text-center mb-2">
                         {{-- キャンセルボタン --}}
@@ -227,7 +231,7 @@
                             <i class="fas fa-times"></i> キャンセル
                         </button>
                         {{-- 削除ボタン --}}
-                        <button type="button" class="btn btn-danger" onclick="deleteContents()"><i class="fas fa-check"></i> 本当に削除する</button>
+                        <button type="button" class="btn btn-danger" onclick="deleteContents{{$frame_id}}()"><i class="fas fa-check"></i> 本当に削除する</button>
                     </div>
                 </div>
             </div>
@@ -235,4 +239,5 @@
     </div>
 </div>
 @endcan
+</div>
 @endsection


### PR DESCRIPTION
## 概要
以下内容を対応しました。
- 削除処理完了後のリダイレクトでシステムエラーとなる
  - #1020の対応漏れが原因でした。
  - リダイレクト先を修正して対応しました。
- 1ページにキャビネットのフレームが複数あると正常にファイルを選択できない
  - Javascriptのセレクタでフレーム間に同名のものが出てきてしまっていたので、削除処理が想定通りに動かなくなっていました。
  - ID属性にフレームIDを入れて対応しました。

## 関連Pull requests/Issues
#1023

## 参考

## DB変更の有無
無し

## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
