### PR TITLE
change: 管理者メニュー, 表示見直し

### DIFF
--- a/resources/views/plugins/manage/menus_list.blade.php
+++ b/resources/views/plugins/manage/menus_list.blade.php
@@ -87,61 +87,66 @@
             <a href="{{url('/')}}/manage/service" class="list-group-item">外部サービス設定</a>
         @endif
     @endif
-    <div class="list-group-item text-secondary bg-light">データ管理系</div>
-    @if (Auth::user()->can('admin_site'))
-        @if (isset($plugin_name) && $plugin_name == 'uploadfile')
-            <a href="{{url('/')}}/manage/uploadfile" class="list-group-item active">アップロードファイル</a>
-        @else
-            <a href="{{url('/')}}/manage/uploadfile" class="list-group-item">アップロードファイル</a>
-        @endif
-    @endif
-    @if (Auth::user()->can('admin_site'))
-        @if (isset($plugin_name) && $plugin_name == 'reservation')
-            <a href="{{url('/')}}/manage/reservation" class="list-group-item active">施設管理</a>
-        @else
-            <a href="{{url('/')}}/manage/reservation" class="list-group-item">施設管理</a>
-        @endif
-    @endif
-    @if (Auth::user()->can('admin_site'))
-        @if (isset($plugin_name) && $plugin_name == 'theme')
-            <a href="{{url('/')}}/manage/theme" class="list-group-item active">テーマ管理</a>
-        @else
-            <a href="{{url('/')}}/manage/theme" class="list-group-item">テーマ管理</a>
-        @endif
-    @endif
-    @if (Auth::user()->can('admin_site'))
-        @if (isset($plugin_name) && $plugin_name == 'number')
-            <a href="{{url('/')}}/manage/number" class="list-group-item active">連番管理</a>
-        @else
-            <a href="{{url('/')}}/manage/number" class="list-group-item">連番管理</a>
-        @endif
-    @endif
-    @if (Auth::user()->can('admin_site'))
-        @if (isset($plugin_name) && $plugin_name == 'code')
-            <a href="{{url('/')}}/manage/code" class="list-group-item active">コード管理</a>
-        @else
-            <a href="{{url('/')}}/manage/code" class="list-group-item">コード管理</a>
-        @endif
-    @endif
-    @if (Auth::user()->can('admin_system'))
-        @if (isset($plugin_name) && $plugin_name == 'log')
-            <a href="{{url('/')}}/manage/log" class="list-group-item active">ログ管理</a>
-        @else
-            <a href="{{url('/')}}/manage/log" class="list-group-item">ログ管理</a>
-        @endif
-    @endif
-    @if (Auth::user()->can('admin_site'))
-        @if (isset($plugin_name) && $plugin_name == 'holiday')
-            <a href="{{url('/')}}/manage/holiday" class="list-group-item active">祝日管理</a>
-        @else
-            <a href="{{url('/')}}/manage/holiday" class="list-group-item">祝日管理</a>
-        @endif
-    @endif
-    @if (Auth::user()->can('admin_system'))
-        @if (isset($plugin_name) && $plugin_name == 'migration')
-            <a href="{{url('/')}}/manage/migration" class="list-group-item active">他システム移行</a>
-        @else
-            <a href="{{url('/')}}/manage/migration" class="list-group-item">他システム移行</a>
-        @endif
-    @endif
 </div>
+
+@if (Auth::user()->can('admin_site') || Auth::user()->can('admin_system'))
+    <div class="list-group mt-2">
+        <div class="list-group-item bg-light">データ管理系</div>
+        @if (Auth::user()->can('admin_site'))
+            @if (isset($plugin_name) && $plugin_name == 'uploadfile')
+                <a href="{{url('/')}}/manage/uploadfile" class="list-group-item active">アップロードファイル</a>
+            @else
+                <a href="{{url('/')}}/manage/uploadfile" class="list-group-item">アップロードファイル</a>
+            @endif
+        @endif
+        @if (Auth::user()->can('admin_site'))
+            @if (isset($plugin_name) && $plugin_name == 'reservation')
+                <a href="{{url('/')}}/manage/reservation" class="list-group-item active">施設管理</a>
+            @else
+                <a href="{{url('/')}}/manage/reservation" class="list-group-item">施設管理</a>
+            @endif
+        @endif
+        @if (Auth::user()->can('admin_site'))
+            @if (isset($plugin_name) && $plugin_name == 'theme')
+                <a href="{{url('/')}}/manage/theme" class="list-group-item active">テーマ管理</a>
+            @else
+                <a href="{{url('/')}}/manage/theme" class="list-group-item">テーマ管理</a>
+            @endif
+        @endif
+        @if (Auth::user()->can('admin_site'))
+            @if (isset($plugin_name) && $plugin_name == 'number')
+                <a href="{{url('/')}}/manage/number" class="list-group-item active">連番管理</a>
+            @else
+                <a href="{{url('/')}}/manage/number" class="list-group-item">連番管理</a>
+            @endif
+        @endif
+        @if (Auth::user()->can('admin_site'))
+            @if (isset($plugin_name) && $plugin_name == 'code')
+                <a href="{{url('/')}}/manage/code" class="list-group-item active">コード管理</a>
+            @else
+                <a href="{{url('/')}}/manage/code" class="list-group-item">コード管理</a>
+            @endif
+        @endif
+        @if (Auth::user()->can('admin_system'))
+            @if (isset($plugin_name) && $plugin_name == 'log')
+                <a href="{{url('/')}}/manage/log" class="list-group-item active">ログ管理</a>
+            @else
+                <a href="{{url('/')}}/manage/log" class="list-group-item">ログ管理</a>
+            @endif
+        @endif
+        @if (Auth::user()->can('admin_site'))
+            @if (isset($plugin_name) && $plugin_name == 'holiday')
+                <a href="{{url('/')}}/manage/holiday" class="list-group-item active">祝日管理</a>
+            @else
+                <a href="{{url('/')}}/manage/holiday" class="list-group-item">祝日管理</a>
+            @endif
+        @endif
+        @if (Auth::user()->can('admin_system'))
+            @if (isset($plugin_name) && $plugin_name == 'migration')
+                <a href="{{url('/')}}/manage/migration" class="list-group-item active">他システム移行</a>
+            @else
+                <a href="{{url('/')}}/manage/migration" class="list-group-item">他システム移行</a>
+            @endif
+        @endif
+    </div>
+@endif


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* データ管理系 の文字色を黒に。
* データ管理系と、その上のメニューを分けて表示

## 修正後画面
### 管理者メニュー（PC:左側）
![image](https://user-images.githubusercontent.com/2756509/176189858-b9b2337a-243c-4de1-94d5-5b9fba5734d9.png)
![image](https://user-images.githubusercontent.com/2756509/176189621-81527b30-9fdb-4963-b447-a69e9d141076.png)

### 管理者メニュー（スマートフォン）
![image](https://user-images.githubusercontent.com/2756509/176190006-d9dd3ae3-8219-4797-9500-d438ec8e69df.png)
![image](https://user-images.githubusercontent.com/2756509/176190113-c6b77208-eeb7-480c-8663-1df0467914b0.png)

## （参考）修正前画面
### （修正前）管理者メニュー（PC:左側）
![image](https://user-images.githubusercontent.com/2756509/176190870-f4415d3d-93c8-4c49-9f3b-bdbd8e542d34.png)

### （修正前）管理者メニュー（スマートフォン）
![image](https://user-images.githubusercontent.com/2756509/176190997-d3e17ff5-0bfb-462e-bdbe-f01daf78ca07.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

社内で確認

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
