### PR TITLE
add: NC2移行, オプション設定で「すべての会員をデフォルトで参加させる」ルームを、グループ作成して「メンバーシップページ」で移行できるようにする

### DIFF
--- a/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
@@ -86,6 +86,9 @@ cc_import_users = true
 ; --- エクスポート
 nc2_export_groups = true
 
+;「すべての会員をデフォルトで参加させる」ルームを、グループ作成して「メンバーシップページ」で移行する。falseの場合「ログインユーザ全員参加」ページで移行しグループ作成しない。
+nc2_export_make_group_of_default_entry_room = false
+
 ; --- インポート
 cc_import_groups = true
 


### PR DESCRIPTION

## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration

