### PR TITLE
アイコンメニューテンプレ追加

### DIFF
--- a/resources/views/plugins/user/menus/breadcrumbs/template.ini
+++ b/resources/views/plugins/user/menus/breadcrumbs/template.ini
@@ -1,3 +1,3 @@
 [base]
 template_name = パンくず
-display_sequence = 8
+display_sequence = 9

--- a/resources/views/plugins/user/menus/footersitemap/template.ini
+++ b/resources/views/plugins/user/menus/footersitemap/template.ini
@@ -1,3 +1,3 @@
 [base]
 template_name = フッター用サイトマップ
-display_sequence = 10
+display_sequence = 12

--- a/resources/views/plugins/user/menus/footersitemap_no_rootrink/template.ini
+++ b/resources/views/plugins/user/menus/footersitemap_no_rootrink/template.ini
@@ -1,3 +1,3 @@
 [base]
 template_name = フッター用サイトマップ（ルートのリンクなし）
-display_sequence = 12
+display_sequence = 13

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_children.blade.php
@@ -1,7 +1,7 @@
 {{--
  * メニューの子要素表示画面
  *
- * @param obj $pages ページデータの配列
+ * @param obj $children ページデータの配列
  * @author 牧野　可也子 <makino@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category メニュープラグイン
@@ -16,9 +16,9 @@
     @endif
 
         {{-- 各ページの深さをもとにインデントの表現 --}}
-        {{-- @for ($i = 0; $i < $children->depth; $i++)
+        @for ($i = 0; $i < $children->depth; $i++)
             @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
-        @endfor --}}
+        @endfor
         {{$children->page_name}}
     </a>
     @if ($children->children && count($children->children) > 0)

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_children.blade.php
@@ -1,0 +1,32 @@
+{{--
+ * メニューの子要素表示画面
+ *
+ * @param obj $pages ページデータの配列
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category メニュープラグイン
+--}}
+
+@if ($children->isView(Auth::user(), false, true, $page_roles))
+<li>
+    @if ($children->id == $page_id)
+    <a class="dropdown-item {{ 'depth-' . $children->depth }} active" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} aria-current="page">
+    @else
+    <a class="dropdown-item {{ 'depth-' . $children->depth }}" href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!}>
+    @endif
+
+        {{-- 各ページの深さをもとにインデントの表現 --}}
+        {{-- @for ($i = 0; $i < $children->depth; $i++)
+            @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
+        @endfor --}}
+        {{$children->page_name}}
+    </a>
+    @if ($children->children && count($children->children) > 0)
+        <ul>
+            @foreach($children->children as $ckey => $depth_children)
+                @include('plugins.user.menus.mouseover_dropdown_no_rootlink_for_icon.menu_children',['children' => $children->children[$ckey]])
+            @endforeach
+        </ul>
+    @endif
+</li>
+@endif

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_children.blade.php
@@ -2,7 +2,7 @@
  * メニューの子要素表示画面
  *
  * @param obj $pages ページデータの配列
- * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牧野　可也子 <makino@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category メニュープラグイン
 --}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_parent.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_parent.blade.php
