### PR TITLE
Update: フレームデザインの色を選択時にわかるようにする

### DIFF
--- a/resources/views/core/cms_frame_edit.blade.php
+++ b/resources/views/core/cms_frame_edit.blade.php
@@ -107,12 +107,12 @@
                     <option value="">Choose...</option>
                     <option value="none"      @if($frame->frame_design=="none")      selected @endif>None</option>
                     <option value="default"   @if($frame->frame_design=="default")   selected @endif>Default</option>
-                    <option value="primary"   @if($frame->frame_design=="primary")   selected @endif>Primary</option>
-                    <option value="secondary" @if($frame->frame_design=="secondary") selected @endif>Secondary</option>
-                    <option value="success"   @if($frame->frame_design=="success")   selected @endif>Success</option>
-                    <option value="info"      @if($frame->frame_design=="info")      selected @endif>Info</option>
-                    <option value="warning"   @if($frame->frame_design=="warning")   selected @endif>Warning</option>
-                    <option value="danger"    @if($frame->frame_design=="danger")    selected @endif>Danger</option>
+                    <option value="primary"   @if($frame->frame_design=="primary")   selected @endif class="text-primary">Primary</option>
+                    <option value="secondary" @if($frame->frame_design=="secondary") selected @endif class="text-secondary">Secondary</option>
+                    <option value="success"   @if($frame->frame_design=="success")   selected @endif class="text-success">Success</option>
+                    <option value="info"      @if($frame->frame_design=="info")      selected @endif class="text-info">Info</option>
+                    <option value="warning"   @if($frame->frame_design=="warning")   selected @endif class="text-warning">Warning</option>
+                    <option value="danger"    @if($frame->frame_design=="danger")    selected @endif class="text-danger">Danger</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
フレーム編集画面のフレームデザインプルダウン

選んだときにどうような色になるかが、設定してみないとわかりませんでした。
プルダウンの選択肢に色付けすることで、設定せずとも色がわかるようにしました。

![image](https://user-images.githubusercontent.com/32890286/177296385-ec9858ff-d918-4c0d-baf1-c01728bda547.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り / 無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
