### PR TITLE
Add:グループの ユーザー追加、削除機能

### DIFF
--- a/app/Plugins/Manage/GroupManage/GroupManage.php
+++ b/app/Plugins/Manage/GroupManage/GroupManage.php
@@ -230,7 +230,7 @@ class GroupManage extends ManagePluginBase
     {
         // グループユーザー参加
         $group_user = GroupUser::updateOrCreate(
-            ['group_id' => $id, 'user_id' => $id],
+            ['group_id' => $id, 'user_id' => $request->user_id],
             [
                 'group_id' => $id,
                 'user_id' => $request->user_id,

--- a/app/Plugins/Manage/GroupManage/GroupManage.php
+++ b/app/Plugins/Manage/GroupManage/GroupManage.php
@@ -1,18 +1,21 @@
 <?php
 
 namespace App\Plugins\Manage\GroupManage;
-
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
+
+
+use App\Enums\UserStatus;
 
 use App\Models\Common\Group;
 use App\Models\Common\GroupUser;
 
 use App\Plugins\Manage\ManagePluginBase;
-
+use App\User;
 use App\Utilities\String\StringUtils;
 
 /**
@@ -39,6 +42,9 @@ class GroupManage extends ManagePluginBase
         $role_ckeck_table["edit"]               = array('admin_user');
         $role_ckeck_table["update"]             = array('admin_user');
         $role_ckeck_table["delete"]             = array('admin_user');
+        $role_ckeck_table["removeUser"] = array('admin_user');
+        $role_ckeck_table["joinUser"] = array('admin_user');
+        $role_ckeck_table["notJoinedUsers"] = array('admin_user');
         // $role_ckeck_table["list"]               = array('admin_user');
         return $role_ckeck_table;
     }
@@ -204,5 +210,53 @@ class GroupManage extends ManagePluginBase
             "plugin_name" => "group",
             "group_users" => $group_users,
         ]);
+    }
+
+    /**
+     *  グループユーザー削除
+     */
+    public function removeUser($request, $id)
+    {
+        // グループユーザーから削除
+        GroupUser::where('group_id', $id)->where('user_id', $request->user_id)->delete();
+
+        return redirect('manage/group/edit/' . $id);
+    }
+
+    /**
+     *  グループユーザー参加
+     */
+    public function joinUser($request, $id)
+    {
+        // グループユーザー参加
+        $group_user = GroupUser::updateOrCreate(
+            ['group_id' => $id, 'user_id' => $id],
+            [
+                'group_id' => $id,
+                'user_id' => $request->user_id,
+                'group_role' => 'general',
+            ]
+        );
+
+        return redirect('manage/group/edit/' . $id);
+    }
+
+    /**
+     * グループ不参加のユーザー取得
+     */
+    public function notJoinedUsers($request)
+    {
+        $users = User::where('name', 'LIKE', $request->user_name . '%')
+            ->where('status', UserStatus::active)
+            ->whereNotExists(function ($query) use ($request) {
+                $query->select(DB::raw(1))
+                      ->from('group_users')
+                      ->where('group_id', $request->group_id)
+                      ->whereNull('deleted_at')
+                      ->whereRaw('group_users.user_id = users.id');
+            })
+            ->orderBy('id')
+            ->get();
+        return $users;
     }
 }

--- a/app/Plugins/Manage/GroupManage/GroupManage.php
+++ b/app/Plugins/Manage/GroupManage/GroupManage.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
-
 use App\Enums\UserStatus;
 
 use App\Models\Common\Group;

--- a/app/Plugins/Manage/GroupManage/GroupManage.php
+++ b/app/Plugins/Manage/GroupManage/GroupManage.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace App\Plugins\Manage\GroupManage;
+
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;

--- a/resources/views/plugins/manage/group/edit.blade.php
+++ b/resources/views/plugins/manage/group/edit.blade.php
@@ -89,6 +89,46 @@
 @endif
 
 @if (isset($id) && $id)
+
+    {{-- ユーザーのグループ脱退 --}}
+    <form id="remove-user" name="removeuser" method="POST" action="{{url('/manage/group/removeUser/')}}/{{$id}}">
+        {{csrf_field()}}
+        <input type="hidden" id="user_id" name="user_id" value="">
+    </form>
+    <script>
+        function removeUser(user_id, user_name) {
+            if (window.confirm(user_name + "がグループ不参加になります。よろしいですか？")) {
+                document.getElementById("user_id").value = user_id;
+                document.removeuser.action = document.removeuser.action;
+                document.removeuser.submit();
+            }
+        }
+    </script>
+
+    {{-- ユーザーのグループ参加 --}}
+    <form id="join-user" name="joinuser" method="POST" action="{{url('/manage/group/joinUser/')}}/{{$id}}">
+        {{csrf_field()}}
+        <input type="hidden" id="user_id" name="user_id" value="">
+    </form>
+
+    <div class="card mt-3" id="list">
+        <div class="card-header">ユーザ参加</div>
+        <div class="card-body">
+            <div class="input-group mb-3">
+                <div class="input-group-prepend">
+                    <button class="btn btn-primary" type="button" v-on:click="getUsers()">ユーザ検索</button>
+                </div>
+                <input type="text" class="form-control" placeholder="ユーザ名で検索できます" v-model="keyword">
+            </div>
+            <ul class="list-group" id="users">
+                <li class="list-group-item" v-for="user in users">
+                    <button class="btn btn-primary btn-sm" v-on:click="joinUser(user.id, user.name)">参加</button>
+                    <span>@{{ user.name }}</span>
+                </li>
+            </ul>
+        </div>
+    </div>
+
     <div class="card mt-3">
         <div class="card-header">【{{$group->name}}】グループ参加ユーザ一覧</div>
         <div class="card-body">
@@ -101,6 +141,7 @@
                             {{-- <th nowrap>グループ権限</th> --}}
                             <th nowrap>作成日</th>
                             <th nowrap>更新日</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -110,6 +151,11 @@
                                 {{-- <td>{{GroupType::getDescription($group_user->group_role)}}</td> --}}
                                 <td>{{$group_user->created_at->format('Y/m/d')}}</td>
                                 <td>{{$group_user->updated_at->format('Y/m/d')}}</td>
+                                <td>
+                                    <button type="button" class="btn btn-danger btn-sm" onclick="removeUser({{$group_user->user_id}}, '{{$group_user->user_name}}');">
+                                        <i class="fas fa-minus"></i>
+                                    </button>
+                                </td>
                             </tr>
                         @endforeach
                     </tbody>
@@ -124,5 +170,44 @@
             @endif
         </div>
     </div>
+
+    <script>
+        new Vue({
+            el: '#list',
+            data: {
+                keyword: '',
+                users: [],
+            },
+            methods: {
+                // ユーザーを取得する
+                getUsers: function() {
+                    let self = this;
+
+                    if (self.keyword === '') {
+                        self.users = [];
+                        return;
+                    }
+
+                    //  非同期通信でユーザ取得
+                    axios.get(
+                            "{{ url('/') }}/manage/group/notJoinedUsers?user_name=" + self.keyword + '&group_id=' + {{$id}})
+                        .then(function(res) {
+                            self.users = res.data;
+                        })
+                        .catch(function(error) {
+                            console.log(error)
+                        });
+                },
+                // ユーザーをグループ参加させる
+                joinUser: function(user_id, user_name) {
+                    if (window.confirm(user_name + "がグループに参加します。よろしいですか？")) {
+                        document.getElementById("user_id").value = user_id;
+                        document.removeuser.action = document.joinuser.action;
+                        document.removeuser.submit();
+                    }
+                }
+            }
+        })
+    </script>
 @endif
 @endsection

--- a/resources/views/plugins/manage/group/edit.blade.php
+++ b/resources/views/plugins/manage/group/edit.blade.php
@@ -153,7 +153,7 @@
                                 <td>{{$group_user->updated_at->format('Y/m/d')}}</td>
                                 <td>
                                     <button type="button" class="btn btn-danger btn-sm" onclick="removeUser({{$group_user->user_id}}, '{{$group_user->user_name}}');">
-                                        <i class="fas fa-minus"></i>
+                                        <i class="fas fa-trash-alt"></i>
                                     </button>
                                 </td>
                             </tr>


### PR DESCRIPTION
## 概要

グループ管理のグループ変更画面でユーザの参加・不参加を変更できるようにしました。
<img width="454" alt="image" src="https://user-images.githubusercontent.com/32890286/180213010-bd077ba0-ed73-4153-99fb-9690583a5f6a.png">

### 参加

ユーザー名で検索して参加させる利用者を選択できます。

### 不参加

一覧のマイナスボタンを押下して不参加にすることができます。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

7/29（金）

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
