### PR TITLE
OW-528 Add: INFOレベルの日時ログ出力 

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -54,6 +54,13 @@ return [
             'days' => 14,
         ],
 
+        'daily_info' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => 'info',
+            'days' => 14,
+        ],
+
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),


### PR DESCRIPTION
## 概要

DEBUGレベルだと出力が多すぎるため、INFOレベルの日時ログを出力する選択肢を増やしました。 

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
6/30

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
