### PR TITLE
add: ブログ, コピーして登録画面へ機能追加

### DIFF
--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -94,7 +94,7 @@ class BlogsPlugin extends UserPluginBase
     {
         if (is_null($action)) {
             // プラグイン内からの呼び出しを想定。処理を通す。
-        } elseif (in_array($action, ['edit', 'save', 'temporarysave', 'delete'])) {
+        } elseif (in_array($action, ['edit', 'save', 'temporarysave', 'delete', 'copy'])) {
             // コアから呼び出し。posts.update|posts.deleteの権限チェックを指定したアクションは、処理を通す。
         } else {
             // それ以外のアクションは null で返す。

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -54,8 +54,8 @@ class BlogsPlugin extends UserPluginBase
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
         $functions = array();
-        $functions['get']  = ['settingBlogFrame', 'saveLikeJson'];
-        $functions['post'] = ['saveBlogFrame', 'copy'];
+        $functions['get']  = ['settingBlogFrame', 'saveLikeJson', 'copy'];
+        $functions['post'] = ['saveBlogFrame'];
         return $functions;
     }
 
@@ -738,7 +738,7 @@ WHERE status = 0
     /**
      * 記事編集画面
      */
-    public function edit($request, $page_id, $frame_id, $blogs_posts_id = null)
+    public function edit($request, $page_id, $frame_id, $blogs_posts_id = null, $is_copy = false)
     {
         // セッション初期化などのLaravel 処理。
         // $request->flash();
@@ -750,6 +750,12 @@ WHERE status = 0
         $blogs_post = $this->getPost($blogs_posts_id);
         if (empty($blogs_post->id)) {
             return $this->view_error("403_inframe", null, 'editのユーザー権限に応じたPOST ID チェック');
+        }
+
+        // 記事コピーの場合は、id消して新規登録画面へ & 投稿日時を今に変更
+        if ($is_copy) {
+            $blogs_post->id = null;
+            $blogs_post->posted_at = date('Y-m-d H:i:00');
         }
 
         // カテゴリ
@@ -976,11 +982,8 @@ WHERE status = 0
      */
     public function copy($request, $page_id = null, $frame_id = null, $id = null)
     {
-        // セッション初期化などのLaravel 処理。oldを保存。
-        $request->flash();
-
-        // 登録画面にリダイレクト
-        return collect(['redirect_path' => url('/') . "/plugin/blogs/create/{$page_id}/{$frame_id}#frame-{$frame_id}"]);
+        $is_copy = true;
+        return $this->edit($request, $page_id, $frame_id, $id, $is_copy);
     }
 
     /**

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -55,7 +55,7 @@ class BlogsPlugin extends UserPluginBase
         // 標準関数以外で画面などから呼ばれる関数の定義
         $functions = array();
         $functions['get']  = ['settingBlogFrame', 'saveLikeJson'];
-        $functions['post'] = ['saveBlogFrame'];
+        $functions['post'] = ['saveBlogFrame', 'copy'];
         return $functions;
     }
 
@@ -71,6 +71,7 @@ class BlogsPlugin extends UserPluginBase
         $role_check_table = [];
         $role_check_table["settingBlogFrame"]        = ['frames.edit'];
         $role_check_table["saveBlogFrame"]           = ['frames.edit'];
+        $role_check_table["copy"]                    = ['posts.create', 'posts.update'];
 
         return $role_check_table;
     }
@@ -968,6 +969,18 @@ WHERE status = 0
 
         // 登録後は表示用の初期処理を呼ぶ。
         // return $this->index($request, $page_id, $frame_id);
+    }
+
+    /**
+     * コピーして登録画面へ
+     */
+    public function copy($request, $page_id = null, $frame_id = null, $id = null)
+    {
+        // セッション初期化などのLaravel 処理。oldを保存。
+        $request->flash();
+
+        // 登録画面にリダイレクト
+        return collect(['redirect_path' => url('/') . "/plugin/blogs/create/{$page_id}/{$frame_id}#frame-{$frame_id}"]);
     }
 
     /**

--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -196,9 +196,17 @@
                     @if ($post->status == 1)
                         <span class="badge badge-warning align-bottom">一時保存</span>
                     @endif
-                    <a href="{{url('/')}}/plugin/blogs/edit/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}">
-                        <span class="btn btn-success btn-sm"><i class="far fa-edit"></i> <span class="hidden-xs">編集</span></span>
-                    </a>
+                    <div class="btn-group">
+                        <a href="{{url('/')}}/plugin/blogs/edit/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}" class="btn btn-success btn-sm">
+                            <i class="far fa-edit"></i> <span class="hidden-xs">編集</span>
+                        </a>
+                        <button type="button" class="btn btn-success btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <span class="sr-only">ドロップダウンボタン</span>
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-right">
+                            <a href="{{url('/')}}/plugin/blogs/copy/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}" class="dropdown-item"><i class="fas fa-copy "></i> コピー</a>
+                        </div>
+                    </div>
                 @endcan
                 </div>
             </footer>

--- a/resources/views/plugins/user/blogs/default/blogs_input.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_input.blade.php
@@ -32,6 +32,14 @@ use App\Models\User\Blogs\BlogsPosts;
         @endif
         form_blogs_posts{{$frame_id}}.submit();
     }
+
+    @if ($blogs_posts->id)
+        function copy_action() {
+            form_blogs_posts{{$frame_id}}.action = "{{url('/')}}/redirect/plugin/blogs/copy/{{$page->id}}/{{$frame_id}}/{{$blogs_posts->id}}#frame-{{$frame->id}}";
+            // form_blogs_posts{{$frame_id}}.redirect_path = "{{url('/')}}/plugin/blogs/create/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}";
+            form_blogs_posts{{$frame_id}}.submit();
+        }
+    @endif
 </script>
 
 {{-- 投稿用フォーム --}}
@@ -44,6 +52,17 @@ use App\Models\User\Blogs\BlogsPosts;
 @endif
     {{ csrf_field() }}
     <input type="hidden" name="blogs_id" value="{{$blog_frame->blogs_id}}">
+
+    @if ($blogs_posts->id)
+        <div class="form-group">
+            <label class="control-label">コピーして登録画面へ</label>
+            <div>
+                <button type="button" class="btn btn-outline-primary form-horizontal" onclick="copy_action()">
+                    <i class="fas fa-copy "></i> コピー
+                </button>
+            </div>
+        </div>
+    @endif
 
     <div class="form-group">
         <label class="control-label">タイトル <span class="badge badge-danger">必須</span></label>

--- a/resources/views/plugins/user/blogs/default/blogs_input.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_input.blade.php
@@ -32,14 +32,6 @@ use App\Models\User\Blogs\BlogsPosts;
         @endif
         form_blogs_posts{{$frame_id}}.submit();
     }
-
-    @if ($blogs_posts->id)
-        function copy_action() {
-            form_blogs_posts{{$frame_id}}.action = "{{url('/')}}/redirect/plugin/blogs/copy/{{$page->id}}/{{$frame_id}}/{{$blogs_posts->id}}#frame-{{$frame->id}}";
-            // form_blogs_posts{{$frame_id}}.redirect_path = "{{url('/')}}/plugin/blogs/create/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}";
-            form_blogs_posts{{$frame_id}}.submit();
-        }
-    @endif
 </script>
 
 {{-- 投稿用フォーム --}}
@@ -52,17 +44,6 @@ use App\Models\User\Blogs\BlogsPosts;
 @endif
     {{ csrf_field() }}
     <input type="hidden" name="blogs_id" value="{{$blog_frame->blogs_id}}">
-
-    @if ($blogs_posts->id)
-        <div class="form-group">
-            <label class="control-label">コピーして登録画面へ</label>
-            <div>
-                <button type="button" class="btn btn-outline-primary form-horizontal" onclick="copy_action()">
-                    <i class="fas fa-copy "></i> コピー
-                </button>
-            </div>
-        </div>
-    @endif
 
     <div class="form-group">
         <label class="control-label">タイトル <span class="badge badge-danger">必須</span></label>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り。

## 画面
### 一覧画面（コピーのプルダウン追加）
![image](https://user-images.githubusercontent.com/2756509/142339975-524e9e07-6892-4bbc-b7c5-a7d918746614.png)

※ コピー押下後、登録画面へ。投稿日時は今の時間で。
![image](https://user-images.githubusercontent.com/2756509/142340104-4d9c01f7-101d-4cbd-8037-63543d7ade6a.png)


## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms-ideas/issues/95

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
