### PR TITLE
【コードスタディ・フォトアルバム】複数ファイルダウンロードでAllowed memory sizeエラー時のtmpファイル削除対応

### DIFF
--- a/app/Plugins/User/Codestudies/CodestudiesPlugin.php
+++ b/app/Plugins/User/Codestudies/CodestudiesPlugin.php
@@ -520,6 +520,11 @@ class CodestudiesPlugin extends UserPluginBase
 
         // 空のZIPファイルが出来たら404
         if ($zip->count() === 0) {
+            // zipファイル後始末
+            $zip->close();
+            if (file_exists($save_path)) {
+                unlink($save_path);
+            }
             abort(404, 'ファイルがありません。');
         }
         $zip->close();

--- a/app/Plugins/User/Codestudies/CodestudiesPlugin.php
+++ b/app/Plugins/User/Codestudies/CodestudiesPlugin.php
@@ -433,7 +433,7 @@ class CodestudiesPlugin extends UserPluginBase
     }
 
     /**
-     *  成績ダウンロード指示画面
+     *  学習結果ダウンロード指示画面
      */
     public function viewDownload($request, $page_id, $frame_id)
     {
@@ -444,7 +444,7 @@ class CodestudiesPlugin extends UserPluginBase
     }
 
     /**
-     *  成績ダウンロード実行
+     *  学習結果ダウンロード実行
      */
     public function download($request, $page_id, $frame_id)
     {

--- a/app/Plugins/User/Codestudies/CodestudiesPlugin.php
+++ b/app/Plugins/User/Codestudies/CodestudiesPlugin.php
@@ -452,12 +452,15 @@ class CodestudiesPlugin extends UserPluginBase
         $save_path = $this->getTmpDirectory() . uniqid('', true) . '.zip';
         $this->makeZip($save_path, $request);
 
-        // 一時ファイルは削除して、ダウンロードレスポンスを返す
-        return response()->download(
+        // 一時ファイルは削除して、ダウンロードレスポンスを返す. download()でAllowed memory sizeエラー時にtmpファイル削除対応
+        $response = response()->download(
             $save_path,
             'StudyCodes.zip',
             ['Content-Disposition' => 'filename=StudyCodes.zip']
-        )->deleteFileAfterSend(true);
+        );
+        // )->deleteFileAfterSend(true);
+        register_shutdown_function('unlink', $save_path);
+        return $response;
     }
 
     /**

--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -960,6 +960,11 @@ class PhotoalbumsPlugin extends UserPluginBase
                         ->leftJoin('uploads', 'photoalbum_contents.upload_id', '=', 'uploads.id')
                         ->descendantsAndSelf($photoalbum_content_id);
             if (!$this->canDownload($request, $contents)) {
+                // zipファイル後始末
+                $zip->close();
+                if (file_exists($save_path)) {
+                    unlink($save_path);
+                }
                 abort(403, 'ファイル参照権限がありません。');
             }
             // フォルダがないとzipファイルを作れない
@@ -972,6 +977,11 @@ class PhotoalbumsPlugin extends UserPluginBase
 
         // 空のZIPファイルが出来たら404
         if ($zip->count() === 0) {
+            // zipファイル後始末
+            $zip->close();
+            if (file_exists($save_path)) {
+                unlink($save_path);
+            }
             abort(404, 'ファイルがありません。');
         }
         $zip->close();

--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -933,12 +933,15 @@ class PhotoalbumsPlugin extends UserPluginBase
         $save_path = $this->getTmpDirectory() . uniqid('', true) . '.zip';
         $this->makeZip($save_path, $request);
 
-        // 一時ファイルは削除して、ダウンロードレスポンスを返す
-        return response()->download(
+        // 一時ファイルは削除して、ダウンロードレスポンスを返す. download()でAllowed memory sizeエラー時にtmpファイル削除対応
+        $response = response()->download(
             $save_path,
             'Files.zip',
             ['Content-Disposition' => 'filename=Files.zip']
-        )->deleteFileAfterSend(true);
+        );
+        // )->deleteFileAfterSend(true);
+        register_shutdown_function('unlink', $save_path);
+        return $response;
     }
 
     /**


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* #1382 

動作確認済み

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1374
* https://github.com/opensource-workshop/connect-cms/pull/1376#discussion_r928361627

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
