### PR TITLE
ユーザ配置ファイルのConnect-CMS閲覧制御

### DIFF
--- a/app/Http/Controllers/Core/UploadController.php
+++ b/app/Http/Controllers/Core/UploadController.php
@@ -192,6 +192,82 @@ class UploadController extends ConnectController
     }
 
     /**
+     * ユーザファイル送出
+     */
+    public function getUserFile(Request $request, $dir, $filename)
+    {
+        // dir、filename がない場合は空を返す。
+        if (empty($dir) || empty($filename)) {
+            return;
+        }
+
+        // ファイルの実体がない場合は空を返す。
+        if (!Storage::disk('user')->exists($dir . '/' . $filename)) {
+            return;
+        }
+
+        // ファイルの制限確認
+        $userdir_allow = Configs::where('category', 'userdir_allow')->where('name', $dir)->first();
+
+        // NGチェック
+        if (empty($userdir_allow)) {
+            // 該当ディレクトリの制限設定がされていないとき。
+            return;
+        }
+        if (empty($userdir_allow->value)) {
+            // 該当ディレクトリの制限設定が閲覧させない場合
+            return;
+        }
+
+        // OKチェック
+        if ($userdir_allow->value == 'allow_login') {
+            // 該当ディレクトリの制限設定がログインユーザのみ閲覧許可の場合
+            if (Auth::user()) {
+                // ログイン中なのでOK
+            } else {
+                // ログインしてないのでNG
+                return;
+            }
+        } elseif ($userdir_allow->value = 'allow_all') {
+            // 該当ディレクトリの制限設定が誰でも閲覧許可の場合
+        } else {
+            // OK条件に合致しない場合はNG
+            return;
+        }
+
+        // ファイルを返す
+        $fullpath = storage_path('user/') . $dir . '/' . $filename;
+
+        // httpヘッダー
+        $content_disposition = 'inline; filename="'. $filename .'"' . "; filename*=UTF-8''" . rawurlencode($filename);
+
+        // インライン表示する拡張子
+        $inline_extensions = [
+            'pdf',
+            'png',
+            'jpg',
+            'jpe',
+            'jpeg',
+            'gif',
+        ];
+
+        if (in_array(strtolower(pathinfo($filename, PATHINFO_EXTENSION)), $inline_extensions) && $request->response != 'download') {
+            return response()
+                    ->file(
+                        $fullpath,
+                        ['Content-Disposition' => $content_disposition]
+                    );
+        } else {
+            return response()
+                    ->download(
+                        $fullpath,
+                        $filename,
+                        ['Content-Disposition' => $content_disposition]
+                    );
+        }
+    }
+
+    /**
      * ファイルチェックメソッドの呼び出し
      */
     private function callCheckMethod($request, $upload)

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -65,6 +65,12 @@ return [
             'endpoint' => env('AWS_ENDPOINT'),
         ],
 
+        // ユーザのアップロードファイル用ディスクの追加
+        'user' => [
+            'driver' => 'local',
+            'root' => storage_path('user'),
+        ],
+
     ],
 
 ];

--- a/resources/views/plugins/manage/uploadfile/uploadfile_manage_tab.blade.php
+++ b/resources/views/plugins/manage/uploadfile/uploadfile_manage_tab.blade.php
@@ -21,6 +21,13 @@
                 @endif
                 </li>
                 <li role="presentation" class="nav-item">
+                @if ($function == "userdir")
+                    <span class="nav-link"><span class="active">ユーザディレクトリ一覧</span></span>
+                @else
+                    <a href="{{url('/manage/uploadfile/userdir')}}" class="nav-link">ユーザディレクトリ一覧</a></li>
+                @endif
+                </li>
+                <li role="presentation" class="nav-item">
                 @if ($function == "edit")
                     <span class="nav-link"><span class="active">アップロードファイル編集</span></span>
                 @endif

--- a/resources/views/plugins/manage/uploadfile/userdir.blade.php
+++ b/resources/views/plugins/manage/uploadfile/userdir.blade.php
@@ -1,0 +1,88 @@
+{{--
+ * ユーザファイル管理の編集テンプレート
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category アップロードファイル管理
+ --}}
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.uploadfile.uploadfile_manage_tab')
+    </div>
+
+    <form action="{{url('/manage/uploadfile/saveUserdir')}}" method="POST" class="form-horizontal">
+        {{ csrf_field() }}
+
+        <div class="card-body table-responsive">
+
+            @if (session('info_message'))
+                <div class="alert alert-info">
+                    {{session('info_message')}}
+                </div>
+            @endif
+
+            <table class="table text-nowrap">
+            <thead>
+                <tr>
+                    <th nowrap="">ディレクトリ名</th>
+                    <th nowrap="">閲覧設定</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($user_directories as $user_directory)
+
+                    @php
+                        $value = "0";
+                        $userdir_allow = $userdir_allows->where('name', $user_directory)->first();
+                        if ($userdir_allow) {
+                            $value = $userdir_allow->value;
+                        }
+                    @endphp
+                <tr>
+                    <td nowrap="">{{$user_directory}}</td>
+                    <td nowrap="">
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input
+                                type="radio" value="" class="custom-control-input" id="{{$user_directory}}_0"
+                                name="userdir[{{$user_directory}}]" @if(old('{{$user_directory}}', $value) == "") checked @endif>
+                            <label class="custom-control-label" for="{{$user_directory}}_0" id="{{$user_directory}}_0">
+                                閲覧させない。
+                            </label>
+                        </div>
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input
+                                type="radio" value="allow_all" class="custom-control-input" id="{{$user_directory}}_1"
+                                name="userdir[{{$user_directory}}]" @if(old('{{$user_directory}}', $value) == "allow_all") checked @endif>
+                            <label class="custom-control-label" for="{{$user_directory}}_1" id="{{$user_directory}}_1">
+                                誰でも閲覧許可
+                            </label>
+                        </div>
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input
+                                type="radio" value="allow_login" class="custom-control-input" id="{{$user_directory}}_2"
+                                name="userdir[{{$user_directory}}]" @if(old('{{$user_directory}}', $value) == "allow_login") checked @endif>
+                            <label class="custom-control-label" for="{{$user_directory}}_2" id="{{$user_directory}}_2">
+                                ログインユーザのみ閲覧許可
+                            </label>
+                        </div>
+                    </td>
+                </tr>
+                @endforeach
+            </tbody>
+            </table>
+        </div>
+
+        <div class="form-group text-center">
+            <button type="reset" class="btn btn-secondary mr-2"><i class="fas fa-undo-alt"></i><span class="d-none d-md-inline"> キャンセル</span></button>
+            <button type="submit" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
+        </div>
+    </form>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -96,6 +96,9 @@ Route::get('/file/css/{page_id?}.css', 'Core\UploadController@getCss')->name('ge
 Route::post('/upload/{method?}', 'Core\UploadController@postInvoke')->name('post_upload');
 
 // アップロードファイルの取得アクション
+Route::get('/file/user/{dir}/{filename}', 'Core\UploadController@getUserFile')->name('get_userfile');
+
+// アップロードファイルの取得アクション
 Route::get('/file/{id?}', 'Core\UploadController@getFile')->name('get_file');
 
 // 言語切り替えアクション

--- a/storage/user/.gitignore
+++ b/storage/user/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
- サーバに直接ファイルを置ける環境の場合
- 置いたファイルもConnect-CMSで閲覧制限したい。
- 閲覧制限はディレクトリ単位で行いたい。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
