### PR TITLE
add: メニュー, タブテンプレートでページ名を改行させない対応

### DIFF
--- a/resources/views/plugins/user/menus/tab/menus.blade.php
+++ b/resources/views/plugins/user/menus/tab/menus.blade.php
@@ -18,9 +18,9 @@
     {{-- 非表示のページは対象外 --}}
     @if ($page->isView(Auth::user(), false, true, $page_roles))
         @if ($ancestors->contains('id', $page->id))
-            <li role="presentation" class="nav-item {{ 'depth-' . $page->depth }} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link active">{{$page->page_name}}</a></li>
+            <li role="presentation" class="nav-item text-nowrap {{ 'depth-' . $page->depth }} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link active">{{$page->page_name}}</a></li>
         @else
-            <li role="presentation" class="nav-item {{ 'depth-' . $page->depth }} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link">{{$page->page_name}}</a></li>
+            <li role="presentation" class="nav-item text-nowrap {{ 'depth-' . $page->depth }} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link">{{$page->page_name}}</a></li>
         @endif
     @endif
 @endforeach

--- a/resources/views/plugins/user/menus/tab_flat/menu_children.blade.php
+++ b/resources/views/plugins/user/menus/tab_flat/menu_children.blade.php
@@ -10,9 +10,9 @@
 {{-- 自階層で非表示のページは対象外 --}}
 @if ($children->isView(Auth::user(), false, true, $page_roles))
     @if ($active_page_id == $children->id)
-        <li role="presentation" class="nav-item {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="nav-link active">{{$children->page_name}}</a></li>
+        <li role="presentation" class="nav-item text-nowrap {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="nav-link active">{{$children->page_name}}</a></li>
     @else
-        <li role="presentation" class="nav-item {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="nav-link">{{$children->page_name}}</a></li>
+        <li role="presentation" class="nav-item text-nowrap {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$children->getUrl()}}" {!!$children->getUrlTargetTag()!!} class="nav-link">{{$children->page_name}}</a></li>
     @endif
 @endif
 

--- a/resources/views/plugins/user/menus/tab_flat/menus.blade.php
+++ b/resources/views/plugins/user/menus/tab_flat/menus.blade.php
@@ -20,9 +20,9 @@
         {{-- 自階層で非表示のページは対象外 --}}
         @if ($page->isView(Auth::user(), false, true, $page_roles))
             @if ($active_page_id == $page->id)
-                <li role="presentation" class="nav-item {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link active">{{$page->page_name}}</a></li>
+                <li role="presentation" class="nav-item text-nowrap {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link active">{{$page->page_name}}</a></li>
             @else
-                <li role="presentation" class="nav-item {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link">{{$page->page_name}}</a></li>
+                <li role="presentation" class="nav-item text-nowrap {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link">{{$page->page_name}}</a></li>
             @endif
 
             @php

--- a/resources/views/plugins/user/menus/tab_flat/template.ini
+++ b/resources/views/plugins/user/menus/tab_flat/template.ini
@@ -1,3 +1,3 @@
 [base]
 template_name = タブフラット
-display_sequence = 15
+display_sequence = 3


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## 修正後画面
### タブ
![image](https://user-images.githubusercontent.com/2756509/177254273-e157bf12-874f-4dfd-98bd-217b28913a7e.png)

### タブフラット

![image](https://user-images.githubusercontent.com/2756509/177254422-13975346-1906-45e7-b9f4-de44ebdcb788.png)

### （修正前）タブ

![image](https://user-images.githubusercontent.com/2756509/177254810-54689f97-073b-4d83-a2a4-3dfbe1356a1a.png)

### （修正前）タブフラット
![image](https://user-images.githubusercontent.com/2756509/177254714-25de63d4-095d-4edf-9e03-deca60b56828.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
