### PR TITLE
change: ページ管理, ページ権限設定の参加ユーザに、グループ変更画面へのリンク付ける

### DIFF
--- a/resources/views/plugins/manage/page/role.blade.php
+++ b/resources/views/plugins/manage/page/role.blade.php
@@ -109,7 +109,7 @@
 
                             <div class="mt-1 mb-1">
                                 <small>
-                                    <b>参加ユーザ</b>：{{$group->group_user_names}}
+                                    <b><a href="{{url('/manage/group/edit')}}/{{$group->id}}" target="_blank">参加ユーザ <i class="fas fa-external-link-alt"></i></a></b>：{{$group->group_user_names}}
                                 </small>
                             </div>
 


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## 修正後画面
### ページ管理＞ページ権限設定

![image](https://user-images.githubusercontent.com/2756509/180637671-0c3f07cb-b544-43b3-87a3-1f789429cdda.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1359

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
