### PR TITLE
Fix: 1ページの表示件数を空白で登録するとシステムエラーとなる

### DIFF
--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -351,7 +351,7 @@ class SearchsPlugin extends UserPluginBase
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
             'search_name'     => ['required'],
-            'count'           => ['nullable', 'numeric'],
+            'count'           => ['required', 'numeric'],
             'target_plugin'   => ['required'],
         ]);
         $validator->setAttributeNames([


### PR DESCRIPTION
## 概要

画面上、必須項目なのに必須チェックが入っていませんでした。
対応するDB(searchs.count)の項目にNOT NULL制約が入っていたため、NULLを登録するとSQLエラーが発生していました。

必須チェックを追加する対応を行いました。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク --> 
#1272

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