@@ -1,8 +1,8 @@
 {{--
- * メニュー表示画面
+ * メニューの親要素表示画面
  *
  * @param obj $pages ページデータの配列
- * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牧野　可也子 <makino@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category メニュープラグイン
 --}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_parent.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_parent.blade.php
@@ -1,7 +1,7 @@
 {{--
  * メニューの親要素表示画面
  *
- * @param obj $pages ページデータの配列
+ * @param obj $page_obj ページデータの配列
  * @author 牧野　可也子 <makino@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category メニュープラグイン

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_parent.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_parent.blade.php
@@ -1,0 +1,44 @@
+{{--
+ * メニュー表示画面
+ *
+ * @param obj $pages ページデータの配列
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category メニュープラグイン
+--}}
+
+{{-- 非表示のページは対象外 --}}
+@if ($page_obj->isView(Auth::user(), false, true, $page_roles))
+
+    {{-- 子供のページがあり、表示する子ページがある場合 --}}
+    @if (count($page_obj->children) > 0 && $page->existChildrenPagesToDisplay($page_obj->children))
+
+        <li class="nav-item icon_menu_main_list dropdown {{$page_obj->getClass()}}" onmouseleave="$(this).find('a.nav-link').click();$(this).find('a.nav-link').blur();">
+        {{-- カレント --}}
+        @if ($page_obj->id == $page_id)
+            <a class="nav-link active dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();" aria-current="page">
+        @else
+            <a class="nav-link dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
+        @endif
+
+                <span class="d-md-block d-none">{{$page_obj->page_name}}</span>
+                <span class="caret"></span>
+            </a>
+            <div class="dropdown-menu dropdown-menu-right">
+                <ul class="icon_menu_second_list">
+
+                {{-- 子要素を再帰的に表示するため、別ファイルに分けてinclude --}}
+                    @foreach($page_obj->children as $children)
+                        @include('plugins.user.menus.mouseover_dropdown_no_rootlink_for_icon.menu_children',['children' => $children])
+                    @endforeach
+                </ul>
+            </div>
+        </li>
+    @else
+        <li class="nav-item icon_menu_main_list active {{$page_obj->getClass()}}">
+            <a class="nav-link text-nowrap" href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!}>
+                <span class="d-md-block d-none">{{$page_obj->page_name}}</span>
+            </a>
+        </li>
+    @endif
+@endif

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
@@ -2,7 +2,7 @@
  * メニュー表示画面
  *
  * @param obj $pages ページデータの配列
- * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牧野　可也子 <makino@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category メニュープラグイン
 --}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
@@ -14,7 +14,6 @@
     <ul class="nav nav-justified d-md-flex">
     {{-- 事前チェック。第一階層に表示できるページがあるかどうか、もしあるとした時、１つだけなのかどうか --}}
     <?php $count=0 ?>
-    <?php $menu_pages=null ?>
     @foreach($pages as $page_obj)
         @if ($page_obj->isView(Auth::user(), false, true, $page_roles))
             <?php $count++ ?>

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
@@ -1,0 +1,61 @@
+{{--
+ * メニュー表示画面
+ *
+ * @param obj $pages ページデータの配列
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category メニュープラグイン
+--}}
+@extends('core.cms_frame_base')
+
+@section("plugin_contents_$frame->id")
+@if ($pages)
+    <nav aria-label="アイコンメニュー">
+    <ul class="nav nav-justified d-md-flex">
+    {{-- 事前チェック。第一階層に表示できるページがあるかどうか、もしあるとした時、１つだけなのかどうか --}}
+    <?php $count=0 ?>
+    <?php $menu_pages=null ?>
+    @foreach($pages as $page_obj)
+        @if ($page_obj->isView(Auth::user(), false, true, $page_roles))
+            <?php $count++ ?>
+        @endif
+    @endforeach
+    @if ($count==0)
+        {{-- 第一階層に表示できるページがない：第二階層をメイン階層として処理する --}}
+        @foreach($pages as $page_obj)
+            @if (count($page_obj->children) > 0 && $page->existChildrenPagesToDisplay($page_obj->children))
+                @foreach($page_obj->children as $children)
+                    @include('plugins.user.menus.mouseover_dropdown_no_rootlink_for_icon.menu_parent',['page_obj' => $children])
+                @endforeach
+            @endif
+        @endforeach
+    @elseif ($count==1)
+        {{-- 第一階層に表示できるページが１つしかない：第一階層と第二階層を横並びで表示する（※ルーム貸し対応） --}}
+        @foreach($pages as $page_obj)
+            @if ($page_obj->isView(Auth::user(), false, true, $page_roles))
+                {{-- 第一階層を表示 --}}
+                <li class="nav-item icon_menu_main_list active {{$page_obj->getClass()}}">
+                    <a class="nav-link text-nowrap" href="{{$page_obj->getUrl()}}" {!!$page_obj->getUrlTargetTag()!!}>
+                        <span class="d-md-block d-none">{{$page_obj->page_name}}</span>
+                    </a>
+                </li>
+
+                {{-- 第二階層を表示 --}}
+                @if (count($page_obj->children) > 0 && $page->existChildrenPagesToDisplay($page_obj->children))
+                    @foreach($page_obj->children as $children)
+                        @include('plugins.user.menus.mouseover_dropdown_no_rootlink_for_icon.menu_parent',['page_obj' => $children])
+                    @endforeach
+                @endif
+            @endif
+        @endforeach
+    @else
+        {{-- 上記以外 --}}
+        @foreach($pages as $page_obj)
+            @include('plugins.user.menus.mouseover_dropdown_no_rootlink_for_icon.menu_parent',['page_obj' => $page_obj])
+        @endforeach
+    @endif
+
+    </ul>
+    </nav>
+@endif
+@endsection

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/template.ini
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/template.ini
@@ -1,3 +1,3 @@
 [base]
 template_name = マウスオーバードロップダウン（ルートのリンクなし）アイコン用
-display_sequence = 17
+display_sequence = 8

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/template.ini
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/template.ini
@@ -1,0 +1,3 @@
+[base]
+template_name = マウスオーバードロップダウン（ルートのリンクなし）アイコン用
+display_sequence = 17

--- a/resources/views/plugins/user/menus/parentsandchild/template.ini
+++ b/resources/views/plugins/user/menus/parentsandchild/template.ini
@@ -1,3 +1,3 @@
 [base]
 template_name = 親子のみ
-display_sequence = 13
+display_sequence = 14

--- a/resources/views/plugins/user/menus/sitemap/template.ini
+++ b/resources/views/plugins/user/menus/sitemap/template.ini
@@ -1,3 +1,3 @@
 [base]
 template_name = サイトマップ
-display_sequence = 9
+display_sequence = 10

--- a/resources/views/plugins/user/menus/sitemap_no_rootlink/template.ini
+++ b/resources/views/plugins/user/menus/sitemap_no_rootlink/template.ini
@@ -1,3 +1,3 @@
 [base]
 template_name = サイトマップ（ルートのリンクなし）
-display_sequence = 10
+display_sequence = 11


### PR DESCRIPTION
アイコンメニューテンプレ追加

## 概要
メニュープラグインに、アイコン埋めこみ用デザインテンプレを追加

- 親階層が全て非表示だった場合、第二階層以降をメニューに表示できるようにした
- 親階層で表示できるページが１つしかない場合、子階層も並べて表示できるようにした（ルーム貸し対応）
- スマホ表示した場合、メニューが消えないように対応
- スマホ表示した場合、ページ名が消えるように対応
- ドロップダウンされる子要素が親要素の右側に合わせた位置に表示されるようにし、ブラウザ幅からはみ出さないようにした
- メニューの親要素にだけアイコン指定ができるようにclass指定を追加
- メニューの子要素にだけスタイルがあてられるようにclass指定を追加

## アイコンを当てる時のCSS例
```
<style>
.dropdown-toggle::after { content: unset; }  /* 子要素がある時▼が出ないようにする */
.icon_menu_main_list {display: inline-block; text-align: center; min-width: 90px;} /* 親メニューの見た目調整 */
.icon_menu_main_list li { list-style: none; } /* 子要素の記号除去 */
.icon_menu_second_list { padding-left: 0;} /* 子要素の不要なpadding除去 */
/* 1個目のアイコン */
.icon_menu_main_list:nth-child(1) > a:before {
content: url(/file/4) "\A";
white-space: pre;
}
/* 2個目のアイコン */
.icon_menu_main_list:nth-child(2) > a:before {
content: url(/file/5) "\A";
white-space: pre;
}
/* 3個目のアイコン */
.icon_menu_main_list:nth-child(3) > a:before {
content: url(/file/6) "\A";
white-space: pre;
}
/* 4個目のアイコン */
.icon_menu_main_list:nth-child(4) > a:before {
content: url(/file/7) "\A";
white-space: pre;
}
/* 5個目のアイコン */
.icon_menu_main_list:nth-child(5) > a:before {
content: url(/file/8) "\A";
white-space: pre;
}
</style>
```

## 関連Pull requests/Issues
なし

## 参考
なし

## DB変更の有無
なし

## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
