### PR TITLE
change: ユーザ管理, 一覧のグループ表示見直し

### DIFF
--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -37,6 +37,10 @@ use App\Models\Core\UsersColumns;
         user_download.character_code.value = '{{CsvCharacterCode::utf_8}}';
         user_download.submit();
     }
+
+    $(function () {
+        $('[data-toggle="popover"]').popover()
+    })
 </script>
 
 <div class="card">
@@ -320,28 +324,20 @@ use App\Models\Core\UsersColumns;
                     <td nowrap>
                         {{-- <a href="{{url('/')}}/manage/user/groups/{{$user->id}}" title="グループ参加"><i class="far fa-edit"></i></a> --}}
                         {{-- {{$user->convertLoopValue('group_users', 'name')}} --}}
-                        @if (count($user->group_users) > 0)
-                            <div class="btn-group">
-                                <a href="{{url('/')}}/manage/user/groups/{{$user->id}}" class="btn btn-success btn-sm" title="グループ参加">
-                                    <i class="fas fa-users"></i> <span class="badge badge-light">{{count($user->group_users)}}</span>
-                                    {{-- <small>グループ <span class="badge badge-light">{{count($user->group_users)}}</span></small> --}}
-                                </a>
-                                <button type="button" class="btn btn-success btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <span class="sr-only">下三角ボタン</span>
-                                </button>
-                                <div class="dropdown-menu">
-                                    <h6 class="dropdown-header">参加グループ</h6>
-                                    @foreach($user->group_users as $group_user)
-                                        <span class="dropdown-item-text small">{{$group_user->name}}</span>
-                                    @endforeach
-                                </div>
-                            </div>
-                        @else
-                            <a href="{{url('/')}}/manage/user/groups/{{$user->id}}" class="btn btn-outline-success btn-sm" title="グループ参加">
-                                <i class="fas fa-users"></i> <span class="badge badge-light">{{count($user->group_users)}}</span>
-                                {{-- <small>グループ <span class="badge badge-light">{{count($user->group_users)}}</span></small> --}}
-                            </a>
-                        @endif
+                        <a href="{{url('/')}}/manage/user/groups/{{$user->id}}" class="btn btn-success btn-sm" title="グループ参加">
+                            <i class="fas fa-users"></i>
+                        </a>
+
+                        <button type="button" class="btn btn-outline-primary btn-sm" data-container="body" data-toggle="popover" data-placement="right"
+                            title="参加グループ"
+                            data-html="true"
+                            data-content='
+                            @foreach($user->group_users as $group_user)
+                                <div class="small">{{$group_user->name}}</div>
+                            @endforeach
+                            '>
+                            <span class="badge badge-light">{{count($user->group_users)}}</span>
+                        </button>
                     </td>
                     <td>{{$user->email}}</td>
                     @foreach($users_columns as $users_column)

--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -317,9 +317,31 @@ use App\Models\Core\UsersColumns;
                         {{$user->userid}}
                     </td>
                     <td>{{$user->name}}</td>
-                    <td>
-                        <a href="{{url('/')}}/manage/user/groups/{{$user->id}}" title="グループ参加"><i class="far fa-edit"></i></a>
-                        {{$user->convertLoopValue('group_users', 'name')}}
+                    <td nowrap>
+                        {{-- <a href="{{url('/')}}/manage/user/groups/{{$user->id}}" title="グループ参加"><i class="far fa-edit"></i></a> --}}
+                        {{-- {{$user->convertLoopValue('group_users', 'name')}} --}}
+                        @if (count($user->group_users) > 0)
+                            <div class="btn-group">
+                                <a href="{{url('/')}}/manage/user/groups/{{$user->id}}" class="btn btn-success btn-sm" title="グループ参加">
+                                    <i class="fas fa-users"></i> <span class="badge badge-light">{{count($user->group_users)}}</span>
+                                    {{-- <small>グループ <span class="badge badge-light">{{count($user->group_users)}}</span></small> --}}
+                                </a>
+                                <button type="button" class="btn btn-success btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <span class="sr-only">下三角ボタン</span>
+                                </button>
+                                <div class="dropdown-menu">
+                                    <h6 class="dropdown-header">参加グループ</h6>
+                                    @foreach($user->group_users as $group_user)
+                                        <span class="dropdown-item-text small">{{$group_user->name}}</span>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @else
+                            <a href="{{url('/')}}/manage/user/groups/{{$user->id}}" class="btn btn-outline-success btn-sm" title="グループ参加">
+                                <i class="fas fa-users"></i> <span class="badge badge-light">{{count($user->group_users)}}</span>
+                                {{-- <small>グループ <span class="badge badge-light">{{count($user->group_users)}}</span></small> --}}
+                            </a>
+                        @endif
                     </td>
                     <td>{{$user->email}}</td>
                     @foreach($users_columns as $users_column)


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

NC2移行で各権限に対応するために、１ルーム⇒５グループ（パブリック_コンテンツ管理者, パブリック_モデレータ, パブリック_編集者 等）で移行するよう修正しました。
その結果、管理者等で参加グループが多くなりました。

参加グループが多いと、ユーザ一覧画面のグループ名表示が長すぎるため、見直したいと思ってます。

## 修正後画面
### ユーザ管理＞ユーザ一覧

![image](https://user-images.githubusercontent.com/2756509/181466314-d2734cf0-70fd-4b84-8157-e4911b2fa2e4.png)

![image](https://user-images.githubusercontent.com/2756509/181466982-3265cb36-f07b-4102-8d58-960bb7280871.png)

### （参考：修正前）ユーザ管理＞ユーザ一覧

![ユーザ管理の一覧_グループ参加_長すぎる](https://user-images.githubusercontent.com/2756509/181466850-cb08f935-03ad-4b57-bc13-b59ae6223bfb.jpg)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
