### PR TITLE
データベース検索　カードタイプテンプレートの修正

### DIFF
--- a/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
+++ b/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
@@ -14,6 +14,7 @@ use App\Plugins\User\UserPluginBase;
 use App\Plugins\User\Databases\DatabasesTool;
 
 use App\Enums\DatabaseSearcherSortType;
+use App\Enums\StatusType;
 
 /**
  * データベース検索プラグイン
@@ -246,7 +247,8 @@ class DatabasesearchesPlugin extends UserPluginBase
                                 ->join('databases_columns', 'databases_columns.id', '=', 'databases_input_cols.databases_columns_id')
                                 ->join('databases', 'databases.id', '=', 'databases_columns.databases_id')
                                 ->join('frames', 'frames.bucket_id', '=', 'databases.bucket_id')
-                                ->join('databases_inputs', 'databases_inputs.id', '=', 'databases_input_cols.databases_inputs_id')
+                                ->join('databases_inputs', function($join) { $join->on('databases_inputs.id', '=', 'databases_input_cols.databases_inputs_id')
+                                                                                  ->where('databases_inputs.status','=', StatusType::active); })
                                 ->whereIn('databases_inputs_id', $inputs_ids_marge)
                                 ->groupBy('databases_inputs_id')
                                 ->groupBy('frames.id')

--- a/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
@@ -19,46 +19,38 @@
     <div class="row">
         @foreach($inputs_ids as $input_id)
             <div class="col-12 col-sm-6 col-md-6 col-lg-3 p-2 dbsearch_card">
-                <dl>
-                @foreach($view_columns as $view_column)
-                    @php
-                    // 表示項目
-                    $view_col = $input_cols->where('databases_inputs_id', $input_id->databases_inputs_id)
-                                            ->where('column_name', trim($view_column))
-                                            ->first();
-                    @endphp
+                <div class="dbsearch_data_{{$input_id->databases_inputs_id}}">
+                    <a href="{{url('/')}}/plugin/databases/detail/{{$input_id->page_id}}/{{$input_id->frames_id}}/{{$input_id->databases_inputs_id}}#frame-{{$input_id->frames_id}}" style="text-decoration: none; color: initial;">
+                        @foreach($view_columns as $view_column)
+                            @php
+                            // 表示項目
+                            $view_col = $input_cols->where('databases_inputs_id', $input_id->databases_inputs_id)
+                                                    ->where('column_name', trim($view_column))
+                                                    ->first();
+                            @endphp
 
-                    @if($view_col)
-                        @if($loop->first)
-                            <dt class="dbsearch_col_{{$view_col->databases_columns_id}}">
-                            <a href="{{url('/')}}/plugin/databases/detail/{{$input_id->page_id}}/{{$input_id->frames_id}}/{{$input_id->databases_inputs_id}}#frame-{{$input_id->frames_id}}">
-                                @if($view_col->value)
-                                    {{-- 画像の場合はその画像を表示する --}}
-                                    @if ($view_col->column_type == DatabaseColumnType::image)
-                                        <img class="img-fluid" src="{{url('/')}}/file/{{$view_col->value}}">
-                                    @else
-                                        {{$view_col->value}}
-                                    @endif
-                                @else
-                                    (無題)
-                                @endif
-                            </a>
-                            </dt>
-                        @else
-                            <dd class="dbsearch_col_{{$view_col->databases_columns_id}}" style="display: -webkit-box; -webkit-box-orient: vertical; overflow: hidden;">
-                            @if ($view_col->column_type == DatabaseColumnType::wysiwyg)
-                                <span class="column_title">{{$view_column}}：</span><span class="column_value">{!! $view_col->value !!}</span>
-                            @elseif ($view_col->column_type == DatabaseColumnType::image)
-                                <img class="img-fluid" src="{{url('/')}}/file/{{$view_col->value}}">
-                            @else
-                            <span class="column_title">{{$view_column}}：</span><span class="column_value">{{$view_col->value}}</span>
+                            @if($view_col)
+                                <div class="dbsearch_col_{{$view_col->databases_columns_id}}" >
+                                    <p>
+                                        @if ($view_col->column_type == DatabaseColumnType::wysiwyg)
+                                            {{-- wysiwygエディタ項目の場合 --}}
+                                            <span class="column_title">{{$view_column}}：</span><span class="column_value">{!! $view_col->value !!}</span>
+                                        @elseif ($view_col->column_type == DatabaseColumnType::image)
+                                            {{-- 画像項目の場合 --}}
+                                            <img class="img-fluid" src="{{url('/')}}/file/{{$view_col->value}}">
+                                        @elseif ($view_col->column_type == DatabaseColumnType::date)
+                                            {{-- 日付項目の場合 --}}
+                                            <span class="column_title">{{$view_column}}：</span><span class="column_value">@php echo date('Y/m/d', strtotime($view_col->value)) @endphp</span>
+                                        @else
+                                            <span class="column_title">{{$view_column}}：</span><span class="column_value">{{$view_col->value}}</span>
+                                        @endif
+                                    </p>
+                                </div>
                             @endif
-                            </dd>
-                        @endif
-                    @endif
 
-                @endforeach
-                </dl>
+                        @endforeach
+                    </a>
+                </div>
             </div>
         @endforeach
     </div>

--- a/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
@@ -39,6 +39,8 @@
                                             <img class="img-fluid" src="{{url('/')}}/file/{{$view_col->value}}">
                                         @elseif ($view_col->column_type == DatabaseColumnType::date)
                                             {{-- 日付項目の場合 --}}
+                                            {{-- TODO：NC2から移行されてきたデータが「yyyy-mm-dd 00:00:00」で保存されてしまっている
+                                                 移行プログラムが修正されるまでは、データフォーマット処理を入れたままとする。issues:1155 --}}
                                             <p><span class="column_title">{{$view_column}}：</span><span class="column_value">@php echo date('Y/m/d', strtotime($view_col->value)) @endphp</span></p>
                                         @else
                                             <p><span class="column_title">{{$view_column}}：</span><span class="column_value">{{$view_col->value}}</span></p>

--- a/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
@@ -19,7 +19,7 @@
     <div class="row">
         @foreach($inputs_ids as $input_id)
             <div class="col-12 col-sm-6 col-md-6 col-lg-3 p-2 dbsearch_card">
-                <div class="dbsearch_data_{{$input_id->databases_inputs_id}}">
+                <div class="dbsearch_card_data">
                     <a href="{{url('/')}}/plugin/databases/detail/{{$input_id->page_id}}/{{$input_id->frames_id}}/{{$input_id->databases_inputs_id}}#frame-{{$input_id->frames_id}}" style="text-decoration: none; color: initial;">
                         @foreach($view_columns as $view_column)
                             @php

--- a/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
@@ -31,7 +31,6 @@
 
                             @if($view_col)
                                 <div class="dbsearch_col_{{$view_col->databases_columns_id}}" >
-                                    <p>
                                         @if ($view_col->column_type == DatabaseColumnType::wysiwyg)
                                             {{-- wysiwygエディタ項目の場合 --}}
                                             <span class="column_title">{{$view_column}}：</span><span class="column_value">{!! $view_col->value !!}</span>
@@ -40,11 +39,10 @@
                                             <img class="img-fluid" src="{{url('/')}}/file/{{$view_col->value}}">
                                         @elseif ($view_col->column_type == DatabaseColumnType::date)
                                             {{-- 日付項目の場合 --}}
-                                            <span class="column_title">{{$view_column}}：</span><span class="column_value">@php echo date('Y/m/d', strtotime($view_col->value)) @endphp</span>
+                                            <p><span class="column_title">{{$view_column}}：</span><span class="column_value">@php echo date('Y/m/d', strtotime($view_col->value)) @endphp</span></p>
                                         @else
-                                            <span class="column_title">{{$view_column}}：</span><span class="column_value">{{$view_col->value}}</span>
+                                            <p><span class="column_title">{{$view_column}}：</span><span class="column_value">{{$view_col->value}}</span></p>
                                         @endif
-                                    </p>
                                 </div>
                             @endif
 


### PR DESCRIPTION
## 概要
データベース検索のカードタイプテンプレートの修正
・最初の項目のみにリンクを張るのではなく、カード全体にリンクを張るように修正
・カード部にCSSを当てられるようにdivを一つ追加
・項目種別が日付の場合、y/m/d形式で時間が出力されないように修正
・ウィジウィグ以外で文字列が出力された時用に、pタグを追加

## 関連Pull requests/Issues
なし

## 参考
なし

## DB変更の有無
なし

## チェックリスト

- [x] PHP_CodeSnifferを実行して、本PR内に指摘が存在しないことを確認しました。https://github.com/opensource-workshop/connect-cms/wiki/PHP_CodeSniffer
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
