### PR TITLE
データベースの公開終了機能

### DIFF
--- a/app/Models/User/Databases/DatabasesInputs.php
+++ b/app/Models/User/Databases/DatabasesInputs.php
@@ -12,7 +12,7 @@ class DatabasesInputs extends Model
     use UserableNohistory;
 
     // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = ['posted_at'];
+    protected $dates = ['posted_at', 'expires_at'];
 
     // 更新する項目の定義
     protected $fillable = [
@@ -20,6 +20,7 @@ class DatabasesInputs extends Model
         'status',
         'display_sequence',
         'posted_at',
+        'expires_at',
         'first_committed_at',
         'created_at',
         'updated_at'

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3542,7 +3542,7 @@ class DatabasesPlugin extends UserPluginBase
         // 行頭（固定項目） の id 分で+1, 行末に追加で+1 = col+2ずらす
         $rules[$col + 2] = ['required', 'date_format:Y/n/j H:i'];
         // 表示順
-        $rules[$col + 3] = ['nullable', 'numeric'];
+        $rules[$col + 3] = ['present', 'nullable', 'numeric'];
         // 表示終了日時
         $rules[$col + 4] = ['present', 'nullable', 'date_format:Y/n/j H:i', 'after:' . ($col + 2)];
 

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -4005,6 +4005,10 @@ AND databases_inputs.posted_at <= NOW()
                    })
                     ->where('databases_inputs.status', StatusType::active)
                     ->where('databases_inputs.posted_at', '<=', Carbon::now())
+                    ->where(function ($query) {
+                        $query->whereNull('databases_inputs.expires_at')
+                            ->orWhere('databases_inputs.expires_at', '>', Carbon::now());
+                    })
                     ->whereIn('pages.id', $page_ids);
 
             // 全データベースの検索キーワードの絞り込み と カラムの絞り込み

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -1236,8 +1236,10 @@ class DatabasesPlugin extends UserPluginBase
 
         // 固定項目エリア
         $validator_array['column']['posted_at'] = ['required', 'date_format:Y-m-d H:i'];
+        $validator_array['column']['expires_at'] = ['nullable', 'date_format:Y-m-d H:i', 'after:posted_at'];
         $validator_array['column']['display_sequence'] = ['nullable', 'numeric'];
         $validator_array['message']['posted_at'] = '公開日時';
+        $validator_array['message']['expires_at'] = '公開終了日時';
         $validator_array['message']['display_sequence'] = '表示順';
 
         // --- 入力値変換
@@ -1426,6 +1428,9 @@ class DatabasesPlugin extends UserPluginBase
             $databases_inputs->status = $status;
             $databases_inputs->display_sequence = $display_sequence;
             $databases_inputs->posted_at = $request->posted_at . ':00';
+            if ($request->filled('expires_at')) {
+                $databases_inputs->expires_at = $request->expires_at . ':00';
+            }
             $databases_inputs->save();
         } else {
             $databases_inputs = DatabasesInputs::where('id', $id)->first();
@@ -1438,6 +1443,9 @@ class DatabasesPlugin extends UserPluginBase
             $databases_inputs->status = $status;
             $databases_inputs->display_sequence = $display_sequence;
             $databases_inputs->posted_at = $request->posted_at . ':00';
+            if ($request->filled('expires_at')) {
+                $databases_inputs->expires_at = $request->expires_at . ':00';
+            }
             $databases_inputs->update();
         }
 

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3936,6 +3936,10 @@ AND databases_inputs.posted_at <= NOW()
             })
 
             ->where('databases_inputs.status', StatusType::active)
+            ->where(function ($query) {
+                $query->whereNull('databases_inputs.expires_at')
+                    ->orWhere('databases_inputs.expires_at', '>', Carbon::now());
+            })
             ->where('databases_inputs.posted_at', '<=', Carbon::now());
 
         // 全データベースの検索キーワードの絞り込み と カラムの絞り込み

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -2818,8 +2818,10 @@ class DatabasesPlugin extends UserPluginBase
         // 見出し行-末尾（固定項目）
         $csv_array[0]['posted_at'] = '公開日時';
         $csv_array[0]['display_sequence'] = '表示順';
