### PR TITLE
Add: 自動ユーザ登録の管理者承認機能

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -3,7 +3,7 @@ name: PHPCS check
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - '**.php'
       - '!bootstrap/**'

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,6 +1,22 @@
 name: PHPCS check
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.php'
+      - '!bootstrap/**'
+      - '!config/**'
+      - '!database/**'
+      - '!node_modules/**'
+      - '!routes/**'
+      - '!resources/**'
+      - '!storage/**'
+      - '!vendor/**'
+      - '!server.php'
+      - '!app/Console/Kernel.php'
+      - '!tests/CreatesApplication.php'
   pull_request:
   workflow_dispatch:
 

--- a/app/Enums/UserStatus.php
+++ b/app/Enums/UserStatus.php
@@ -14,11 +14,13 @@ final class UserStatus extends EnumsBase
     const not_active = 1;
     const temporary_delete = 3;
     const temporary = 2;
+    const pending_approval = 4;
 
     // key/valueの連想配列
     const enum = [
         self::active => '利用可能',
         self::not_active => '利用不可',
+        self::pending_approval  => '承認待ち',
         self::temporary_delete => '仮削除',
         self::temporary => '仮登録',
     ];

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -145,7 +145,7 @@ class RegisterController extends Controller
         // ただし、承認待ちより仮登録を優先する（仮登録でメールアドレスの正当性を担保した後に承認待ちにする）
         $status = $data['status'];
         if (Configs::getConfigsValue($configs, 'user_registration_require_approval')
-            && $data['status'] != UserStatus::temporary && (!Auth::user() || !Auth::user()->can('admin_user')) ) {
+            && $data['status'] != UserStatus::temporary && (!Auth::user() || !Auth::user()->can('admin_user'))) {
             $status = UserStatus::pending_approval;
         }
 

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Enums\UserStatus;
 use App\Http\Controllers\Controller;
 //use App\Providers\RouteServiceProvider;
 use App\User;
@@ -137,15 +138,17 @@ class RegisterController extends Controller
             $this->redirectTo = '/';
         }
 
-        // ユーザ登録
-        // change: ユーザーの追加項目に対応
-        // return User::create([
-        //     'name' => $data['name'],
-        //     'email' => $data['email'],
-        //     'userid' => $data['userid'],
-        //     'password' => bcrypt($data['password']),
-        //     'status' => $data['status'],
-        // ]);
+        // 設定の取得
+        $configs = Configs::get();
+
+        // ユーザー登録に承認が必要な場合は、強制的にステータスを承認待ちにする
+        // ただし、承認待ちより仮登録を優先する（仮登録でメールアドレスの正当性を担保した後に承認待ちにする）
+        $status = $data['status'];
+        if (Configs::getConfigsValue($configs, 'user_registration_require_approval')
+            && $data['status'] != UserStatus::temporary && (!Auth::user() || !Auth::user()->can('admin_user')) ) {
+            $status = UserStatus::pending_approval;
+        }
+
         $user = User::create([
             'name' => $data['name'],
             'email' => $data['email'],
@@ -153,7 +156,7 @@ class RegisterController extends Controller
             // change to laravel6.
             // 'password' => bcrypt($data['password']),
             'password' => Hash::make($data['password']),
-            'status' => $data['status'],
+            'status' => $status,
         ]);
 
         //// ユーザーの追加項目の登録.

--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -378,7 +378,7 @@ trait RegistersUsers
             ]);
         }
 
-        if ($user->status == \UserStatus::active) {
+        if ($user->status == \UserStatus::active || $user->status == \UserStatus::pending_approval) {
             // session()->flash('flash_message_for_header', '既に認証済みです。登録したログインID、パスワードでログインしてください。');
             // return redirect(RouteServiceProvider::HOME);
             // エラー画面へ
@@ -441,7 +441,7 @@ trait RegistersUsers
             ]);
         }
 
