### PR TITLE
外部プラグインのコピーバッチでシーダーとメールテンプレートを対応しました

### DIFF
--- a/dev_2_option_private.ps1.example
+++ b/dev_2_option_private.ps1.example
@@ -1,24 +1,24 @@
 ##########################################################
-### �O���v���O�C��PUSH-Windows�p�iConnect-CMS�� �� �O���v���O�C���j
+### 外部プラグインPUSH-Windows用（Connect-CMS環境 → 外部プラグイン）
 ##########################################################
 #
-# �O���v���O�C����Connect-CMS�Ƃ͕ʃf�B���N�g����Git�Ǘ��������ꍇ�ȂǂɎg�p����A�R�s�[PowerShell�ł��B
-# Connect-CMS���f�B���N�g������A�O���v���O�C���f�B���N�g���ɃR�s�[���܂��B
-# �R�s�[�s�v�̃f�B���N�g���́A�R�����g�A�E�g���Ă��������B
-# �����R�[�h�� Shift-JIS �ł��B
+# 外部プラグインをConnect-CMSとは別ディレクトリでGit管理したい場合などに使用する、コピーPowerShellです。
+# Connect-CMS環境ディレクトリから、外部プラグインディレクトリにコピーします。
+# コピー不要のディレクトリは、コメントアウトしてください。
+# 文字コードは Shift-JIS です。
 #
-# �R�}���h�v�����v�g��PowerShell�����s�j
+# コマンドプロンプトでPowerShellを実行）
 # powershell -NoProfile -ExecutionPolicy Unrestricted .\dev_2_option_private.ps1
 #
 
-### PATH���̏�����ϐ��ɐݒ�
-# �R�s�[���̃��[�gPATH
+### PATH等の条件を変数に設定
+# コピー元のルートPATH
 $src_root_dir = "C:\path_to_dev_connect-cms\"
 
-# �R�s�[��̃��[�gPATH
+# コピー先のルートPATH
 $dist_root_dir = "C:\path_to_option_private_dir\"
 
-# �R�s�[�Ώۂ̃v���O�C���f�B���N�g����
+# コピー対象のプラグインディレクトリ名
 $option_plugin = "PluginName"
 $option_plugin_controller_dir = "User\PluginName"
 $option_plugin_resources_dir = "user\pluginname"
@@ -26,7 +26,7 @@ $option_plugin_model_dir = $option_plugin_controller_dir
 $option_plugin_command_dir = $option_plugin_controller_dir
 
 
-### �R�s�[�irobocopy <�R�s�[��> <�R�s�[��>�j
+### コピー（robocopy <コピー元> <コピー先>）
 robocopy "${src_root_dir}app\PluginsOption\${option_plugin_controller_dir}" "${dist_root_dir}${option_plugin}\app\PluginsOption\${option_plugin_controller_dir}" /s /MIR
 robocopy "${src_root_dir}app\ModelsOption\${option_plugin_model_dir}" "${dist_root_dir}${option_plugin}\app\ModelsOption\${option_plugin_model_dir}" /s /MIR
 robocopy "${src_root_dir}resources\views\plugins_option\${option_plugin_resources_dir}" "${dist_root_dir}${option_plugin}\resources\views\plugins_option\${option_plugin_resources_dir}" /s /MIR
@@ -38,7 +38,7 @@ robocopy "${src_root_dir}database\seeds\options\${option_plugin}" "${dist_root_d
 robocopy "${src_root_dir}app\EnumsOption" "${dist_root_dir}${option_plugin}\app\EnumsOption" /s /MIR
 robocopy "${src_root_dir}public\images\plugins\${option_plugin}" "${dist_root_dir}${option_plugin}\public\images\plugins\${option_plugin}" /s /MIR
 
-# 1�t�@�C���̂݃R�s�[��
+# 1ファイルのみコピー例
 #Copy-Item -Path "${src_root_dir}resources\views\plugins_option\manage\menus_list.blade.php" -Destination "${dist_root_dir}${option_plugin}\resources\views\plugins_option\manage\"
 
 exit

--- a/dev_2_option_private.ps1.example
+++ b/dev_2_option_private.ps1.example
@@ -1,24 +1,24 @@
 ##########################################################
