### PR TITLE
【ユーザ管理】ユーザ情報の任意項目の設定画面追加 

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 
 use App\Models\Core\Configs;
+use App\Models\Core\UsersColumns;
+use App\Models\Core\UsersColumnsSelects;
 use App\Models\Core\UsersRoles;
 use App\Models\Core\UsersInputCols;
 use App\Models\Core\UsersLoginHistories;
@@ -31,6 +33,7 @@ use App\Utilities\Csv\CsvUtils;
 use App\Utilities\String\StringUtils;
 
 use App\Enums\CsvCharacterCode;
+use App\Enums\Required;
 use App\Enums\UserColumnType;
 use App\Enums\UserRegisterNoticeEmbeddedTag;
 use App\Enums\UserStatus;
@@ -79,6 +82,19 @@ class UserManage extends ManagePluginBase
         $role_check_table["loginHistory"]       = ['admin_user'];
         $role_check_table["mail"]               = ['admin_user'];
         $role_check_table["mailSend"]           = ['admin_user'];
+        // 項目設定
+        $role_check_table["editColumns"]          = ['admin_site'];
+        $role_check_table["addColumn"]            = ['admin_site'];
+        $role_check_table["updateColumn"]         = ['admin_site'];
+        $role_check_table["updateColumnSequence"] = ['admin_site'];
+        $role_check_table["deleteColumn"]         = ['admin_site'];
+        // 項目詳細設定
+        $role_check_table["editColumnDetail"]     = ['admin_site'];
+        $role_check_table["updateColumnDetail"]   = ['admin_site'];
+        $role_check_table["addSelect"]            = ['admin_site'];
+        $role_check_table["updateSelect"]         = ['admin_site'];
+        $role_check_table["updateSelectSequence"] = ['admin_site'];
+        $role_check_table["deleteSelect"]         = ['admin_site'];
 
         return $role_check_table;
     }
