### PR TITLE
fix: 新着の取得方式が日数で表示するのときにもっと見るボタンが表示されない

### DIFF
--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -328,19 +328,8 @@ class WhatsnewsPlugin extends UserPluginBase
             )
             ->leftJoin('categories', 'categories.id', '=', 'whatsnews_dual.categories_id');
 
-        // 新着の取得方式が「日数で表示する」の場合用の条件日付を生成
-        $where_date = null;
-        if ($whatsnews_frame->view_pattern == 1) {
-            $where_date = date("Y-m-d", strtotime("-" . $whatsnews_frame->days ." day"));
-        }
-
         // 各プラグインのSQLにwhere条件を付加してUNION
         foreach ($union_sqls as $union_sql) {
-            // （where条件）日付
-            if ($where_date) {
-                $union_sql->where('posted_at', '>=', $where_date);
-            }
-
             // （where条件）フレーム選択
             if ($whatsnews_frame->frame_select == 1) {
                 $union_sql->whereIn('frames.id', explode(',', $whatsnews_frame->target_frame_ids));


### PR DESCRIPTION
## 概要

バグフィックスです。
getWhatsnews()にて日数で絞り込むため、修正箇所では絞り込まないようにしました。

## 関連Pull requests/Issues

#1063

## 参考

#883

## DB変更の有無

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。