-### ŠO•”ƒvƒ‰ƒOƒCƒ“PUSH-Windows—piConnect-CMSŠÂ‹« ¨ ŠO•”ƒvƒ‰ƒOƒCƒ“j
+### ï¿½Oï¿½ï¿½ï¿½vï¿½ï¿½ï¿½Oï¿½Cï¿½ï¿½PUSH-Windowsï¿½pï¿½iConnect-CMSï¿½Â‹ï¿½ ï¿½ï¿½ ï¿½Oï¿½ï¿½ï¿½vï¿½ï¿½ï¿½Oï¿½Cï¿½ï¿½ï¿½j
 ##########################################################
 #
-# ŠO•”ƒvƒ‰ƒOƒCƒ“‚ğConnect-CMS‚Æ‚Í•ÊƒfƒBƒŒƒNƒgƒŠ‚ÅGitŠÇ—‚µ‚½‚¢ê‡‚È‚Ç‚Ég—p‚·‚éAƒRƒs[PowerShell‚Å‚·B
-# Connect-CMSŠÂ‹«ƒfƒBƒŒƒNƒgƒŠ‚©‚çAŠO•”ƒvƒ‰ƒOƒCƒ“ƒfƒBƒŒƒNƒgƒŠ‚ÉƒRƒs[‚µ‚Ü‚·B
-# ƒRƒs[•s—v‚ÌƒfƒBƒŒƒNƒgƒŠ‚ÍAƒRƒƒ“ƒgƒAƒEƒg‚µ‚Ä‚­‚¾‚³‚¢B
-# •¶šƒR[ƒh‚Í Shift-JIS ‚Å‚·B
+# ï¿½Oï¿½ï¿½ï¿½vï¿½ï¿½ï¿½Oï¿½Cï¿½ï¿½ï¿½ï¿½Connect-CMSï¿½Æ‚Í•Êƒfï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ï¿½Gitï¿½Ç—ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ê‡ï¿½È‚Ç‚Égï¿½pï¿½ï¿½ï¿½ï¿½Aï¿½Rï¿½sï¿½[PowerShellï¿½Å‚ï¿½ï¿½B
+# Connect-CMSï¿½Â‹ï¿½ï¿½fï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Aï¿½Oï¿½ï¿½ï¿½vï¿½ï¿½ï¿½Oï¿½Cï¿½ï¿½ï¿½fï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ÉƒRï¿½sï¿½[ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+# ï¿½Rï¿½sï¿½[ï¿½sï¿½vï¿½Ìƒfï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ÍAï¿½Rï¿½ï¿½ï¿½ï¿½ï¿½gï¿½Aï¿½Eï¿½gï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
+# ï¿½ï¿½ï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ Shift-JIS ï¿½Å‚ï¿½ï¿½B
 #
-# ƒRƒ}ƒ“ƒhƒvƒƒ“ƒvƒg‚ÅPowerShell‚ğÀsj
+# ï¿½Rï¿½}ï¿½ï¿½ï¿½hï¿½vï¿½ï¿½ï¿½ï¿½ï¿½vï¿½gï¿½ï¿½PowerShellï¿½ï¿½ï¿½ï¿½ï¿½sï¿½j
 # powershell -NoProfile -ExecutionPolicy Unrestricted .\dev_2_option_private.ps1
 #
 
-### PATH“™‚ÌğŒ‚ğ•Ï”‚Éİ’è
-# ƒRƒs[Œ³‚Ìƒ‹[ƒgPATH
+### PATHï¿½ï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ï¿½Ïï¿½ï¿½Éİ’ï¿½
+# ï¿½Rï¿½sï¿½[ï¿½ï¿½ï¿½Ìƒï¿½ï¿½[ï¿½gPATH
 $src_root_dir = "C:\path_to_dev_connect-cms\"
 
-# ƒRƒs[æ‚Ìƒ‹[ƒgPATH
+# ï¿½Rï¿½sï¿½[ï¿½ï¿½Ìƒï¿½ï¿½[ï¿½gPATH
 $dist_root_dir = "C:\path_to_option_private_dir\"
 
