### PR TITLE
Fix: モデレータでユーザ登録すると登録完了後の遷移先で権限なしエラーとなる

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -132,8 +132,8 @@ class RegisterController extends Controller
      */
     protected function create(array $data)
     {
-        // ユーザ自動登録の場合（認証されていない）は、トップページに遷移する。
-        if (!Auth::user()) {
+        // ユーザ自動登録の場合（認証されていない）、もしくはユーザ管理者以外は、トップページに遷移する。
+        if (!Auth::user() || !Auth::user()->can('admin_user')) {
             $this->redirectTo = '/';
         }
 


### PR DESCRIPTION
## 概要

モデレータには遷移先だったユーザー管理画面の閲覧権限がないので、遷移先をルートにすることでエラーとならないようにしました。

## 関連Pull requests/Issues

* #1211

## 参考


## DB変更の有無

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
