### PR TITLE
Fix: バケツ選択メッセージが表示されない

### DIFF
--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -28,7 +28,7 @@
     </div>
 @else
     {{-- 新規登録 --}}
-    @can('posts.create',[[null, $frame->plugin_name, $buckets]])
+    @can('frames.edit',[[null, null, null, $frame]])
         <div class="card border-danger">
             <div class="card-body">
                 <p class="text-center cc_margin_bottom_0">フレームの設定画面から、使用するブログを選択するか、作成してください。</p>

--- a/resources/views/plugins/user/blogs/designbase/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs.blade.php
@@ -8,28 +8,31 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
-{{-- 新規登録 --}}
-@can('posts.create',[[null, $frame->plugin_name, $buckets]])
-    @if (isset($buckets) && isset($frame) && $frame->bucket_id)
-        <div class="row">
-            <p class="text-left col-6">
-                @if (isset($blog_frame->rss) && $blog_frame->rss == 1)
-                <a href="{{url('/')}}/redirect/plugin/blogs/rss/{{$page->id}}/{{$frame_id}}/"><span class="badge badge-info">RSS2.0</span></a>
-                @endif
-            </p>
+@if (isset($buckets) && isset($frame) && $frame->bucket_id)
+    <div class="row">
+        <p class="text-left col-6">
+            @if (isset($blog_frame->rss) && $blog_frame->rss == 1)
+            <a href="{{url('/')}}/redirect/plugin/blogs/rss/{{$page->id}}/{{$frame_id}}/"><span class="badge badge-info">RSS2.0</span></a>
+            @endif
+        </p>
+        {{-- 新規登録 --}}
+        @can('posts.create',[[null, $frame->plugin_name, $buckets]])
             <p class="text-right col-6">
                 {{-- 新規登録ボタン --}}
                 <button type="button" class="btn btn-success" onclick="location.href='{{url('/')}}/plugin/blogs/create/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}'"><i class="far fa-edit"></i> 新規登録</button>
             </p>
+        @endcan
+    </div>
+@else
+    {{-- 新規登録 --}}
+    @can('frames.edit',[[null, null, null, $frame]])
+    <div class="card border-danger">
+        <div class="card-body">
+            <p class="text-center cc_margin_bottom_0">フレームの設定画面から、使用するブログを選択するか、作成してください。</p>
         </div>
-    @else
-        <div class="card border-danger">
-            <div class="card-body">
-                <p class="text-center cc_margin_bottom_0">フレームの設定画面から、使用するブログを選択するか、作成してください。</p>
-            </div>
-        </div>
-    @endif
-@endcan
+    </div>
+    @endcan
+@endif
 
 {{-- ブログ表示 --}}
 @if (isset($blogs_posts))

--- a/resources/views/plugins/user/faqs/default/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/default/faqs.blade.php
@@ -18,23 +18,26 @@
 </div>
 @endif
 
-{{-- 新規登録 --}}
-@can('posts.create',[[null, 'faqs', $buckets]])
-    @if (isset($frame) && $frame->bucket_id)
+@if (isset($frame) && $frame->bucket_id)
+    {{-- 新規登録 --}}
+    @can('posts.create',[[null, 'faqs', $buckets]])
         <div class="row">
             <p class="text-right col-12">
                 {{-- 新規登録ボタン --}}
                 <button type="button" class="btn btn-success" onclick="location.href='{{url('/')}}/plugin/faqs/create/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}'"><i class="far fa-edit"></i> 新規登録</button>
             </p>
         </div>
-    @else
+    @endcan
+@else
+    {{-- 新規登録 --}}
+    @can('frames.edit',[[null, null, null, $frame]])
         <div class="card border-danger">
             <div class="card-body">
                 <p class="text-center cc_margin_bottom_0">フレームの設定画面から、使用するFAQを選択するか、作成してください。</p>
             </div>
         </div>
-    @endif
-@endcan
+    @endcan
+@endif
 
 {{-- FAQ表示 --}}
 @if (isset($faqs_posts))

--- a/resources/views/plugins/user/learningtasks/default/learningtasks.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks.blade.php
@@ -9,23 +9,26 @@
 
 @section("plugin_contents_$frame->id")
 
-{{-- 新規登録 --}}
-@can('posts.create',[[null, 'learningtasks', $buckets]])
-    @if (isset($frame) && $frame->bucket_id)
+@if (isset($frame) && $frame->bucket_id)
+    {{-- 新規登録 --}}
+    @can('posts.create',[[null, 'learningtasks', $buckets]])
         <div class="row">
             <p class="text-right col-12">
                 {{-- 新規登録ボタン --}}
                 <button type="button" class="btn btn-success" onclick="location.href='{{url('/')}}/plugin/learningtasks/create/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}'"><i class="far fa-edit"></i> 新規登録</button>
             </p>
         </div>
-    @else
+    @endcan
+@else
+    {{-- 新規登録 --}}
+    @can('frames.edit',[[null, null, null, $frame]])
         <div class="card border-danger">
             <div class="card-body">
                 <p class="text-center cc_margin_bottom_0">フレームの設定画面から、使用する課題管理を選択するか、作成してください。</p>
             </div>
         </div>
-    @endif
-@endcan
+    @endcan
+@endif
 
 {{-- 要処理一覧：教員機能 --}}
 {{--

--- a/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
@@ -8,6 +8,20 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+
+@if (isset($frame) && $frame->bucket_id)
+    {{-- バケツあり --}}
+@else
+@can('frames.edit',[[null, null, null, $frame]])
+    {{-- バケツなし --}}
+    <div class="card border-danger">
+        <div class="card-body">
+            <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => '新着情報']) }}</p>
+        </div>
+    </div>
+    @endcan
+@endif
+
 @if ($whatsnews)
 
 @if (isset($whatsnews_frame->rss) && $whatsnews_frame->rss == UseType::use)

--- a/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
@@ -8,6 +8,20 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+
+@if (isset($frame) && $frame->bucket_id)
+    {{-- バケツあり --}}
+@else
+@can('frames.edit',[[null, null, null, $frame]])
+    {{-- バケツなし --}}
+    <div class="card border-danger">
+        <div class="card-body">
+            <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => '新着情報']) }}</p>
+        </div>
+    </div>
+    @endcan
+@endif
+
 @if ($whatsnews)
 <p class="text-left">
     @if (isset($whatsnews_frame->rss) && $whatsnews_frame->rss == 1)

--- a/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
@@ -8,6 +8,20 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+
+@if (isset($frame) && $frame->bucket_id)
+    {{-- バケツあり --}}
+@else
+@can('frames.edit',[[null, null, null, $frame]])
+    {{-- バケツなし --}}
+    <div class="card border-danger">
+        <div class="card-body">
+            <p class="text-center cc_margin_bottom_0">{{ __('messages.empty_bucket', ['plugin_name' => '新着情報']) }}</p>
+        </div>
+    </div>
+    @endcan
+@endif
+
 @if ($whatsnews)
 
 @if (isset($whatsnews_frame->rss) && $whatsnews_frame->rss == 1)


### PR DESCRIPTION
## 概要

バケツ選択メッセージがされないプラグインがあったので、表示されるよう修正しました。

- すべてのユーザーで表示されない
  - 新着情報
- プラグイン管理者で表示されない
  - FAQ
  - ブログ
  - 課題管理

## 関連Pull requests/Issues

#1066 

## 参考

#1109 

## DB変更の有無

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。
