### PR TITLE
Add: フォームのコピー機能

### DIFF
--- a/resources/views/plugins/user/forms/default/forms_list_buckets.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_buckets.blade.php
@@ -40,6 +40,12 @@
         <input type="hidden" name="character_code" value="">
     </form>
 
+    {{-- コピー用フォーム --}}
+    <form action="" method="POST" name="form_copy" class="d-inline">
+        {{ csrf_field() }}
+        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/forms/listBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
+    </form>
+
     <script type="text/javascript">
         {{-- ダウンロードのsubmit JavaScript --}}
         function submit_download_shift_jis(id) {
@@ -57,6 +63,14 @@
             form_download.action = "{{url('/')}}/download/plugin/forms/downloadCsv/{{$page->id}}/{{$frame_id}}/" + id;
             form_download.character_code.value = '{{CsvCharacterCode::utf_8}}';
             form_download.submit();
+        }
+
+        function copy_form(form_id) {
+            if( !confirm('フォーム設定と項目設定をコピーして新しいフォームを作成します。\nよろしいですか？') ) {
+                return;
+            }
+            form_copy.action = "{{url('/')}}/redirect/plugin/forms/copyForm/{{$page->id}}/{{$frame_id}}/" + form_id;
+            form_copy.submit();
         }
 
         /**
@@ -102,6 +116,10 @@
                         <a class="btn btn-success btn-sm mr-1" href="{{url('/')}}/plugin/forms/listInputs/{{$page->id}}/{{$frame_id}}/{{$plugin->id}}#frame-{{$frame_id}}">
                             <i class="fas fa-list"></i> 登録一覧
                         </a>
+
+                        <button type="button" class="btn btn-primary btn-sm mr-1" onclick="copy_form({{$plugin->id}});">
+                            <i class="fas fa-copy"></i> コピーして新規
+                        </button>
 
                         <div class="btn-group">
                             <button type="button" class="btn btn-primary btn-sm" onclick="submit_download_shift_jis({{$plugin->id}});">


### PR DESCRIPTION
## 概要

定期的な内容※に関しては、フォーム設定、項目設定が同じなことがあるため、
作成済みのフォームをコピーして作成できるようにしました。

※ 毎年の満足度調査といった年度ごとのアンケート等

フォーム選択画面の詳細列に"コピーして新規"ボタンを設けました。
こちらから、フォームをコピーできます。
違う場所に配置したほうがいい等の意見があればいただきたいです！
<img width="300" alt="image" src="https://user-images.githubusercontent.com/32890286/152511387-31596886-5fda-4f78-8979-dc11279a48c9.png">

## 関連Pull requests/Issues

#1123

## 参考


## DB変更の有無

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
