### PR TITLE
ハンバーガーメニューを追加

### DIFF
--- a/resources/views/plugins/user/menus/hamburger_button/menus.blade.php
+++ b/resources/views/plugins/user/menus/hamburger_button/menus.blade.php
@@ -1,0 +1,90 @@
+{{--
+ * メニュー（ハンバーガーメニュー）表示画面
+ *
+ * @param obj $pages ページデータの配列
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>, 牧野　可也子 <makino@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category メニュープラグイン
+--}}
+@extends('core.cms_frame_base')
+
+@section("plugin_contents_$frame->id")
+@if ($pages)
+
+{{-- ハンバーガーメニュー用script&CSS読み込み --}}
+@include('plugins.user.menus.hamburger_button.menus_script')
+
+{{-- ハンバーガーメニュー --}}
+<div class="menu-humburger-button">
+    <a class="menu-humburger-link" href="#">
+        <p></p>
+        <p></p>
+        <p></p>
+    </a>
+</div>
+
+{{-- メニュー本体 --}}
+<div class="hamburger-menu-area">
+<div class="list-group mb-0 hamburger-menu" role="navigation" aria-label="メニュー">
+    @foreach($pages as $page)
+
+        {{-- 子供のページがある場合 --}}
+        @if (count($page->children) > 0)
+
+            {{-- 非表示のページは対象外(非表示の判断はこのページのみで、子のページはそのページでの判断を行う) --}}
+            @if ($page->isView(Auth::user(), false, true, $page_roles))
+
+                {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
+                @if ($page->id == $page_id)
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }} active" aria-current="page">
+                @else
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }}">
+                @endif
+                    {{-- 各ページの深さをもとにインデントの表現 --}}
+                    @for ($i = 0; $i < $page->depth; $i++)
+                        @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
+                    @endfor
+                    {{$page->page_name}}
+
+                    {{-- メニュー設定が生成されていて、表示する子ページがあり、カレントもしくは自分のルート筋なら＋、違えば－を表示する --}}
+                    @if ($menu && $page->existChildrenPagesToDisplay($page->children))
+                        @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
+                            {!!$menu->getFolderCloseFont()!!}
+                        @else
+                            {!!$menu->getFolderOpenFont()!!}
+                        @endif
+                    @endif
+                </a>
+            @endif
+
+            {{-- カレントもしくは自分のルート筋なら表示する --}}
+            @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
+                {{-- 子要素を再帰的に表示するため、別ファイルに分けてinclude --}}
+                @foreach($page->children as $children)
+                    @include('plugins.user.menus.opencurrenttree.menu_children',['children' => $children, 'page_id' => $page_id])
+                @endforeach
+            @endif
+        @else
+
+            {{-- 非表示のページは対象外 --}}
+            @if ($page->isView(Auth::user(), false, true, $page_roles))
+
+                {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
+                @if ($page->id == $page_id)
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item active" aria-current="page">
+                @else
+                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item">
+                @endif
+                    {{-- 各ページの深さをもとにインデントの表現 --}}
+                    @for ($i = 0; $i < $page->depth; $i++)
+                        @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
+                    @endfor
+                    {{$page->page_name}}
+                </a>
+            @endif
+        @endif
+    @endforeach
+</div>
+</div>
+@endif
+@endsection

--- a/resources/views/plugins/user/menus/hamburger_button/menus.blade.php
+++ b/resources/views/plugins/user/menus/hamburger_button/menus.blade.php
@@ -26,64 +26,7 @@
 {{-- メニュー本体 --}}
 <div class="hamburger-menu-area">
 <div class="list-group mb-0 hamburger-menu" role="navigation" aria-label="メニュー">
-    @foreach($pages as $page)
-
-        {{-- 子供のページがある場合 --}}
-        @if (count($page->children) > 0)
-
-            {{-- 非表示のページは対象外(非表示の判断はこのページのみで、子のページはそのページでの判断を行う) --}}
-            @if ($page->isView(Auth::user(), false, true, $page_roles))
-
-                {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
-                @if ($page->id == $page_id)
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }} active" aria-current="page">
-                @else
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }}">
-                @endif
-                    {{-- 各ページの深さをもとにインデントの表現 --}}
-                    @for ($i = 0; $i < $page->depth; $i++)
-                        @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
-                    @endfor
-                    {{$page->page_name}}
-
-                    {{-- メニュー設定が生成されていて、表示する子ページがあり、カレントもしくは自分のルート筋なら＋、違えば－を表示する --}}
-                    @if ($menu && $page->existChildrenPagesToDisplay($page->children))
-                        @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
-                            {!!$menu->getFolderCloseFont()!!}
-                        @else
-                            {!!$menu->getFolderOpenFont()!!}
-                        @endif
-                    @endif
-                </a>
-            @endif
-
-            {{-- カレントもしくは自分のルート筋なら表示する --}}
-            @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
-                {{-- 子要素を再帰的に表示するため、別ファイルに分けてinclude --}}
-                @foreach($page->children as $children)
-                    @include('plugins.user.menus.opencurrenttree.menu_children',['children' => $children, 'page_id' => $page_id])
-                @endforeach
-            @endif
-        @else
-
-            {{-- 非表示のページは対象外 --}}
-            @if ($page->isView(Auth::user(), false, true, $page_roles))
-
-                {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
-                @if ($page->id == $page_id)
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item active" aria-current="page">
-                @else
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item">
-                @endif
-                    {{-- 各ページの深さをもとにインデントの表現 --}}
-                    @for ($i = 0; $i < $page->depth; $i++)
-                        @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
-                    @endfor
-                    {{$page->page_name}}
-                </a>
-            @endif
-        @endif
-    @endforeach
+    @include('plugins.user.menus.opencurrenttree.menu_parent')
 </div>
 </div>
 @endif

--- a/resources/views/plugins/user/menus/hamburger_button/menus_script.blade.php
+++ b/resources/views/plugins/user/menus/hamburger_button/menus_script.blade.php
@@ -84,6 +84,6 @@
     }
     /* メニューを画面右に隠す為、スクロールバーが出ないようにhmltとbodyタグに指定 */
     html,body{
-        overflow-x: hidden;
+        overflow-x: clip;
       }
     </style>

