### PR TITLE
【施設予約】予約終了時間に 24:00 を入力できるようにする

### DIFF
--- a/app/Models/User/Reservations/ReservationsInput.php
+++ b/app/Models/User/Reservations/ReservationsInput.php
@@ -37,4 +37,17 @@ class ReservationsInput extends Model
 
         return $display;
     }
+
+    /**
+     * 表示する予約終了時間
+     * end_datetime は not nullのため、空にならない想定
+     */
+    public function displayEndtime()
+    {
+        $endtime = $this->end_datetime->format('H:i');
+        if ($endtime == '00:00') {
+            $endtime = '24:00';
+        }
+        return $endtime;
+    }
 }

--- a/app/Plugins/User/Reservations/ReservationsPlugin.php
+++ b/app/Plugins/User/Reservations/ReservationsPlugin.php
@@ -959,7 +959,9 @@ class ReservationsPlugin extends UserPluginBase
             $validator_array['column']['rrule_repeat_end'][] = new CustomValiAvailableDayOfTheWeekBookings($request->facility_id, $occurrence_dates, '利用できない曜日が含まれています。繰り返し内容を見直してください。');
         }
 
-        $validator_array['column']['end_datetime'] = ['required', 'date_format:H:i', 'after:start_datetime'];
+        // 24h登録対応
+        // $validator_array['column']['end_datetime'] = ['required', 'date_format:H:i', 'after:start_datetime'];
+        $validator_array['column']['end_datetime'] = ['required', 'regex:/^([0-1][0-9]|[2][0-4]):[0-5][0-9]$/', 'after:start_datetime'];
         $validator_array['message']['target_date']    = '予約日';
         $validator_array['message']['start_datetime'] = '予約開始時間';
         $validator_array['message']['end_datetime']   = '予約終了時間';
@@ -1012,7 +1014,6 @@ class ReservationsPlugin extends UserPluginBase
 
         // 新規登録時のみの登録項目
         if (!$booking_id) {
-            // $reservations_inputs->reservations_id = $request->reservations_id;
             $reservations_inputs->facility_id = $request->facility_id;
             $reservations_inputs->created_id  = Auth::user()->id;            // 登録ユーザ
         }
@@ -1113,7 +1114,6 @@ class ReservationsPlugin extends UserPluginBase
         $columns_value = $request->columns_value ?? [];
         foreach (array_keys($columns_value) as $key) {
             // 予約明細 更新レコード取得
-            // $reservations_inputs_columns = ReservationsInputsColumn::where('reservations_id', $request->reservations_id)
             $reservations_inputs_columns = ReservationsInputsColumn::where('inputs_parent_id', $reservations_inputs->inputs_parent_id)
                 ->where('column_id', $key)
                 ->first();
@@ -1122,7 +1122,6 @@ class ReservationsPlugin extends UserPluginBase
             if (!$reservations_inputs_columns) {
                 $reservations_inputs_columns = new ReservationsInputsColumn();
                 // 新規登録時のみの登録項目
-                // $reservations_inputs_columns->reservations_id = $request->reservations_id;
                 $reservations_inputs_columns->inputs_parent_id = $reservations_inputs->id;
                 $reservations_inputs_columns->column_id = $key;
             }
@@ -1130,9 +1129,13 @@ class ReservationsPlugin extends UserPluginBase
 
             $reservations_inputs_columns->save();
         }
-        // $str_mode = $request->booking_id ? '更新' : '登録';
-        // $message = '予約を' . $str_mode . 'しました。【場所】' . $facility->facility_name . ' 【日時】' . date_format($reservations_inputs->start_datetime, 'Y年m月d日 H時i分') . ' ～ ' . date_format($reservations_inputs->end_datetime, 'H時i分');
-        $start_end_datetime_str = date_format($reservations_inputs->start_datetime, 'Y年m月d日 H時i分') . ' ～ ' . date_format($reservations_inputs->end_datetime, 'H時i分');
+
+        $end_datetime_str = date_format($reservations_inputs->end_datetime, 'H時i分');
+        if ($end_datetime_str == '00時00分') {
+            $end_datetime_str = '24時00分';
+        }
+
+        $start_end_datetime_str = date_format($reservations_inputs->start_datetime, 'Y年m月d日 H時i分') . ' ～ ' . $end_datetime_str;
         $flash_message = "{$str_mode}【場所】{$facility->facility_name} 【日時】{$start_end_datetime_str}";
 
         // 繰り返しあり
