### PR TITLE
フォームの連番管理でデータ名にフォーム名を表示する

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -1501,10 +1501,7 @@ class FormsPlugin extends UserPluginBase
         // 画面から渡ってくるforms_id が空ならバケツとフォームを新規登録
         if (empty($forms_id)) {
             // バケツの登録
-            $bucket = new Buckets();
-            $bucket->bucket_name = '無題';
-            $bucket->plugin_name = 'forms';
-            $bucket->save();
+            $bucket = $this->saveFormBucket($request->forms_name);
 
             // フォームデータ新規オブジェクト
             $forms = new Forms();
@@ -2463,12 +2460,6 @@ ORDER BY forms_inputs_id, forms_columns_id
      */
     public function copyForm($request, $page_id, $frame_id, $form_id)
     {
-        // バケツの登録
-        $bucket = new Buckets();
-        $bucket->bucket_name = '無題';
-        $bucket->plugin_name = PluginName::forms;
-        $bucket->save();
-
         // formsのコピー
         $form = Forms::find($form_id);
 
@@ -2484,6 +2475,10 @@ ORDER BY forms_inputs_id, forms_columns_id
         if (strlen($forms_name) > self::FORM_NAME_SIZE) {
             $forms_name = mb_strcut($forms_name, 0, self::FORM_NAME_SIZE);
         }
+
+        // バケツの登録
+        $bucket = $this->saveFormBucket($forms_name);
+
         $copy_form->forms_name = $forms_name;
         $copy_form->bucket_id = $bucket->id;
         $copy_form->save();
@@ -2503,5 +2498,20 @@ ORDER BY forms_inputs_id, forms_columns_id
                 $copy_form_column_select->save();
             }
         }
+    }
+
+    /**
+     * フォームのバケツを登録する
+     *
+     * @param string $form_name フォーム名
+     * @return Buckets フォームのバケツ
+     */
+    private function saveFormBucket($form_name)
+    {
+        $bucket = new Buckets();
+        $bucket->bucket_name = $form_name;
+        $bucket->plugin_name = PluginName::forms;
+        $bucket->save();
+        return $bucket;
     }
 }

--- a/database/migrations/2022_02_08_151632_set_form_bucket_name.php
+++ b/database/migrations/2022_02_08_151632_set_form_bucket_name.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Common\Buckets;
+use App\Models\User\Forms\Forms;
+use Illuminate\Database\Migrations\Migration;
+
+class SetFormBucketName extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $forms = Forms::get();
+        foreach ($forms as $form) {
+            $bucket = Buckets::find($form->bucket_id);
+            $bucket->bucket_name = $form->forms_name;
+            $bucket->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $forms = Forms::get();
+        foreach ($forms as $form) {
+            $bucket = Buckets::find($form->bucket_id);
+            $bucket->bucket_name = '無題';
+            $bucket->save();
+        }
+    }
+}


### PR DESCRIPTION
## 概要

フォームの連番管理でデータ名がすべて"無題"となっていました。
buckets.bucket_name（＝連番管理のデータ名）が"無題”固定で登録されていたため、当事象が発生していました。
buckets.bucket_nameにフォーム名を登録するよう修正しました。

既存データを更新するため、マイグレーションありです。

## 関連Pull requests/Issues

#1146 

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無

有り

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
