### PR TITLE
【フォーム】投稿したフォームデータに採番値を追加＆CSVダウンロードで確認できるようにする（仮登録フローでの対応漏れ）

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -1148,6 +1148,12 @@ class FormsPlugin extends UserPluginBase
         // forms_inputs 更新
         // 本登録
         $forms_inputs->status = FormStatusType::active;
+        $number = null;
+        if ($form->numbering_use_flag) {
+            // 採番は本登録の時のみする ※[採番プレフィックス文字列] + [ゼロ埋め採番6桁]
+            $number = $form->numbering_prefix . sprintf('%06d', $this->getNo('forms', $form->bucket_id, $form->numbering_prefix));
+            $forms_inputs->number_with_prefix = $number;
+        }
         $forms_inputs->save();
 
         // フォームのカラムデータ
@@ -1211,10 +1217,6 @@ class FormsPlugin extends UserPluginBase
         // dd($user_mailaddresses);
 
         // 本登録
-        // 採番は本登録の時のみする
-
-        // 採番 ※[採番プレフィックス文字列] + [ゼロ埋め採番6桁]
-        $number = $form->numbering_use_flag ? $form->numbering_prefix . sprintf('%06d', $this->getNo('forms', $form->bucket_id, $form->numbering_prefix)) : null;
 
         // 登録後メッセージ内の採番文字列を置換
         $after_message = str_replace('[[number]]', $number, $form->after_message);


### PR DESCRIPTION
## 概要
先のPRに対応漏れ（仮登録フローでの本登録時に採番値が登録されない）があり、これのバグFIX対応です。

## レビュー完了希望日
- バグなので急ぎたいですが、お手すきの際で結構です。よろしくお願いいたします。

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/issues/659
https://github.com/opensource-workshop/connect-cms/pull/1285

## 参考
なし

## DB変更の有無
なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
