### PR TITLE
ブログ designbaseテンプレートでTwitter又はFBアイコンをONで記事詳細開くとエラー

### DIFF
--- a/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
@@ -63,11 +63,14 @@
     ])
 
     {{-- Twitterボタン --}}
-    @include('plugins.common.twitter')
+    @include('plugins.common.twitter', [
+        'post_title' => $post->post_title,
+    ])
 
     {{-- Facebookボタン --}}
-    @include('plugins.common.facebook')
-
+    @include('plugins.common.facebook', [
+        'post_title' => $post->post_title,
+    ])
     {{-- タグ --}}
     @isset($post_tags)
         @foreach($post_tags as $tags)


### PR DESCRIPTION
## 概要
https://github.com/opensource-workshop/connect-cms/issues/1120

## DB変更の有無
無し

## チェックリスト
- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer