### PR TITLE
change: ページ管理, ページ変更画面の関連機能をタブメニューとして分離

### DIFF
--- a/resources/views/plugins/manage/page/migration_order.blade.php
+++ b/resources/views/plugins/manage/page/migration_order.blade.php
@@ -16,6 +16,10 @@
         {{-- 機能選択タブ --}}
         @include('plugins.manage.page.page_manage_tab')
     </div>
+
+    {{-- ページ変更関連タブ --}}
+    @include('plugins.manage.page.page_edit_tab')
+
     <div class="card-body">
 
         <div class="alert alert-info" style="margin-top: 10px;">

--- a/resources/views/plugins/manage/page/page_edit.blade.php
+++ b/resources/views/plugins/manage/page/page_edit.blade.php
@@ -16,6 +16,10 @@
         {{-- 機能選択タブ --}}
         @include('plugins.manage.page.page_manage_tab')
     </div>
+
+    {{-- ページ変更関連タブ --}}
+    @include('plugins.manage.page.page_edit_tab')
+
     <div class="card-body">
 
         {{-- 編集画面(入力フォーム) --}}

--- a/resources/views/plugins/manage/page/page_edit_tab.blade.php
+++ b/resources/views/plugins/manage/page/page_edit_tab.blade.php
@@ -1,0 +1,36 @@
+{{--
+ * ページ変更画面tabテンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ページ管理
+--}}
+@if (($function == "edit" || $function == "role" || $function == "migrationOrder") && $page->id)
+    <nav class="p-1">
+        <ul class="nav nav-tabs">
+            <li role="presentation" class="nav-item">
+                @if ($function == "edit")
+                    <span class="nav-link active py-1">ページ変更</span>
+                @else
+                    <a href="{{url('/manage/page/edit')}}/{{$page->id}}" class="nav-link py-1">ページ変更</a></li>
+                @endif
+            </li>
+
+            <li role="presentation" class="nav-item">
+                @if ($function == "role")
+                    <span class="nav-link active py-1">ページ権限設定</span>
+                @else
+                    <a href="{{url('/manage/page/role')}}/{{$page->id}}" class="nav-link py-1">ページ権限設定</a></li>
+                @endif
+            </li>
+
+            <li role="presentation" class="nav-item">
+                @if ($function == "migrationOrder")
+                    <span class="nav-link active py-1">外部ページインポート</span>
+                @else
+                    <a href="{{url('/manage/page/migrationOrder')}}/{{$page->id}}" class="nav-link py-1">外部ページインポート</a></li>
+                @endif
+            </li>
+        </ul>
+    </nav>
+@endif

--- a/resources/views/plugins/manage/page/page_manage_tab.blade.php
+++ b/resources/views/plugins/manage/page/page_manage_tab.blade.php
@@ -30,35 +30,6 @@
             @else
                 <li class="nav-item"><a href="{{url('/manage/page/import')}}" class="nav-link">CSVインポート</a></li>
             @endif
-
-            @if (($function == "edit" || $function == "role" || $function == "migrationOrder") && $page->id)
-                <li class="nav-item dropdown">
-                    <a href="#" class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        ページ変更
-                    </a>
-                    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-
-                        @if ($function == "edit")
-                            <a href="{{url('/manage/page/edit')}}/{{$page->id}}" class="dropdown-item active bg-light">ページ変更</a>
-                        @else
-                            <a href="{{url('/manage/page/edit')}}/{{$page->id}}" class="dropdown-item">ページ変更</a>
-                        @endif
-
-                        @if ($function == "role")
-                            <a href="{{url('/manage/page/role')}}/{{$page->id}}" class="dropdown-item active bg-light">ページ権限設定</a>
-                        @else
-                            <a href="{{url('/manage/page/role')}}/{{$page->id}}" class="dropdown-item">ページ権限設定</a>
-                        @endif
-
-                        @if ($function == "migrationOrder")
-                            <a href="{{url('/manage/page/migrationOrder')}}/{{$page->id}}" class="dropdown-item active bg-light">外部ページインポート</a>
-                        @else
-                            <a href="{{url('/manage/page/migrationOrder')}}/{{$page->id}}" class="dropdown-item">外部ページインポート</a>
-                        @endif
-                    </div>
-                </li>
-            @endif
-
             </ul>
         </div>
     </nav>

--- a/resources/views/plugins/manage/page/role.blade.php
+++ b/resources/views/plugins/manage/page/role.blade.php
@@ -16,6 +16,10 @@
         {{-- 機能選択タブ --}}
         @include('plugins.manage.page.page_manage_tab')
     </div>
+
+    {{-- ページ変更関連タブ --}}
+    @include('plugins.manage.page.page_edit_tab')
+
     <div class="card-body">
 
         <div class="alert alert-info">


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## 修正後画面
### ページ管理＞ページ変更画面

![image](https://user-images.githubusercontent.com/2756509/180638406-5c2deabd-4488-434d-947c-8d436150c679.png)

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1366

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
