### PR TITLE
Fix: 未ログインユーザにバケツなしフレームのバケツ選択メッセージが見える

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -415,7 +415,7 @@ class FormsPlugin extends UserPluginBase
         } else {
             // エラーあり
             return $this->view('forms_error_messages', [
-                'error_messages' => $setting_error_messages,
+                'setting_error_messages' => $setting_error_messages,
             ]);
         }
     }

--- a/resources/views/plugins/user/bbses/default/index.blade.php
+++ b/resources/views/plugins/user/bbses/default/index.blade.php
@@ -20,12 +20,14 @@
 @if (isset($frame) && $frame->bucket_id)
     {{-- バケツあり --}}
 @else
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     {{-- バケツなし --}}
     <div class="card border-danger">
         <div class="card-body">
             <p class="text-center cc_margin_bottom_0">フレームの設定画面から、使用する掲示板を選択するか、作成してください。</p>
         </div>
     </div>
+    @endcan
 @endif
 
 {{-- 新規登録 --}}

--- a/resources/views/plugins/user/bbses/default/index.blade.php
+++ b/resources/views/plugins/user/bbses/default/index.blade.php
@@ -20,7 +20,7 @@
 @if (isset($frame) && $frame->bucket_id)
     {{-- バケツあり --}}
 @else
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     {{-- バケツなし --}}
     <div class="card border-danger">
         <div class="card-body">

--- a/resources/views/plugins/user/cabinets/default/empty_bucket.blade.php
+++ b/resources/views/plugins/user/cabinets/default/empty_bucket.blade.php
@@ -6,10 +6,12 @@
 @section("plugin_contents_$frame->id")
 
 {{-- バケツなし --}}
+@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
 <div class="card border-danger">
     <div class="card-body">
         <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => 'キャビネット']) }}</p>
     </div>
 </div>
+@endcan
 
 @endsection

--- a/resources/views/plugins/user/cabinets/default/empty_bucket.blade.php
+++ b/resources/views/plugins/user/cabinets/default/empty_bucket.blade.php
@@ -6,7 +6,7 @@
 @section("plugin_contents_$frame->id")
 
 {{-- バケツなし --}}
-@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+@can('frames.edit',[[null, null, null, $frame]])
 <div class="card border-danger">
     <div class="card-body">
         <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => 'キャビネット']) }}</p>

--- a/resources/views/plugins/user/conventions/default/index.blade.php
+++ b/resources/views/plugins/user/conventions/default/index.blade.php
@@ -22,7 +22,7 @@
     @endcan
 @endif
 
-@if (isset($posts))
+@if ($convention->exists)
 {{-- トラックの表 --}}
 <table class="table table-bordered">
 <thead>

--- a/resources/views/plugins/user/conventions/default/index.blade.php
+++ b/resources/views/plugins/user/conventions/default/index.blade.php
@@ -12,7 +12,7 @@
 @if (isset($frame) && $frame->bucket_id)
     {{-- バケツあり --}}
 @else
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     {{-- バケツなし --}}
     <div class="card border-danger">
         <div class="card-body">

--- a/resources/views/plugins/user/conventions/default/index.blade.php
+++ b/resources/views/plugins/user/conventions/default/index.blade.php
@@ -12,12 +12,14 @@
 @if (isset($frame) && $frame->bucket_id)
     {{-- バケツあり --}}
 @else
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     {{-- バケツなし --}}
     <div class="card border-danger">
         <div class="card-body">
             <p class="text-center cc_margin_bottom_0">フレームの設定画面から、使用するイベントを選択するか、作成してください。</p>
         </div>
     </div>
+    @endcan
 @endif
 
 @if (isset($posts))

--- a/resources/views/plugins/user/counters/default/empty_bucket.blade.php
+++ b/resources/views/plugins/user/counters/default/empty_bucket.blade.php
@@ -6,10 +6,12 @@
 @section("plugin_contents_$frame->id")
 
 {{-- バケツなし --}}
+@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
 <div class="card border-danger">
     <div class="card-body">
         <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => 'カウンター']) }}</p>
     </div>
 </div>
+@endcan
 
 @endsection

