### PR TITLE
【フォーム】投稿したフォームデータに採番値を追加＆CSVダウンロードで確認できるようにする

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -789,6 +789,7 @@ class FormsPlugin extends UserPluginBase
         $forms_inputs->forms_id = $form->id;
 
         $user_token = null;
+        $number = null;
         if ($form->use_temporary_regist_mail_flag) {
             // 仮登録
             // トークン生成 (メール送信用でユーザのみ知る. DB保存しない)
@@ -802,6 +803,11 @@ class FormsPlugin extends UserPluginBase
         } else {
             // 本登録
             $forms_inputs->status = FormStatusType::active;
+            if ($form->numbering_use_flag) {
+                // 採番は本登録の時のみする ※[採番プレフィックス文字列] + [ゼロ埋め採番6桁]
+                $number = $form->numbering_prefix . sprintf('%06d', $this->getNo('forms', $form->bucket_id, $form->numbering_prefix));
+                $forms_inputs->number_with_prefix = $number;
+            }
         }
 
         $forms_inputs->save();
@@ -914,10 +920,6 @@ class FormsPlugin extends UserPluginBase
             }
         } else {
             // 本登録
-            // 採番は本登録の時のみする
-
-            // 採番 ※[採番プレフィックス文字列] + [ゼロ埋め採番6桁]
-            $number = $form->numbering_use_flag ? $form->numbering_prefix . sprintf('%06d', $this->getNo('forms', $form->bucket_id, $form->numbering_prefix)) : null;
 
             // 登録後メッセージ内の採番文字列を置換
             $after_message = str_replace('[[number]]', $number, $form->after_message);

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -2268,6 +2268,7 @@ class FormsPlugin extends UserPluginBase
                 select(
                     'forms_inputs.id as inputs_id',
                     'forms_inputs.status as inputs_status',
+                    'forms_inputs.number_with_prefix as number_with_prefix',
                     'forms_inputs.created_at as inputs_created_at',
                     'forms_input_cols.*'
                 )
@@ -2326,6 +2327,11 @@ ORDER BY forms_inputs_id, forms_columns_id
             $csv_array[0][$column->id] = $column->column_name;
             $copy_base[$column->id] = '';
         }
+        if ($form->numbering_use_flag) {
+            // 見出し行-行末１つ手前（採番項目）
+            $csv_array[0]['number_with_prefix'] = '採番';
+            $copy_base['number_with_prefix'] = '';
+        }
         // 見出し行-行末（固定項目）
         $csv_array[0]['created_at'] = '登録日時';
         $copy_base['created_at'] = '';
@@ -2338,6 +2344,10 @@ ORDER BY forms_inputs_id, forms_columns_id
 
                 // 初回で固定項目をセット
                 $csv_array[$input_col->inputs_id]['status'] = $input_col->inputs_status;
+                if ($form->numbering_use_flag) {
+                    // 採番項目
+                    $csv_array[$input_col->inputs_id]['number_with_prefix'] = $input_col->number_with_prefix;
+                }
                 $csv_array[$input_col->inputs_id]['created_at'] = $input_col->inputs_created_at;
             }
             $csv_array[$input_col->inputs_id][$input_col->forms_columns_id] = $input_col->value;

--- a/database/migrations/2022_05_11_164539_add_number_2_forms_inputs_table.php
+++ b/database/migrations/2022_05_11_164539_add_number_2_forms_inputs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNumber2FormsInputsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms_inputs', function (Blueprint $table) {
+            $table->string('number_with_prefix')->nullable()->after('add_token_created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms_inputs', function (Blueprint $table) {
+            $table->dropColumn('number_with_prefix');
+        });
+    }
+}

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -412,7 +412,8 @@
             <input type="text" id="numbering_prefix" name="numbering_prefix" value="{{old('numbering_prefix', $form->numbering_prefix)}}" class="form-control" v-model="v_numbering_prefix">
             <small class="text-muted">
                 ※ 採番イメージ：@{{ v_numbering_prefix + '000001' }}<br>
-                ※ 初回採番後のデータは<a href="{{ url('/manage/number') }}" target="_blank">管理画面</a>から確認できます。
+                ※ 初回採番後のデータは<a href="{{ url('/manage/number') }}" target="_blank">管理画面</a>から確認できます。<br>
+                ※ 採番機能の使用時は<a href="{{ url("/plugin/forms/listInputs/{$page->id}/{$frame_id}#frame-{$frame_id}") }}" target="_blank">登録一覧</a>からも採番値が確認できます。
             </small>
         </div>
     </div>

--- a/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
@@ -63,6 +63,9 @@
             @foreach($columns as $column)
                 <th>{{$column->column_name}}</th>
             @endforeach
+            @if ($form->numbering_use_flag)
+                <th nowrap>採番</th>
+            @endif
             <th nowrap>登録日時</th>
         </tr>
     </thead>
@@ -92,6 +95,12 @@
                     @include('plugins.user.forms.default.forms_include_value')
                 </td>
             @endforeach
+
+            @if ($form->numbering_use_flag)
+                <td>
+                    {{$input->number_with_prefix}}
+                </td>
+            @endif
 
             <td nowrap>
                 {{$input->created_at}}


### PR DESCRIPTION
## 概要
掲題の通り。契約クライアントから要望あり。

## レビュー完了希望日
- 契約クライアントには「5月中に提供可能」で伝えてある為、急ぎません。
    - （急ぎませんが）5月16日～週のどこかからフォーム＋採番値の業務運用を想定している、との発言もあり。5月中で了承頂いているので5月中であれば問題ないですが、早ければ尚、ありがたい、といったところです。

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/issues/659

## 参考
なし

## DB変更の有無
有り

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
