### PR TITLE
change: 【メニュー】タブフラットの表示見直し

### DIFF
--- a/resources/views/plugins/user/menus/tab_flat/menus.blade.php
+++ b/resources/views/plugins/user/menus/tab_flat/menus.blade.php
@@ -17,18 +17,17 @@
     <ul class="nav nav-tabs nav-justified d-none d-md-flex">
     @foreach($pages as $page)
 
-        {{-- 自階層で非表示のページは対象外 --}}
+        {{-- 自階層ページの表示非表示 --}}
         @if ($page->isView(Auth::user(), false, true, $page_roles))
             @if ($active_page_id == $page->id)
                 <li role="presentation" class="nav-item text-nowrap {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link active">{{$page->page_name}}</a></li>
             @else
                 <li role="presentation" class="nav-item text-nowrap {{'depth-' . $page->depth}} {{$page->getClass()}}"><a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="nav-link">{{$page->page_name}}</a></li>
             @endif
+        @endif
 
-            @php
-                $view_pages[] = $page->id;
-            @endphp
-
+        {{-- 下階層の表示非表示処理のため、自階層の表示非表示は display_flag を考慮せずチェック --}}
+        @if ($page->isView(Auth::user(), true, true, $page_roles))
             {{-- 子供のページがある場合 --}}
             @if (count($page->children) > 0)
                 {{-- 子要素を再帰的に表示するため、別ファイルに分けてinclude --}}


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1348

## 修正後画面
### メニュー（タブフラット テンプレート）
![image](https://user-images.githubusercontent.com/2756509/183368655-3a168c5e-3175-41f9-984d-491cfde14dea.png)
![image](https://user-images.githubusercontent.com/2756509/183368798-43e2a26a-b5fa-4755-9760-a62c4caedc75.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
