### PR TITLE
Fix: プラグイン管理者がフレームの歯車ボタンを押すと権限なしエラーになる

### DIFF
--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -182,11 +182,6 @@ class SlideshowsPlugin extends UserPluginBase
      */
     public function editBuckets($request, $page_id, $frame_id, $slideshows_id = null, $is_create = false, $message = null, $errors = null)
     {
-        // 権限チェック
-        if ($this->can('role_article_admin')) {
-            return $this->view_error(403);
-        }
-
         // セッション初期化などのLaravel 処理。
         $request->flash();
 


### PR DESCRIPTION
## 概要

Coreでチェックされるので、プラグインでのチェック処理を削除しました。

## 関連Pull requests/Issues

#1110

## 参考

歯車押下時のアクション:  /plugin/slideshows/**createBuckets**/{page_id}/{frame_id}

https://github.com/opensource-workshop/connect-cms/blob/6cc8157b95ecd30b81b87af9e0f40f30de53d841/config/cc_role.php#L143

createBucketsアクションではframes.createのチェックが適用されます。

## DB変更の有無

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。
