### PR TITLE
OW-1010 Add: Connect-CMSのバージョンを出力する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,3 @@ REQUIRE_AWS_SDK_PATH=C:\Lib\aws\aws-autoloader.php
 
 # add theme dir.
 #ADD_THEME_DIR=C:\SitesLaravel\theme\
-
-# show installed version of Connect-CMS at index page of manage area.
-SHOW_CC_VERSION=false

--- a/.env.example
+++ b/.env.example
@@ -143,3 +143,5 @@ REQUIRE_AWS_SDK_PATH=C:\Lib\aws\aws-autoloader.php
 # add theme dir.
 #ADD_THEME_DIR=C:\SitesLaravel\theme\
 
+# show installed version of Connect-CMS at index page of manage area.
+SHOW_CC_VERSION=false

--- a/app/Console/Commands/Migration/Version.php
+++ b/app/Console/Commands/Migration/Version.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands\Migration;
+
+use Illuminate\Console\Command;
+
+class Version extends Command
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:version';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Output installed version of Connect-CMS.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->line(config('version.cc_version'));
+    }
+}

--- a/config/version.php
+++ b/config/version.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Connect-CMS Version
+    |--------------------------------------------------------------------------
+    |
+    | This is the version of Connect-CMS.
+    |
+    */
+
+    'cc_version' => 'develop',
+    'show_cc_version' => env('SHOW_CC_VERSION', false),
+];

--- a/config/version.php
+++ b/config/version.php
@@ -7,10 +7,12 @@ return [
     | Connect-CMS Version
     |--------------------------------------------------------------------------
     |
-    | This is the version of Connect-CMS.
+    | This is the version of Connect-CMS. If you want to hide version information
+    | from manage page, set 'show_cc_version' to false.
     |
     */
 
     'cc_version' => 'develop',
-    'show_cc_version' => env('SHOW_CC_VERSION', false),
+
+    'show_cc_version' => false,
 ];

--- a/resources/views/plugins/manage/index/index.blade.php
+++ b/resources/views/plugins/manage/index/index.blade.php
@@ -11,6 +11,16 @@
 {{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
 @section('manage_content')
 
+{{-- バージョン情報 --}}
+@if (config('version.show_cc_version'))
+<div class="card mb-2">
+    <div class="card-header">Connect-CMS について</div>
+    <div class="card-body">
+        バージョン: {{config('version.cc_version')}}
+    </div>
+</div>
+@endif
+
 @if($rss_xml)
 <div class="card">
     <div class="card-header">Connect-CMS 更新情報等</div>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

画面とバッチで出力可能にしました。

### 画面

<img width="935" alt="image" src="https://user-images.githubusercontent.com/32890286/180431106-e2511791-d783-45f6-a1e6-a075dd49f09e.png">
 
.env で表示可否を決定しています（SHOW_CC_VERSION）
バージョン1.0.0がリリースされるまでは、隠しておきます。

### バッチ

<img width="416" alt="image" src="https://user-images.githubusercontent.com/32890286/180431378-a27c5384-a8b3-491a-9b99-da87de425e6c.png">

``` bash
php artisan command:version
```

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り / 無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
