### PR TITLE
【グループ管理】グループ参加人数が一覧とグループ詳細ページで違う不具合修正

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -824,6 +824,10 @@ class UserManage extends ManagePluginBase
             $users_input_cols_ids = UsersInputCols::where('users_id', $id)->pluck('id');
             UsersInputCols::destroy($users_input_cols_ids);
 
+            // 参加グループ削除
+            $group_user_ids = GroupUser::where('user_id', $id)->pluck('id');
+            GroupUser::destroy($group_user_ids);
+
             // データを削除する。
             User::destroy($id);
         }

--- a/database/migrations/2022_07_06_160526_migrate_deleted_user_from_group_users.php
+++ b/database/migrations/2022_07_06_160526_migrate_deleted_user_from_group_users.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+use App\User;
+use App\Models\Common\GroupUser;
+
+class MigrateDeletedUserFromGroupUsers extends Migration
+{
+    /**
+     * ユーザ削除時にGroupUserを削除していなかったため、グループ管理の一覧で参加ユーザ数が多い（削除したユーザ含んでいた）
+     * 削除したユーザの参加グループは削除するデータ修正パッチ
+     * @see https://github.com/opensource-workshop/connect-cms/issues/1357
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // 参加グループ削除
+        $group_user_ids = GroupUser::whereNotIn('user_id', User::pluck('id'))->pluck('id');
+        GroupUser::destroy($group_user_ids);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1357

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
