### PR TITLE
[データベース]tableテンプレートでのスマホ時の表横スクロールとタイトル行の改行禁止

### DIFF
--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -24,7 +24,7 @@
             <tr>
             @foreach($columns as $column)
                 @if($column->list_hide_flag == 0)
-                <th nowrap>{{$column->column_name}}</th>
+                <th class="text-nowrap">{{$column->column_name}}</th>
                 @endif
             @endforeach
             </tr>

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -17,13 +17,14 @@
     @if ($default_hide_list)
     @else
         {{-- データのループ --}}
+        <div class="table-responsive">
         <table class="table table-bordered">
             <caption class="sr-only">{{$database_frame->databases_name}}</caption>
             <thead class="thead-light">
             <tr>
             @foreach($columns as $column)
                 @if($column->list_hide_flag == 0)
-                <th>{{$column->column_name}}</th>
+                <th nowrap>{{$column->column_name}}</th>
                 @endif
             @endforeach
             </tr>
@@ -59,6 +60,7 @@
             @endforeach
             </tbody>
         </table>
+        </div>
 
         {{-- ページング処理 --}}
         @include('plugins.common.user_paginate', ['posts' => $inputs, 'frame' => $frame, 'aria_label_name' => $database_frame->databases_name])


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
スマホで見た時に、表が画面幅を飛び出してしまい、表示がおかしいので対応しました。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
軽微な改修なので急ぎません。
永原が自分のサイトで使っていて、あれ？となったものです。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
画面はこんな感じになります。
![image](https://user-images.githubusercontent.com/3079435/182285933-86a91bc9-157b-4351-a523-7154549622fc.png)

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
無し

## チェックリスト
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
