### PR TITLE
add: スライドショーの高さ指定機能

### DIFF
--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -227,6 +227,8 @@ class SlideshowsPlugin extends UserPluginBase
         $validator_attributes['slideshows_name'] = 'スライドショー名';
         $validator_values['image_interval'] = ['required', 'numeric', 'integer', 'min:1', 'max:60000'];
         $validator_attributes['image_interval'] = '画像の静止時間';
+        $validator_values['height'] = ['nullable', 'numeric', 'max:65535'];
+        $validator_attributes['height'] = '高さ';
 
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), $validator_values);
@@ -287,6 +289,7 @@ class SlideshowsPlugin extends UserPluginBase
         $slideshows->indicators_display_flag = $request->indicators_display_flag;
         $slideshows->fade_use_flag = $request->fade_use_flag;
         $slideshows->image_interval = $request->image_interval;
+        $slideshows->height = $request->height;
         $slideshows->save();
 
         // 新規作成フラグを更新モードにセットして設定変更画面へ遷移

--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -227,7 +227,7 @@ class SlideshowsPlugin extends UserPluginBase
         $validator_attributes['slideshows_name'] = 'スライドショー名';
         $validator_values['image_interval'] = ['required', 'numeric', 'integer', 'min:1', 'max:60000'];
         $validator_attributes['image_interval'] = '画像の静止時間';
-        $validator_values['height'] = ['nullable', 'numeric', 'max:65535'];
+        $validator_values['height'] = ['nullable', 'numeric', 'min:1', 'max:65535'];
         $validator_attributes['height'] = '高さ';
 
         // 項目のエラーチェック

--- a/database/migrations/2022_01_13_103252_add_height_to_slideshows.php
+++ b/database/migrations/2022_01_13_103252_add_height_to_slideshows.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddHeightToSlideshows extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('slideshows', function (Blueprint $table) {
+            $table->unsignedSmallInteger('height')->nullable()->comment('高さ')->after('image_interval');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('slideshows', function (Blueprint $table) {
+            $table->dropColumn('height');
+        });
+    }
+}

--- a/resources/views/plugins/user/slideshows/default/slideshows.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows.blade.php
@@ -37,6 +37,7 @@
                                 <img
                                     src="{{url('/')}}/file/{{ $item->uploads_id }}"
                                     class="d-block w-100"
+                                    @if (!empty($slideshow->height)) style="object-fit: contain; height: {{$slideshow->height}}px;" @endif
                                 >
                             </a>
                         @else
@@ -44,6 +45,7 @@
                             <img
                                 src="{{url('/')}}/file/{{ $item->uploads_id }}"
                                 class="d-block w-100"
+                                @if (!empty($slideshow->height)) style="object-fit: contain; height: {{$slideshow->height}}px;" @endif
                             >
                         @endif
                         {{-- キャプション ※設定があれば表示 --}}

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_slideshow.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_slideshow.blade.php
@@ -145,6 +145,22 @@
                 </div>
             </div>
 
+            {{-- スライドショーの高さ --}}
+            <div class="form-group row">
+                <label class="{{$frame->getSettingLabelClass()}}">
+                    高さ（px）
+                </label>
+                <div class="{{$frame->getSettingInputClass()}}">
+                    <input
+                        type="number"
+                        name="height"
+                        value="{{old('height', isset($slideshow->height) ? $slideshow->height : '')}}"
+                        class="form-control @if ($errors && $errors->has('height')) border-danger @endif"
+                    >
+                    @if ($errors && $errors->has('height')) <div class="text-danger">{{$errors->first('height')}}</div> @endif
+                </div>
+            </div>
+
             {{-- Submitボタン --}}
             <div class="form-group text-center">
                 <div class="row">

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_slideshow.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_slideshow.blade.php
@@ -158,6 +158,7 @@
                         class="form-control @if ($errors && $errors->has('height')) border-danger @endif"
                     >
                     @if ($errors && $errors->has('height')) <div class="text-danger">{{$errors->first('height')}}</div> @endif
+                    <small class="text-muted">未指定の場合、フレーム幅に合わせた画像の高さで表示されます。</small>
                 </div>
             </div>
 


### PR DESCRIPTION
## 概要

スライドショーで画像の高さをしていできるようにしました。
スライドショー設定画面から設定可能です。

スライドショーで高さ・横幅が違う画像を設定したときに
画像が切り替わるたび画面が上下するのを防ぐため対応しました。

## 関連Pull requests/Issues

#1075

## 参考

https://github.com/opensource-workshop/connect-cms-ideas/issues/109

## DB変更の有無

有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