-# ƒRƒs[‘ÎÛ‚Ìƒvƒ‰ƒOƒCƒ“ƒfƒBƒŒƒNƒgƒŠ–¼
+# ï¿½Rï¿½sï¿½[ï¿½ÎÛ‚Ìƒvï¿½ï¿½ï¿½Oï¿½Cï¿½ï¿½ï¿½fï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ï¿½
 $option_plugin = "PluginName"
 $option_plugin_controller_dir = "User\PluginName"
 $option_plugin_resources_dir = "user\pluginname"
@@ -26,16 +26,19 @@ $option_plugin_model_dir = $option_plugin_controller_dir
 $option_plugin_command_dir = $option_plugin_controller_dir
 
 
-### ƒRƒs[irobocopy <ƒRƒs[Œ³> <ƒRƒs[æ>j
+### ï¿½Rï¿½sï¿½[ï¿½irobocopy <ï¿½Rï¿½sï¿½[ï¿½ï¿½> <ï¿½Rï¿½sï¿½[ï¿½ï¿½>ï¿½j
 robocopy "${src_root_dir}app\PluginsOption\${option_plugin_controller_dir}" "${dist_root_dir}${option_plugin}\app\PluginsOption\${option_plugin_controller_dir}" /s /MIR
 robocopy "${src_root_dir}app\ModelsOption\${option_plugin_model_dir}" "${dist_root_dir}${option_plugin}\app\ModelsOption\${option_plugin_model_dir}" /s /MIR
 robocopy "${src_root_dir}resources\views\plugins_option\${option_plugin_resources_dir}" "${dist_root_dir}${option_plugin}\resources\views\plugins_option\${option_plugin_resources_dir}" /s /MIR
+robocopy "${src_root_dir}resources\views\mail_option\${option_plugin_resources_dir}" "${dist_root_dir}${option_plugin}\resources\views\plugins_option\${option_plugin_resources_dir}" /s /MIR
 robocopy "${src_root_dir}app\Console\CommandsOption\${option_plugin_command_dir}" "${dist_root_dir}${option_plugin}\app\Console\CommandsOption\${option_plugin_command_dir}" /s /MIR
 
 robocopy "${src_root_dir}database\migrations_option" "${dist_root_dir}${option_plugin}\database\migrations_option" /s /xf _readme.txt
+robocopy "${src_root_dir}database\seeds\options\${option_plugin}" "${dist_root_dir}${option_plugin}\database\seeds\options\${option_plugin}" /s /MIR
 robocopy "${src_root_dir}app\EnumsOption" "${dist_root_dir}${option_plugin}\app\EnumsOption" /s /MIR
+robocopy "${src_root_dir}public\images\plugins\${option_plugin}" "${dist_root_dir}${option_plugin}\public\images\plugins\${option_plugin}" /s /MIR
 
-# 1ƒtƒ@ƒCƒ‹‚Ì‚İƒRƒs[—á
+# 1ï¿½tï¿½@ï¿½Cï¿½ï¿½ï¿½Ì‚İƒRï¿½sï¿½[ï¿½ï¿½
 #Copy-Item -Path "${src_root_dir}resources\views\plugins_option\manage\menus_list.blade.php" -Destination "${dist_root_dir}${option_plugin}\resources\views\plugins_option\manage\"
 
 exit

--- a/option_private_2_dev.ps1.example
+++ b/option_private_2_dev.ps1.example
@@ -1,35 +1,35 @@
 ####################################################
-### Connect-CMS���\�z-Windows�p�i�O���v���O�C�� �� Connect-CMS���j
+### Connect-CMS環境構築-Windows用（外部プラグイン → Connect-CMS環境）
 ####################################################
 #
-# �O���v���O�C����Connect-CMS�Ƃ͕ʃf�B���N�g����Git�Ǘ��������ꍇ�ȂǂɎg�p����A�R�s�[PowerShell�ł��B
-# �O���v���O�C���f�B���N�g������AConnect-CMS���f�B���N�g���ɃR�s�[���܂��B
-# �R�s�[�s�v�̃f�B���N�g���́A�R�����g�A�E�g���Ă��������B
-# �����R�[�h�� Shift-JIS �ł��B
+# 外部プラグインをConnect-CMSとは別ディレクトリでGit管理したい場合などに使用する、コピーPowerShellです。
+# 外部プラグインディレクトリから、Connect-CMS環境ディレクトリにコピーします。
+# コピー不要のディレクトリは、コメントアウトしてください。
+# 文字コードは Shift-JIS です。
 #
