### PR TITLE
フォーム名更新時にバケツ名も更新する

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -1527,6 +1527,9 @@ class FormsPlugin extends UserPluginBase
             // フォームデータ取得
             $forms = Forms::where('id', $forms_id)->first();
 
+            // バケツ名を入力されたフォーム名で更新
+            $bucket = $this->saveFormBucket($request->forms_name, $forms->bucket_id);
+
             $message = 'フォーム設定を変更しました。';
         }
 
@@ -2504,11 +2507,12 @@ ORDER BY forms_inputs_id, forms_columns_id
      * フォームのバケツを登録する
      *
      * @param string $form_name フォーム名
+     * @param int $bucket_id バケツID
      * @return Buckets フォームのバケツ
      */
-    private function saveFormBucket($form_name)
+    private function saveFormBucket($form_name, $bucket_id = null)
     {
-        $bucket = new Buckets();
+        $bucket = Buckets::findOrNew($bucket_id);
         $bucket->bucket_name = $form_name;
         $bucket->plugin_name = PluginName::forms;
         $bucket->save();

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -2514,7 +2514,7 @@ ORDER BY forms_inputs_id, forms_columns_id
     {
         $bucket = Buckets::findOrNew($bucket_id);
         $bucket->bucket_name = $form_name;
-        $bucket->plugin_name = PluginName::forms;
+        $bucket->plugin_name = PluginName::getPluginName(PluginName::forms);
         $bucket->save();
         return $bucket;
     }


### PR DESCRIPTION
## 概要

フォーム名とバケツ名は同一であるべきものなため、対応しました。
フォームコピー後にフォーム名を修正することが主であるため、バケツ名も更新します。
（フォームをコピーするとフォーム名は「〇〇_copy」となります）

新たに追加した、saveFormBucket()でplugin_nameの登録が他機能と異なっていたので、
合わせて修正しています。
（plugin_nameは全小文字が正しい。先頭大文字になっていました）

## 関連Pull requests/Issues

#1146 

## 参考

## DB変更の有無

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
