### PR TITLE
Add: ページ一覧でメニュー表示の切り替えを行う

### DIFF
--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -60,6 +60,7 @@ class PageManage extends ManagePluginBase
         $role_ckeck_table["migrationGet"]    = array('admin_page');
         $role_ckeck_table["migrationImort"]  = array('admin_page');
         $role_ckeck_table["migrationFileDelete"] = array('admin_page');
+        $role_ckeck_table["toggleDisplay"] = array('admin_page');
 
 /*
         $role_ckeck_table = array();
@@ -790,5 +791,35 @@ class PageManage extends ManagePluginBase
 
         // 指示された画面に戻る。
         return $this->migrationOrder($request, $page_id);
+    }
+
+    /**
+     * 表示フラグを切り替える
+     */
+    public function toggleDisplay($request, $page_id)
+    {
+        // ページID で1件取得
+        $page = Page::find($page_id);
+
+        // ページデータ取得
+        if (empty($page)) {
+            // 画面呼び出し
+            return view('plugins.manage.page.error', [
+                "function"     => __FUNCTION__,
+                "plugin_name"  => "page",
+                "message"      => "指定されたページID が存在しません。",
+            ]);
+        }
+
+        // 表示フラグを切り替える
+        if ($page->base_display_flag) {
+            $page->base_display_flag = 0;
+        } else {
+            $page->base_display_flag = 1;
+        }
+        $page->save();
+
+        // ページ管理画面に戻る
+        return redirect("/manage/page");
     }
 }

--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -819,6 +819,6 @@ class PageManage extends ManagePluginBase
         $page->save();
 
         // ページ管理画面に戻る
-        return redirect("/manage/page");
+        return redirect("/manage/page#$page_id");
     }
 }

--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -801,9 +801,8 @@ class PageManage extends ManagePluginBase
         // ページID で1件取得
         $page = Page::find($page_id);
 
-        // ページデータ取得
+        // 指定ページがなければエラー
         if (empty($page)) {
-            // 画面呼び出し
             return view('plugins.manage.page.error', [
                 "function"     => __FUNCTION__,
                 "plugin_name"  => "page",

--- a/resources/views/plugins/manage/page/page.blade.php
+++ b/resources/views/plugins/manage/page/page.blade.php
@@ -48,6 +48,11 @@ use App\Models\Common\Page;
                     form_move_page.submit();
                 }
             }
+            {{-- 表示切り替え用フォームのsubmit JavaScript --}}
+            function submit_toggle_display( source_id ) {
+                form_toggle_display.action = form_toggle_display.action + "/" + source_id;
+                form_toggle_display.submit();
+            }
         </script>
 
         {{-- ページの上移動用フォーム(POSTのためのフォーム。一つ用意して一覧からJavascriptで呼び出し) --}}
@@ -68,6 +73,11 @@ use App\Models\Common\Page;
         <form action="{{url('/manage/page/movePage')}}" method="POST" name="form_move_page" id="form_move_page" class="form-horizontal">
             {{ csrf_field() }}
             <input type="hidden" name="destination_id" value="">
+        </form>
+
+        {{-- 表示切り替え用フォーム(POSTのためのフォーム。一つ用意して一覧からJavascriptで呼び出し) --}}
+        <form action="{{url('/manage/page/toggleDisplay')}}" method="POST" name="form_toggle_display" id="form_toggle_display" class="form-horizontal">
+            {{ csrf_field() }}
         </form>
 
         <div class="table-responsive">
@@ -148,9 +158,9 @@ use App\Models\Common\Page;
                     </td>
                     <td class="table-text p-1">
                         @if ($page_item->base_display_flag == 1)
-                            <div><i class="far fa-eye" title="メニューに表示する"></i></div>
+                            <div><a href="javascript:void(0);" onclick="submit_toggle_display({{$page_item->id}});"><i class="far fa-eye" title="メニューに表示する"></i></a></div>
                         @else
-                            <div><i class="far fa-eye-slash" title="メニューから隠す"></i></div>
+                            <div><a href="javascript:void(0);" onclick="submit_toggle_display({{$page_item->id}});"><i class="far fa-eye-slash" title="メニューから隠す"></i></a></div>
                         @endif
                     </td>
                     <td class="table-text p-1" nowrap>

--- a/resources/views/plugins/manage/page/page.blade.php
+++ b/resources/views/plugins/manage/page/page.blade.php
@@ -104,7 +104,7 @@ use App\Models\Common\Page;
             </thead>
             <tbody>
                 @foreach($pages as $page_item)
-                <tr>
+                <tr id="{{$page_item->id}}">
                     @php
                     // 自分のページから親を遡って取得（＋トップページ）
                     $page_tree = $page_item->getPageTreeByGoingBackParent(null);
@@ -158,9 +158,9 @@ use App\Models\Common\Page;
                     </td>
                     <td class="table-text p-1">
                         @if ($page_item->base_display_flag == 1)
-                            <div><a href="javascript:void(0);" onclick="submit_toggle_display({{$page_item->id}});"><i class="far fa-eye" title="メニューに表示する"></i></a></div>
+                            <div class="mr-1"><a href="javascript:void(0);" class="btn btn-primary btn-sm" onclick="submit_toggle_display({{$page_item->id}});"><i class="far fa-eye" title="メニューに表示する"></i></a></div>
                         @else
-                            <div><a href="javascript:void(0);" onclick="submit_toggle_display({{$page_item->id}});"><i class="far fa-eye-slash" title="メニューから隠す"></i></a></div>
+                            <div class="mr-1"><a href="javascript:void(0);" class="btn btn-outline-primary btn-sm" onclick="submit_toggle_display({{$page_item->id}});"><i class="far fa-eye-slash" title="メニューから隠す"></i></a></div>
                         @endif
                     </td>
                     <td class="table-text p-1" nowrap>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
編集画面に遷移して更新するのは一手間かかるため、
一覧の目玉アイコンをクリックすると切り替えられるようにしました。
![image](https://user-images.githubusercontent.com/32890286/177237975-3168416d-767f-49a7-a934-3c962a64ef49.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
7/12

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
