### PR TITLE
ブログの表示件数をバケツからフレーム保持に変更しました

### DIFF
--- a/app/Enums/BlogFrameConfig.php
+++ b/app/Enums/BlogFrameConfig.php
@@ -13,11 +13,13 @@ final class BlogFrameConfig extends EnumsBase
     const blog_display_created_name = 'blog_display_created_name';
     const blog_display_twitter_button = 'blog_display_twitter_button';
     const blog_display_facebook_button = 'blog_display_facebook_button';
+    const blog_view_count = 'blog_view_count';
 
     // key/valueの連想配列
     const enum = [
         self::blog_display_created_name => '投稿者名',
         self::blog_display_twitter_button => 'Twitterアイコン表示',
         self::blog_display_facebook_button => 'Facebookアイコン表示',
+        self::blog_view_count => '表示件数',
     ];
 }

--- a/app/Models/User/Blogs/Blogs.php
+++ b/app/Models/User/Blogs/Blogs.php
@@ -15,7 +15,6 @@ class Blogs extends Model
     protected $fillable = [
         'bucket_id',
         'blog_name',
-        'view_count',
         'use_like',
     ];
 }

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1389,7 +1389,7 @@ EOD;
 
         // 項目のエラーチェック
         $validator_values['scope_value'] = ['nullable', 'digits:4'];
-        $validator_values[BlogFrameConfig::blog_view_count] = ['required', 'numeric', 'min:1'];
+        $validator_values[BlogFrameConfig::blog_view_count] = ['required', 'numeric', 'min:1', 'max:100'];
         if ($request->scope == 'year' || $request->scope == 'fiscal') {
             $validator_values['scope_value'][] = ['required'];
         }

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -182,7 +182,6 @@ class BlogsPlugin extends UserPluginBase
                 'frames.*',
                 'blogs.id as blogs_id',
                 'blogs.blog_name',
-                'blogs.view_count',
                 'blogs.rss',
                 'blogs.rss_count',
                 'blogs.use_like',
@@ -263,7 +262,7 @@ class BlogsPlugin extends UserPluginBase
         //$blogs_posts = null;
 
         // 件数
-        $count = $blog_frame->view_count;
+        $count = FrameConfig::getConfigValue($this->frame_configs, BlogFrameConfig::blog_view_count);
         if ($option_count != null) {
             $count = $option_count;
         }