-# �R�}���h�v�����v�g��PowerShell�����s�j
+# コマンドプロンプトでPowerShellを実行）
 # powershell -NoProfile -ExecutionPolicy Unrestricted .\option_private_2_dev.ps1
 #
 
-# �A�Z���u���̃��[�h
+# アセンブリのロード
 Add-Type -AssemblyName System.Windows.Forms
 
-# ���s�m�F
+# 実行確認
 $result = [System.Windows.Forms.MessageBox]::Show("Connect-CMS���̃��\�[�X���㏑�����܂����A��낵���ł����H","�m�F","YesNo","Question","Button2")
 
-# ���s�ۂ𔻒�
+# 実行可否を判定
 If($result -eq "No"){
     exit
 }
 
-### PATH���̏�����ϐ��ɐݒ�
-# �R�s�[���̃��[�gPATH
+### PATH等の条件を変数に設定
+# コピー元のルートPATH
 $src_root_dir = "C:\path_to_option_private_dir\"
 
-# �R�s�[��̃��[�gPATH
+# コピー先のルートPATH
 $dist_root_dir = "C:\path_to_dev_connect-cms\"
 
-# �R�s�[�Ώۂ̃v���O�C���f�B���N�g����
+# コピー対象のプラグインディレクトリ名
 $option_plugin = "PluginName"
 $option_plugin_controller_dir = "User\PluginName"
 $option_plugin_resources_dir = "user\pluginname"
@@ -37,7 +37,7 @@ $option_plugin_model_dir = $option_plugin_controller_dir
 $option_plugin_command_dir = $option_plugin_controller_dir
 
 
-### �R�s�[�irobocopy <�R�s�[��> <�R�s�[��>�j
+### コピー（robocopy <コピー元> <コピー先>）
 robocopy "${src_root_dir}${option_plugin}\app\PluginsOption\${option_plugin_controller_dir}" "${dist_root_dir}app\PluginsOption\${option_plugin_controller_dir}" /s
 robocopy "${src_root_dir}${option_plugin}\app\ModelsOption\${option_plugin_model_dir}" "${dist_root_dir}app\ModelsOption\${option_plugin_model_dir}" /s
 robocopy "${src_root_dir}${option_plugin}\resources\views\plugins_option\${option_plugin_resources_dir}" "${dist_root_dir}resources\views\plugins_option\${option_plugin_resources_dir}" /s
@@ -49,7 +49,7 @@ robocopy "${src_root_dir}${option_plugin}\database\seeds\options\${option_plugin
 robocopy "${src_root_dir}${option_plugin}\app\EnumsOption" "${dist_root_dir}app\EnumsOption" /s
 robocopy "${src_root_dir}${option_plugin}\public\images\plugins\${option_plugin}" "${dist_root_dir}public\images\plugins\${option_plugin}" /s /MIR
 
-# 1�t�@�C���̂݃R�s�[��
+# 1ファイルのみコピー例
 #Copy-Item -Path "${src_root_dir}${option_plugin}\resources\views\plugins_option\manage\menus_list.blade.php" -Destination "${dist_root_dir}resources\views\plugins_option\manage\"
 
 exit

--- a/option_private_2_dev.ps1.example
+++ b/option_private_2_dev.ps1.example
@@ -15,7 +15,7 @@
 Add-Type -AssemblyName System.Windows.Forms
 
 # 実行確認
