### PR TITLE
fix: upload_max_sizeの1GBがKB変換値となっていない

### DIFF
--- a/app/Enums/UploadMaxSize.php
+++ b/app/Enums/UploadMaxSize.php
@@ -17,7 +17,7 @@ final class UploadMaxSize extends EnumsBase
     const fifty_mega_byte = '51200';
     const hundred_mega_byte = '102400';
     const two_hundred_mega_byte = '204800';
-    const one_giga_byte = '1024000';
+    const one_giga_byte = '1048576';
     const infinity = 'infinity';
 
     // key/valueの連想配列

--- a/database/migrations/2022_01_14_172016_resize_upload_max_size_to_cabinets.php
+++ b/database/migrations/2022_01_14_172016_resize_upload_max_size_to_cabinets.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User\Cabinets\Cabinet;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ResizeUploadMaxSizeToCabinets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Cabinet::where('upload_max_size', '1024000')->update(['upload_max_size' => '1048576']);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Cabinet::where('upload_max_size', '1048576')->update(['upload_max_size' => '1024000']);
+    }
+}


### PR DESCRIPTION
## 概要

### 事象

#1080 の状態でNC2移行を実行すると、
cabinets.upload_max_sizeに'1048576'（1GBをKB単位に変換した値）が設定されます。
その'1048576'で app/Enums/UploadMaxSize を参照しようとして、Undefined offsetの例外が発生していました。

### 原因

app/Enums/UploadMaxSize.php 
`const one_giga_byte = '1024000';`

上記定数が1GBをKB単位に変換した値になっていませんでした。

### 対応

定数UploadMaxSizeの1GB(one_giga_byte)を正しい値('1048576')に修正しました。


## 関連Pull requests/Issues

 #1080

## 参考


## DB変更の有無

有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
