### PR TITLE
【データベース】メール通知の埋め込みタグ強化対応

### DIFF
--- a/app/Enums/DatabaseNoticeEmbeddedTag.php
+++ b/app/Enums/DatabaseNoticeEmbeddedTag.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\NoticeEmbeddedTag;
+
+/**
+ * データベースの通知の埋め込みタグ
+ */
+final class DatabaseNoticeEmbeddedTag extends NoticeEmbeddedTag
+{
+    // 定数メンバ
+    const posted_at = 'posted_at';
+    const expires_at = 'expires_at';
+    const display_sequence = 'display_sequence';
+
+    // key/valueの連想配列
+    const enum = [
+        self::site_name => 'サイト名',
+        self::method => '処理名',
+        self::title => 'タイトル',
+        self::body => '本文',
+        self::posted_at => '公開日時',
+        self::expires_at => '公開終了日時',
+        self::display_sequence => '表示順',
+        self::url => 'URL',
+        self::delete_comment => '削除時のコメント',
+        self::created_name => '登録者',
+        self::created_at => '登録日時',
+        self::updated_name => '更新者',
+        self::updated_at => '更新日時',
+    ];
+
+    /**
+     * 埋め込みタグの説明を取得
+     */
+    public static function getDescriptionEmbeddedTags(bool $use_title = false, bool $use_body = false): array
+    {
+        // 埋め込みタグ, 内容
+        $embedded_tags[] = ['[[' . self::site_name . ']]',        self::getDescription(self::site_name)];
+        $embedded_tags[] = ['[[' . self::method . ']]',           self::getDescription(self::method)];
+        $embedded_tags[] = ['[[' . self::title . ']]',            self::getDescription(self::title)];
+        $embedded_tags[] = ['[[' . self::posted_at . ']]',        self::getDescription(self::posted_at)];
+        $embedded_tags[] = ['[[' . self::expires_at . ']]',       self::getDescription(self::expires_at)];
+        $embedded_tags[] = ['[[' . self::display_sequence . ']]', self::getDescription(self::display_sequence)];
+        $embedded_tags[] = ['[[' . self::url . ']]',              self::getDescription(self::url)];
+        $embedded_tags[] = ['[[' . self::delete_comment . ']]',   self::getDescription(self::delete_comment)];
+        $embedded_tags[] = ['[[' . self::created_name . ']]',     self::getDescription(self::created_name)];
+        $embedded_tags[] = ['[[' . self::created_at . ']]',       self::getDescription(self::created_at)];
+        $embedded_tags[] = ['[[' . self::updated_name . ']]',     self::getDescription(self::updated_name)];
+        $embedded_tags[] = ['[[' . self::updated_at . ']]',       self::getDescription(self::updated_at)];
+        return $embedded_tags;
+    }
+}

--- a/app/Models/User/Databases/DatabasesColumns.php
+++ b/app/Models/User/Databases/DatabasesColumns.php
@@ -59,12 +59,12 @@ class DatabasesColumns extends Model
     /**
      * ファイルタイプのカラム型か
      */