-$result = [System.Windows.Forms.MessageBox]::Show("Connect-CMS���̃��\�[�X���㏑�����܂����A��낵���ł����H","�m�F","YesNo","Question","Button2")
+$result = [System.Windows.Forms.MessageBox]::Show("Connect-CMS環境のリソースを上書きしますが、よろしいですか？","確認","YesNo","Question","Button2")
 
 # 実行可否を判定
 If($result -eq "No"){

--- a/option_private_2_dev.ps1.example
+++ b/option_private_2_dev.ps1.example
@@ -1,35 +1,35 @@
 ####################################################
-### Connect-CMSŠÂ‹«\’z-Windows—piŠO•”ƒvƒ‰ƒOƒCƒ“ ¨ Connect-CMSŠÂ‹«j
+### Connect-CMSï¿½Â‹ï¿½ï¿½\ï¿½z-Windowsï¿½pï¿½iï¿½Oï¿½ï¿½ï¿½vï¿½ï¿½ï¿½Oï¿½Cï¿½ï¿½ ï¿½ï¿½ Connect-CMSï¿½Â‹ï¿½ï¿½j
 ####################################################
 #
-# ŠO•”ƒvƒ‰ƒOƒCƒ“‚ğConnect-CMS‚Æ‚Í•ÊƒfƒBƒŒƒNƒgƒŠ‚ÅGitŠÇ—‚µ‚½‚¢ê‡‚È‚Ç‚Ég—p‚·‚éAƒRƒs[PowerShell‚Å‚·B
-# ŠO•”ƒvƒ‰ƒOƒCƒ“ƒfƒBƒŒƒNƒgƒŠ‚©‚çAConnect-CMSŠÂ‹«ƒfƒBƒŒƒNƒgƒŠ‚ÉƒRƒs[‚µ‚Ü‚·B
-# ƒRƒs[•s—v‚ÌƒfƒBƒŒƒNƒgƒŠ‚ÍAƒRƒƒ“ƒgƒAƒEƒg‚µ‚Ä‚­‚¾‚³‚¢B
-# •¶šƒR[ƒh‚Í Shift-JIS ‚Å‚·B
+# ï¿½Oï¿½ï¿½ï¿½vï¿½ï¿½ï¿½Oï¿½Cï¿½ï¿½ï¿½ï¿½Connect-CMSï¿½Æ‚Í•Êƒfï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ï¿½Gitï¿½Ç—ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ê‡ï¿½È‚Ç‚Égï¿½pï¿½ï¿½ï¿½ï¿½Aï¿½Rï¿½sï¿½[PowerShellï¿½Å‚ï¿½ï¿½B
+# ï¿½Oï¿½ï¿½ï¿½vï¿½ï¿½ï¿½Oï¿½Cï¿½ï¿½ï¿½fï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ï¿½ï¿½ï¿½AConnect-CMSï¿½Â‹ï¿½ï¿½fï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ÉƒRï¿½sï¿½[ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½B
+# ï¿½Rï¿½sï¿½[ï¿½sï¿½vï¿½Ìƒfï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ÍAï¿½Rï¿½ï¿½ï¿½ï¿½ï¿½gï¿½Aï¿½Eï¿½gï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
+# ï¿½ï¿½ï¿½ï¿½ï¿½Rï¿½[ï¿½hï¿½ï¿½ Shift-JIS ï¿½Å‚ï¿½ï¿½B
 #
-# ƒRƒ}ƒ“ƒhƒvƒƒ“ƒvƒg‚ÅPowerShell‚ğÀsj
+# ï¿½Rï¿½}ï¿½ï¿½ï¿½hï¿½vï¿½ï¿½ï¿½ï¿½ï¿½vï¿½gï¿½ï¿½PowerShellï¿½ï¿½ï¿½ï¿½ï¿½sï¿½j
 # powershell -NoProfile -ExecutionPolicy Unrestricted .\option_private_2_dev.ps1
 #
 
-# ƒAƒZƒ“ƒuƒŠ‚Ìƒ[ƒh
+# ï¿½Aï¿½Zï¿½ï¿½ï¿½uï¿½ï¿½ï¿½Ìƒï¿½ï¿½[ï¿½h
 Add-Type -AssemblyName System.Windows.Forms
 
-# ÀsŠm”F
-$result = [System.Windows.Forms.MessageBox]::Show("Connect-CMSŠÂ‹«‚ÌƒŠƒ\[ƒX‚ğã‘‚«‚µ‚Ü‚·‚ªA‚æ‚ë‚µ‚¢‚Å‚·‚©H","Šm”F","YesNo","Question","Button2")
+# ï¿½ï¿½ï¿½sï¿½mï¿½F
+$result = [System.Windows.Forms.MessageBox]::Show("Connect-CMSï¿½Â‹ï¿½ï¿½Ìƒï¿½ï¿½\ï¿½[ï¿½Xï¿½ï¿½ï¿½ã‘ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½ï¿½Aï¿½ï¿½ë‚µï¿½ï¿½ï¿½Å‚ï¿½ï¿½ï¿½ï¿½H","ï¿½mï¿½F","YesNo","Question","Button2")
 
-# Às‰Â”Û‚ğ”»’è
+# ï¿½ï¿½ï¿½sï¿½Â”Û‚ğ”»’ï¿½
 If($result -eq "No"){
     exit
 }
 
-### PATH“™‚ÌğŒ‚ğ•Ï”‚Éİ’è
-# ƒRƒs[Œ³‚Ìƒ‹[ƒgPATH
+### PATHï¿½ï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ï¿½Ïï¿½ï¿½Éİ’ï¿½
+# ï¿½Rï¿½sï¿½[ï¿½ï¿½ï¿½Ìƒï¿½ï¿½[ï¿½gPATH
 $src_root_dir = "C:\path_to_option_private_dir\"
 
-# ƒRƒs[æ‚Ìƒ‹[ƒgPATH
+# ï¿½Rï¿½sï¿½[ï¿½ï¿½Ìƒï¿½ï¿½[ï¿½gPATH
 $dist_root_dir = "C:\path_to_dev_connect-cms\"
 
-# ƒRƒs[‘ÎÛ‚Ìƒvƒ‰ƒOƒCƒ“ƒfƒBƒŒƒNƒgƒŠ–¼
+# ï¿½Rï¿½sï¿½[ï¿½ÎÛ‚Ìƒvï¿½ï¿½ï¿½Oï¿½Cï¿½ï¿½ï¿½fï¿½Bï¿½ï¿½ï¿½Nï¿½gï¿½ï¿½ï¿½ï¿½
 $option_plugin = "PluginName"
 $option_plugin_controller_dir = "User\PluginName"
 $option_plugin_resources_dir = "user\pluginname"
@@ -37,16 +37,19 @@ $option_plugin_model_dir = $option_plugin_controller_dir
 $option_plugin_command_dir = $option_plugin_controller_dir
 
 
-### ƒRƒs[irobocopy <ƒRƒs[Œ³> <ƒRƒs[æ>j
+### ï¿½Rï¿½sï¿½[ï¿½irobocopy <ï¿½Rï¿½sï¿½[ï¿½ï¿½> <ï¿½Rï¿½sï¿½[ï¿½ï¿½>ï¿½j
 robocopy "${src_root_dir}${option_plugin}\app\PluginsOption\${option_plugin_controller_dir}" "${dist_root_dir}app\PluginsOption\${option_plugin_controller_dir}" /s
 robocopy "${src_root_dir}${option_plugin}\app\ModelsOption\${option_plugin_model_dir}" "${dist_root_dir}app\ModelsOption\${option_plugin_model_dir}" /s
 robocopy "${src_root_dir}${option_plugin}\resources\views\plugins_option\${option_plugin_resources_dir}" "${dist_root_dir}resources\views\plugins_option\${option_plugin_resources_dir}" /s
+robocopy "${src_root_dir}${option_plugin}\resources\views\mail_option\${option_plugin_resources_dir}" "${dist_root_dir}resources\views\mail_option\${option_plugin_resources_dir}" /s
 robocopy "${src_root_dir}${option_plugin}\app\Console\CommandsOption\${option_plugin_command_dir}" "${dist_root_dir}app\Console\CommandsOption\${option_plugin_command_dir}" /s
 
 robocopy "${src_root_dir}${option_plugin}\database\migrations_option" "${dist_root_dir}database\migrations_option" /s
+robocopy "${src_root_dir}${option_plugin}\database\seeds\options\${option_plugin}" "${dist_root_dir}database\seeds\options\${option_plugin}" /s /MIR
 robocopy "${src_root_dir}${option_plugin}\app\EnumsOption" "${dist_root_dir}app\EnumsOption" /s
+robocopy "${src_root_dir}${option_plugin}\public\images\plugins\${option_plugin}" "${dist_root_dir}public\images\plugins\${option_plugin}" /s /MIR
 
-# 1ƒtƒ@ƒCƒ‹‚Ì‚İƒRƒs[—á
+# 1ï¿½tï¿½@ï¿½Cï¿½ï¿½ï¿½Ì‚İƒRï¿½sï¿½[ï¿½ï¿½
 #Copy-Item -Path "${src_root_dir}${option_plugin}\resources\views\plugins_option\manage\menus_list.blade.php" -Destination "${dist_root_dir}resources\views\plugins_option\manage\"
 
 exit

--- a/sync_dev_2_option_private.sh.example
+++ b/sync_dev_2_option_private.sh.example
@@ -29,6 +29,8 @@ rsync -arvz --delete "${src_root_dir}resources/views/plugins_option/user/${optio
 rsync -arvz --delete "${src_root_dir}app/Console/CommandsOption/${option_plugin_command_dir}" "${dist_root_dir}${option_plugin}/app/Console/CommandsOption/" 
 # マイグレーション
 rsync -arvz --delete --exclude '2020_06_03_163936_optionsamples_table.php' --exclude '_readme.txt' "${src_root_dir}database/migrations_option" "${dist_root_dir}${option_plugin}/database/"
+# シーダー
+rsync -arvz --delete "${src_root_dir}database/seeds/options/${option_plugin}" "${dist_root_dir}${option_plugin}/database/seeds/options/"
 # Enum
 rsync -arvz --delete "${src_root_dir}app/EnumsOption" "${dist_root_dir}${option_plugin}/app/"
 # 画像

--- a/sync_dev_2_option_private.sh.example
+++ b/sync_dev_2_option_private.sh.example
@@ -35,3 +35,5 @@ rsync -arvz --delete "${src_root_dir}database/seeds/options/${option_plugin}" "$
 rsync -arvz --delete "${src_root_dir}app/EnumsOption" "${dist_root_dir}${option_plugin}/app/"
 # 画像
 rsync -arvz --delete "${src_root_dir}public/images/plugins/${option_plugin_resources_dir}" "${dist_root_dir}${option_plugin}/public/images/plugins/"
+# メールテンプレート
+rsync -arvz --delete "${src_root_dir}resources/views/mail_option/${option_plugin_resources_dir}" "${dist_root_dir}${option_plugin}/resources/views/mail_option/"

--- a/sync_option_private_2_dev.sh.example
+++ b/sync_option_private_2_dev.sh.example
@@ -35,3 +35,5 @@ rsync -arvz "${src_root_dir}${option_plugin}/database/seeds/options/${option_plu
 rsync -arvz --delete "${src_root_dir}${option_plugin}/app/EnumsOption" "${dist_root_dir}app/"
 # 画像
 rsync -arvz --delete "${src_root_dir}${option_plugin}/public/images/plugins/${option_plugin_resources_dir}" "${dist_root_dir}public/images/plugins/"
+# メールテンプレート
+rsync -arvz --delete "${src_root_dir}${option_plugin}/resources/views/mail_option/${option_plugin_resources_dir}" "${dist_root_dir}resources/views/mail_option/"

--- a/sync_option_private_2_dev.sh.example
+++ b/sync_option_private_2_dev.sh.example
@@ -29,6 +29,8 @@ rsync -arvz --delete "${src_root_dir}${option_plugin}/resources/views/plugins_op
 rsync -arvz --delete "${src_root_dir}${option_plugin}/app/Console/CommandsOption/${option_plugin_command_dir}" "${dist_root_dir}app/Console/CommandsOption/" 
 # マイグレーション
 rsync -arvz --delete --exclude '2020_06_03_163936_optionsamples_table.php' --exclude '_readme.txt' "${src_root_dir}${option_plugin}/database/migrations_option" "${dist_root_dir}database/"
+# シーダー
+rsync -arvz "${src_root_dir}${option_plugin}/database/seeds/options/${option_plugin}" "${dist_root_dir}database/seeds/options/"
 # Enum
 rsync -arvz --delete "${src_root_dir}${option_plugin}/app/EnumsOption" "${dist_root_dir}app/"
 # 画像


### PR DESCRIPTION
## 概要

外部プラグインのコピーバッチでシーダーとメールテンプレートもコピーされるよう対応しました。

## 関連Pull requests/Issues
プライベートリポジトリでの対応

## 参考
無し

## DB変更の有無
無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