-        if ($user->status == \UserStatus::active) {
+        if ($user->status == \UserStatus::active || $user->status == \UserStatus::pending_approval) {
             // session()->flash('flash_message_for_header', '既に認証済みです。登録したログインID、パスワードでログインしてください。');
             // return redirect(RouteServiceProvider::HOME);
             // エラー画面へ
@@ -451,7 +451,13 @@ trait RegistersUsers
         }
 
         // 登録完了
-        $user->status = \UserStatus::active;
+        if (Configs::getConfigsValue($configs, 'user_registration_require_approval')) {
+            // 承認要のため承認待ち
+            $user->status = \UserStatus::pending_approval;
+        } else {
+            // 承認不要なので利用可能に
+            $user->status = \UserStatus::active;
+        }
         $user->save();
 
         // 本登録時のメール送信

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -676,6 +676,10 @@ class UserManage extends ManagePluginBase
             return redirect()->back()->withErrors($validator)->withInput();
         }
 
+        // 更新前のステータス（承認完了判定用）
+        $user = User::find($id);
+        $before_status = $user ? $user->status : null;
+
         // 更新内容の配列
         $update_array = [
             'name'     => $request->name,
@@ -755,6 +759,12 @@ class UserManage extends ManagePluginBase
                     'role_value' => 1
                 ]);
             }
+        }
+
+        // 承認完了メール送信
+        if ($before_status === UserStatus::pending_approval
+            && (int)$request->status === UserStatus::active) {
+            $this->sendMailApproved($user);
         }
 
         // 変更画面に戻る
@@ -1065,6 +1075,15 @@ class UserManage extends ManagePluginBase
             ]
         );
 
+        // 管理者の承認
+        $configs = Configs::updateOrCreate(
+            ['name' => 'user_registration_require_approval'],
+            [
+                'category' => 'user_register',
+                'value' => $request->user_registration_require_approval
+            ]
+        );
+
         // 以下のアドレスにメール送信する
         $configs = Configs::updateOrCreate(
             ['name' => 'user_register_mail_send_flag'],
@@ -1152,6 +1171,24 @@ class UserManage extends ManagePluginBase
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_after_message
+            ]
+        );
+
+        // 承認完了メール件名
+        $configs = Configs::updateOrCreate(
+            ['name' => 'user_register_approved_mail_subject'],
+            [
+                'category' => 'user_register',
+                'value' => $request->user_register_approved_mail_subject
+            ]
+        );
+
+        // 承認完了メールフォーマット
+        $configs = Configs::updateOrCreate(
+            ['name' => 'user_register_approved_mail_format'],
+            [
+                'category' => 'user_register',
+                'value' => $request->user_register_approved_mail_format
             ]
         );
 
@@ -1911,5 +1948,37 @@ class UserManage extends ManagePluginBase
             "user" => $user,
             "users_login_histories" => $users_login_histories,
         ]);
+    }
+
+    /**
+     * 承認完了メールを送信する
+     *
+     * @param User $user 承認したユーザ
+     */
+    private function sendMailApproved($user)
+    {
+        $configs = Configs::get();
+        // 登録者にメール送信する
+        $user_register_user_mail_send_flag = Configs::getConfigsValue($configs, 'user_register_user_mail_send_flag');
+
+        // メール送信
+        if ($user_register_user_mail_send_flag && $user->email) {
+            // メール件名の組み立て
+            $subject = Configs::getConfigsValue($configs, 'user_register_approved_mail_subject');
+
+            // メール件名内のサイト名文字列を置換
+            $subject = str_replace('[[site_name]]', Configs::getConfigsValue($configs, 'base_site_name'), $subject);
+
+            // メール本文の組み立て
+            $mail_text = Configs::getConfigsValue($configs, 'user_register_approved_mail_format');
+            // メール本文内のサイト名文字列を置換
+            $mail_text = str_replace('[[site_name]]', Configs::getConfigsValue($configs, 'base_site_name'), $mail_text);
+            $mail_text = str_replace('[[login_id]]', $user->userid, $mail_text);
+
+            // メールオプション
+            $mail_options = ['subject' => $subject, 'template' => 'mail.send'];
+
+            $this->sendMail($user->email, $mail_options, ['content' => $mail_text], 'RegistersUsers');
+        }
     }
 }

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1987,6 +1987,7 @@ class UserManage extends ManagePluginBase
 
             $this->sendMail($user->email, $mail_options, ['content' => $mail_text], 'RegistersUsers');
         }
