### PR TITLE
change: wysiwyg, 入力エリアを横にも広げられるようにする

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -304,6 +304,7 @@
 
         relative_urls : false,
         height: {{ isset($height) ? $height : 300 }},
+        resize: 'both',
         branding: false,
         //forced_root_block : false,
         valid_children : "+body[style|input],+a[div|p],",


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## 修正後画面
### wysiwyg（右下端っこつまむと、横にも広げられる）
![image](https://user-images.githubusercontent.com/2756509/176096213-127809ce-c6bc-4a2f-9300-7614156ff5cb.png)
![image](https://user-images.githubusercontent.com/2756509/176096277-315e915a-3d9a-47bd-82e4-9a159a57104a.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://www.tiny.cloud/docs/tinymce/6/editor-size-options/#resize
* https://stackoverflow.com/questions/55105275/tinymce-5-manual-resize

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
