### PR TITLE
OW-1098 change: wysiwyg, 文字の大きさの選択ラベルを％に変更

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -267,7 +267,7 @@
         {!!$toolbar!!}
 
         // fontsize_formats: '8pt 10pt 12pt 14pt 16pt 18pt 24pt 36pt',
-        fontsize_formats: '0.65rem 0.85rem 1rem 1.15rem 1.3rem 1.5rem 2rem 3rem',
+        fontsize_formats: '65%=0.65rem 85%=0.85rem 100%=1rem 115%=1.15rem 130%=1.3rem 150%=1.5rem 200%=2rem 300%=3rem',
 
         {{-- テーマ固有書式 --}}
         {!!$style_formats_file!!}

--- a/resources/views/plugins/manage/service/index.blade.php
+++ b/resources/views/plugins/manage/service/index.blade.php
@@ -26,7 +26,7 @@
 
         <div class="alert alert-info">
             <i class="fas fa-exclamation-circle"></i> 外部サービスを利用するWYSIWYG設定です。<br />
-            他のWYSIWYG設定は [ サイト管理＞その他設定＞<a href="{{url('/')}}/manage/site/wysiwyg">WYSIWYG設定</a> ] から行えます。
+            他のWYSIWYG設定は [ サイト管理＞<a href="{{url('/')}}/manage/site/wysiwyg">WYSIWYG設定</a> ] から行えます。
         </div>
 
         <div class="form-group">

--- a/resources/views/plugins/manage/site/site_manage_tab.blade.php
+++ b/resources/views/plugins/manage/site/site_manage_tab.blade.php
@@ -45,6 +45,14 @@
                 @endif
                 </li>
 
+                <li role="presentation" class="nav-item">
+                @if ($function == "wysiwyg")
+                    <span class="nav-link"><span class="active">WYSIWYG設定</span></span>
+                @else
+                    <a href="{{url('/manage/site/wysiwyg')}}" class="nav-link">WYSIWYG設定</a>
+                @endif
+                </li>
+
                 <li class="nav-item dropdown">
                     <a href="#" class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         その他設定
@@ -73,12 +81,6 @@
                             <a href="{{url('/manage/site/favicon')}}" class="dropdown-item active bg-light">ファビコン</a>
                         @else
                             <a href="{{url('/manage/site/favicon')}}" class="dropdown-item">ファビコン</a>
-                        @endif
-
-                        @if ($function == "wysiwyg")
-                            <a href="{{url('/manage/site/wysiwyg')}}" class="dropdown-item active bg-light">WYSIWYG設定</a>
-                        @else
-                            <a href="{{url('/manage/site/wysiwyg')}}" class="dropdown-item">WYSIWYG設定</a>
                         @endif
 
                         @if ($function == "document")


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1319
> ・単位がピクセルではなく、remなので大きさのイメージがつかめない

という意見あり。
確かにわかりずらい（牟田口実装した本人ですが、remってわからずネットで調べました。）

文字の大きさラベル表示のみ変更。大きさ指定はremのまま。

* [change: サイト管理, 頭メニューのWYSIWYG設定のメニュー位置を変更](https://github.com/opensource-workshop/connect-cms/pull/1320/commits/8572184c279ff07f869db966c092f332710c4e49)
  * サイト管理＞その他設定＞WYSIWYG設定→サイト管理＞WYSIWYG設定に移動

## 修正後画面
### wysiwyg

![image](https://user-images.githubusercontent.com/2756509/175205325-a7988d87-aff3-431f-be53-20b1ff62e49c.png)

### サイト管理＞WYSIWYG設定

![image](https://user-images.githubusercontent.com/2756509/175231148-3c5b8b9d-beee-49f9-a1f3-1ea41c554df0.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://www.pc-koubou.jp/magazine/23912
> ![image](https://user-images.githubusercontent.com/2756509/175205595-06925128-af8b-470a-a0e7-c4795ce7748c.png)
* https://www.tiny.cloud/docs-3x/reference/Configuration3x/Configuration3x@style_formats/
* https://www.tiny.cloud/docs-4x/configure/content-formatting/#fontsize_formats
* https://hazimaru.jp/2106/
> 	$setting['fontsize_formats'] = "超小さい=60% 小さい=75% 普通=100% 大きい=125% 超大きい=150%";

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
