### PR TITLE
[コア]リリースノート自動生成で利用する設定ファイルを追加しました

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - ignore for release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking change
+    - title: Exciting New Features 🎉
+      labels:
+        - new feature
+    - title: Enhancements ❤️
+      labels:
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Security Fixes 🐛
+      labels:
+        -  security fix
+    - title: developer update 👷
+      labels:
+        - developer update
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -17,9 +17,6 @@ changelog:
     - title: Bug Fixes 🐛
       labels:
         - bug
-    - title: Security Fixes 🐛
-      labels:
-        -  security fix
     - title: developer update 👷
       labels:
         - developer update


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
GitHubのリリースノート自動生成で利用する設定ファイルを追加しました。
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り / 無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