--- a/resources/views/plugins/user/counters/default/empty_bucket.blade.php
+++ b/resources/views/plugins/user/counters/default/empty_bucket.blade.php
@@ -6,7 +6,7 @@
 @section("plugin_contents_$frame->id")
 
 {{-- バケツなし --}}
-@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+@can('frames.edit',[[null, null, null, $frame]])
 <div class="card border-danger">
     <div class="card-body">
         <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => 'カウンター']) }}</p>

--- a/resources/views/plugins/user/databases/default/databases.blade.php
+++ b/resources/views/plugins/user/databases/default/databases.blade.php
@@ -109,7 +109,7 @@
     @endif
 
 @else
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     {{-- フレームに紐づくコンテンツがない場合等、表示に支障がある場合は、データ登録を促す等のメッセージを表示 --}}
     <div class="card border-danger">
         <div class="card-body">

--- a/resources/views/plugins/user/databases/default/databases.blade.php
+++ b/resources/views/plugins/user/databases/default/databases.blade.php
@@ -109,6 +109,7 @@
     @endif
 
 @else
+    @can('posts.create',[[null, $frame->plugin_name, $buckets]])
     {{-- フレームに紐づくコンテンツがない場合等、表示に支障がある場合は、データ登録を促す等のメッセージを表示 --}}
     <div class="card border-danger">
         <div class="card-body">
@@ -117,5 +118,6 @@
             @endforeach
         </div>
     </div>
+    @endcan
 @endif
 @endsection

--- a/resources/views/plugins/user/databases/default/databases.blade.php
+++ b/resources/views/plugins/user/databases/default/databases.blade.php
@@ -109,7 +109,7 @@
     @endif
 
 @else
