### PR TITLE
add: 【ユーザ管理】ユーザ登録時のメール送信画面に画面名等追加

### DIFF
--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -252,7 +252,7 @@ trait RegistersUsers
 
         //Log::debug("register end brfore.");
         return $this->registered($request, $user)
-                        ?: redirect($this->redirectPath());
+                        ?: redirect($this->redirectPath())->with('flash_message', 'ユーザ登録しました。');;
     }
 
     /**

--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -252,7 +252,7 @@ trait RegistersUsers
 
         //Log::debug("register end brfore.");
         return $this->registered($request, $user)
-                        ?: redirect($this->redirectPath())->with('flash_message', 'ユーザ登録しました。');;
+                        ?: redirect($this->redirectPath())->with('flash_message', 'ユーザ登録しました。');
     }
 
     /**

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1255,9 +1255,8 @@ class UserManage extends ManagePluginBase
             ]
         );
 
-        // ページ管理画面に戻る
         // 自動ユーザ登録設定画面に戻る
-        return redirect("/manage/user/autoRegist");
+        return redirect("/manage/user/autoRegist")->with('flash_message', '更新しました。');
     }
 
     /**

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -793,7 +793,7 @@ class UserManage extends ManagePluginBase
 
         // 変更画面に戻る
         // return $this->edit($request, $id);
-        return redirect("/manage/user/edit/$id");
+        return redirect("/manage/user/edit/$id")->with('flash_message', 'ユーザ変更しました。');
     }
 
     /**

--- a/database/seeds/DefaultConfigsTableSeeder.php
+++ b/database/seeds/DefaultConfigsTableSeeder.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
 
 use App\Models\Core\Configs;
 
@@ -17,8 +16,8 @@ class DefaultConfigsTableSeeder extends Seeder
      */
     public function run()
     {
-        if (DB::table('configs')->count() == 0) {
-            DB::table('configs')->insert(
+        if (Configs::count() == 0) {
+            Configs::insert(
                 [
                     [
                         'name'=>'base_background_color',
@@ -101,7 +100,7 @@ class DefaultConfigsTableSeeder extends Seeder
             );
         }
 
-        if (DB::table('configs')->where('name', 'base_login_password_reset')->count() == 0) {
+        if (Configs::where('name', 'base_login_password_reset')->count() == 0) {
             // パスワードリセットの使用
             $configs = Configs::create([
                 'name' => 'base_login_password_reset',
@@ -110,7 +109,7 @@ class DefaultConfigsTableSeeder extends Seeder
             ]);
         }
 
-        if (DB::table('configs')->where('name', 'use_mypage')->count() == 0) {
+        if (Configs::where('name', 'use_mypage')->count() == 0) {
             // マイページの使用
             $configs = Configs::create([
                 'name' => 'use_mypage',
@@ -119,7 +118,7 @@ class DefaultConfigsTableSeeder extends Seeder
             ]);
         }
 
-        if (DB::table('configs')->where('name', 'use_normal_login_along_with_auth_method')->count() == 0) {
+        if (Configs::where('name', 'use_normal_login_along_with_auth_method')->count() == 0) {
             // 外部認証と併せて、通常ログインも使用
             $configs = Configs::create([
                 'name' => 'use_normal_login_along_with_auth_method',
@@ -128,7 +127,7 @@ class DefaultConfigsTableSeeder extends Seeder
             ]);
         }
 
-        if (DB::table('configs')->where('name', 'base_login_redirect_previous_page')->count() == 0) {
+        if (Configs::where('name', 'base_login_redirect_previous_page')->count() == 0) {
             // ログイン時に元いたページに遷移 設定
             $configs = Configs::create([
                 'name' => 'base_login_redirect_previous_page',
@@ -137,7 +136,7 @@ class DefaultConfigsTableSeeder extends Seeder
             ]);
         }
 
-        if (DB::table('configs')->where('name', 'user_register_after_message')->count() == 0) {
+        if (Configs::where('name', 'user_register_after_message')->count() == 0) {
             // 本登録後のメッセージ
             $configs = Configs::create([
                 'name' => 'user_register_after_message',
@@ -146,7 +145,7 @@ class DefaultConfigsTableSeeder extends Seeder
             ]);
         }
 
-        if (DB::table('configs')->where('name', 'base_header_font_color_class')->count() == 0) {
+        if (Configs::where('name', 'base_header_font_color_class')->count() == 0) {
             // 画面の基本のヘッダー文字色
             $configs = Configs::create([
                 'name' => 'base_header_font_color_class',
@@ -155,7 +154,7 @@ class DefaultConfigsTableSeeder extends Seeder
             ]);
         }
 
-        if (DB::table('configs')->where('name', 'fontsizeselect')->count() == 0) {
+        if (Configs::where('name', 'fontsizeselect')->count() == 0) {
             // wysiwygで文字サイズの使用
             $configs = Configs::create([
                 'name' => 'fontsizeselect',
@@ -164,7 +163,7 @@ class DefaultConfigsTableSeeder extends Seeder
             ]);
         }
 
-        if (DB::table('configs')->where('name', 'memory_limit_for_image_resize')->count() == 0) {
+        if (Configs::where('name', 'memory_limit_for_image_resize')->count() == 0) {
             // 画像リサイズ時のPHPメモリ数
             $configs = Configs::create([
                 'name' => 'memory_limit_for_image_resize',
@@ -179,6 +178,29 @@ class DefaultConfigsTableSeeder extends Seeder
                 'name' => 'resized_image_size_initial',
                 'category' => 'wysiwyg',
                 'value' => ResizedImageSize::getDefault(),
+            ]);
+        }
+
+        if (Configs::where('name', 'user_register_mail_subject')->count() == 0) {
+            // 本登録メール件名
+            $configs = Configs::create([
+                'name' => 'user_register_mail_subject',
+                'category' => 'user_register',
+                'value' => 'ユーザ登録が完了しました - [[site_name]]'
+            ]);
+        }
+
+        if (Configs::where('name', 'user_register_mail_format')->count() == 0) {
+            // 本登録メールフォーマット
+            $configs = Configs::create([
+                'name' => 'user_register_mail_format',
+                'category' => 'user_register',
+                'value' => '--- 登録内容
+
+[[body]]
+
+
+ユーザ登録が完了しました。登録したログインID、パスワードでログインしてください。'
             ]);
         }
 

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -18,6 +18,9 @@
 
         @include('plugins.common.errors_form_line')
 
+        {{-- 登録後メッセージ表示 --}}
+        @include('plugins.common.flash_message')
+
         <form action="{{url('/')}}/manage/user/autoRegistUpdate" method="POST">
             {{csrf_field()}}
 
@@ -115,9 +118,9 @@
                     <div class="custom-control custom-checkbox">
                         <input type="hidden" name="user_register_temporary_regist_mail_flag" value="0">
                         @if(Configs::getConfigsValueAndOld($configs, "user_register_temporary_regist_mail_flag") == "1")
-                            <input type="checkbox" name="user_register_temporary_regist_mail_flag" value="1" class="custom-control-input" id="user_register_temporary_regist_mail_flag" checked=checked>
+                            <input type="checkbox" name="user_register_temporary_regist_mail_flag" value="1" class="custom-control-input"  data-toggle="collapse" data-target="#collapse_register_temporary" aria-expanded="false" aria-controls="collapse_register_temporary" id="user_register_temporary_regist_mail_flag" checked=checked>
                         @else
-                            <input type="checkbox" name="user_register_temporary_regist_mail_flag" value="1" class="custom-control-input" id="user_register_temporary_regist_mail_flag">
+                            <input type="checkbox" name="user_register_temporary_regist_mail_flag" value="1" class="custom-control-input" data-toggle="collapse" data-target="#collapse_register_temporary" aria-expanded="false" aria-controls="collapse_register_temporary" id="user_register_temporary_regist_mail_flag">
                         @endif
                         <label class="custom-control-label" for="user_register_temporary_regist_mail_flag">登録者に仮登録メールを送信する</label>
                     </div>
@@ -130,36 +133,38 @@
                 </div>
             </div>
 
-            <div class="form-group row">
-                <label class="col-md-3 col-form-label text-md-right"></label>
-                <div class="col">
-                    <label class="control-label">仮登録メール件名</label>
-                    <input type="text" name="user_register_temporary_regist_mail_subject" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_temporary_regist_mail_subject')}}" class="form-control" placeholder="（例）仮登録のお知らせと本登録のお願い">
-                    <small class="text-muted">
-                        ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
-                    </small>
+            <div class="collapse" id="collapse_register_temporary">
+                <div class="form-group row">
+                    <label class="col-md-3 col-form-label text-md-right"></label>
+                    <div class="col">
+                        <label class="control-label">仮登録メール件名</label>
+                        <input type="text" name="user_register_temporary_regist_mail_subject" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_temporary_regist_mail_subject')}}" class="form-control" placeholder="（例）仮登録のお知らせと本登録のお願い">
+                        <small class="text-muted">
+                            ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                        </small>
+                    </div>
                 </div>
-            </div>
 
-            <div class="form-group row">
-                <label class="col-md-3 col-form-label text-md-right"></label>
-                <div class="col">
-                    <label class="control-label">仮登録メールフォーマット</label>
-                    <textarea name="user_register_temporary_regist_mail_format" class="form-control" rows=5 placeholder="（例）ユーザ仮登録を受け付けました。&#13;&#10;引き続き、下記のURLへアクセスしていただき、ユーザ本登録を行ってください。&#13;&#10;&#13;&#10;↓ユーザ本登録URL&#13;&#10;[[entry_url]]&#13;&#10;&#13;&#10;※お使いのメールソフトによっては、URLが途中で切れてアクセスできない場合があります。&#13;&#10;　その場合はクリックされるのではなくURLをブラウザのアドレス欄にコピー＆ペーストしてアクセスしてください。&#13;&#10;----------------------------------&#13;&#10;[[body]]&#13;&#10;----------------------------------">{{Configs::getConfigsValueAndOld($configs, "user_register_temporary_regist_mail_format")}}</textarea>
-                    <small class="text-muted">
-                        ※ [[entry_url]] を記述すると本登録URLが入ります。本登録URLの有効期限は仮登録後60分です。<br>
-                        ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
-                        ※ [[body]] を記述すると該当部分に登録内容が入ります。
-                    </small>
-                    @if ($errors && $errors->has('user_register_temporary_regist_mail_format')) <div class="text-danger">{{$errors->first('user_register_temporary_regist_mail_format')}}</div> @endif
+                <div class="form-group row">
+                    <label class="col-md-3 col-form-label text-md-right"></label>
+                    <div class="col">
+                        <label class="control-label">仮登録メールフォーマット</label>
+                        <textarea name="user_register_temporary_regist_mail_format" class="form-control" rows=5 placeholder="（例）ユーザ仮登録を受け付けました。&#13;&#10;引き続き、下記のURLへアクセスしていただき、ユーザ本登録を行ってください。&#13;&#10;&#13;&#10;↓ユーザ本登録URL&#13;&#10;[[entry_url]]&#13;&#10;&#13;&#10;※お使いのメールソフトによっては、URLが途中で切れてアクセスできない場合があります。&#13;&#10;　その場合はクリックされるのではなくURLをブラウザのアドレス欄にコピー＆ペーストしてアクセスしてください。&#13;&#10;----------------------------------&#13;&#10;[[body]]&#13;&#10;----------------------------------">{{Configs::getConfigsValueAndOld($configs, "user_register_temporary_regist_mail_format")}}</textarea>
+                        <small class="text-muted">
+                            ※ [[entry_url]] を記述すると本登録URLが入ります。本登録URLの有効期限は仮登録後60分です。<br>
+                            ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                            ※ [[body]] を記述すると該当部分に登録内容が入ります。
+                        </small>
+                        @if ($errors && $errors->has('user_register_temporary_regist_mail_format')) <div class="text-danger">{{$errors->first('user_register_temporary_regist_mail_format')}}</div> @endif
+                    </div>
                 </div>
-            </div>
 
-            <div class="form-group row">
-                <label class="col-md-3 col-form-label text-md-right">仮登録後のメッセージ</label>
-                <div class="col">
-                    <input type="text" name="user_register_temporary_regist_after_message" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_temporary_regist_after_message')}}" class="form-control">
-                    <small class="text-muted">※ （例）ユーザを仮登録しました。メールを送信しましたので、記載されているリンクより登録を完了してください。</small>
+                <div class="form-group row">
+                    <label class="col-md-3 col-form-label text-md-right">仮登録後のメッセージ</label>
+                    <div class="col">
+                        <input type="text" name="user_register_temporary_regist_after_message" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_temporary_regist_after_message')}}" class="form-control">
+                        <small class="text-muted">※ （例）ユーザを仮登録しました。メールを送信しましたので、記載されているリンクより登録を完了してください。</small>
+                    </div>
                 </div>
             </div>
 
@@ -324,4 +329,13 @@
         </form>
     </div>
 </div>
+
+{{-- 初期状態で開くもの --}}
+@if(Configs::getConfigsValueAndOld($configs, "user_register_temporary_regist_mail_flag") == "1")
+    <script>
+    $('#collapse_register_temporary').collapse({
+        toggle: true
+    })
+    </script>
+@endif
 @endsection

--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -45,6 +45,10 @@ use App\Models\Core\UsersColumns;
         @include('plugins.manage.user.user_manage_tab')
     </div>
     <div class="card-body">
+
+        {{-- 登録後メッセージ表示 --}}
+        @include('plugins.common.flash_message')
+
         <div class="accordion" id="search_accordion">
             <div class="card">
                 <button class="btn btn-link p-0 text-left collapsed" type="button" data-toggle="collapse" data-target="#search_collapse" aria-expanded="false" aria-controls="search_collapse">

--- a/resources/views/plugins/manage/user/mail.blade.php
+++ b/resources/views/plugins/manage/user/mail.blade.php
@@ -20,6 +20,15 @@
 
         @include('plugins.common.errors_form_line')
 
+        {{-- 登録後メッセージ表示 --}}
+        @include('plugins.common.flash_message')
+
+        {{-- メッセージエリア --}}
+        <div class="alert alert-info">
+            <i class="fas fa-exclamation-circle"></i> メールで登録内容を通知する場合、「送信」ボタンを押してください。<br />
+            　件名・本文のフォーマットは、[ <a href="{{url('/')}}/manage/user/autoRegist" target="_blank">自動ユーザ登録設定 <i class="fas fa-external-link-alt"></i></a> ] の「本登録メール件名」「本登録メールフォーマット」から設定できます。
+        </div>
+
         <form action="{{url('/')}}/manage/user/mailSend/{{$user->id}}" method="POST">
             {{csrf_field()}}
 

--- a/resources/views/plugins/manage/user/regist.blade.php
+++ b/resources/views/plugins/manage/user/regist.blade.php
@@ -20,6 +20,9 @@
 </div>
 <div class="card-body">
 
+    {{-- 登録後メッセージ表示 --}}
+    @include('plugins.common.flash_message')
+
     {{-- フォームをincude --}}
     @include('auth.registe_form')
 


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1305

## 修正後画面
### 自動ユーザ登録設定（メール仮登録は折りたたむ）
![image](https://user-images.githubusercontent.com/2756509/174536994-99d571a8-75b4-491d-b4f3-8ace376125b4.png)

### メール送信画面（メール送信画面にタイトル付ける）
![image](https://user-images.githubusercontent.com/2756509/174537377-5eae1130-eb33-4dd5-9294-25682dfc0cd4.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

seeder追加

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
