### PR TITLE
add: メンテナンス画面追加

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -1491,7 +1491,7 @@ trait MigrationTrait
             ]);
 
             // 選択肢型の追加
-            if (in_array($column_type, ['radio','select','checkbox'])){
+            if (in_array($column_type, ['radio','select','checkbox'])) {
                 // マッピングテーブルの取得
                 $mapping = MigrationMapping::where('target_source_table', 'users_columns_selects')->where('source_key', $nc2_item_id)->first();
                 // マッピングテーブルを確認して、あれば削除
@@ -1502,7 +1502,7 @@ trait MigrationTrait
                     $mapping->delete();
                 }
                 $select_values = explode('|', $this->getArrayValue($ini, 'users_columns_selects_base', 'value'));
-                foreach($select_values as $i => $value) {
+                foreach ($select_values as $i => $value) {
                     $display_sequence = $i;
                     $display_sequence++;
                     $users_column_select = UsersColumnsSelects::create([
@@ -7388,17 +7388,17 @@ trait MigrationTrait
             } elseif (array_key_exists($user_column_type, $convert_user_column_types)) {
                 $user_column_type = $convert_user_column_types[$user_column_type];
                 $users_columns_selects_ini  = "[users_columns_selects_base]\n";
-                switch($user_column_type) {
+                switch ($user_column_type) {
                     case 'radio':
                     case 'select':
                     case 'checkbox':
                         $options = rtrim($nc2_any_item->options, '|');// 最後のパイプは削除する
                         $users_columns_selects_ini .= "value      = \"" . $options . "\"\n";
                         $users_columns_selects_ini .= "\n";
-                    break;
+                        break;
                     default:
                         $users_columns_selects_ini = "\n";
-                    break;
+                        break;
                 }
 
             } else {

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -31,7 +31,7 @@
     @php
         $default_html = '
 <div class="text-center mt-4">
-    <h1>サイトメンテナンス</h1>
+    <h1>ただいまサイトメンテナンス中です。</h1>
     <p>作業終了までしばらくお待ちください。</p>
 </div>
 ';

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -1,0 +1,41 @@
+{{--
+ * メンテナンスモード画面（503）
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category コア
+ *
+ * @see resources\views\layouts\app.blade.php
+ * @see vendor\laravel\framework\src\Illuminate\Foundation\Exceptions\views\503.blade.php
+ * @see vendor\laravel\framework\src\Illuminate\Foundation\Exceptions\views\minimal.blade.php
+--}}
+<!DOCTYPE html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Styles -->
+    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+
+    <!-- Fonts -->
+    <link href="{{asset('fontawesome/css/all.min.css')}}" rel='stylesheet' type='text/css'>
+
+    <!-- Scripts -->
+    {{-- <script src="{{asset('js/app.js')}}"></script> --}}
+
+    <title>サイトメンテナンス</title>
+</head>
+<body>
+    @php
+        $default_html = '
+<div class="text-center mt-4">
+    <h1>サイトメンテナンス</h1>
+    <p>作業終了までしばらくお待ちください。</p>
+</div>
+';
+    @endphp
+    {!! __($exception->getMessage() ?: $default_html) !!}
+</body>
+</html>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

Laravel標準のメンテナンス画面がありますが、メッセージを改行できず使い勝手が悪いため、
メンテナンス画面の追加しました。
社内確認後、マージ予定です。

## 画面

### メンテナンスモード

コマンド
```
php artisan down
```

#### 修正後
![image](https://user-images.githubusercontent.com/2756509/169045463-745a9f3f-ea46-4278-aa96-c3d0db026db1.png)

#### 修正前
![image](https://user-images.githubusercontent.com/2756509/169046584-a95c4151-5a85-4874-a200-a92e0791d189.png)

コマンド メッセージ設定
```
php artisan down --message="<div class=\"text-center mt-4\"><h1>ただいまサイトメンテナンス中です。</h1><h3>【作業日時】</h3><h3 class=\"text-danger\">2022年○○月○○日13:00～18:00</h3><p>作業終了までしばらくお待ちください。</p></div>"
```
#### 修正後
![image](https://user-images.githubusercontent.com/2756509/169045786-6fc9ec4d-99e0-4273-9d31-3c22379c2f4a.png)

#### 修正前
![image](https://user-images.githubusercontent.com/2756509/169046338-d0605600-6a34-455a-939c-aa8107f2e4cd.png)

### 参考：メンテナンスモード解除

```
php artisan up
```


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* [Laravel 8.x更新で変わったこと（１）メンテナンス中のアクセス – ララジャパン](https://www.larajapan.com/2021/10/31/laravel-8-x%E6%9B%B4%E6%96%B0%E3%81%A7%E5%A4%89%E3%82%8F%E3%81%A3%E3%81%9F%E3%81%93%E3%81%A8%EF%BC%88%EF%BC%91%EF%BC%89%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E4%B8%AD%E3%81%AE%E3%82%A2/)
* [Laravel 8 の php artisan down では --allow ではなく --secret を使う - Qiita](https://qiita.com/Crowmaru/items/a3dd10786a1764d292ad)

Laravel8でメンテナンスモード変わる。
Connectは現在Laravel6。
Laravel9 LTSにアップグレード時に注意かなぁ。

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