-    @can('posts.create',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     {{-- フレームに紐づくコンテンツがない場合等、表示に支障がある場合は、データ登録を促す等のメッセージを表示 --}}
     <div class="card border-danger">
         <div class="card-body">

--- a/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
@@ -65,7 +65,7 @@
     @endif
 
 @else
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     {{-- フレームに紐づくコンテンツがない場合等、表示に支障がある場合は、データ登録を促す等のメッセージを表示 --}}
     <div class="card border-danger">
         <div class="card-body">

--- a/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
@@ -65,6 +65,7 @@
     @endif
 
 @else
+    @can('posts.create',[[null, $frame->plugin_name, $buckets]])
     {{-- フレームに紐づくコンテンツがない場合等、表示に支障がある場合は、データ登録を促す等のメッセージを表示 --}}
     <div class="card border-danger">
         <div class="card-body">
@@ -73,5 +74,6 @@
             @endforeach
         </div>
     </div>
+    @endcan
 @endif
 @endsection

--- a/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
@@ -65,7 +65,7 @@
     @endif
 
 @else
-    @can('posts.create',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     {{-- フレームに紐づくコンテンツがない場合等、表示に支障がある場合は、データ登録を促す等のメッセージを表示 --}}
     <div class="card border-danger">
         <div class="card-body">

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -66,7 +66,7 @@
     @endif
 
 @else
-    @can('posts.create',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     {{-- フレームに紐づくコンテンツがない場合等、表示に支障がある場合は、データ登録を促す等のメッセージを表示 --}}
     <div class="card border-danger">
         <div class="card-body">

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -66,7 +66,7 @@
     @endif
 
 @else
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     {{-- フレームに紐づくコンテンツがない場合等、表示に支障がある場合は、データ登録を促す等のメッセージを表示 --}}
     <div class="card border-danger">
         <div class="card-body">

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -66,6 +66,7 @@
     @endif
 
 @else
+    @can('posts.create',[[null, $frame->plugin_name, $buckets]])
     {{-- フレームに紐づくコンテンツがない場合等、表示に支障がある場合は、データ登録を促す等のメッセージを表示 --}}
     <div class="card border-danger">
         <div class="card-body">
@@ -74,5 +75,6 @@
             @endforeach
         </div>
     </div>
+    @endcan
 @endif
 @endsection

--- a/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
@@ -70,7 +70,7 @@
 </div>
 
 @else
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     <div class="alert alert-danger" style="margin-top: 10px;">
         <i class="fas fa-exclamation-circle"></i>
         編集画面から、データベース検索の設定を作成してください。

--- a/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
@@ -70,9 +70,11 @@
 </div>
 
 @else
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     <div class="alert alert-danger" style="margin-top: 10px;">
         <i class="fas fa-exclamation-circle"></i>
         編集画面から、データベース検索の設定を作成してください。
     </div>
+    @endcan
 @endif
 @endsection

--- a/resources/views/plugins/user/databasesearches/default/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/default/databasesearches.blade.php
@@ -63,9 +63,11 @@
 @include('plugins.common.user_paginate', ['posts' => $inputs_ids, 'frame' => $frame, 'aria_label_name' => $databasesearches->databasesearches_name])
 
 @else
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     <div class="alert alert-danger" style="margin-top: 10px;">
         <i class="fas fa-exclamation-circle"></i>
         編集画面から、データベース検索の設定を作成してください。
     </div>
+    @endcan
 @endif
 @endsection

--- a/resources/views/plugins/user/databasesearches/default/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/default/databasesearches.blade.php
@@ -63,7 +63,7 @@
 @include('plugins.common.user_paginate', ['posts' => $inputs_ids, 'frame' => $frame, 'aria_label_name' => $databasesearches->databasesearches_name])
 
 @else
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     <div class="alert alert-danger" style="margin-top: 10px;">
         <i class="fas fa-exclamation-circle"></i>
         編集画面から、データベース検索の設定を作成してください。

--- a/resources/views/plugins/user/forms/default/forms_error_messages.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_error_messages.blade.php
@@ -17,7 +17,7 @@
 
 {{-- フォーム設定者向けのシステムメッセージ バケツ未設定など --}}
 @isset($setting_error_messages)
-@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+@can('frames.edit',[[null, null, null, $frame]])
 <div class="card border-danger">
     <div class="card-body">
         @foreach ($setting_error_messages as $error_message)

--- a/resources/views/plugins/user/forms/default/forms_error_messages.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_error_messages.blade.php
@@ -4,6 +4,8 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+{{-- フォーム利用者向けの業務メッセージ　表示期間外など --}}
+@isset($error_messages)
 <div class="card border-danger">
     <div class="card-body">
         @foreach ($error_messages as $error_message)
@@ -11,4 +13,19 @@
         @endforeach
     </div>
 </div>
+@endisset
+
+{{-- フォーム設定者向けのシステムメッセージ バケツ未設定など --}}
+@isset($setting_error_messages)
+@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+<div class="card border-danger">
+    <div class="card-body">
+        @foreach ($setting_error_messages as $error_message)
+            <p class="text-center cc_margin_bottom_0">{!! nl2br(e($error_message)) !!}</p>
+        @endforeach
+    </div>
+</div>
+@endcan
+@endisset
+
 @endsection

--- a/resources/views/plugins/user/linklists/default/index.blade.php
+++ b/resources/views/plugins/user/linklists/default/index.blade.php
@@ -13,7 +13,7 @@
     {{-- バケツあり --}}
 @else
     {{-- バケツなし --}}
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     <div class="card border-danger">
         <div class="card-body">
             <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => $frame->plugin_name_full]) }}</p>

--- a/resources/views/plugins/user/linklists/default/index.blade.php
+++ b/resources/views/plugins/user/linklists/default/index.blade.php
@@ -13,11 +13,13 @@
     {{-- バケツあり --}}
 @else
     {{-- バケツなし --}}
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     <div class="card border-danger">
         <div class="card-body">
             <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => $frame->plugin_name_full]) }}</p>
         </div>
     </div>
+    @endcan
 @endif
 
 {{-- 新規登録 --}}

--- a/resources/views/plugins/user/opacs/default/opacs_no_frame_setting.blade.php
+++ b/resources/views/plugins/user/opacs/default/opacs_no_frame_setting.blade.php
@@ -8,7 +8,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     <div class="alert alert-warning text-center">
         <i class="fas fa-exclamation-circle"></i>
         Opac フレームの設定を行ってください。

--- a/resources/views/plugins/user/opacs/default/opacs_no_frame_setting.blade.php
+++ b/resources/views/plugins/user/opacs/default/opacs_no_frame_setting.blade.php
@@ -8,8 +8,10 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     <div class="alert alert-warning text-center">
         <i class="fas fa-exclamation-circle"></i>
         Opac フレームの設定を行ってください。
     </div>