+        $csv_array[0]['expires_at'] = '公開終了日時';
         $copy_base['posted_at'] = '';
         $copy_base['display_sequence'] = '';
+        $copy_base['expires_at'] = '';
 
         // $data_output_flag = falseは、CSVフォーマットダウンロード処理
         if ($data_output_flag) {
@@ -2830,6 +2832,7 @@ class DatabasesPlugin extends UserPluginBase
                                             'databases_inputs.created_at as inputs_created_at',
                                             'databases_inputs.updated_at as inputs_updated_at',
                                             'databases_inputs.posted_at as inputs_posted_at',
+                                            'databases_inputs.expires_at as inputs_expires_at',
                                             'databases_inputs.display_sequence as inputs_display_sequence'
                                         )
                                         ->join('databases_inputs', 'databases_inputs.id', '=', 'databases_input_cols.databases_inputs_id')
@@ -2857,6 +2860,9 @@ class DatabasesPlugin extends UserPluginBase
                     $csv_array[$input_col->databases_inputs_id]['posted_at'] = $databases_inputs->posted_at->format('Y/n/j H:i');
 
                     $csv_array[$input_col->databases_inputs_id]['display_sequence'] = $databases_inputs->display_sequence;
+                    if (!empty($databases_inputs->expires_at)) {
+                        $csv_array[$input_col->databases_inputs_id]['expires_at'] = $databases_inputs->expires_at->format('Y/n/j H:i');
+                    }
 
                     // 登録日型、更新日型、公開日型は $input_cols に含まれないので、初回でセット
                     foreach ($columns as $column) {
@@ -3302,8 +3308,11 @@ class DatabasesPlugin extends UserPluginBase
             // Log::debug('$csv_columns:'. var_export($csv_columns, true));
 
             // 配列の末尾から要素を取り除いて取得。CSVのデータ行の末尾は必ず下記固定項目の想定
-            // 配列末尾：表示順
+            // 配列末尾：公開終了日時
+            // 次の末尾：表示順
             // 次の末尾：公開日時
+            $expires_at = array_pop($csv_columns);
+            $expires_at = new Carbon($expires_at);
             $display_sequence = array_pop($csv_columns);
             $display_sequence = $this->getSaveDisplaySequence($display_sequence, $database->id, $databases_inputs_id);
             $posted_at = array_pop($csv_columns);
@@ -3326,6 +3335,8 @@ class DatabasesPlugin extends UserPluginBase
                 // 公開日時
                 // $databases_inputs->posted_at = $posted_at . ':00';
                 $databases_inputs->posted_at = $posted_at;
+                // 公開終了日時
+                $databases_inputs->expires_at = $expires_at;
                 $databases_inputs->save();
             } else {
                 // 更新
@@ -3339,6 +3350,8 @@ class DatabasesPlugin extends UserPluginBase
                 $databases_inputs->display_sequence = $display_sequence;
                 // 公開日時
                 $databases_inputs->posted_at = $posted_at;
+                // 公開終了日時
+                $databases_inputs->expires_at = $expires_at;
                 $databases_inputs->update();
 
                 // databases_inputs_id（行 id）が渡ってきたら、詳細データは一度消す。その後、登録と同じ処理にする。
@@ -3437,6 +3450,7 @@ class DatabasesPlugin extends UserPluginBase
         // ヘッダ行-末尾（固定項目）
         $header_column_format[] = '公開日時';
         $header_column_format[] = '表示順';
+        $header_column_format[] = '公開終了日時';
 
         // 項目の不足チェック
         $shortness = array_diff($header_column_format, $header_columns);
@@ -3529,6 +3543,8 @@ class DatabasesPlugin extends UserPluginBase
         $rules[$col + 2] = ['required', 'date_format:Y/n/j H:i'];
         // 表示順
         $rules[$col + 3] = ['nullable', 'numeric'];
+        // 表示終了日時
+        $rules[$col + 4] = ['present', 'nullable', 'date_format:Y/n/j H:i', 'after:' . ($col + 2)];
 
         // ヘッダー行が1行目なので、2行目からデータ始まる
         $line_count = 2;
@@ -3620,6 +3636,7 @@ class DatabasesPlugin extends UserPluginBase
             // 行頭（固定項目）の id 分で+1, 行末に追加で+1 = col+2ずらす
             $attribute_names[$col + 2] = $line_count . '行目の公開日時';
             $attribute_names[$col + 3] = $line_count . '行目の表示順';
+            $attribute_names[$col + 4] = $line_count . '行目の公開終了日時';
 
             $validator->setAttributeNames($attribute_names);
             // Log::debug(var_export($attribute_names, true));

--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -1487,6 +1487,14 @@ class UserPluginBase extends PluginBase
             if (Schema::hasColumn($table_name, 'posted_at')) {
                 $query->where($table_name . '.posted_at', '<=', Carbon::now());
             }
+
+            // DBカラム expires_at(終了日時) 存在するか
+            if (Schema::hasColumn($table_name, 'expires_at')) {
+                $query->where(function($query){
+                    $query->whereNull('expires_at')
+                        ->orWhere('expires_at', '>', Carbon::now());
+                });
+            }
         }
 
         return $query;