@@ -992,7 +991,7 @@ WHERE status = 0
     public function listBuckets($request, $page_id, $frame_id, $id = null)
     {
         // Frame データ
-        $blog_frame = Frame::select('frames.*', 'blogs.id as blogs_id', 'blogs.view_count')
+        $blog_frame = Frame::select('frames.*', 'blogs.id as blogs_id')
             ->leftJoin('blogs', 'blogs.bucket_id', '=', 'frames.bucket_id')
             ->where('frames.id', $frame_id)->first();
 
@@ -1078,11 +1077,9 @@ WHERE status = 0
     {
         // デフォルトでチェック
         $validator_values['blog_name'] = ['required'];
-        $validator_values['view_count'] = ['required', 'numeric'];
         $validator_values['rss_count'] = ['required', 'numeric'];
 
         $validator_attributes['blog_name'] = 'ブログ名';
-        $validator_attributes['view_count'] = '表示件数';
         $validator_attributes['rss_count'] = 'RSS件数';
 
         // 項目のエラーチェック
@@ -1131,7 +1128,6 @@ WHERE status = 0
 
         // ブログ設定
         $blogs->blog_name     = $request->blog_name;
-        $blogs->view_count    = (intval($request->view_count) < 0) ? 0 : intval($request->view_count);
         $blogs->rss           = $request->rss;
         $blogs->rss_count     = $request->rss_count;
         $blogs->use_like      = $request->use_like;
@@ -1393,10 +1389,12 @@ EOD;
 
         // 項目のエラーチェック
         $validator_values['scope_value'] = ['nullable', 'digits:4'];
+        $validator_values[BlogFrameConfig::blog_view_count] = ['required', 'numeric', 'min:1'];
         if ($request->scope == 'year' || $request->scope == 'fiscal') {
             $validator_values['scope_value'][] = ['required'];
         }
         $validator_attributes['scope_value'] = '指定年';
+        $validator_attributes[BlogFrameConfig::blog_view_count] = BlogFrameConfig::getDescription('blog_view_count');
 
         $validator = Validator::make($request->all(), $validator_values);
         $validator->setAttributeNames($validator_attributes);

--- a/database/migrations/2022_01_14_143252_drop_column_view_count_to_blogs.php
+++ b/database/migrations/2022_01_14_143252_drop_column_view_count_to_blogs.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Enums\BlogFrameConfig;
+use App\Models\Core\FrameConfig;
+use App\Models\User\Blogs\Blogs;
+use App\Models\User\Blogs\BlogsFrames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropColumnViewCountToBlogs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // 表示件数の移行　バケツからフレームへ
+        $blogs = Blogs::get();
+        foreach ($blogs as $blog) {
+            $blog_frames = BlogsFrames::where('blogs_id', $blog->id)->get();
+            foreach ($blog_frames as $blog_frame) {
+                $frame_config = new FrameConfig();
+                $frame_config->frame_id = $blog_frame->frames_id;
+                $frame_config->name = BlogFrameConfig::blog_view_count;
+                $frame_config->value = $blog->view_count;
+                $frame_config->save();
+            }
+        }
+
+        // カラム削除
+        Schema::table('blogs', function (Blueprint $table) {
+            $table->dropColumn('view_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // カラム復活
+        Schema::table('blogs', function (Blueprint $table) {
+            $table->integer('view_count')->after('blog_name');
+        });
+
+        // 表示件数の移行　フレームからバケツへ
+        $frame_configs = FrameConfig::where('name', BlogFrameConfig::blog_view_count)->get();
+        foreach ($frame_configs as $frame_config) {
+            $blog_frame = BlogsFrames::where('frames_id', $frame_config->frame_id)->first();
+            Blogs::where('id', $blog_frame->blogs_id)->update(['view_count' => $frame_config->value]);
+            $frame_config->forceDelete();
+        }
+    }
+}

--- a/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
@@ -63,14 +63,6 @@
     </div>
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">表示件数 <span class="badge badge-danger">必須</span></label>
-        <div class="{{$frame->getSettingInputClass()}}">
-            <input type="text" name="view_count" value="{{old('view_count', $blog->view_count)}}" class="form-control col-sm-3 @if ($errors->has('view_count')) border-danger @endif">
-            @include('plugins.common.errors_inline', ['name' => 'view_count'])
-        </div>
-    </div>
-
-    <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass(true)}}">RSSの表示</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-radio custom-control-inline">

--- a/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
@@ -53,6 +53,7 @@
                         required
                     >
                     @include('plugins.common.errors_inline', ['name' => BlogFrameConfig::blog_view_count])
+                    <small class="text-muted">※ 初期値は15件です。</small>
                 </div>
             </div>
 

--- a/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
@@ -45,6 +45,8 @@
                 <div class="{{$frame->getSettingInputClass()}}">
                     <input 
                         type="number"
+                        min="1"
+                        max="100"
                         class="form-control col-sm-3 @if ($errors->has(BlogFrameConfig::blog_view_count)) border-danger @endif"
                         value="{{FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_view_count)}}"
                         id="{{BlogFrameConfig::blog_view_count}}" name="{{BlogFrameConfig::blog_view_count}}"

--- a/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
@@ -36,6 +36,24 @@
             <input type="hidden" name="blogs_id" value="{{$blog_frame->blogs_id}}">
             <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/blogs/settingBlogFrame/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
 
+            {{-- 表示件数 --}}
+            <div class="form-group row">
+                <label class="{{$frame->getSettingLabelClass()}}">
+                    {{BlogFrameConfig::getDescription('blog_view_count')}}
+                    <span class="badge badge-danger">必須</span>
+                </label>
+                <div class="{{$frame->getSettingInputClass()}}">
+                    <input 
+                        type="number"
+                        class="form-control col-sm-3 @if ($errors->has(BlogFrameConfig::blog_view_count)) border-danger @endif"
+                        value="{{FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_view_count)}}"
+                        id="{{BlogFrameConfig::blog_view_count}}" name="{{BlogFrameConfig::blog_view_count}}"
+                        required
+                    >
+                    @include('plugins.common.errors_inline', ['name' => BlogFrameConfig::blog_view_count])
+                </div>
+            </div>
+
             <div class="form-group row">
                 <label class="{{$frame->getSettingLabelClass()}}">表示条件</label>
                 <div class="{{$frame->getSettingInputClass(true)}}">


### PR DESCRIPTION
## 概要

ブログの表示件数をバケツからフレーム保持に変更しました。

### 変更内容
- 設定変更画面から表示件数の入力項目を削除しました。
- 新規作成画面から表示件数の入力項目を削除しました。
- 表示条件設定画面に表示件数の入力項目を追加しました。

### 留意事項

- blogs.view_countを列削除して、frame_configsに表示件数を保持するように変更しました
  - 上記より列削除＆データ移行するマイグレーションを追加しました。
- 表示件数の初期値を設定するとなるとコアの修正が必要になりそうだったため、初期値無しにしています。
  - 初期値がないとLaravelのデフォルトで15件となります。
  - 変更したい場合は表示条件設定画面にてユーザが変更するようになります。

## 関連Pull requests/Issues

#1077

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無

有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
