### PR TITLE
bugfix: システム管理, メール設定画面でMAIL_FROM_NAMEがダブルクォートで囲われていないと変更されない不具合修正

### DIFF
--- a/app/Plugins/Manage/SystemManage/SystemManage.php
+++ b/app/Plugins/Manage/SystemManage/SystemManage.php
@@ -231,8 +231,9 @@ class SystemManage extends ManagePluginBase
         if (file_exists($path)) {
             file_put_contents($path, str_replace('MAIL_FROM_ADDRESS=' . config('mail.from.address'), "MAIL_FROM_ADDRESS={$request->mail_from_address}", file_get_contents($path)));
 
-            // ${APP_NAME} は一度取り除いてから置換
+            // ${APP_NAME}, ダブルクォート囲みなし は先に置換
             file_put_contents($path, str_replace('MAIL_FROM_NAME="${APP_NAME}"', "MAIL_FROM_NAME=\"{$request->mail_from_name}\"", file_get_contents($path)));
+            file_put_contents($path, str_replace('MAIL_FROM_NAME=' . config('mail.from.name'), "MAIL_FROM_NAME=\"{$request->mail_from_name}\"", file_get_contents($path)));
             file_put_contents($path, str_replace('MAIL_FROM_NAME="' . config('mail.from.name') . '"', "MAIL_FROM_NAME=\"{$request->mail_from_name}\"", file_get_contents($path)));
 
             file_put_contents($path, str_replace('MAIL_HOST=' . config('mail.host'), "MAIL_HOST={$request->mail_host}", file_get_contents($path)));


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1401
  * MAIL_FROM_NAMEがダブルクォートで囲われてなかったら、ダブルクォートを付けるように修正
    * これでMAIL_FROM_NAMEがダブルクォートで囲われてなくても、画面から変更可能になりました。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