@@ -1298,7 +1301,7 @@ class ReservationsPlugin extends UserPluginBase
 
             // 表示値をセット
             $inputs->reservation_date_display = $inputs->displayDate();
-            $inputs->reservation_time_display = $inputs->start_datetime->format('H:i') . ' ~ ' . $inputs->end_datetime->format('H:i');
+            $inputs->reservation_time_display = $inputs->start_datetime->format('H:i') . ' ~ ' . $inputs->displayEndtime();
             $repeat->reservation_repeat_display = $repeat->showRruleDisplay();
             $repeat->reservation_repeat_end_display = $repeat->showRruleEndDisplay();
 

--- a/app/Plugins/User/Reservations/ReservationsPlugin.php
+++ b/app/Plugins/User/Reservations/ReservationsPlugin.php
@@ -1014,8 +1014,9 @@ class ReservationsPlugin extends UserPluginBase
 
         // 新規登録時のみの登録項目
         if (!$booking_id) {
-            $reservations_inputs->facility_id = $request->facility_id;
-            $reservations_inputs->created_id  = Auth::user()->id;            // 登録ユーザ
+            $reservations_inputs->facility_id        = $request->facility_id;
+            $reservations_inputs->first_committed_at = now();               // 初回確定日時
+            $reservations_inputs->created_id         = Auth::user()->id;    // 登録ユーザ
         }
         $reservations_inputs->start_datetime = new ConnectCarbon($request->target_date . ' ' . $request->start_datetime . ':00');
         $reservations_inputs->end_datetime = new ConnectCarbon($request->target_date . ' ' . $request->end_datetime . ':00');
@@ -1102,9 +1103,10 @@ class ReservationsPlugin extends UserPluginBase
 
                 // コピー
                 $reservations_inputs_tmp = $reservations_inputs->replicate();
-                $reservations_inputs_tmp->start_datetime = new ConnectCarbon($occurrence->format('Y-m-d') . ' ' . $request->start_datetime . ':00');
-                $reservations_inputs_tmp->end_datetime = new ConnectCarbon($occurrence->format('Y-m-d') . ' ' . $request->end_datetime . ':00');
-                $reservations_inputs_tmp->created_id  = $reservations_inputs->created_id;    // 登録ユーザをコピー元からコピー
+                $reservations_inputs_tmp->start_datetime     = new ConnectCarbon($occurrence->format('Y-m-d') . ' ' . $request->start_datetime . ':00');
+                $reservations_inputs_tmp->end_datetime       = new ConnectCarbon($occurrence->format('Y-m-d') . ' ' . $request->end_datetime . ':00');
+                $reservations_inputs_tmp->first_committed_at = $reservations_inputs->first_committed_at;    // 初回確定日時
+                $reservations_inputs_tmp->created_id         = $reservations_inputs->created_id;            // 登録ユーザをコピー元からコピー
                 $reservations_inputs_tmp->save();
             }
         }

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -9542,11 +9542,12 @@ trait MigrationTrait
             $start_time->addHour($nc2_reservation_location->timezone_offset); // 例）9.0 = 9時間後
             $end_time = new Carbon($nc2_reservation_location->end_time);
             $end_time->addHour($nc2_reservation_location->timezone_offset);