+    }
 
     /**
      * メール送信画面

--- a/app/Traits/ConnectCommonTrait.php
+++ b/app/Traits/ConnectCommonTrait.php
@@ -440,7 +440,8 @@ trait ConnectCommonTrait
         // 利用不可・仮登録・仮削除ならfalse
         if ($user->status == UserStatus::not_active ||
                 $user->status == UserStatus::temporary ||
-                $user->status == UserStatus::temporary_delete) {
+                $user->status == UserStatus::temporary_delete ||
+                $user->status == UserStatus::pending_approval) {
 
             $error_msg = UserStatus::getDescription($user->status) . "のため、ログインできません。";
             return false;

--- a/app/User.php
+++ b/app/User.php
@@ -75,6 +75,9 @@ class User extends Authenticatable
         } elseif ($this->status == UserStatus::temporary_delete) {
             // 仮削除
             return "cc-bg-red";
+        } elseif ($this->status == UserStatus::pending_approval) {
+            // 承認待ち
+            return "bg-info";
         }
         return "";
     }
@@ -167,6 +170,12 @@ class User extends Authenticatable
 
         // 登録の時は 仮削除 を選択させない
         if (!$is_function_edit && $enum_value == UserStatus::temporary_delete) {
+            return "disabled";
+        }
+
+        // 承認待ち以外のステータスから承認待ちへできないようにする
+        if ($enum_value ===  UserStatus::pending_approval
+            && $this->status !== UserStatus::pending_approval) {
             return "disabled";
         }
 

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -45,6 +45,25 @@
                 </div>
             </div>
 
+            {{-- 承認要否 --}}
+            @php
+                $require_approval = Configs::getConfigsValueAndOld($configs, 'user_registration_require_approval', '0');
+            @endphp
+            <div class="form-group row">
+                <label class="col-md-3 col-form-label text-md-right pt-0">管理者の承認</label>
+                <div class="col pt-0">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        <input type="radio" value="1" id="require_approval_enable" name="user_registration_require_approval" class="custom-control-input" @if ($require_approval === '1') checked="checked" @endif>
+                        <label class="custom-control-label" for="require_approval_enable" id="label_require_approval_enable">必要</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        <input type="radio" value="0" id="require_approval_disable" name="user_registration_require_approval" class="custom-control-input" @if ($require_approval === '0') checked="checked" @endif>
+                        <label class="custom-control-label" for="require_approval_disable" id="label_require_approval_disable">不要</label>
+                    </div>
+                    <small class="form-text text-muted">ユーザ登録に管理者の承認が必要か選択してください。</small>
+                </div>
+            </div>
+
             {{-- 自動ユーザ登録時に以下のアドレスにメール送信する --}}
             <div class="form-group row">
                 <label class="col-md-3 col-form-label text-md-right pt-0">メール送信先</label>
@@ -152,6 +171,9 @@
                     <small class="text-muted">
                         ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
                     </small>
+                    <small class="text-danger">
+                        ※ 管理者の承認を必要にしている場合は、本登録メールが登録申請メールとなります。
+                    </small>
                 </div>
             </div>
 
@@ -171,7 +193,33 @@
                 <label class="col-md-3 col-form-label text-md-right">本登録後のメッセージ</label>
                 <div class="col">
                     <input type="text" name="user_register_after_message" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_after_message')}}" class="form-control">
-                    <small class="text-muted">※ （例）ユーザ登録が完了しました。登録したログインID、パスワードでログインしてください。</small>
+                    <small class="text-muted">※ （例）ユーザ登録が完了しました。登録したログインID、パスワードでログインしてください。<br></small>
+                    <small class="text-danger">※ 管理者の承認を必要にしている場合は、本登録後のメッセージが登録申請後のメッセージとなります。<br></small>
+                    <small class="text-muted">（例）ユーザの登録申請が完了しました。承認をお待ちください。</small>
+                </div>
+            </div>
+
+            {{-- 承認完了メール --}}
+            <div class="form-group row">
+                <label class="col-md-3 col-form-label text-md-right pt-0">承認完了メール</label>
+                <div class="col">
+                    <label class="control-label">承認完了メール件名</label>
+                    <input type="text" name="user_register_approved_mail_subject" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_approved_mail_subject')}}" class="form-control">
+                    <small class="text-muted">
+                        ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                    </small>
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <label class="col-md-3 col-form-label text-md-right"></label>
+                <div class="col">
+                    <label class="control-label">承認完了メールフォーマット</label>
+                    <textarea name="user_register_approved_mail_format" class="form-control" rows=5 placeholder="（例）ユーザー登録が承認されました。&#13;&#10;登録したログインID、パスワードでログインしてください。&#13;&#10;----------------------------------&#13;&#10;[[body]]&#13;&#10;----------------------------------">{{Configs::getConfigsValueAndOld($configs, 'user_register_approved_mail_format')}}</textarea>
+                    <small class="text-muted">
+                        ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                        ※ [[login_id]] を記述すると該当部分に登録内容が入ります。<br>
+                    </small>
                 </div>
             </div>
 

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -168,12 +168,6 @@
                 <div class="col">
                     <label class="control-label">本登録メール件名</label>
                     <input type="text" name="user_register_mail_subject" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_mail_subject')}}" class="form-control">
-                    <small class="text-muted">
-                        ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
-                    </small>
-                    <small class="text-danger">
-                        ※ 管理者の承認を必要にしている場合は、本登録メールが登録申請メールとなります。
-                    </small>
                 </div>
             </div>
 
@@ -183,6 +177,9 @@
                     <label class="control-label">本登録メールフォーマット</label>
                     <textarea name="user_register_mail_format" class="form-control" rows=5 placeholder="（例）登録内容をお知らせいたします。&#13;&#10;----------------------------------&#13;&#10;[[body]]&#13;&#10;----------------------------------">{{Configs::getConfigsValueAndOld($configs, 'user_register_mail_format')}}</textarea>
                     @include('plugins.common.description_frame_mails_common', ['embedded_tags' => UserRegisterNoticeEmbeddedTag::getDescriptionEmbeddedTags()])
+                    <small class="text-danger">
+                        ※ 管理者の承認を必要にしている場合は、本登録メールが登録申請メールとなります。
+                    </small>
                 </div>
             </div>
 


### PR DESCRIPTION
## 概要

自動ユーザ登録に管理者承認機能を追加しました。
承認がないと、利用可能とならないようにできます。

承認機能を実現するため、ユーザの状態に”承認待ち”を新たに設けます。

ユーザが公開側のユーザ登録画面（/register）から登録した場合、状態が"承認待ち"になります。
（この操作を登録申請とします）
ただし、仮登録設定が有効の場合は、状態が"仮登録"となり、
メールアドレスの有効性を確認した後で、 "承認待ち"になります。

まとめると、ユーザの状態は以下のように遷移します。

- 仮登録が有効の場合
  - 仮登録→承認待ち→利用可能
- 仮登録が無効の場合
  - 承認待ち→利用可能

管理者はユーザ詳細画面から状態を変更することで登録申請の承認を行えます。

### 機能追加

- ユーザ管理 ユーザ一覧画面
  - 絞り込み条件：状態に"承認待ち"を追加
  - 一覧の承認待ち行の背景色をbg-infoで表示
- ユーザ管理 ユーザ登録画面、ユーザ詳細画面
  - 状態の選択肢に承認待ちを追加
    - 一度、承認待ち以外にすると承認待ちは選択できないようになる
    - 承認待ちから利用可能に変更すると、承認完了メールが飛ぶ
- ユーザ管理 自動ユーザ登録設定画面
  - 以下の設定を追加
    - 管理者の承認
    - 承認完了メール件名
    - 承認完了メールフォーマット

### 機能変更

- ユーザ登録画面
  - 承認機能が有効の場合、状態を"承認待ち"で登録する（仮登録が有効の場合を除く）
- トークンを使った本登録の確定画面
  - 承認機能が有効の場合、状態を"承認待ち"に更新する

## 関連Pull requests/Issues

#1220

## 参考


## DB変更の有無

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
