### PR TITLE
Add: 自動ユーザ登録の初期権限を選択可能にする

### DIFF
--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -140,12 +140,12 @@ trait RegistersUsers
             }
         }
 
-        // ユーザー自動登録（未ログイン）の場合、.env のSELF_REGISTER_ROLE を元に権限登録する。
+        // ユーザー自動登録（未ログイン、ユーザ管理者以外）の場合、.env のSELF_REGISTER_ROLE を元に権限登録する。
         // envの設定がなければ、自動ユーザ登録設定をもとに権限を登録する
-        if (!Auth::user()) {
+        if (!Auth::user() || !$this->isCan('admin_user')) {
             $self_register_base_roles_env = '';
             if (config('connect.SELF_REGISTER_BASE_ROLES') !== null) {
-            $self_register_base_roles_env = config('connect.SELF_REGISTER_BASE_ROLES');
+                $self_register_base_roles_env = config('connect.SELF_REGISTER_BASE_ROLES');
             } else {
                 $self_register_base_roles_env = Configs::getConfigsValue($configs, 'user_register_base_roles');
             }
@@ -165,8 +165,8 @@ trait RegistersUsers
             }
         }
 
-        // ユーザー自動登録（未ログイン）
-        if (!Auth::user()) {
+        // ユーザー自動登録（未ログイン、ユーザ管理者以外）
+        if (!Auth::user() || !$this->isCan('admin_user')) {
             // session()->flash('flash_message_for_header', 'ユーザ登録が完了しました。登録したログインID、パスワードでログインしてください。');
 
 

--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -141,8 +141,14 @@ trait RegistersUsers
         }
 
         // ユーザー自動登録（未ログイン）の場合、.env のSELF_REGISTER_ROLE を元に権限登録する。
+        // envの設定がなければ、自動ユーザ登録設定をもとに権限を登録する
         if (!Auth::user()) {
+            $self_register_base_roles_env = '';
+            if (config('connect.SELF_REGISTER_BASE_ROLES') !== null) {
             $self_register_base_roles_env = config('connect.SELF_REGISTER_BASE_ROLES');
+            } else {
+                $self_register_base_roles_env = Configs::getConfigsValue($configs, 'user_register_base_roles');
+            }
             $self_register_base_roles = array();
             if (!empty($self_register_base_roles_env)) {
                 $self_register_base_roles = explode(',', $self_register_base_roles_env);

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1183,6 +1183,17 @@ class UserManage extends ManagePluginBase
             ]
         );
 
+        // 初期コンテンツ権限
+        // 空要素の削除
+        $base_roles = array_filter($request->base_roles, 'strlen');
+        $configs = Configs::updateOrCreate(
+            ['name' => 'user_register_base_roles'],
+            [
+                'category' => 'user_register',
+                'value' => $base_roles ? implode(',', $base_roles) : '',
+            ]
+        );
+
         // ページ管理画面に戻る
         return redirect("/manage/user/autoRegist");
     }