+            $end_time_str = $end_time->format('H:i:s');
 
             // 開始～終了 の差が 24h なら「利用時間の制限なし」
             if ($start_time->diffInHours($end_time) == 24) {
-                // 24:00 は0:00表示になってしまうため、23:55に修正
-                $end_time = new Carbon($end_time->format('Ymd') . '235500');
+                // 24:00 は0:00表示になってしまうため、文字列をセット
+                $end_time_str = '24:00:00';
                 // 制限なし
                 $ini .= "is_time_control = 0\n";
             } else {
@@ -9557,7 +9558,7 @@ trait MigrationTrait
             // 利用時間-開始 例）20220203150000 = yyyyMMddhhiiss = 15(+9) = 24:00
             $ini .= "start_time = " . $start_time->format('H:i:s') . "\n";
             // 利用時間-終了 例）20220204150000 = yyyyMMddhhiiss = 15(+9) = 翌日24:00
-            $ini .= "end_time = " . $end_time->format('H:i:s') . "\n";
+            $ini .= "end_time = " . $end_time_str . "\n";
             // （画面に対象となる項目なし）duplication_flag、例) 0、※ DBから直接 1 にすると予約重複可能になるが、知られてない
             // $ini .= "duplication_flag = " . $nc2_reservation_location->duplication_flag . "\n";
             // 個人的な予約を受け付ける
@@ -9695,15 +9696,13 @@ trait MigrationTrait
                 //     // -1日
                 //     $end_time_full = $end_time_full->subDay();
                 // } elseif ($end_time_full->format('H:i:s') == '00:00:00') {
-                if ($end_time_full->format('H:i:s') == '00:00:00') {
-                    // 全日以外で終了日時が0:00の変換対応. -5分する。
-                    // ※ 例えばNC2の「時間指定」で10:00～24:00という予定に対応して、10:00～23:55に終了時間を変換する
+                // if ($end_time_full->format('H:i:s') == '00:00:00') {
+                //     // 全日以外で終了日時が0:00の変換対応. -5分する。
+                //     // ※ 例えばNC2の「時間指定」で10:00～24:00という予定に対応して、10:00～23:55に終了時間を変換する
 
-                    // -5分
-                    $end_time_full = $end_time_full->subMinute(5);
-                }
-                // $tsv_record['end_date'] = $reservation_reserve->end_date;
-                // $tsv_record['end_time'] = $reservation_reserve->end_time;
+                //     // -5分
+                //     $end_time_full = $end_time_full->subMinute(5);
+                // }
                 $tsv_record['end_date'] = $end_time_full->format('Y-m-d');
                 $tsv_record['end_time'] = $end_time_full->format('H:i:s');
                 $tsv_record['end_time_full'] = $end_time_full;

--- a/database/migrations/2022_05_08_110631_migrate_endtime_24h_from_reservations_inputs_and_reservations_facilities.php
+++ b/database/migrations/2022_05_08_110631_migrate_endtime_24h_from_reservations_inputs_and_reservations_facilities.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+use App\Models\User\Reservations\ReservationsFacility;
+use App\Models\User\Reservations\ReservationsInput;
+
+class MigrateEndtime24hFromReservationsInputsAndReservationsFacilities extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // 予約
+        $inputs = ReservationsInput::whereTime('end_datetime', '23:55:00')->get();
+        foreach ($inputs as $input) {
+            // 終了時間 23:55 を +5分で 24h に更新
+            $input->end_datetime = $input->end_datetime->addMinutes(5);
+            $input->update();
+        }
+
+        // 施設
+        ReservationsFacility::where('end_time', '23:55:00')->update(['end_time' => '24:00:00']);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2022_05_08_121316_migrate_first_committed_at_is_not_null_from_reservations_inputs.php
+++ b/database/migrations/2022_05_08_121316_migrate_first_committed_at_is_not_null_from_reservations_inputs.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+use App\Models\User\Reservations\ReservationsInput;
+
+class MigrateFirstCommittedAtIsNotNullFromReservationsInputs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // 予約
+        $inputs = ReservationsInput::whereNull('first_committed_at')->get();
+        foreach ($inputs as $input) {
+            $input->first_committed_at = $input->created_at;
+            $input->update();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/resources/views/plugins/manage/reservation/edit.blade.php
+++ b/resources/views/plugins/manage/reservation/edit.blade.php
@@ -52,7 +52,20 @@ use App\Models\User\Reservations\ReservationsFacility;
         $('#start_time').datetimepicker(time_setting);
         // 利用終了時間ボタン押下
         $('#end_time').datetimepicker(time_setting);
+
+        $('#end_time').on('change.datetimepicker', function(e) {
+            convert_endtime_0h_to_24h();
+        });
     });