--- a/resources/views/plugins/user/menus/hamburger_button/menus_script.blade.php
+++ b/resources/views/plugins/user/menus/hamburger_button/menus_script.blade.php
@@ -53,6 +53,7 @@
     }
     /* メニュー本体のサイズ設定 */
     .hamburger-menu-area {
+        overflow-x: clip;
         position: relative;
         top: 50px;
     }
@@ -82,8 +83,4 @@
             opacity: 0;
         }
     }
-    /* メニューを画面右に隠す為、スクロールバーが出ないようにhmltとbodyタグに指定 */
-    html,body{
-        overflow-x: clip;
-      }
     </style>

--- a/resources/views/plugins/user/menus/hamburger_button/menus_script.blade.php
+++ b/resources/views/plugins/user/menus/hamburger_button/menus_script.blade.php
@@ -1,0 +1,89 @@
+{{--
+ * メニュー：ハンバーガーメニュー用のscript・CSSテンプレート
+ *
+ * @author 牧野 可也子 <makino@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category メニュープラグイン
+--}}
+
+<!-- ハンバーガーメニューの表示/非表示制御スクリプト -->
+<script>
+    $(function(){
+     $('.menu-humburger-link').on('click', function() {
+       $('.menu-humburger-button').toggleClass('active');
+       $('.hamburger-menu').toggleClass('active');
+       return false;
+     });
+   });
+</script>
+
+<!-- ハンバーガーメニューの基本CSS -->
+<style>
+    /* ハンバーガーボタンのデザインCSS */
+    .menu-humburger-button {
+        float: right;
+        text-align: -webkit-center;
+        padding: 5px 0;
+        width: 60px;
+        justify-content: center;
+        border-radius: 3px;
+    }
+    .menu-humburger-button p {
+        margin: 8px 0 8px 0;
+        content: '';
+        display: block;
+        height: 3px;
+        width: 30px;
+        border-radius: 3px;
+        background-color: #ccc;
+        transition: all 0.5s;
+    }
+    /* ハンバーガーボタン：押下時のデザインCSS */
+    .menu-humburger-button.active p:nth-of-type(1) {
+        transform: translateY(11px) rotate(-45deg);
+        transition: all 0.5s;
+    }
+    .menu-humburger-button.active p:nth-of-type(2) {
+        transform: translateY(0) rotate(45deg);
+        transition: all 0.5s;
+    }
+    .menu-humburger-button.active p:nth-of-type(3) {
+        opacity: 0;
+        transition: all 0s;
+    }
+    /* メニュー本体のサイズ設定 */
+    .hamburger-menu-area {
+        position: relative;
+        top: 50px;
+    }
+    .hamburger-menu {
+        clear: both;
+        width:500px;
+        right: -100%;
+        overflow: auto;
+        position: absolute;
+        z-index: 9999;
+        opacity: 0;
+        transition: all 0.5s;
+    }
+    .hamburger-menu.active {
+        right: 0;
+        opacity: 1;
+        transition: all 0.5s;
+    }
+    @media (max-width: 576px) {
+        .hamburger-menu {
+            clear: both;
+            width:100%;
+            right: -100%;
+            overflow: auto;
+            position: absolute;
+            z-index: 9999;
+            opacity: 0;
+        }
+    }
+    /* メニューを画面右に隠す為、スクロールバーが出ないようにhmltとbodyタグに指定 */
+    html,body{
+        overflow-x: hidden;
+      }
+    </style>

--- a/resources/views/plugins/user/menus/hamburger_button/template.ini
+++ b/resources/views/plugins/user/menus/hamburger_button/template.ini
@@ -1,0 +1,3 @@
+[base]
+template_name = ハンバーガーメニュー
+display_sequence = 17

