### PR TITLE
 [フォトアルバム]画像拡大表示の不具合修正（スマホでの画面はみだし、画像のマウスカーソル）

### DIFF
--- a/resources/views/plugins/user/photoalbums/default/index.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index.blade.php
@@ -439,10 +439,10 @@
             <div class="modal fade" id="image_Modal_{{$loop->iteration}}" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel_{{$loop->iteration}}">
                 <div class="modal-dialog modal-lg modal-middle">{{-- モーダルウィンドウの縦表示位置を調整・画像を大きく見せる --}}
                     <div class="modal-content pb-3">
-                        <div class="modal-body mx-auto">
+                        <div class="modal-body mx-auto" style="{{$photoalbum_content->getModalMinSize()}}">
                             {{-- 拡大表示ウィンドウにも、初期設定でサムネイルを設定しておき、クリック時に実寸画像を読み込みなおす --}}
                             <img src="{{url('/')}}/file/{{$photoalbum_content->upload_id}}?size=small"
-                                 style="object-fit: scale-down;"
+                                 style="object-fit: scale-down; cursor:pointer;"
                                  id="popup_photo_{{$loop->iteration}}"
                                  class="img-fluid"/>
                         </div>

--- a/resources/views/plugins/user/photoalbums/default/index.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index.blade.php
@@ -439,10 +439,10 @@
             <div class="modal fade" id="image_Modal_{{$loop->iteration}}" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel_{{$loop->iteration}}">
                 <div class="modal-dialog modal-lg modal-middle">{{-- モーダルウィンドウの縦表示位置を調整・画像を大きく見せる --}}
                     <div class="modal-content pb-3">
-                        <div class="modal-body mx-auto" style="{{$photoalbum_content->getModalMinSize()}}">
+                        <div class="modal-body mx-auto">
                             {{-- 拡大表示ウィンドウにも、初期設定でサムネイルを設定しておき、クリック時に実寸画像を読み込みなおす --}}
                             <img src="{{url('/')}}/file/{{$photoalbum_content->upload_id}}?size=small"
-                                 style="object-fit: scale-down; cursor:pointer;"
+                                 style="object-fit: scale-down;"
                                  id="popup_photo_{{$loop->iteration}}"
                                  class="img-fluid"/>
                         </div>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
フォトアルバムで画像の拡大表示の不具合（スマホでの画面はみだし、画像のマウスカーソル） #1394
の修正です。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
* https://github.com/opensource-workshop/connect-cms/issues/1394

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
無し

## チェックリスト
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