+    @endcan
 @endsection

--- a/resources/views/plugins/user/openingcalendars/default/openingcalendars.blade.php
+++ b/resources/views/plugins/user/openingcalendars/default/openingcalendars.blade.php
@@ -9,10 +9,12 @@
 
 @section("plugin_contents_$frame->id")
 @if (!$frame->bucket_id)
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     <div class="alert alert-warning" style="margin-top: 10px;">
         <i class="fas fa-exclamation-circle"></i>
         開館カレンダーが設定されていません。
     </div>
+    @endcan
 @else
 
 <div class="openingcalendar-pdf">

--- a/resources/views/plugins/user/openingcalendars/default/openingcalendars.blade.php
+++ b/resources/views/plugins/user/openingcalendars/default/openingcalendars.blade.php
@@ -9,7 +9,7 @@
 
 @section("plugin_contents_$frame->id")
 @if (!$frame->bucket_id)
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     <div class="alert alert-warning" style="margin-top: 10px;">
         <i class="fas fa-exclamation-circle"></i>
         開館カレンダーが設定されていません。

--- a/resources/views/plugins/user/photoalbums/default/empty_bucket.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/empty_bucket.blade.php
@@ -9,7 +9,7 @@
 
 @section("plugin_contents_$frame->id")
 
-@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+@can('frames.edit',[[null, null, null, $frame]])
 {{-- バケツなし --}}
 <div class="card border-danger">
     <div class="card-body">

--- a/resources/views/plugins/user/photoalbums/default/empty_bucket.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/empty_bucket.blade.php
@@ -9,11 +9,13 @@
 
 @section("plugin_contents_$frame->id")
 
+@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
 {{-- バケツなし --}}
 <div class="card border-danger">
     <div class="card-body">
         <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => 'フォトアルバム']) }}</p>
     </div>
 </div>
+@endcan
 
 @endsection

--- a/resources/views/plugins/user/searchs/default/searchs.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs.blade.php
@@ -11,7 +11,7 @@
 @if ($searchs_frame->id)
     @include('plugins.user.searchs.default.searchs_form')
 @else
-    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
     <div class="alert alert-danger" style="margin-top: 10px;">
         <i class="fas fa-exclamation-circle"></i>
         検索設定を作成してください。

--- a/resources/views/plugins/user/searchs/default/searchs.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs.blade.php
@@ -11,9 +11,11 @@
 @if ($searchs_frame->id)
     @include('plugins.user.searchs.default.searchs_form')
 @else
+    @can('frames.edit',[[null, $frame->plugin_name, $buckets]])
     <div class="alert alert-danger" style="margin-top: 10px;">
         <i class="fas fa-exclamation-circle"></i>
         検索設定を作成してください。
     </div>
+    @endcan
 @endif
 @endsection

--- a/resources/views/plugins/user/slideshows/default/slideshows_error_messages.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_error_messages.blade.php
@@ -4,6 +4,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
 <div class="card border-danger">
     <div class="card-body">
         @foreach ($error_messages as $error_message)
@@ -11,4 +12,5 @@
         @endforeach
     </div>
 </div>
+@endcan
 @endsection

--- a/resources/views/plugins/user/slideshows/default/slideshows_error_messages.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_error_messages.blade.php
@@ -4,7 +4,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
-@can('frames.edit',[[null, $frame->plugin_name, $buckets]])
+@can('frames.edit',[[null, null, null, $frame]])
 <div class="card border-danger">
     <div class="card-body">
         @foreach ($error_messages as $error_message)


### PR DESCRIPTION
## 概要

未ログインユーザにバケツなしフレームのバケツ選択メッセージが見えています。
ユーザー全般に対してのメッセージではないため、
バケツを設定できる権限のないユーザにはメッセージが表示されないように修正しました。

- [x] スライドショー
- [x] データベース
- [x] フォーム
- [x] 掲示板
- [x] キャビネット
- [x] カウンター
- [x] リンクリスト
- [x] サイト内検索
- [x] データベース検索
- [x] Opac
- [x] 開館カレンダー
- [x] イベント
- [x] フォトアルバム
- [ ] ~~データ収集~~

## 関連Pull requests/Issues

#1066

## 参考


## DB変更の有無

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。
