### PR TITLE
Fix: データベースの公開終了日時を空に更新できない

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -1430,9 +1430,7 @@ class DatabasesPlugin extends UserPluginBase
             $databases_inputs->status = $status;
             $databases_inputs->display_sequence = $display_sequence;
             $databases_inputs->posted_at = $request->posted_at . ':00';
-            if ($request->filled('expires_at')) {
-                $databases_inputs->expires_at = $request->expires_at . ':00';
-            }
+            $databases_inputs->expires_at = $request->filled('expires_at') ? $request->expires_at . ':00' : null;
             $databases_inputs->save();
         } else {
             $databases_inputs = DatabasesInputs::where('id', $id)->first();
@@ -1445,9 +1443,7 @@ class DatabasesPlugin extends UserPluginBase
             $databases_inputs->status = $status;
             $databases_inputs->display_sequence = $display_sequence;
             $databases_inputs->posted_at = $request->posted_at . ':00';
-            if ($request->filled('expires_at')) {
-                $databases_inputs->expires_at = $request->expires_at . ':00';
-            }
+            $databases_inputs->expires_at = $request->filled('expires_at') ? $request->expires_at . ':00' : null;
             $databases_inputs->update();
         }
 


### PR DESCRIPTION
## 概要

値が空で渡ってきたとき、NULLでsaveされていませんでした。
空でリクエストがあったとき、NULLになるよう修正しました。

## 関連Pull requests/Issues

#1233

## 参考


## DB変更の有無

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