--- a/resources/views/plugins/user/menus/opencurrenttree/menu_parent.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree/menu_parent.blade.php
@@ -1,0 +1,66 @@
+{{--
+ * メニュー表示画面：親要素表示
+ *
+ * @param obj $pages ページデータの配列
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category メニュープラグイン
+--}}
+@foreach($pages as $page)
+
+    {{-- 子供のページがある場合 --}}
+    @if (count($page->children) > 0)
+
+        {{-- 非表示のページは対象外(非表示の判断はこのページのみで、子のページはそのページでの判断を行う) --}}
+        @if ($page->isView(Auth::user(), false, true, $page_roles))
+
+            {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
+            @if ($page->id == $page_id)
+            <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }} active" aria-current="page">
+            @else
+            <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }}">
+            @endif
+                {{-- 各ページの深さをもとにインデントの表現 --}}
+                @for ($i = 0; $i < $page->depth; $i++)
+                    @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
+                @endfor
+                {{$page->page_name}}
+
+                {{-- メニュー設定が生成されていて、表示する子ページがあり、カレントもしくは自分のルート筋なら＋、違えば－を表示する --}}
+                @if ($menu && $page->existChildrenPagesToDisplay($page->children))
+                    @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
+                        {!!$menu->getFolderCloseFont()!!}
+                    @else
+                        {!!$menu->getFolderOpenFont()!!}
+                    @endif
+                @endif
+            </a>
+        @endif
+
+        {{-- カレントもしくは自分のルート筋なら表示する --}}
+        @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
+            {{-- 子要素を再帰的に表示するため、別ファイルに分けてinclude --}}
+            @foreach($page->children as $children)
+                @include('plugins.user.menus.opencurrenttree.menu_children',['children' => $children, 'page_id' => $page_id])
+            @endforeach
+        @endif
+    @else
+
+        {{-- 非表示のページは対象外 --}}
+        @if ($page->isView(Auth::user(), false, true, $page_roles))
+
+            {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
+            @if ($page->id == $page_id)
+            <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item active" aria-current="page">
+            @else
+            <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item">
+            @endif
+                {{-- 各ページの深さをもとにインデントの表現 --}}
+                @for ($i = 0; $i < $page->depth; $i++)
+                    @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
+                @endfor
+                {{$page->page_name}}
+            </a>
+        @endif
+    @endif
+@endforeach

--- a/resources/views/plugins/user/menus/opencurrenttree/menus.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree/menus.blade.php
@@ -10,66 +10,8 @@
 
 @section("plugin_contents_$frame->id")
 @if ($pages)
-
     <div class="list-group mb-0" role="navigation" aria-label="メニュー">
-    @foreach($pages as $page)
-
-        {{-- 子供のページがある場合 --}}
-        @if (count($page->children) > 0)
-
-            {{-- 非表示のページは対象外(非表示の判断はこのページのみで、子のページはそのページでの判断を行う) --}}
-            @if ($page->isView(Auth::user(), false, true, $page_roles))
-
-                {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
-                @if ($page->id == $page_id)
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }} active" aria-current="page">
-                @else
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }}">
-                @endif
-                    {{-- 各ページの深さをもとにインデントの表現 --}}
-                    @for ($i = 0; $i < $page->depth; $i++)
-                        @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
-                    @endfor
-                    {{$page->page_name}}
-
-                    {{-- メニュー設定が生成されていて、表示する子ページがあり、カレントもしくは自分のルート筋なら＋、違えば－を表示する --}}
-                    @if ($menu && $page->existChildrenPagesToDisplay($page->children))
-                        @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
-                            {!!$menu->getFolderCloseFont()!!}
-                        @else
-                            {!!$menu->getFolderOpenFont()!!}
-                        @endif
-                    @endif
-                </a>
-            @endif
-
-            {{-- カレントもしくは自分のルート筋なら表示する --}}
-            @if ($page->isAncestorOf($current_page) || $current_page->id == $page->id)
-                {{-- 子要素を再帰的に表示するため、別ファイルに分けてinclude --}}
-                @foreach($page->children as $children)
-                    @include('plugins.user.menus.opencurrenttree.menu_children',['children' => $children, 'page_id' => $page_id])
-                @endforeach
-            @endif
-        @else
-
-            {{-- 非表示のページは対象外 --}}
-            @if ($page->isView(Auth::user(), false, true, $page_roles))
-
-                {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
-                @if ($page->id == $page_id)
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item active" aria-current="page">
-                @else
-                <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item">
-                @endif
-                    {{-- 各ページの深さをもとにインデントの表現 --}}
-                    @for ($i = 0; $i < $page->depth; $i++)
-                        @if ($i+1==$children->depth && $menu) {!!$menu->getIndentFont()!!} @else <span class="px-2"></span>@endif
-                    @endfor
-                    {{$page->page_name}}
-                </a>
-            @endif
-        @endif
-    @endforeach
+        @include('plugins.user.menus.opencurrenttree.menu_parent')
     </div>
 @endif
 @endsection


### PR DESCRIPTION
メニュープラグインにハンバーガーメニューテンプレート追加

## 概要
メニュープラグインに、ハンバーガーメニューテンプレート追加
メニュー本体の仕様は「ディレクトリ展開式」をそのまま利用しています。

## DB変更の有無
なし
## チェックリスト

- [ ] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