+
+    /**
+     * 終了時間を0時から24時に変換
+     */
+     function convert_endtime_0h_to_24h() {
+        if (form_reservation.end_time.value == '00:00') {
+            form_reservation.end_time.value = '24:00';
+        }
+    }
 </script>
 
 <div class="card">
@@ -154,6 +167,7 @@ use App\Models\User\Reservations\ReservationsFacility;
                                 </div>
                             </div>
                             @include('plugins.common.errors_inline', ['name' => 'end_time'])
+                            <small class="text-muted">※ 00:00 は 24:00 に自動変換します。</small>
                         </div>
                     </div>
                 </div>
@@ -320,5 +334,13 @@ use App\Models\User\Reservations\ReservationsFacility;
 
     </div>
 </div>
+
+{{-- 初期状態で開くもの --}}
+<script>
+    // ページの読み込みが完了したとき
+    window.addEventListener('load', function(){
+        convert_endtime_0h_to_24h();
+    });
+</script>
 
 @endsection

--- a/resources/views/plugins/user/reservations/default/edit_booking.blade.php
+++ b/resources/views/plugins/user/reservations/default/edit_booking.blade.php
@@ -68,7 +68,33 @@ use App\Models\User\Reservations\ReservationsFacility;
         $('#start_datetime').datetimepicker(time_setting);
         // 予約終了時間ボタン押下
         $('#end_datetime').datetimepicker(time_setting);
+
+        $('#end_datetime').on('change.datetimepicker', function(e) {
+            convert_endtime_0h_to_24h();
+        });
     });
+
+    /**
+     * 終了時間を0時から24時に変換
+     */
+    function convert_endtime_0h_to_24h() {
+        if (form_save_booking{{$frame_id}}.end_datetime.value == '00:00') {
+            form_save_booking{{$frame_id}}.end_datetime.value = '24:00';
+        }
+    }
+
+    /**
+     * 終日ボタン押下
+     */
+     function all_day() {
+        @if ($facility->is_time_control)
+            form_save_booking{{$frame_id}}.start_datetime.value = '{{ substr($facility->start_time, 0, -3) }}';
+            form_save_booking{{$frame_id}}.end_datetime.value = '{{ substr($facility->end_time, 0, -3) }}';
+        @else
+            form_save_booking{{$frame_id}}.start_datetime.value = '00:00';
+            form_save_booking{{$frame_id}}.end_datetime.value = '24:00';
+        @endif
+    }
 
     /**
      * 繰り返しselect.change
@@ -122,19 +148,6 @@ use App\Models\User\Reservations\ReservationsFacility;
                 $('#repeat_rule_monthly_id').collapse('hide');
                 $('#repeat_rule_yearly_id').collapse('hide');
         }
-    }
-
-    /**
-     * 終日ボタン押下
-     */
-     function all_day() {
-        @if ($facility->is_time_control)
-            form_save_booking{{$frame_id}}.start_datetime.value = '{{ substr($facility->start_time, 0, -3) }}';
-            form_save_booking{{$frame_id}}.end_datetime.value = '{{ substr($facility->end_time, 0, -3) }}';
-        @else
-            form_save_booking{{$frame_id}}.start_datetime.value = '00:00';
-            form_save_booking{{$frame_id}}.end_datetime.value = '23:55';
-        @endif
     }
 </script>
 
