### PR TITLE
アイコンメニュー対応変更

### DIFF
--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_parent.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menu_parent.blade.php
@@ -21,7 +21,7 @@
             <a class="nav-link dropdown-toggle {{ 'depth-' . $page_obj->depth }}" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" onmouseover="this.click();this.blur();">
         @endif
 
-                <span class="d-md-block d-none">{{$page_obj->page_name}}</span>
+                <span class="d-md-block">{{$page_obj->page_name}}</span>
                 <span class="caret"></span>
             </a>
             <div class="dropdown-menu dropdown-menu-right">

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
@@ -11,7 +11,7 @@
 @section("plugin_contents_$frame->id")
 @if ($pages)
     <nav aria-label="アイコンメニュー">
-    <ul class="nav nav-justified d-md-flex">
+    <ul class="nav nav-justified d-none d-md-flex">
     {{-- 事前チェック。第一階層に表示できるページがあるかどうか、もしあるとした時、１つだけなのかどうか --}}
     <?php $count=0 ?>
     @foreach($pages as $page_obj)


### PR DESCRIPTION
スマホ表示にした時に、メニューそのものを隠すように修正

## 概要
修正前：スマホ表示にした時、ページ名だけが隠れる
修正後：スマホ表示にした時、アイコンメニューそのものが隠れる

## 関連Pull requests/Issues
なし

## 参考
なし

## DB変更の有無
なし

## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