@@ -1900,6 +1916,10 @@ class UserManage extends ManagePluginBase
 
     /**
      * ログイン履歴画面
+     *
+     * @method_title ログイン履歴
+     * @method_desc 今までのログイン日時を確認できます。
+     * @method_detail ログインしてきたIPアドレスやユーザエージェントも確認できます。
      */
     public function loginHistory($request, $id = null)
     {
@@ -1922,6 +1942,10 @@ class UserManage extends ManagePluginBase
 
     /**
      * メール送信画面
+     *
+     * @method_title メール送信
+     * @method_desc ユーザ登録後に登録内容のメールを送信できます。
+     * @method_detail メールアドレスがあった場合のみ当画面を開きます。
      */
     public function mail($request, $id = null)
     {
@@ -1965,5 +1989,372 @@ class UserManage extends ManagePluginBase
 
         // ユーザ管理画面に戻る
         return redirect("/manage/user");
+    }
+
+    /**
+     * 項目設定 初期表示
+     *
+     * @method_title 項目編集
+     * @method_desc ユーザ項目の設定を行います。
+     * @method_detail カラム名と型を指定してカラムを作成します。
+     */
+    public function editColumns($request, $id)
+    {
+        // ユーザーのカラム
+        $columns = UsersTool::getUsersColumns();
+
+        // カラムの選択肢
+        $users_columns_selects = UsersColumnsSelects::select('users_columns_selects.*')
+                ->orderBy('users_columns_selects.users_columns_id', 'asc')
+                ->orderBy('users_columns_selects.display_sequence', 'asc')
+                ->get();
+
+        foreach ($columns as &$column) {
+            $column->select_count = $users_columns_selects->where('users_columns_id', $column->id)->count();
+            $column->select_names = $users_columns_selects->where('users_columns_id', $column->id)->pluck('value')->implode(',');
+        }
+
+        return view('plugins.manage.user.edit_columns', [
+            "function"       => __FUNCTION__,
+            "plugin_name"    => "user",
+            'columns'        => $columns,
+        ]);
+    }
+
+    /**
+     * 項目の登録
+     */
+    public function addColumn($request, $id)
+    {
+        // エラーチェック
+        $validator = Validator::make($request->all(), [
+            'column_name' => ['required'],
+            'column_type' => ['required'],
+        ]);
+        $validator->setAttributeNames([
+            'column_name' => '項目名',
+            'column_type' => '型',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        // 新規登録時の表示順を設定
+        $max_display_sequence = UsersColumns::max('display_sequence');
+        $max_display_sequence = $max_display_sequence ? $max_display_sequence + 1 : 1;
+
+        // 項目の登録処理
+        $column = new UsersColumns();
+        $column->column_name = $request->column_name;
+        $column->column_type = $request->column_type;
+        $column->required = $request->required ? Required::on : Required::off;
+        $column->display_sequence = $max_display_sequence;
+        $column->save();
+        $message = '項目【 '. $request->column_name .' 】を追加しました。';
+
+        // 編集画面を呼び出す
+        return redirect("/manage/user/editColumns")->with('flash_message', $message);
+    }
+
+    /**
+     * 項目の更新
+     */
+    public function updateColumn($request, $id)
+    {
+        // 明細行から更新対象を抽出する為のnameを取得
+        $str_column_name = "column_name_"."$request->column_id";
+        $str_column_type = "column_type_"."$request->column_id";
+        $str_required = "required_"."$request->column_id";
+
+        // エラーチェック
+        $validator = Validator::make($request->all(), [
+            $str_column_name => ['required'],
+            $str_column_type => ['required'],
+        ]);
+        $validator->setAttributeNames([
+            $str_column_name => '項目名',
+            $str_column_type => '型',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        // 項目の更新処理
+        $column = UsersColumns::where('id', $request->column_id)->first();
+        $column->column_name = $request->$str_column_name;
+        $column->column_type = $request->$str_column_type;
+        $column->required = $request->$str_required ? Required::on : Required::off;
+        $column->save();
+        $message = '項目【 '. $request->$str_column_name .' 】を更新しました。';
+
+        // 編集画面を呼び出す
+        return redirect("/manage/user/editColumns")->with('flash_message', $message);
+    }
+
+    /**
+     * 項目の表示順の更新
+     */
+    public function updateColumnSequence($request, $id)
+    {
+        // ボタンが押された行の施設データ
+        $target_column = UsersColumns::where('id', $request->column_id)
+            ->first();
+
+        // ボタンが押された前（後）の施設データ
+        $query = UsersColumns::query();
+        $pair_column = $request->display_sequence_operation == 'up' ?
+            $query->where('display_sequence', '<', $request->display_sequence)->orderby('display_sequence', 'desc')->limit(1)->first() :
+            $query->where('display_sequence', '>', $request->display_sequence)->orderby('display_sequence', 'asc')->limit(1)->first();
+
+        // それぞれの表示順を退避
+        $target_column_display_sequence = $target_column->display_sequence;
+        $pair_column_display_sequence = $pair_column->display_sequence;
+
+        // 入れ替えて更新
+        $target_column->display_sequence = $pair_column_display_sequence;
+        $target_column->save();
+        $pair_column->display_sequence = $target_column_display_sequence;
+        $pair_column->save();
+
+        $message = '項目【 '. $target_column->column_name .' 】の表示順を更新しました。';
+
+        // 編集画面を呼び出す
+        return redirect("/manage/user/editColumns")->with('flash_message', $message);
+    }
+
+    /**
+     * 項目の削除
+     */
+    public function deleteColumn($request, $id)
+    {
+        // 明細行から削除対象の項目名を抽出
+        $str_column_name = "column_name_"."$request->column_id";
+
+        // 項目の削除
+        UsersColumns::destroy('id', $request->column_id);
+
+        // 項目に紐づく選択肢の削除
+        // deleted_id, deleted_nameを自動セットするため、複数件削除する時は collectionのpluck('id')でid配列を取得して destroy()で消す。
+        $select_ids = UsersColumnsSelects::where('users_columns_id', $request->column_id)->pluck('id');
+        UsersColumnsSelects::destroy($select_ids);
+
+        $message = '項目【 '. $request->$str_column_name .' 】を削除しました。';
+
+        // 編集画面を呼び出す
+        return redirect("/manage/user/editColumns")->with('flash_message', $message);
+    }
+
+    /**
+     * 項目の設定画面の表示
+     *
+     * @method_title 項目の詳細編集
+     * @method_desc ユーザ項目の詳細設定を行います。
+     * @method_detail 入力チェック、キャプションやプレースホルダなどを設定できます。
+     */
+    public function editColumnDetail($request, $id)
+    {
+        // --- 画面に値を渡す準備
+        $column = UsersColumns::where('id', $id)->first();
+        if (!$column) {
+            abort(404, 'カラムデータがありません。');
+        }
+
+        $selects = UsersColumnsSelects::where('users_columns_id', $column->id)->orderby('display_sequence')->get();
+
+        return view('plugins.manage.user.edit_column_detail', [
+            "function"       => __FUNCTION__,
+            "plugin_name"    => "user",
+            'column'          => $column,
+            'selects'         => $selects,
+        ]);
+    }
+
+    /**
+     * 項目に紐づく詳細設定の更新
+     */
+    public function updateColumnDetail($request, $id)
+    {
+
+        $validator_values = null;
+        $validator_attributes = null;
+
+        // 桁数チェックの指定時、入力値が数値であるかチェック
+        if ($request->rule_digits_or_less) {
+            $validator_values['rule_digits_or_less'] = [
+                'numeric',
+            ];
+            $validator_attributes['rule_digits_or_less'] = '入力桁数';
+        }
+        // 最大値の指定時、入力値が数値であるかチェック
+        if ($request->rule_max) {
+            $validator_values['rule_max'] = [
+                'numeric',
+            ];
+            $validator_attributes['rule_max'] = '最大値';
+        }
+        // 最小値の指定時、入力値が数値であるかチェック
+        if ($request->rule_min) {
+            $validator_values['rule_min'] = [
+                'numeric',
+            ];
+            $validator_attributes['rule_min'] = '最小値';
+        }
+        // 入力文字数の指定時、入力値が数値であるかチェック
+        if ($request->rule_word_count) {
+            $validator_values['rule_word_count'] = [
+                'numeric',
+            ];
+            $validator_attributes['rule_word_count'] = '入力最大文字数';
+        }
+
+        // エラーチェック
+        if ($validator_values) {
+            $validator = Validator::make($request->all(), $validator_values);
+            $validator->setAttributeNames($validator_attributes);
+
+            if ($validator->fails()) {
+                return redirect()->back()->withErrors($validator)->withInput();
+            }
+        }
+
+
+        $column = UsersColumns::where('id', $request->column_id)->first();
+
+        // 項目の更新処理
+        $column->caption = $request->caption;
+        $column->caption_color = $request->caption_color;
+        $column->place_holder = $request->place_holder;
+        // 数値のみ許容
+        $column->rule_allowed_numeric = (empty($request->rule_allowed_numeric)) ? 0 : $request->rule_allowed_numeric;
+        // 英数値のみ許容
+        $column->rule_allowed_alpha_numeric = (empty($request->rule_allowed_alpha_numeric)) ? 0 : $request->rule_allowed_alpha_numeric;
+        // 入力桁数
+        $column->rule_digits_or_less = $request->rule_digits_or_less;
+        // 入力文字数
+        $column->rule_word_count = $request->rule_word_count;
+        // 最大値
+        $column->rule_max = $request->rule_max;
+        // 最小値
+        $column->rule_min = $request->rule_min;
+        // 正規表現
+        $column->rule_regex = $request->rule_regex;
+
+        // 保存
+        $column->save();
+
+        $message = '項目【 '. $column->column_name .' 】の詳細設定を更新しました。';
+
+        return redirect("/manage/user/editColumnDetail/" . $request->column_id)->with('flash_message', $message);
+    }
+
+    /**
+     * 予約詳細項目（選択肢）の登録
+     */
+    public function addSelect($request, $id)
+    {
+        // エラーチェック
+        $validator = Validator::make($request->all(), [
+            'select_name'  => ['required'],
+        ]);
+        $validator->setAttributeNames([
+            'select_name'  => '選択肢名',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        // 新規登録時の表示順を設定
+        $max_display_sequence = UsersColumnsSelects::where('users_columns_id', $request->column_id)->max('display_sequence');
+        $max_display_sequence = $max_display_sequence ? $max_display_sequence + 1 : 1;
+
+        // 施設の登録処理
+        $select = new UsersColumnsSelects();
+        $select->users_columns_id = $request->column_id;
+        $select->value = $request->select_name;
+        $select->display_sequence = $max_display_sequence;
+        $select->save();
+        $message = '選択肢【 '. $request->select_name .' 】を追加しました。';
+
+        // 編集画面を呼び出す
+        return redirect("/manage/user/editColumnDetail/" . $request->column_id)->with('flash_message', $message);
+    }
+
+    /**
+     * 選択肢の更新
+     */
+    public function updateSelect($request, $id)
+    {
+        // 明細行から更新対象を抽出する為のnameを取得
+        $str_select_name = "select_name_"."$request->select_id";
+
+        // エラーチェック
+        $validator = Validator::make($request->all(), [
+            $str_select_name => ['required'],
+        ]);
+        $validator->setAttributeNames([
+            $str_select_name => '選択肢名',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        // 項目の更新処理
+        $select = UsersColumnsSelects::where('id', $request->select_id)->first();
+        $select->value = $request->$str_select_name;
+        $select->save();
+        $message = '選択肢【 '. $request->$str_select_name .' 】を更新しました。';
+
+        // 編集画面を呼び出す
+        return redirect("/manage/user/editColumnDetail/" . $request->column_id)->with('flash_message', $message);
+    }
+
+    /**
+     * 選択肢の表示順の更新
+     */
+    public function updateSelectSequence($request, $id)
+    {
+        // ボタンが押された行の施設データ
+        $target_select = UsersColumnsSelects::where('id', $request->select_id)->first();
+
+        // ボタンが押された前（後）の施設データ
+        $query = UsersColumnsSelects::where('users_columns_id', $request->column_id);
+        $pair_select = $request->display_sequence_operation == 'up' ?
+            $query->where('display_sequence', '<', $request->display_sequence)->orderby('display_sequence', 'desc')->limit(1)->first() :
+            $query->where('display_sequence', '>', $request->display_sequence)->orderby('display_sequence', 'asc')->limit(1)->first();
+
+        // それぞれの表示順を退避
+        $target_select_display_sequence = $target_select->display_sequence;
+        $pair_select_display_sequence = $pair_select->display_sequence;
+
+        // 入れ替えて更新
+        $target_select->display_sequence = $pair_select_display_sequence;
+        $target_select->save();
+        $pair_select->display_sequence = $target_select_display_sequence;
+        $pair_select->save();
+
+        $message = '選択肢【 '. $target_select->select_name .' 】の表示順を更新しました。';
+
+        // 編集画面を呼び出す
+        return redirect("/manage/user/editColumnDetail/" . $request->column_id)->with('flash_message', $message);
+    }
+
+    /**
+     * 項目に紐づく選択肢の削除
+     */
+    public function deleteSelect($request, $id)
+    {
+        // 削除
+        UsersColumnsSelects::destroy('id', $request->select_id);
+
+        // 明細行から削除対象の選択肢名を抽出
+        $str_select_name = "select_name_"."$request->select_id";
+        $message = '選択肢【 '. $request->$str_select_name .' 】を削除しました。';
+
+        // 編集画面を呼び出す
+        return redirect("/manage/user/editColumnDetail/" . $request->column_id)->with('flash_message', $message);
     }
 }

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -1,0 +1,379 @@
+{{--
+ * 項目の選択肢設定画面
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ユーザ管理
+--}}
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<script type="text/javascript">
+    /**
+     * 選択肢追加ボタン押下
+     */
+    function submit_add_select(btn) {
+        form_selects.action = "{{url('/')}}/manage/user/addSelect";
+        btn.disabled = true;
+        form_selects.submit();
+    }
+
+    /**
+     * 表示順操作ボタン押下
+     */
+    function submit_display_sequence(select_id, display_sequence, display_sequence_operation) {
+        form_selects.action = "{{url('/')}}/manage/user/updateSelectSequence";
+        form_selects.select_id.value = select_id;
+        form_selects.display_sequence.value = display_sequence;
+        form_selects.display_sequence_operation.value = display_sequence_operation;
+        form_selects.submit();
+    }
+
+    /**
+     * 選択肢の更新ボタン押下
+     */
+    function submit_update_select(select_id) {
+        form_selects.action = "{{url('/')}}/manage/user/updateSelect";
+        form_selects.select_id.value = select_id;
+        form_selects.submit();
+    }
+
+    /**
+     * その他の設定の更新ボタン押下
+     */
+    function submit_update_column_detail() {
+        form_selects.action = "{{url('/')}}/manage/user/updateColumnDetail";
+        form_selects.submit();
+    }
+
+    /**
+     * 選択肢の削除ボタン押下
+     */
+     function submit_delete_select(select_id) {
+        if (confirm('選択肢を削除します。\nよろしいですか？')){
+            form_selects.action = "{{url('/')}}/manage/user/deleteSelect";
+            form_selects.select_id.value = select_id;
+            form_selects.submit();
+        }
+        return false;
+    }
+
+    // ツールチップ
+    $(function () {
+        // 有効化
+        $('[data-toggle="tooltip"]').tooltip()
+    })
+</script>
+
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.user.user_manage_tab')
+    </div>
+    <div class="card-body">
+
+        <form action="" id="form_selects" name="form_selects" method="POST" class="form-horizontal">
+            {{ csrf_field() }}
+            <input type="hidden" name="column_id" value="{{ $column->id }}">
+            <input type="hidden" name="select_id" value="">
+            <input type="hidden" name="display_sequence" value="">
+            <input type="hidden" name="display_sequence_operation" value="">
+
+            {{-- 登録後メッセージ表示 --}}
+            @include('plugins.common.flash_message')
+
+            {{-- メッセージエリア --}}
+            <div class="alert alert-info mt-2">
+                <i class="fas fa-exclamation-circle"></i> {{ '項目【 ' . $column->column_name . ' 】の詳細設定を行います。' }}
+            </div>
+
+            {{-- エラーメッセージエリア --}}
+            @if ($errors && $errors->any())
+                <div class="alert alert-danger mt-2">
+                    @foreach ($errors->all() as $error)
+                        <i class="fas fa-exclamation-circle"></i> {{ $error }}<br>
+                    @endforeach
+                </div>
+            @endif
+
+            @if ($column->column_type == UserColumnType::radio)
+                {{-- 選択肢の設定 --}}
+                <div class="card mb-4">
+                    <h5 class="card-header">選択肢の設定</h5>
+                    <div class="card-body">
+
+                        <div class="table-responsive">
+
+                            {{-- 選択項目の一覧 --}}
+                            <table class="table table-hover table-sm">
+                                <thead class="thead-light">
+                                    <tr>
+                                        @if (count($selects) > 0)
+                                            <th class="text-center" nowrap>表示順</th>
+                                            <th class="text-center" nowrap>選択肢名</th>
+                                            <th class="text-center" nowrap>更新</th>
+                                            <th class="text-center" nowrap>削除</th>
+                                        @endif
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {{-- 更新用の行 --}}
+                                    @foreach($selects as $select)
+                                        <tr  @if ($select->hide_flag) class="table-secondary" @endif>
+                                            {{-- 表示順操作 --}}
+                                            <td class="text-center" nowrap>
+                                                {{-- 上移動 --}}
+                                                <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->first) disabled @endif onclick="javascript:submit_display_sequence({{ $select->id }}, {{ $select->display_sequence }}, 'up')">
+                                                    <i class="fas fa-arrow-up"></i>
+                                                </button>
+
+                                                {{-- 下移動 --}}
+                                                <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->last) disabled @endif onclick="javascript:submit_display_sequence({{ $select->id }}, {{ $select->display_sequence }}, 'down')">
+                                                    <i class="fas fa-arrow-down"></i>
+                                                </button>
+                                            </td>
+
+                                            {{-- 選択肢名 --}}
+                                            <td>
+                                                <input class="form-control @if ($errors && $errors->has('select_name_'.$select->id)) border-danger @endif" type="text" name="select_name_{{ $select->id }}" value="{{ old('select_name_'.$select->id, $select->value)}}">
+                                            </td>
+
+                                            {{-- 更新ボタン --}}
+                                            <td class="align-middle text-center">
+                                                <button
+                                                    class="btn btn-primary cc-font-90 text-nowrap"
+                                                    onclick="javascript:submit_update_select({{ $select->id }});"
+                                                >
+                                                    <i class="fas fa-check"></i> <span class="d-sm-none">更新</span>
+                                                </button>
+                                            </td>
+
+                                            {{-- 削除ボタン --}}
+                                            <td class="text-center">
+                                                <button
+                                                    class="btn btn-danger cc-font-90 text-nowrap"
+                                                    onclick="javascript:return submit_delete_select({{ $select->id }});"
+                                                >
+                                                    <i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                    <tr class="thead-light">
+                                        <th colspan="7">【選択肢の追加行】</th>
+                                    </tr>
+
+                                    {{-- 新規登録用の行 --}}
+                                    <tr>
+                                        <td></td>
+                                        <td>
+                                            {{-- 選択肢名 --}}
+                                            <input class="form-control @if ($errors && $errors->has('select_name')) border-danger @endif" type="text" name="select_name" value="{{ old('select_name') }}" placeholder="選択肢名">
+                                        </td>
+                                        <td class="text-center">
+                                            {{-- ＋ボタン --}}
+                                            <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_add_select(this);"><i class="fas fa-plus"></i> <span class="d-sm-none">追加</span></button>
+                                        </td>
+                                        <td></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+                    </div>
+                </div>
+            @endif
+
+            @if ($column->column_type == UserColumnType::text || $column->column_type == UserColumnType::textarea || $column->column_type == UserColumnType::mail)
+                {{-- チェック処理の設定 --}}
+                <div class="card mb-4" id="div_rule">
+                    <h5 class="card-header">チェック処理の設定</h5>
+                    <div class="card-body">
+                        {{-- 1行文字列型／複数行文字列型のチェック群 --}}
+                        @if ($column->column_type == UserColumnType::text || $column->column_type == UserColumnType::textarea)
+                            {{-- 数値のみ許容 --}}
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right pt-0">入力制御</label>
+                                <div class="col-md-9 align-items-center">
+                                    <div class="custom-control custom-checkbox">
+                                        <input type="checkbox" name="rule_allowed_numeric" id="rule_allowed_numeric" value="1" class="custom-control-input"
+                                            @if(old('rule_allowed_numeric', $column->rule_allowed_numeric)) checked @endif >
+                                        <label class="custom-control-label" for="rule_allowed_numeric">半角数値のみ許容</label><br>
+                                        <small class="text-muted">※ 全角数値を入力した場合は半角数値に補正します。</small>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {{-- 英数値のみ許容 --}}
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right pt-0"></label>
+                                <div class="col-md-9 align-items-center">
+                                    <div class="custom-control custom-checkbox">
+                                        <input type="checkbox" name="rule_allowed_alpha_numeric" id="rule_allowed_alpha_numeric" value="1" class="custom-control-input"
+                                            @if(old('rule_allowed_alpha_numeric', $column->rule_allowed_alpha_numeric)) checked @endif>
+                                        <label class="custom-control-label" for="rule_allowed_alpha_numeric">半角英数値のみ許容</label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {{-- 指定桁数（数値）以下を許容 --}}
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right pt-0">入力桁数</label>
+                                <div class="col-md-9 align-items-center">
+                                    <input type="text" name="rule_digits_or_less" value="{{old('rule_digits_or_less', $column->rule_digits_or_less)}}" class="form-control">
+                                    <small class="text-muted">
+                                        ※ 数値で入力します。<br>
+                                        ※ 入力桁数の指定時は「半角数値のみ許容」も適用されます。
+                                    </small><br>
+                                    @if ($errors && $errors->has('rule_digits_or_less'))
+                                        <div class="text-danger">{{$errors->first('rule_digits_or_less')}}</div>
+                                    @endif
+                                </div>
+                            </div>
+
+                            {{-- 指定文字数以下を許容 --}}
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right pt-0">入力最大文字数</label>
+                                <div class="col-md-9 align-items-center">
+                                    <input type="text" name="rule_word_count" value="{{old('rule_word_count', $column->rule_word_count)}}" class="form-control">
+                                    <small class="text-muted">
+                                        ※ 数値で入力します。<br>
+                                        ※ 全角は2文字、半角は1文字として換算します。
+                                    </small>
+                                    @if ($errors && $errors->has('rule_word_count'))
+                                        <div class="text-danger">{{$errors->first('rule_word_count')}}</div>
+                                    @endif
+                                </div>
+                            </div>
+
+                            {{-- 最大値設定 --}}
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right pt-0">最大値</label>
+                                <div class="col-md-9 align-items-center">
+                                    <input type="text" name="rule_max" value="{{old('rule_max', $column->rule_max)}}" class="form-control">
+                                    <small class="text-muted">※ 数値で入力します。</small>
+                                    @if ($errors && $errors->has('rule_max'))
+                                        <div class="text-danger">{{$errors->first('rule_max')}}</div>
+                                    @endif
+                                </div>
+                            </div>
+
+                            {{-- 最小値設定 --}}
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right pt-0">最小値</label>
+                                <div class="col-md-9 align-items-center">
+                                    <input type="text" name="rule_min" value="{{old('rule_min', $column->rule_min)}}" class="form-control">
+                                    <small class="text-muted">※ 数値で入力します。</small>
+                                    @if ($errors && $errors->has('rule_min'))
+                                        <div class="text-danger">{{$errors->first('rule_min')}}</div>
+                                    @endif
+                                </div>
+                            </div>
+                        @endif
+
+                        @if ($column->column_type == UserColumnType::text || $column->column_type == UserColumnType::textarea || $column->column_type == UserColumnType::mail)
+                            {{-- 正規表現設定 --}}
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right pt-0">正規表現</label>
+                                <div class="col-md-9 align-items-center">
+                                    <input type="text" name="rule_regex" value="{{old('rule_regex', $column->rule_regex)}}" class="form-control">
+                                    <small class="text-muted">
+                                        ※ エラーメッセージは「正しい形式の＜項目名＞を指定してください。」と表示されるため、併せてキャプションの設定をする事をオススメします。<br>
+                                        ※ （設定例：電話番号ハイフンあり）/0\d{1,4}-\d{1,4}-\d{4}/<br>
+                                        ※ （設定例：指定ドメインのメールアドレスのみ）/@example\.com$/<br>
+                                    </small>
+                                    @if ($errors && $errors->has('rule_regex')) <div class="text-danger">{{$errors->first('rule_regex')}}</div> @endif
+                                </div>
+                            </div>
+                        @endif
+
+                        {{-- ボタンエリア --}}
+                        <div class="form-group text-center">
+                            <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary database-horizontal">
+                                <i class="fas fa-check"></i> 更新
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+
+            {{-- キャプション設定 --}}
+            <div class="card mb-4" id="div_caption">
+                <h5 class="card-header">キャプションの設定</h5>
+                <div class="card-body">
+
+                    {{-- キャプション内容 --}}
+                    <div class="form-group row">
+                        <label class="col-md-3 col-form-label text-md-right pt-0">内容 </label>
+                        <div class="col-md-9 align-items-center">
+                            <textarea name="caption" class="form-control" rows="3">{{old('caption', $column->caption)}}</textarea>
+                        </div>
+                    </div>
+
+                    {{-- キャプション文字色 --}}
+                    <div class="form-group row">
+                        <label class="col-md-3 col-form-label text-md-right pt-0">文字色 </label>
+                        <div class="col-md-9 align-items-center">
+                            <select class="form-control" name="caption_color">
+                                @foreach (Bs4TextColor::getMembers() as $key=>$value)
+                                    <option value="{{$key}}" class="{{ $key }}" @if($key == old('caption_color', $column->caption_color)) selected @endif>
+                                        {{ $value }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                    </div>
+
+                    {{-- ボタンエリア --}}
+                    <div class="form-group text-center">
+                        <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary database-horizontal">
+                            <i class="fas fa-check"></i> 更新
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+
+            @if (
+                $column->column_type == UserColumnType::text ||
+                $column->column_type == UserColumnType::textarea ||
+                $column->column_type == UserColumnType::mail
+                )
+                {{-- プレースホルダ設定 --}}
+                <div class="card mb-4">
+                    <h5 class="card-header">プレースホルダの設定</h5>
+                    <div class="card-body">
+
+                        {{-- プレースホルダ内容 --}}
+                        <div class="form-group row">
+                            <label class="col-md-3 col-form-label text-md-right pt-0">内容 </label>
+                            <div class="col-md-9 align-items-center">
+                                <input type="text" name="place_holder" class="form-control" value="{{old('place_holder', $column->place_holder)}}">
+                            </div>
+                        </div>
+
+                        {{-- ボタンエリア --}}
+                        <div class="form-group text-center">
+                            <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
+                        </div>
+                    </div>
+                </div>
+                <br>
+            @endif
+
+            {{-- ボタンエリア --}}
+            <div class="form-group text-center">
+                <a href="{{url('/')}}/manage/user/editColumns" class="btn btn-secondary">
+                    <i class="fas fa-chevron-left"></i> 項目設定へ
+                </a>
+            </div>
+        </form>
+
+    </div>
+</div>
+
+@endsection

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -99,7 +99,11 @@
                 </div>
             @endif
 
-            @if ($column->column_type == UserColumnType::radio)
+            @if (
+                $column->column_type == UserColumnType::radio ||
+                $column->column_type == UserColumnType::select ||
+                $column->column_type == UserColumnType::checkbox
+                )
                 {{-- 選択肢の設定 --}}
                 <div class="card mb-4">
                     <h5 class="card-header">選択肢の設定</h5>

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -42,6 +42,15 @@
     }
 
     /**
+     * 同意内容の更新ボタン押下
+     */
+     function submit_update_agree(select_id) {
+        form_selects.action = "{{url('/')}}/manage/user/updateAgree";
+        form_selects.select_id.value = select_id;
+        form_selects.submit();
+    }
+
+    /**
      * その他の設定の更新ボタン押下
      */
     function submit_update_column_detail() {
@@ -191,6 +200,42 @@
                 </div>
             @endif
 
+            @if ($column->column_type == UserColumnType::agree)
+                {{-- 同意内容の設定 --}}
+                <div class="card mb-4">
+                    <h5 class="card-header">同意内容の設定</h5>
+                    <div class="card-body">
+
+                        {{-- 指定桁数（数値）以下を許容 --}}
+                        <div class="form-group row">
+                            <label class="col-md-3 col-form-label text-md-right">チェックボックスの名称 <span class="badge badge-danger">必須</span></label>
+                            <div class="col-md-9 align-items-center">
+                                <input type="text" name="value" value="{{old('value', $select_agree->value)}}" class="form-control" placeholder="（例）以下の内容に同意します。">
+                                @include('plugins.common.errors_inline', ['name' => 'value'])
+                            </div>
+                        </div>
+
+                        {{-- 同意内容 --}}
+                        <div class="form-group row">
+                            <label class="col-md-3 col-form-label text-md-right pt-0">同意内容 </label>
+                            <div class="col-md-9 align-items-center">
+                                <textarea name="agree_description" class="form-control" rows="3">{{old('agree_description', $select_agree->agree_description)}}</textarea>
+                                <small class="text-muted">
+                                    ※ 自動ユーザ登録時に求める同意の説明文<br />
+                                </small>
+                            </div>
+                            @include('plugins.common.errors_inline', ['name' => 'agree_description'])
+                        </div>
+
+                        {{-- ボタンエリア --}}
+                        <div class="form-group text-center">
+                            <button onclick="javascript:submit_update_agree({{ $select_agree->id }});" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
+                        </div>
+                    </div>
+                </div>
+                <br>
+            @endif
+
             @if ($column->column_type == UserColumnType::text || $column->column_type == UserColumnType::textarea || $column->column_type == UserColumnType::mail)
                 {{-- チェック処理の設定 --}}
                 <div class="card mb-4" id="div_rule">
@@ -225,7 +270,7 @@
 
                             {{-- 指定桁数（数値）以下を許容 --}}
                             <div class="form-group row">
-                                <label class="col-md-3 col-form-label text-md-right pt-0">入力桁数</label>
+                                <label class="col-md-3 col-form-label text-md-right">入力桁数</label>
                                 <div class="col-md-9 align-items-center">
                                     <input type="text" name="rule_digits_or_less" value="{{old('rule_digits_or_less', $column->rule_digits_or_less)}}" class="form-control">
                                     <small class="text-muted">
@@ -240,7 +285,7 @@
 
                             {{-- 指定文字数以下を許容 --}}
                             <div class="form-group row">
-                                <label class="col-md-3 col-form-label text-md-right pt-0">入力最大文字数</label>
+                                <label class="col-md-3 col-form-label text-md-right">入力最大文字数</label>
                                 <div class="col-md-9 align-items-center">
                                     <input type="text" name="rule_word_count" value="{{old('rule_word_count', $column->rule_word_count)}}" class="form-control">
                                     <small class="text-muted">
@@ -255,7 +300,7 @@
 
                             {{-- 最大値設定 --}}
                             <div class="form-group row">
-                                <label class="col-md-3 col-form-label text-md-right pt-0">最大値</label>
+                                <label class="col-md-3 col-form-label text-md-right">最大値</label>
                                 <div class="col-md-9 align-items-center">
                                     <input type="text" name="rule_max" value="{{old('rule_max', $column->rule_max)}}" class="form-control">
                                     <small class="text-muted">※ 数値で入力します。</small>
@@ -267,7 +312,7 @@
 
                             {{-- 最小値設定 --}}
                             <div class="form-group row">
-                                <label class="col-md-3 col-form-label text-md-right pt-0">最小値</label>
+                                <label class="col-md-3 col-form-label text-md-right">最小値</label>
                                 <div class="col-md-9 align-items-center">
                                     <input type="text" name="rule_min" value="{{old('rule_min', $column->rule_min)}}" class="form-control">
                                     <small class="text-muted">※ 数値で入力します。</small>
@@ -281,7 +326,7 @@
                         @if ($column->column_type == UserColumnType::text || $column->column_type == UserColumnType::textarea || $column->column_type == UserColumnType::mail)
                             {{-- 正規表現設定 --}}
                             <div class="form-group row">
-                                <label class="col-md-3 col-form-label text-md-right pt-0">正規表現</label>
+                                <label class="col-md-3 col-form-label text-md-right">正規表現</label>
                                 <div class="col-md-9 align-items-center">
                                     <input type="text" name="rule_regex" value="{{old('rule_regex', $column->rule_regex)}}" class="form-control">
                                     <small class="text-muted">
@@ -320,7 +365,7 @@
 
                     {{-- キャプション文字色 --}}
                     <div class="form-group row">
-                        <label class="col-md-3 col-form-label text-md-right pt-0">文字色 </label>
+                        <label class="col-md-3 col-form-label text-md-right">文字色 </label>
                         <div class="col-md-9 align-items-center">
                             <select class="form-control" name="caption_color">
                                 @foreach (Bs4TextColor::getMembers() as $key=>$value)
@@ -341,7 +386,6 @@
                 </div>
             </div>
 
-
             @if (
                 $column->column_type == UserColumnType::text ||
                 $column->column_type == UserColumnType::textarea ||
@@ -354,7 +398,7 @@
 
                         {{-- プレースホルダ内容 --}}
                         <div class="form-group row">
-                            <label class="col-md-3 col-form-label text-md-right pt-0">内容 </label>
+                            <label class="col-md-3 col-form-label text-md-right">内容 </label>
                             <div class="col-md-9 align-items-center">
                                 <input type="text" name="place_holder" class="form-control" value="{{old('place_holder', $column->place_holder)}}">
                             </div>

--- a/resources/views/plugins/manage/user/edit_columns.blade.php
+++ b/resources/views/plugins/manage/user/edit_columns.blade.php
@@ -1,0 +1,138 @@
+{{--
+ * 項目設定画面のメインテンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ユーザ管理
+--}}
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<script type="text/javascript">
+    /**
+     * 項目の追加
+     */
+    function submit_add_column(btn) {
+        form_columns.action = "{{url('/')}}/manage/user/addColumn";
+        btn.disabled = true;
+        form_columns.submit();
+    }
+
+    /**
+     * 項目の更新
+     */
+    function submit_update_column(column_id) {
+        form_columns.action = "{{url('/')}}/manage/user/updateColumn";
+        form_columns.column_id.value = column_id;
+        form_columns.submit();
+    }
+
+    /**
+     * 項目の表示順操作
+     */
+    function submit_display_sequence(column_id, display_sequence, display_sequence_operation) {
+        form_columns.action = "{{url('/')}}/manage/user/updateColumnSequence";
+        form_columns.column_id.value = column_id;
+        form_columns.display_sequence.value = display_sequence;
+        form_columns.display_sequence_operation.value = display_sequence_operation;
+        form_columns.submit();
+    }
+
+    /**
+     * 項目の削除ボタン押下
+     */
+     function submit_delete_column(column_id) {
+        if (confirm('項目を削除します。\nよろしいですか？')){
+            form_columns.action = "{{url('/')}}/manage/user/deleteColumn";
+            form_columns.column_id.value = column_id;
+            form_columns.submit();
+        }
+        return false;
+    }
+
+    // ツールチップ
+    $(function () {
+        // 有効化
+        $('[data-toggle="tooltip"]').tooltip()
+        // 常時表示 ※表示の判定は項目側で実施
+        $('[id^=detail-button-tip]').tooltip('show');
+    })
+</script>
+
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.user.user_manage_tab')
+    </div>
+    <div class="card-body">
+
+        {{-- 一覧フォーム --}}
+        <form action="{{url('/')}}/manage/user/addColumn" id="form_columns" name="form_columns" method="POST">
+            {{ csrf_field() }}
+            <input type="hidden" name="column_id" value="">
+            <input type="hidden" name="display_sequence" value="">
+            <input type="hidden" name="display_sequence_operation" value="">
+
+            {{-- 登録後メッセージ表示 --}}
+            @include('plugins.common.flash_message')
+
+            {{-- メッセージエリア --}}
+            <div class="alert alert-info">
+                <i class="fas fa-exclamation-circle"></i> ユーザ項目を追加・変更します。
+            </div>
+
+            {{-- エラーメッセージエリア --}}
+            @if ($errors && $errors->any())
+                <div class="alert alert-danger">
+                    @foreach ($errors->all() as $error)
+                        <i class="fas fa-exclamation-circle"></i> {{ $error }}<br>
+                    @endforeach
+                </div>
+            @endif
+
+            <div class="table-responsive">
+
+                {{-- 項目の一覧 --}}
+                <table class="table table-hover table-sm">
+                    <thead class="thead-light">
+                        <tr>
+                            @if (count($columns) > 0)
+                                <th class="text-center" nowrap>表示順</th>
+                                <th class="text-center" style="min-width: 150px" nowrap>項目名</th>
+                                <th class="text-center" nowrap>型</th>
+                                <th class="text-center" nowrap>必須 <span class="fas fa-info-circle" data-toggle="tooltip" title="必須項目として指定します。"></th>
+                                <th class="text-center" nowrap>詳細</th>
+                                <th class="text-center" nowrap>更新</th>
+                                <th class="text-center" nowrap>削除</th>
+                            @endif
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{-- 更新用の行 --}}
+                        @foreach($columns as $column)
+                            @include('plugins.manage.user.include_edit_column_row')
+                        @endforeach
+                        {{-- 新規登録用の行 --}}
+                        <tr class="thead-light">
+                            <th colspan="7">【項目の追加行】</th>
+                        </tr>
+                        @include('plugins.manage.user.include_edit_column_row_add')
+                    </tbody>
+                </table>
+            </div>
+
+            {{-- ボタンエリア --}}
+            <div class="text-center">
+                <a href="{{url('/')}}/manage/user/editColumns" class="btn btn-secondary">
+                    <i class="fas fa-times"></i> キャンセル
+                </a>
+            </div>
+        </form>
+
+    </div>
+</div>
+
+@endsection

--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -1,0 +1,88 @@
+{{--
+ * 項目の更新行
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ユーザ管理
+--}}
+<tr @if ($column->hide_flag) class="table-secondary" @endif>
+    {{-- 表示順操作 --}}
+    <td class="align-middle text-center" nowrap>
+        {{-- 上移動 --}}
+        <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->first) disabled @endif onclick="javascript:submit_display_sequence({{ $column->id }}, {{ $column->display_sequence }}, 'up')">
+            <i class="fas fa-arrow-up"></i>
+        </button>
+
+        {{-- 下移動 --}}
+        <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->last) disabled @endif onclick="javascript:submit_display_sequence({{ $column->id }}, {{ $column->display_sequence }}, 'down')">
+            <i class="fas fa-arrow-down"></i>
+        </button>
+    </td>
+    {{-- 項目名 --}}
+    <td>
+        <input class="form-control @if ($errors && $errors->has('column_name_'.$column->id)) border-danger @endif" type="text" name="column_name_{{ $column->id }}" value="{{ old('column_name_'.$column->id, $column->column_name)}}">
+    </td>
+    {{-- 入力データ型 --}}
+    <td>
+        <select class="form-control" name="column_type_{{ $column->id }}" style="min-width: 140px;">
+            <option value="" disabled>型を指定</option>
+            @foreach (UserColumnType::getMembers() as $key=>$value)
+                <option value="{{$key}}" @if ($key == old("column_type_$column->id", $column->column_type)) selected="selected" @endif>{{ $value }}</option>
+            @endforeach
+        </select>
+    </td>
+    {{-- 必須 --}}
+    <td class="align-middle text-center">
+        <input type="checkbox" name="required_{{ $column->id }}" value="1" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif>
+    </td>
+    {{-- 選択肢の設定ボタン --}}
+    <td class="text-center px-2">
+        <button
+            type="button"
+            class="btn btn-success btn-xs cc-font-90 text-nowrap"
+            @if (
+                $column->column_type == UserColumnType::radio ||
+                $column->column_type == UserColumnType::checkbox ||
+                $column->column_type == UserColumnType::select
+                )
+                {{-- 選択肢の設定がない場合のみツールチップを表示 --}}
+                @if ($column->select_count == 0)
+                    id="detail-button-tip" data-toggle="tooltip" title="選択肢がありません。設定してください。" data-trigger="manual" data-placement="bottom"
+                @endif
+            @endif
+            onclick="location.href='{{url('/')}}/manage/user/editColumnDetail/{{ $column->id }}'"
+        >
+            <i class="far fa-window-restore"></i> <span class="d-sm-none">詳細</span>
+        </button>
+    </td>
+    {{-- 更新ボタン --}}
+    <td class="text-center px-2">
+        <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_update_column({{ $column->id }});">
+            <i class="fas fa-check"></i> <span class="d-sm-none">更新</span>
+        </button>
+    </td>
+
+    {{-- 削除ボタン --}}
+    <td class="text-center px-2">
+        <button class="btn btn-danger cc-font-90 text-nowrap" onclick="javascript:return submit_delete_column({{ $column->id }});"><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+    </td>
+</tr>
+{{-- 選択肢の設定内容の表示行 --}}
+@if (
+    $column->column_type == UserColumnType::radio ||
+    $column->column_type == UserColumnType::checkbox ||
+    $column->column_type == UserColumnType::select
+    )
+    <tr>
+        <td class="pt-0 border border-0"></td>
+        <td class="pt-0 border border-0" colspan="7">
+            @if ($column->select_count > 0)
+                {{-- 選択肢データがある場合、カンマ付で一覧表示する --}}
+                <i class="far fa-list-alt"></i> {{ $column->select_names }}
+            @elseif ($column->select_count == 0)
+                {{-- 選択肢データがない場合はツールチップ分、余白として改行する --}}
+                <br>
+            @endif
+        </td>
+    </tr>
+@endif

--- a/resources/views/plugins/manage/user/include_edit_column_row_add.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row_add.blade.php
@@ -1,0 +1,37 @@
+{{--
+ * 項目の追加行
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ユーザ管理
+ --}}
+<tr>
+    {{-- 余白 --}}
+    <td></td>
+    {{-- 項目名 --}}
+    <td>
+        <input class="form-control @if ($errors && $errors->has('column_name')) border-danger @endif" type="text" name="column_name" value="{{ old('column_name') }}" placeholder="項目名">
+    </td>
+    {{-- 入力データ型 --}}
+    <td>
+        <select class="form-control" name="column_type" style="min-width: 100px;">
+            <option value="" disabled>型を指定</option>
+            @foreach (UserColumnType::getMembers() as $key=>$value)
+                <option value="{{$key}}" @if ($key == old('column_type')) selected="selected" @endif>{{ $value }}</option>
+            @endforeach
+        </select>
+    </td>
+    {{-- 必須 --}}
+    <td class="align-middle text-center">
+        <input type="checkbox" name="required" value="1" @if (old('required') == Required::on) checked="checked" @endif data-toggle="tooltip" title="必須項目として指定します。">
+    </td>
+    {{-- ＋ボタン --}}
+    <td class="text-center">
+        <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_add_column(this);">
+            <i class="fas fa-plus"></i> <span class="d-sm-none">追加</span>
+        </button>
+    </td>
+    {{-- 表示上の区切り線が切れてしまう為、空のtdタグを設置 --}}
+    <td></td>
+    <td></td>
+</tr>

--- a/resources/views/plugins/manage/user/user_manage_tab.blade.php
+++ b/resources/views/plugins/manage/user/user_manage_tab.blade.php
@@ -38,6 +38,20 @@
                 </li>
 
                 <li role="presentation" class="nav-item">
+                    @if ($function == "editColumns")
+                        <span class="nav-link"><span class="active">項目設定</span></span>
+                    @else
+                        <a href="{{url('/manage/user/editColumns')}}" class="nav-link">項目設定</a></li>
+                    @endif
+                </li>
+
+                @if ($function == 'editColumnDetail')
+                    <li role="presentation" class="nav-item">
+                        <span class="nav-link"><span class="active">項目詳細設定</span></span>
+                    </li>
+                @endif
+
+                <li role="presentation" class="nav-item">
                 @if ($function == "autoRegist")
                     <span class="nav-link"><span class="active">自動ユーザ登録設定</span></span>
                 @else


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* #717

## 修正後画面
### 項目設定（新規）
![image](https://user-images.githubusercontent.com/2756509/160363307-9ad7b4bb-b2fc-4e6d-811a-4a488f17f476.png)

### 項目設定詳細（新規）
![localhost_manage_user_editColumnDetail_1](https://user-images.githubusercontent.com/2756509/160363001-d648d73c-eeed-492c-8edb-b834c678f6fb.png)

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し
