### PR TITLE
fix: スライドショーが削除できない

### DIFF
--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -323,7 +323,7 @@ class SlideshowsPlugin extends UserPluginBase
              * 明細データの削除
              */
             foreach ($slideshows_items as $slideshows_item) {
-                SlideshowsItems::where('slideshows_items_id', $slideshows_item->id)->delete();
+                SlideshowsItems::where('id', $slideshows_item->id)->delete();
             }
 
             $slideshows = Slideshows::find($slideshows_id);


### PR DESCRIPTION
## 概要

削除のwhere句カラム指定ミスが原因でSQLエラーが発生していました。

## 関連Pull requests/Issues

#1078

## 参考


## DB変更の有無

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