--- a/config/connect.php
+++ b/config/connect.php
@@ -75,7 +75,7 @@ return [
     'LOGIN_PATH' => env('LOGIN_PATH', 'login'),
 
     // Self register base role.(comma separator. Not set is guest)
-    'SELF_REGISTER_BASE_ROLES' => env('SELF_REGISTER_BASE_ROLES', ''),
+    'SELF_REGISTER_BASE_ROLES' => env('SELF_REGISTER_BASE_ROLES', null),
 
     // Custom message.
     'cc_lang_ja_messages_search_results_empty' => env('cc_lang_ja_messages_search_results_empty'),

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -212,6 +212,69 @@
                 </div>
             </div>
 
+            {{-- 初期コンテンツ権限 --}}
+            @php
+                $base_roles = [];
+                $use_base_role_env = false;
+
+                // envの設定を優先して利用する
+                if (config('connect.SELF_REGISTER_BASE_ROLES') !== null) {
+                    $base_roles = explode(',', config('connect.SELF_REGISTER_BASE_ROLES'));
+                    $use_base_role_env = true;
+                } else {
+                    $base_roles = explode(',', Configs::getConfigsValue($configs, "user_register_base_roles"));
+                    if (old('base_roles') !== null && is_array(old('base_roles'))) {
+                        $base_roles = old('base_roles');
+                    }
+                }
+            @endphp
+            <div class="form-group row">
+                <label class="col-md-3 col-form-label text-md-right pt-0">初期コンテンツ権限</label>
+                <div class="col-md-9">
+                    <input type="hidden" name="base_roles[]" value="">
+                    <div class="custom-control custom-checkbox">
+                        <input name="base_roles[]" value="role_article_admin" type="checkbox" class="custom-control-input" id="role_article_admin"
+                            @if (in_array('role_article_admin', $base_roles)) checked="checked" @endif
+                            @if ($use_base_role_env) disabled="disabled" @endif
+                        >
+                        <label class="custom-control-label" for="role_article_admin" id="label_role_article_admin">コンテンツ管理者</label>
+                    </div>
+                    <div class="custom-control custom-checkbox">
+                        <input name="base_roles[]" value="role_arrangement" type="checkbox" class="custom-control-input" id="role_arrangement"
+                            @if (in_array('role_arrangement', $base_roles))  checked="checked" @endif
+                            @if ($use_base_role_env) disabled="disabled" @endif
+                        >
+                        <label class="custom-control-label" for="role_arrangement" id="label_role_arrangement">プラグイン管理者</label>
+                    </div>
+                    <div class="custom-control custom-checkbox">
+                        <input name="base_roles[]" value="role_article" type="checkbox" class="custom-control-input" id="role_article"
+                            @if (in_array('role_article', $base_roles))  checked="checked" @endif
+                            @if ($use_base_role_env) disabled="disabled" @endif
+                        >
+                        <label class="custom-control-label" for="role_article" id="label_role_article">モデレータ（他ユーザの記事も更新）</label>
+                    </div>
+                    <div class="custom-control custom-checkbox">
+                        <input name="base_roles[]" value="role_approval" type="checkbox" class="custom-control-input" id="role_approval"
+                            @if (in_array('role_approval', $base_roles))  checked="checked" @endif
+                            @if ($use_base_role_env) disabled="disabled" @endif
+                        >
+                        <label class="custom-control-label" for="role_approval" id="label_role_approval">承認者</label>
+                    </div>
+                    <div class="custom-control custom-checkbox">
+                        <input name="base_roles[]" value="role_reporter" type="checkbox" class="custom-control-input" id="role_reporter"
+                            @if (in_array('role_reporter', $base_roles))  checked="checked" @endif
+                            @if ($use_base_role_env) disabled="disabled" @endif
+                        >
+                        <label class="custom-control-label" for="role_reporter" id="label_role_reporter">編集者</label>
+                    </div>
+                    <small class="text-muted">
+                        ※「編集者」、「モデレータ」の記事投稿については、各プラグイン側の権限設定も必要です。<br />
+                        ※「コンテンツ管理者」は、「コンテンツ管理者」権限と同時に「プラグイン管理者」「モデレータ」「承認者」「編集者」権限も併せて持ちます。<br />
+                        ※ 全てのユーザは、「ゲスト」権限も併せて持ちます。<br />
+                    </small>
+                </div>
+            </div>
+
             {{-- Submitボタン --}}
             <div class="form-group text-center">
                 <button type="submit" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>


### PR DESCRIPTION
## 概要

ユーザ管理 自動ユーザ登録画面で、自動ユーザ登録の初期コンテンツ権限を選択可能にしました。

### 機能追加

- ユーザ管理 自動ユーザ登録画面
  - 初期コンテンツ権限の設定を追加
    - .envの設定を優先して表示し、.envの値からは変更できないようにする
    - .envに設定がなければ、画面から変更可能とする

### 機能変更
- ユーザ登録画面
  - ユーザ管理の初期コンテンツ権限設定を参照して権限を登録する

### 留意事項

すでに.envで初期権限を設定できるようになっていました。(SELF_REGISTER_BASE_ROLES)
既存の仕様を生かすため、.envの方を優先して利用するように改修しています。

## 関連Pull requests/Issues

#1226

## 参考


## DB変更の有無

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
