### PR TITLE
change: 独自バリデーションのクラス名修正

### DIFF
--- a/app/Rules/CustomValiExclusiveProcessing.php
+++ b/app/Rules/CustomValiExclusiveProcessing.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Validation\Rule;
  * --- 本処理
  * --- ロックファイル撤去処理
  */
-class CustomVali_ExclusiveProcessing implements Rule
+class CustomValiExclusiveProcessing implements Rule
 {
     protected $lock_file_name;
     /**

--- a/app/Rules/CustomValiTableRecordNotExist.php
+++ b/app/Rules/CustomValiTableRecordNotExist.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\DB;
  * 該当トランザクションテーブルに指定ID($value)のレコードが存在しないこと
  * ※マスタテーブルレコード削除時にトランザクションテーブルに該当マスタ参照が残っていないことのチェックを想定
  */
-class CustomVali_TableRecordNotExist implements Rule
+class CustomValiTableRecordNotExist implements Rule
 {
     // トランザクションテーブル名を指定
     protected $transaction_table_name;


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

リネーム

CustomVali_TableRecordNotExist
CustomVali_ExclusiveProcessing
↓
CustomValiTableRecordNotExist
CustomValiExclusiveProcessing

社内確認後マージ予定。


## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/863

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
