### PR TITLE
fix: Windowsの標準解凍ツールでZIPを解凍できない

### DIFF
--- a/app/Plugins/User/Cabinets/CabinetsPlugin.php
+++ b/app/Plugins/User/Cabinets/CabinetsPlugin.php
@@ -486,10 +486,13 @@ class CabinetsPlugin extends UserPluginBase
      */
     private function addContentsToZip(&$zip, $contents, $parent_name = '')
     {
+        // 保存先のパス
+        $save_path = $parent_name === '' ? $parent_name : $parent_name .'/';
+
         foreach ($contents as $content) {
             // ファイルが格納されていない空のフォルダだったら、空フォルダを追加
             if ($content->is_folder === CabinetContent::is_folder_on && $content->isLeaf()) {
-                $zip->addEmptyDir($parent_name .'/' . $content->name);
+                $zip->addEmptyDir($save_path . $content->name);
 
             // ファイル追加
             } elseif ($content->is_folder === CabinetContent::is_folder_off) {
@@ -503,12 +506,12 @@ class CabinetsPlugin extends UserPluginBase
                 }
                 $zip->addFile(
                     storage_path('app/') . $this->getContentsFilePath($content->upload),
-                    $parent_name .'/'. $content->name
+                    $save_path . $content->name
                 );
                 // ダウンロード回数をカウントアップ
                 Uploads::find($content->upload->id)->increment('download_count');
             }
-            $this->addContentsToZip($zip, $content->children, $parent_name .'/' . $content->name);
+            $this->addContentsToZip($zip, $content->children, $save_path . $content->name);
         }
     }
 


### PR DESCRIPTION
## 概要
Zipファイル直下に空白のディレクトリができていたため解凍できないようになっていました。
例 : [ZIPファイル]\\\\foo\bar

空白のディレクトリが作られないよう修正しました。

## 関連Pull requests/Issues
#1029

## 参考

## DB変更の有無
無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
