### PR TITLE
データベース検索 HTMLエスケープ除外をWYSIWYG型のみに限定

### DIFF
--- a/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
+++ b/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
@@ -265,7 +265,7 @@ class DatabasesearchesPlugin extends UserPluginBase
         // Log::debug(var_export($inputs_ids_marge, true));
 
         // 登録データ詳細の取得
-        $input_cols = DatabasesInputCols::select('databases_input_cols.*', 'databases_columns.column_name', 'uploads.client_original_name')
+        $input_cols = DatabasesInputCols::select('databases_input_cols.*', 'databases_columns.column_name', 'uploads.client_original_name', 'databases_columns.column_type')
                                         ->join('databases_columns', 'databases_columns.id', '=', 'databases_input_cols.databases_columns_id')
                                         ->leftJoin('uploads', 'uploads.id', '=', 'databases_input_cols.value')
                                         ->whereIn('databases_inputs_id', $inputs_ids->pluck('databases_inputs_id'))

--- a/resources/views/plugins/user/databasesearches/default/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/default/databasesearches.blade.php
@@ -45,7 +45,12 @@
                         @endif
                     </a>
                 @else
-                    {!! $view_col->value !!}
+                    @if ($view_col->column_type == DatabaseColumnType::wysiwyg)
+                        {{-- 一旦、WYSIWYGのみHTMLエスケープ除外。resources\views\plugins\user\databases\default\databases_include_value.blade.phpと同様にするかは次の機会に検討する --}}
+                        {!! $view_col->value !!}
+                    @else
+                        {{ $view_col->value }}
+                    @endif
                 @endif
             @endif
         @endforeach


### PR DESCRIPTION
## 概要
- 前回対応だとすべての項目型でサニタイズ除外されてしまいセキュリティ的に良くない為、WYSIWYG型のみに限定

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/pull/1044

## 参考
なし

## DB変更の有無
無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