--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -1490,7 +1490,7 @@ class UserPluginBase extends PluginBase
 
             // DBカラム expires_at(終了日時) 存在するか
             if (Schema::hasColumn($table_name, 'expires_at')) {
-                $query->where(function($query){
+                $query->where(function ($query) {
                     $query->whereNull('expires_at')
                         ->orWhere('expires_at', '>', Carbon::now());
                 });

--- a/database/migrations/2022_03_14_144704_add_expires_at_to_databases_inputs.php
+++ b/database/migrations/2022_03_14_144704_add_expires_at_to_databases_inputs.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddExpiresAtToDatabasesInputs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->dateTime('expires_at')->nullable()->comment('公開終了日時')->after('posted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->dropColumn('expires_at');
+        });
+    }
+}

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -66,7 +66,7 @@ return [
     ],
     'not_in'               => ':attributeには:valuesのうちいずれとも異なる値を指定してください。',
     'numeric'              => ':attributeには数値を指定してください。',
-    'present'              => ':attributeには現在時刻を指定してください。',
+    'present'              => ':attributeが存在していません。',
     'regex'                => '正しい形式の:attributeを指定してください。',
     'required'             => ':attributeは必須です。',
     'required_if'          => ':otherが:valueの時、:attributeは必須です。',

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -32,7 +32,7 @@ return [
     'boolean'              => ':attributeには真偽値を指定してください。',
     'confirmed'            => ':attributeが確認用の値と一致しません。',
     'date'                 => ':attributeには正しい形式の日付、又は、時間を指定してください。',
-    'date_format'          => ':attributeには:format"という形式の日付を指定してください。',
+    'date_format'          => ':attributeには":format"という形式の日付を指定してください。',
     'different'            => ':attributeには:otherとは異なる値を指定してください。',
     'digits'               => ':attributeには:digits桁の数値を指定してください。',
     'digits_between'       => ':attributeには:min〜:max桁の数値を指定してください。',

--- a/resources/views/plugins/user/databases/card_02/databases.blade.php
+++ b/resources/views/plugins/user/databases/card_02/databases.blade.php
@@ -86,6 +86,14 @@
                                     <span class="badge badge-warning align-bottom">一時保存</span>
                                 @endif
 
+                                @if (!empty($input->expires_at) && $input->expires_at <= Carbon::now())
+                                    <span class="badge badge-secondary align-bottom">公開終了</span>
+                                @endif
+
+                                @if ($input->posted_at > Carbon::now())
+                                    <span class="badge badge-info align-bottom">公開前</span>
+                                @endif
+
                                 <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}'">
                                     <i class="far fa-edit"></i> 編集
                                 </button>