@@ -248,7 +261,8 @@ use App\Models\User\Reservations\ReservationsFacility;
                 <div class="col">
                     @include('plugins.common.errors_inline', ['name' => 'start_datetime'])
                     @include('plugins.common.errors_inline', ['name' => 'end_datetime'])
-                    @if ($facility->is_time_control) <small class="text-muted">【利用時間】 {{ substr($facility->start_time, 0, -3) }} ~ {{ substr($facility->end_time, 0, -3) }}</small> @endif
+                    @if ($facility->is_time_control) <small class="text-muted">【利用時間】 {{ substr($facility->start_time, 0, -3) }} ~ {{ substr($facility->end_time, 0, -3) }}<br /></small> @endif
+                    <small class="text-muted">※ 予約終了時間の 00:00 は 24:00 に自動変換します。</small>
                 </div>
             </div>
 
@@ -609,6 +623,11 @@ use App\Models\User\Reservations\ReservationsFacility;
 <script>
     // 繰り返しルールの表示・非表示
     change_repeat_rule('{{old('rrule_freq', $repeat->getRruleFreq())}}');
+
+    // ページの読み込みが完了したとき
+    window.addEventListener('load', function(){
+        convert_endtime_0h_to_24h();
+    });
 </script>
 
 @endsection

--- a/resources/views/plugins/user/reservations/default/include_calendar_modal_call.blade.php
+++ b/resources/views/plugins/user/reservations/default/include_calendar_modal_call.blade.php
@@ -21,7 +21,7 @@
         >
             {{-- 表示用の予約時間 --}}
             <div class="small">
-                {{ $booking['booking_header']->start_datetime->format('H:i')}}~{{$booking['booking_header']->end_datetime->format('H:i') . ' ' . $booking['booking_header']->title }}
+                {{ $booking['booking_header']->start_datetime->format('H:i')}}~{{$booking['booking_header']->displayEndtime() . ' ' . $booking['booking_header']->title }}
                 <span class="badge badge-warning align-bottom">承認待ち</span>
             </div>
         </a>
@@ -30,7 +30,7 @@
         {{-- 承認待ち：リンクなし＆タイトル表示しない --}}
 
         <div class="small">
-            {{ $booking['booking_header']->start_datetime->format('H:i')}}~{{$booking['booking_header']->end_datetime->format('H:i') }}
+            {{ $booking['booking_header']->start_datetime->format('H:i')}}~{{$booking['booking_header']->displayEndtime() }}
             <span class="badge badge-warning align-bottom">承認待ち</span>
         </div>
     @endcan
@@ -50,7 +50,7 @@
     >
         {{-- 表示用の予約時間 --}}
         <div class="small">
-            {{ $booking['booking_header']->start_datetime->format('H:i')}}~{{$booking['booking_header']->end_datetime->format('H:i') . ' ' . $booking['booking_header']->title }}
+            {{ $booking['booking_header']->start_datetime->format('H:i')}}~{{$booking['booking_header']->displayEndtime() . ' ' . $booking['booking_header']->title }}
         </div>
     </a>
 

--- a/resources/views/plugins/user/reservations/default/show_booking.blade.php
+++ b/resources/views/plugins/user/reservations/default/show_booking.blade.php
@@ -26,7 +26,7 @@ if ($frame->isExpandNarrow()) {
     <dd class="{{$value_class}}">{{$inputs->displayDate()}}</dd>
     {{-- 利用時間 --}}
     <dt class="{{$label_class}}">{{__('messages.time_of_use')}}</dt>
-    <dd class="{{$value_class}}">{{$inputs->start_datetime->format('H:i')}} ~ {{$inputs->end_datetime->format('H:i')}}</dd>
+    <dd class="{{$value_class}}">{{$inputs->start_datetime->format('H:i')}} ~ {{$inputs->displayEndtime()}}</dd>
 
     @if ($repeat->id)
         {{-- 繰り返し --}}


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

JSで24:00入力できたため、対応しました。
施設の利用終了時間も24時間設定対応しました。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1262
* https://github.com/opensource-workshop/connect-cms/issues/1280

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