-    public function isFileColumnType()
+    public static function isFileColumnType($column_type)
     {
         // ファイルタイプ
-        if ($this->column_type == DatabaseColumnType::file ||
-                $this->column_type == DatabaseColumnType::image ||
-                $this->column_type == DatabaseColumnType::video) {
+        if ($column_type == DatabaseColumnType::file ||
+                $column_type == DatabaseColumnType::image ||
+                $column_type == DatabaseColumnType::video) {
             return true;
         }
         return false;
@@ -73,13 +73,13 @@ class DatabasesColumns extends Model
     /**
      * 埋め込みタグから除外するカラム型か
      */
-    public function isNotEmbeddedTagsColumnType()
+    public static function isNotEmbeddedTagsColumnType($column_type)
     {
         // 登録日型・更新日型・公開日型・表示順型は入力しない
-        if ($this->column_type == DatabaseColumnType::created ||
-                $this->column_type == DatabaseColumnType::updated ||
-                $this->column_type == DatabaseColumnType::posted ||
-                $this->column_type == DatabaseColumnType::display) {
+        if ($column_type == DatabaseColumnType::created ||
+                $column_type == DatabaseColumnType::updated ||
+                $column_type == DatabaseColumnType::posted ||
+                $column_type == DatabaseColumnType::display) {
             return true;
         }
         return false;

--- a/app/Models/User/Databases/DatabasesColumns.php
+++ b/app/Models/User/Databases/DatabasesColumns.php
@@ -44,13 +44,13 @@ class DatabasesColumns extends Model
     /**
      * 入力しないカラム型か
      */
-    public static function isNotInputColumnType($column_type)
+    public function isNotInputColumnType()
     {
         // 登録日型・更新日型・公開日型・表示順型は入力しない
-        if ($column_type == DatabaseColumnType::created ||
-                $column_type == DatabaseColumnType::updated ||
-                $column_type == DatabaseColumnType::posted ||
-                $column_type == DatabaseColumnType::display) {
+        if ($this->column_type == DatabaseColumnType::created ||
+                $this->column_type == DatabaseColumnType::updated ||
+                $this->column_type == DatabaseColumnType::posted ||
+                $this->column_type == DatabaseColumnType::display) {
             return true;
         }
         return false;
@@ -59,12 +59,27 @@ class DatabasesColumns extends Model
     /**
      * ファイルタイプのカラム型か
      */
-    public static function isFileColumnType($column_type)
+    public function isFileColumnType()
     {
         // ファイルタイプ
-        if ($column_type == DatabaseColumnType::file ||
-                $column_type == DatabaseColumnType::image ||
-                $column_type == DatabaseColumnType::video) {
+        if ($this->column_type == DatabaseColumnType::file ||
+                $this->column_type == DatabaseColumnType::image ||
+                $this->column_type == DatabaseColumnType::video) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 埋め込みタグから除外するカラム型か
+     */
+    public function isNotEmbeddedTagsColumnType()
+    {
+        // 登録日型・更新日型・公開日型・表示順型は入力しない
+        if ($this->column_type == DatabaseColumnType::created ||
+                $this->column_type == DatabaseColumnType::updated ||
+                $this->column_type == DatabaseColumnType::posted ||
+                $this->column_type == DatabaseColumnType::display) {
             return true;
         }
         return false;

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -47,7 +47,7 @@ use App\Enums\DatabaseColumnRoleName;
 use App\Enums\DatabaseRoleName;
 use App\Enums\DatabaseSortFlag;
 use App\Enums\Required;
-use App\Enums\NoticeEmbeddedTag;
+use App\Enums\DatabaseNoticeEmbeddedTag;
 use App\Enums\StatusType;
 
 /**
@@ -1535,8 +1535,11 @@ class DatabasesPlugin extends UserPluginBase
 
         // プラグイン独自の埋め込みタグ
         $overwrite_notice_embedded_tags = [
-            NoticeEmbeddedTag::title => $this->getTitle($databases_inputs),
-            NoticeEmbeddedTag::body => BucketsMail::stripTagsWysiwyg($this->getBody($databases_inputs)),
+            DatabaseNoticeEmbeddedTag::title =>            $this->getTitle($databases_inputs),
+            DatabaseNoticeEmbeddedTag::body =>             BucketsMail::stripTagsWysiwyg($this->getBody($databases_inputs)),
+            DatabaseNoticeEmbeddedTag::posted_at =>        $databases_inputs->posted_at,
+            DatabaseNoticeEmbeddedTag::expires_at =>       $databases_inputs->expires_at,
+            DatabaseNoticeEmbeddedTag::display_sequence => $databases_inputs->display_sequence,
         ];
 
         foreach ($databases_columns as $databases_column) {
@@ -1618,8 +1621,11 @@ class DatabasesPlugin extends UserPluginBase
 
         // プラグイン独自の埋め込みタグ
         $overwrite_notice_embedded_tags = [
-            NoticeEmbeddedTag::title => $this->getTitle($deleted_input),
-            NoticeEmbeddedTag::body => BucketsMail::stripTagsWysiwyg($this->getBody($deleted_input)),
+            DatabaseNoticeEmbeddedTag::title =>            $this->getTitle($deleted_input),
+            DatabaseNoticeEmbeddedTag::body =>             BucketsMail::stripTagsWysiwyg($this->getBody($deleted_input)),
+            DatabaseNoticeEmbeddedTag::posted_at =>        $deleted_input->posted_at,
+            DatabaseNoticeEmbeddedTag::expires_at =>       $deleted_input->expires_at,
+            DatabaseNoticeEmbeddedTag::display_sequence => $deleted_input->display_sequence,
         ];
 
         foreach ($input_cols as $input_col) {

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -1647,7 +1647,7 @@ class DatabasesPlugin extends UserPluginBase
                 }
 
             } else {
-                $overwrite_notice_embedded_tags["X-{$input_col->column_name}"] = $input_col->value;;
+                $overwrite_notice_embedded_tags["X-{$input_col->column_name}"] = $input_col->value;
             }
         }
 

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -1087,7 +1087,7 @@ class DatabasesPlugin extends UserPluginBase
     private function getValidatorRule($validator_array, $databases_column)
     {
         // 入力しないカラム型は、バリデータチェックしない
-        if (DatabasesColumns::isNotInputColumnType($databases_column->column_type)) {
+        if ($databases_column->isNotInputColumnType()) {
             return $validator_array;
         }
 
@@ -1259,7 +1259,7 @@ class DatabasesPlugin extends UserPluginBase
 
         foreach ($databases_columns as $databases_column) {
             // ファイルタイプ以外の入力値をトリム
-            if (! DatabasesColumns::isFileColumnType($databases_column->column_type)) {
+            if (! $databases_column->isFileColumnType()) {
                 if (isset($request->databases_columns_value[$databases_column->id])) {
                     // 一度配列にして、trim後、また文字列に戻す。
                     $tmp_columns_value = StringUtils::trimInput($request->databases_columns_value[$databases_column->id]);
@@ -1336,7 +1336,7 @@ class DatabasesPlugin extends UserPluginBase
 
         // ファイル項目を探して保存
         foreach ($databases_columns as $databases_column) {
-            if (DatabasesColumns::isFileColumnType($databases_column->column_type)) {
+            if ($databases_column->isFileColumnType()) {
                 // ファイル系の処理パターン
                 // 新規登録   ＞ アップロードされたことを hasFile で検知
                 // 変更の削除 ＞ databases_columns_delete_ids に削除するdatabases_input_cols の id を溜める。項目値も一旦クリア。
@@ -1504,7 +1504,7 @@ class DatabasesPlugin extends UserPluginBase
         // databases_input_cols 登録
         foreach ($databases_columns as $databases_column) {
             // 登録日型・更新日型・公開日型・表示順は、databases_inputsテーブルの登録日・更新日・公開日・表示順を利用するため、登録しない
-            if (DatabasesColumns::isNotInputColumnType($databases_column->column_type)) {
+            if ($databases_column->isNotInputColumnType()) {
                 continue;
             }
 
@@ -1526,7 +1526,7 @@ class DatabasesPlugin extends UserPluginBase
                 $databases_input_cols->save();
 
                 // ファイルタイプがファイル系の場合は、uploads テーブルの一時フラグを更新
-                if (DatabasesColumns::isFileColumnType($databases_column->column_type)) {
+                if ($databases_column->isFileColumnType()) {
                     $uploads_count = Uploads::where('id', $value)->update(['temporary_flag' => 0]);
                 }
             }
@@ -1584,7 +1584,7 @@ class DatabasesPlugin extends UserPluginBase
 
         // ファイル型のファイル、uploads テーブルを削除
         foreach ($input_cols as $input_col) {
-            if (DatabasesColumns::isFileColumnType($input_col->column_type)) {
+            if ($input_col->isFileColumnType()) {
                 // 削除するファイルデータ
                 $delete_upload = Uploads::find($input_col->value);
 
@@ -2037,7 +2037,7 @@ class DatabasesPlugin extends UserPluginBase
             $file_column_type_ids = [];
             foreach ($databases_columns as $databases_column) {
                 // ファイルタイプ
-                if (DatabasesColumns::isFileColumnType($databases_column->column_type)) {
+                if ($databases_column->isFileColumnType()) {
                     $file_column_type_ids[] = $databases_column->id;
                 }
             }
@@ -3271,7 +3271,7 @@ class DatabasesPlugin extends UserPluginBase
                     if ($csv_column) {
                         if ($file_extension == 'zip') {
                             // ファイルタイプ
-                            if (DatabasesColumns::isFileColumnType($databases_columns[$col]->column_type)) {
+                            if ($databases_columns[$col]->isFileColumnType()) {
                                 // パスをアップロードIDに書き換える。
                                 $csv_column = array_search($csv_column, $unzip_uploadeds);
                                 $csv_column = $csv_column === false ? null : $csv_column;
@@ -3386,7 +3386,7 @@ class DatabasesPlugin extends UserPluginBase
                 $file_columns_ids = [];
                 foreach ($databases_columns as $databases_column) {
                     // ファイルタイプ
-                    if (DatabasesColumns::isFileColumnType($databases_column->column_type)) {
+                    if ($databases_column->isFileColumnType()) {
                         $file_columns_ids[] = $databases_column->id;
                     }
                 }
@@ -3403,12 +3403,12 @@ class DatabasesPlugin extends UserPluginBase
                 // よってこの２つの配列数は同じになる想定。issetでチェックしているが基本ある想定。
                 if (isset($databases_columns[$col])) {
                     // 登録日型・更新日型・公開日型・表示順は、databases_inputsテーブルの登録日・更新日・公開日・表示順を利用するため、登録しない
-                    if (DatabasesColumns::isNotInputColumnType($databases_columns[$col]->column_type)) {
+                    if ($databases_columns[$col]->isNotInputColumnType()) {
                         continue;
                     }
 
                     // ファイルタイプ
-                    if (DatabasesColumns::isFileColumnType($databases_columns[$col]->column_type)) {
+                    if ($databases_columns[$col]->isFileColumnType()) {
                         if ($file_extension == 'csv') {
                             if (empty($databases_inputs_id)) {
                                 // 登録: ファイルなしは既に$csv_columnにnullをセット済みのため、何もしない.（nullだとno_image画像が表示される）
@@ -3532,7 +3532,7 @@ class DatabasesPlugin extends UserPluginBase
 
                 if ($file_extension == 'csv') {
                     // ファイルタイプ
-                    if (DatabasesColumns::isFileColumnType($databases_column->column_type)) {
+                    if ($databases_column->isFileColumnType()) {
                         // csv単体のインポートでは、ファイルタイプはインポートできないため、バリデーションルールをチェックなしで上書き。
                         // 登録時の値は別途 null に変換してる。
                         $rules[$col + 1] = [];
@@ -3624,7 +3624,7 @@ class DatabasesPlugin extends UserPluginBase
                     if ($csv_column) {
                         if ($file_extension == 'zip') {
                             // ファイルタイプ
-                            if (DatabasesColumns::isFileColumnType($databases_columns[$col]->column_type)) {
+                            if ($databases_columns[$col]->isFileColumnType()) {
                                 // バリデーションのためだけに、一時的にパスをフルパスに書き換える。
                                 if (isset($unzip_uploads_full_paths2[$csv_column])) {
                                     $csv_column = $unzip_uploads_full_paths2[$csv_column];

--- a/config/app.php
+++ b/config/app.php
@@ -293,6 +293,7 @@ $app_array = [
         'NoticeEmbeddedTag' => \App\Enums\NoticeEmbeddedTag::class,
         'ReservationNoticeEmbeddedTag' => \App\Enums\ReservationNoticeEmbeddedTag::class,
         'UserRegisterNoticeEmbeddedTag' => \App\Enums\UserRegisterNoticeEmbeddedTag::class,
+        'DatabaseNoticeEmbeddedTag' => \App\Enums\DatabaseNoticeEmbeddedTag::class,
         'WhatsnewFrameConfig' => \App\Enums\WhatsnewFrameConfig::class,
         'PhotoalbumFrameConfig' => \App\Enums\PhotoalbumFrameConfig::class,
         'PhotoalbumSort' => \App\Enums\PhotoalbumSort::class,

--- a/resources/views/plugins/user/databases/default/databases_confirm.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_confirm.blade.php
@@ -7,10 +7,6 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
 --}}
-@php
-use App\Models\User\Databases\DatabasesColumns;
-@endphp
-
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
@@ -53,7 +49,7 @@ use App\Models\User\Databases\DatabasesColumns;
     @foreach($databases_columns as $database_column)
 
         {{-- 入力しないカラム型は表示しない --}}
-        @if (DatabasesColumns::isNotInputColumnType($database_column->column_type))
+        @if ($database_column->isNotInputColumnType())
             @continue
         @endif
 

--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -7,10 +7,6 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
 --}}
-@php
-use App\Models\User\Databases\DatabasesColumns;
-@endphp
-
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
@@ -49,7 +45,7 @@ use App\Models\User\Databases\DatabasesColumns;
 
         @foreach($databases_columns as $database_column)
             {{-- 入力しないカラム型は表示しない --}}
-            @if (DatabasesColumns::isNotInputColumnType($database_column->column_type))
+            @if ($database_column->isNotInputColumnType())
                 @continue
             @endif
 

--- a/resources/views/plugins/user/databases/description_frame_mails.blade.php
+++ b/resources/views/plugins/user/databases/description_frame_mails.blade.php
@@ -8,9 +8,55 @@
  * copy by resources\views\plugins\common\description_frame_mails.blade.php
 --}}
 @php
-    $use_title = true;
-    $use_body = true;
+use App\Models\User\Databases\DatabasesColumns;
 @endphp
 
-@include('plugins.common.description_frame_mails_common', ['embedded_tags' => NoticeEmbeddedTag::getDescriptionEmbeddedTags($use_title, $use_body)])
+<div class="card bg-light mt-1">
+    <div class="card-body px-2 pt-0 pb-0">
+        <div class="small">
+            埋め込みタグを記述すると件名、本文の該当部分に対応した内容が入ります。<br />
+            <table class="table table-striped table-sm table-bordered">
+                <thead>
+                    <tr>
+                        <th style="width: 50%;">埋め込みタグ</th>
+                        <th>内容</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach(NoticeEmbeddedTag::getDescriptionEmbeddedTags() as $embedded_tag)
+                        <tr>
+                            <td><code>{{$embedded_tag[0]}}</code></td>
+                            <td>{{$embedded_tag[1]}}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
 
+            データベース毎に埋め込みタグが利用できます。<br />
+            @if($database)
+                データベース：{{$database->databases_name}}<br />
+                <table class="table table-striped table-sm table-bordered">
+                    <thead>
+                        <tr>
+                            <th style="width: 50%;">埋め込みタグ</th>
+                            <th>内容</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($columns as $column)
+                            @if (DatabasesColumns::isNotEmbeddedTagsColumnType($column->column_type))
+                                @continue
+                            @endif
+                            <tr>
+                                <td><code>[[X-{{$column->column_name}}]]</code></td>
+                                <td>{{$column->column_name}}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            @else
+                データベース：なし<br />
+            @endforelse
+        </div>
+    </div>
+</div>

--- a/resources/views/plugins/user/databases/description_frame_mails.blade.php
+++ b/resources/views/plugins/user/databases/description_frame_mails.blade.php
@@ -23,7 +23,7 @@ use App\Models\User\Databases\DatabasesColumns;
                     </tr>
                 </thead>
                 <tbody>
-                    @foreach(NoticeEmbeddedTag::getDescriptionEmbeddedTags() as $embedded_tag)
+                    @foreach(DatabaseNoticeEmbeddedTag::getDescriptionEmbeddedTags() as $embedded_tag)
                         <tr>
                             <td><code>{{$embedded_tag[0]}}</code></td>
                             <td>{{$embedded_tag[1]}}</td>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

・汎用項目の埋め込みタグ対応
・公開日、公開終了日、表示順の埋め込みタグ対応

## 修正後画面
### データベースのメール設定

![image](https://user-images.githubusercontent.com/2756509/165704847-149f230b-80f9-423f-b326-25d2381ac720.png)


## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1275

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/commit/a6108b1f68212aaa1f3e3861bd78248ee76e9618

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
