### PR TITLE
Modify: ヘッダーのサイト名が長いときに省略する

### DIFF
--- a/public/css/connect.css
+++ b/public/css/connect.css
@@ -177,6 +177,17 @@ a.cc-icon-external:after {
     background-color: transparent !important;
 }
 
+/* サイト名が長い場合に途切れないようにする */
+@media (max-width: 767px){
+    .cc-custom-brand{
+        overflow: hidden;
+        text-align: left;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 240px;
+    }
+}
+
 /*  Active
 ------------------------------------- */
 .cc-active {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -208,20 +208,7 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
 @if (Auth::check() || Configs::getConfigsValue($cc_configs, 'base_header_hidden') != '1')
 <nav class="navbar navbar-expand-md bg-dark {{$base_header_font_color_class}} @if (Configs::getConfigsValue($cc_configs, 'base_header_fix') == '1') sticky-top @endif {{ $base_header_optional_class }}" aria-label="ヘッダー">
     <!-- Branding Image -->
-    <style>
-        @media (max-width: 768px){
-            .custom-brand{
-                clear: left;
-                float: left;
-                overflow: hidden;
-                text-align: left;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                width: 240px;
-            }
-        }
-    </style>
-    <a class="navbar-brand custom-brand" href="{{ url('/') }}">
+    <a class="navbar-brand cc-custom-brand" href="{{ url('/') }}">
         {{ Configs::getConfigsValue($cc_configs, 'base_site_name', config('app.name', 'Connect-CMS')) }}
     </a>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -208,7 +208,20 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
 @if (Auth::check() || Configs::getConfigsValue($cc_configs, 'base_header_hidden') != '1')
 <nav class="navbar navbar-expand-md bg-dark {{$base_header_font_color_class}} @if (Configs::getConfigsValue($cc_configs, 'base_header_fix') == '1') sticky-top @endif {{ $base_header_optional_class }}" aria-label="ヘッダー">
     <!-- Branding Image -->
-    <a class="navbar-brand" href="{{ url('/') }}">
+    <style>
+        @media (max-width: 768px){
+            .custom-brand{
+                clear: left;
+                float: left;
+                overflow: hidden;
+                text-align: left;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                width: 240px;
+            }
+        }
+    </style>
+    <a class="navbar-brand custom-brand" href="{{ url('/') }}">
         {{ Configs::getConfigsValue($cc_configs, 'base_site_name', config('app.name', 'Connect-CMS')) }}
     </a>
 


### PR DESCRIPTION
## 概要
ヘッダーのサイト名が長いと折り返してハンバーガーメニューが左側に行ってしまうため、
省略して表示するようにしました。

変更前
<img width="250" alt="image" src="https://user-images.githubusercontent.com/32890286/174546430-15dfea8e-87b3-4f53-bd4d-6bb2078e4f62.png">
変更後
<img width="250" alt="image" src="https://user-images.githubusercontent.com/32890286/174546489-9c633177-e132-4b77-a98c-04be6ff8fe8f.png">


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
