### PR TITLE
Fix: ZIPファイルのインポートエラー

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3048,11 +3048,7 @@ class DatabasesPlugin extends UserPluginBase
                 }
 
                 // パターンにマッチするパス名を探す。 csvは１つの想定
-                // winの標準機能でzip圧縮すると、zip内にフォルダが１つでき、その中にファイルが格納されているため、
-                // zip内１つ下のフォルダを検索
-                // $csv_full_path = $unzip_dir_full_path . "database/database.csv";
-                // $csv_full_paths = glob($unzip_dir_full_path . "database/*.csv");
-                $csv_full_paths = glob($unzip_dir_full_path . "*/*.csv");
+                $csv_full_paths = glob($unzip_dir_full_path . "*.csv");
                 // Log::debug(var_export($csv_full_paths, true));
 
                 if (empty($csv_full_paths)) {


### PR DESCRIPTION
## 概要

解凍先パスの指定が誤っていたようです。

元のコメントからすると、Windowsで作成したZIPファイル用に敢えて"\*/\*.csv"にしていたと読めます。
ただ、私の環境(Debian)では、一時フォルダ直下に解凍ファイルが作られます。
Windowsで作成したZIPファイルで動作確認したので、この修正内容で問題ないかとは思います。

## 関連Pull requests/Issues

* #1255

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
