### PR TITLE
change: ユーザ管理, ユーザ変更画面の関連機能をタブメニューとして分離

### DIFF
--- a/resources/views/plugins/manage/user/groups.blade.php
+++ b/resources/views/plugins/manage/user/groups.blade.php
@@ -16,6 +16,10 @@
         {{-- 機能選択タブ --}}
         @include('plugins.manage.user.user_manage_tab')
     </div>
+
+    {{-- ユーザ変更関連タブ --}}
+    @include('plugins.manage.user.user_edit_tab')
+
     <div class="card-body">
 
         <div class="alert alert-info">

--- a/resources/views/plugins/manage/user/login_history.blade.php
+++ b/resources/views/plugins/manage/user/login_history.blade.php
@@ -13,6 +13,10 @@
         {{-- 機能選択タブ --}}
         @include('plugins.manage.user.user_manage_tab')
     </div>
+
+    {{-- ユーザ変更関連タブ --}}
+    @include('plugins.manage.user.user_edit_tab')
+
     <div class="card-body">
 
         <div class="form-group table-responsive">

--- a/resources/views/plugins/manage/user/regist.blade.php
+++ b/resources/views/plugins/manage/user/regist.blade.php
@@ -18,6 +18,10 @@
 @include('plugins.manage.user.user_manage_tab')
 
 </div>
+
+{{-- ユーザ変更関連タブ --}}
+@include('plugins.manage.user.user_edit_tab')
+
 <div class="card-body">
 
     {{-- 登録後メッセージ表示 --}}

--- a/resources/views/plugins/manage/user/user_edit_tab.blade.php
+++ b/resources/views/plugins/manage/user/user_edit_tab.blade.php
@@ -1,0 +1,36 @@
+{{--
+ * ユーザ変更画面tabテンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ユーザ管理
+--}}
+@if (($function == "edit" || $function == "groups" || $function == "loginHistory") && $user->id)
+    <nav class="p-1">
+        <ul class="nav nav-tabs">
+            <li role="presentation" class="nav-item">
+                @if ($function == "edit")
+                    <span class="nav-link active py-1">ユーザ変更</span>
+                @else
+                    <a href="{{url('/manage/user/edit')}}/{{$user->id}}" class="nav-link py-1">ユーザ変更</a></li>
+                @endif
+            </li>
+
+            <li role="presentation" class="nav-item">
+                @if ($function == "groups")
+                    <span class="nav-link active py-1">グループ参加</span>
+                @else
+                    <a href="{{url('/manage/user/groups')}}/{{$user->id}}" class="nav-link py-1">グループ参加</a></li>
+                @endif
+            </li>
+
+            <li role="presentation" class="nav-item">
+                @if ($function == "loginHistory")
+                    <span class="nav-link active py-1">ログイン履歴</span>
+                @else
+                    <a href="{{url('/manage/user/loginHistory')}}/{{$user->id}}" class="nav-link py-1">ログイン履歴</a></li>
+                @endif
+            </li>
+        </ul>
+    </nav>
+@endif

--- a/resources/views/plugins/manage/user/user_manage_tab.blade.php
+++ b/resources/views/plugins/manage/user/user_manage_tab.blade.php
@@ -75,34 +75,6 @@
                     @endif
                 </li>
 
-                @if (($function == "edit" || $function == "groups" || $function == "loginHistory") && $user->id)
-                    <li class="nav-item dropdown">
-                        <a href="#" class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            ユーザ変更
-                        </a>
-                        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-
-                            @if ($function == "edit")
-                                <a href="{{url('/manage/user/edit')}}/{{$user->id}}" class="dropdown-item active bg-light">ユーザ変更</a>
-                            @else
-                                <a href="{{url('/manage/user/edit')}}/{{$user->id}}" class="dropdown-item">ユーザ変更</a>
-                            @endif
-
-                            @if ($function == "groups")
-                                <a href="{{url('/manage/user/groups')}}/{{$user->id}}" class="dropdown-item active bg-light">グループ参加</a>
-                            @else
-                                <a href="{{url('/manage/user/groups')}}/{{$user->id}}" class="dropdown-item">グループ参加</a>
-                            @endif
-
-                            @if ($function == "loginHistory")
-                                <a href="{{url('/manage/user/loginHistory')}}/{{$user->id}}" class="dropdown-item active bg-light">ログイン履歴</a>
-                            @else
-                                <a href="{{url('/manage/user/loginHistory')}}/{{$user->id}}" class="dropdown-item">ログイン履歴</a>
-                            @endif
-                        </div>
-                    </li>
-                @endif
-
             </ul>
         </div>
     </nav>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

ユーザ変更画面から、グループ参加・ログイン履歴に飛べますが、上部メニューに隠れてわかりずらかったです。
そのため、上部メニューの下にタブメニューとして、ユーザ変更・グループ参加・ログイン履歴　を切り出しました。

## 修正後画面
### ユーザ変更画面
![image](https://user-images.githubusercontent.com/2756509/178409746-2cec5cd2-0c04-4e99-88b7-b66379429bdd.png)
![image](https://user-images.githubusercontent.com/2756509/178409771-abc0bf4c-4797-456e-a94c-94d6011ca15f.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
