### PR TITLE
Fix: 条件なしで詳細検索実行するとシステムエラーとなる

### DIFF
--- a/app/Plugins/User/Opacs/OpacsPlugin.php
+++ b/app/Plugins/User/Opacs/OpacsPlugin.php
@@ -610,7 +610,7 @@ class OpacsPlugin extends UserPluginBase
             // 詳細検索
 
             // 検索条件設定
-            $where_querys = null;
+            $where_querys = [];
             if (isset($opac_search_condition['title']) == true && empty($opac_search_condition['title']) == false) {
                 $where_querys[] = array( 'title', 'like', '%' . $opac_search_condition['title'] . '%' );
             }


### PR DESCRIPTION
## 概要

nullの変数にcount()を実行してエラーになっていたので、変数定義時に空のarrayを代入するように修正しました。

## 関連Pull requests/Issues

#1111

## 参考

## DB変更の有無

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。
