### PR TITLE
change: カレンダー, posts.createをループ外で判定

### DIFF
--- a/resources/views/plugins/user/calendars/default/index.blade.php
+++ b/resources/views/plugins/user/calendars/default/index.blade.php
@@ -22,6 +22,13 @@
     </div>
 </div>
 
+{{-- posts.createをループ外で判定 --}}
+@can('posts.create',[[null, $frame->plugin_name, $buckets]])
+    @php $can_posts_create = true; @endphp
+@else
+    @php $can_posts_create = false; @endphp
+@endcan
+
 <table class="table table-bordered">
     <thead>
     <tr class="thead d-none d-md-table-row">
@@ -88,12 +95,12 @@
                         </div>
                     </div>
                     <div class="col-6 text-right">
-                    @can('posts.create',[[null, 'calendars', $buckets]])
+                    @if ($can_posts_create)
                         @if (isset($frame) && $frame->bucket_id)
                             {{-- 新規登録ボタン --}}
                             <a href="{{url('/')}}/plugin/calendars/edit/{{$page->id}}/{{$frame_id}}?date={{$date->format('Y-m-d')}}#frame-{{$frame_id}}"><i class="fas fa-plus"></i></a>
                         @endif
-                    @endcan
+                    @endif
                     </div>
                 </div>
                 {{-- 祝日 --}}

--- a/resources/views/plugins/user/calendars/small_month/index.blade.php
+++ b/resources/views/plugins/user/calendars/small_month/index.blade.php
@@ -15,6 +15,13 @@
     <a href="{{url('/')}}/plugin/calendars/index/{{$page->id}}/{{$frame_id}}?year{{$frame_id}}={{date('Y', strtotime('+1 month', $current_ym_first))}}&month{{$frame_id}}={{date('m', strtotime('+1 month', $current_ym_first))}}#frame-{{$frame_id}}"><i class="fas fa-chevron-circle-right"></i></a>
 </div>
 
+{{-- posts.createをループ外で判定 --}}
+@can('posts.create',[[null, $frame->plugin_name, $buckets]])
+    @php $can_posts_create = true; @endphp
+@else
+    @php $can_posts_create = false; @endphp
+@endcan
+
 <table class="table table-bordered table-sm cc-font-80 mb-1">
     <thead>
     <tr class="thead d-table-row">
@@ -142,12 +149,12 @@
             </div>
 
             <div class="col-6 text-right">
-                @can('posts.create',[[null, 'calendars', $buckets]])
+                @if ($can_posts_create)
                     @if (isset($frame) && $frame->bucket_id)
                         {{-- 新規登録ボタン --}}
                         <a href="{{url('/')}}/plugin/calendars/edit/{{$page->id}}/{{$frame_id}}?date={{$date->format('Y-m-d')}}#frame-{{$frame_id}}"><i class="fas fa-plus"></i></a>
                     @endif
-                @endcan
+                @endif
             </div>
         </div>
 


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

カレンダーの表示パフォーマンス改善です。

posts.createは、投稿権限をチェックする処理です。
カレンダーの月表示では、日毎に「＋」ボタンがある事から、３０回程度同じposts.createチェックが実行されていました。
そのため、ループ外でposts.createをチェックする事で、処理を軽くしました。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし
## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