--- a/resources/views/plugins/user/databases/default/databases.blade.php
+++ b/resources/views/plugins/user/databases/default/databases.blade.php
@@ -81,6 +81,14 @@
                                 <span class="badge badge-warning align-bottom">一時保存</span>
                             @endif
 
+                            @if (!empty($input->expires_at) && $input->expires_at <= Carbon::now())
+                                <span class="badge badge-secondary align-bottom">公開終了</span>
+                            @endif
+
+                            @if ($input->posted_at > Carbon::now())
+                                <span class="badge badge-info align-bottom">公開前</span>
+                            @endif
+
                             <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}'">
                                 <i class="far fa-edit"></i> 編集
                             </button>

--- a/resources/views/plugins/user/databases/default/databases_confirm.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_confirm.blade.php
@@ -178,6 +178,14 @@ use App\Models\User\Databases\DatabasesColumns;
         </div>
     </div>
 
+    <div class="form-group row">
+        <label class="col-sm-3 control-label text-nowrap">公開終了日時</label>
+        <div class="col-sm-9">
+            {{$request->expires_at}}
+            <input name="expires_at" class="form-control" type="hidden" value="{{$request->expires_at}}">
+        </div>
+    </div>
+
     @if ($is_hide_posted)
         <input name="display_sequence" type="hidden" value="{{$request->display_sequence}}">
     @else

--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -24,7 +24,7 @@ use App\Models\User\Databases\DatabasesColumns;
          * 公開日時のカレンダーボタン押下
          */
         $(function () {
-            $('#posted_at{{$frame_id}}').datetimepicker({
+            $('#posted_at{{$frame_id}}, #expires_at{{$frame_id}}').datetimepicker({
                 @if (App::getLocale() == ConnectLocale::ja)
                     dayViewHeaderFormat: 'YYYY年 M月',
                 @endif
@@ -79,6 +79,19 @@ use App\Models\User\Databases\DatabasesColumns;
                     </div>
                 </div>
                 @include('plugins.common.errors_inline', ['name' => 'posted_at'])
+            </div>
+        </div>
+
+        <div class="form-group row">
+            <label class="col-sm-3 control-label">公開終了日時</label>
+            <div class="col-sm-9">
+                <div class="input-group date" id="expires_at{{$frame_id}}" data-target-input="nearest">
+                    <input type="text" name="expires_at" value="{{old('expires_at', $inputs->expires_at)}}" class="form-control datetimepicker-input @if ($errors && $errors->has('expires_at')) border-danger @endif" data-target="#expires_at{{$frame_id}}">
+                    <div class="input-group-append" data-target="#expires_at{{$frame_id}}" data-toggle="datetimepicker">
+                        <div class="input-group-text @if ($errors && $errors->has('expires_at')) border-danger @endif"><i class="far fa-clock"></i></div>
+                    </div>
+                </div>
+                @include('plugins.common.errors_inline', ['name' => 'expires_at'])
             </div>
         </div>
 


### PR DESCRIPTION
## 概要

データベースの１データに公開終了日時を持たせて、到来時に自動で閲覧不可にする機能を追加しました。

### 機能追加

- データの新規登録画面に公開終了日時を追加
- CSVエクスポート機能に公開終了日時を追加
- CSVインポート機能に公開終了日時を追加
- データベースの新着情報について、公開終了データは対象外とする
- データベースのサイト内検索について、公開終了データは対象外とする

### 修正内容

- CSVインポート機能の項目不足でエラーとする
  - データ行で表示順がＣＳＶの項目として抜けててもエラーとなっていなかった
  - ヘッダーは項目抜けをチェックしていたので、合わせる形で修正
- Laravel のバリデーション　日本語エラーメッセージ修正
  - present : 正しい日本語訳に修正
  - date_format : typo修正（開くダブルクォーテーションが抜けていた） 

## 関連Pull requests/Issues

#1207 

## 参考


## DB変更の有無

有り

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
