### PR TITLE
core, プラグイン内のシステムエラー表示をフレーム内に納める対応の不具合修正

### DIFF
--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -732,7 +732,7 @@ class UserPluginBase extends PluginBase
                  ->update(['bucket_id' => $buckets->id]);
         }
 
-        // Backet が取れないとおかしな操作をした可能性があるのでエラーにしておく。
+        // Bucket が取れないとおかしな操作をした可能性があるのでエラーにしておく。
         if (empty($buckets)) {
             return $this->viewError("error_inframe", "存在しないBucket");
         }

--- a/resources/views/core/cms_frame.blade.php
+++ b/resources/views/core/cms_frame.blade.php
@@ -122,15 +122,7 @@ if ($frame->isInvisiblePrivateFrame()) {
                             $plugin_instances[$frame->frame_id]->putLog($e);
                     @endphp
                     {{-- debug_message は互換性のために残している。有効な活用方法は今後、検討 --}}
-                    @if ($e->getStatusCode() == 403)
-                        @include('errors.403_inframe' ,['message' => $e->getMessage(), 'debug_message' => $e->getMessage()])
-                    @elseif ($e->getStatusCode() == 404)
-                        @include('errors.404_inframe' ,['message' => $e->getMessage(), 'debug_message' => $e->getMessage()])
-                    @elseif ($e->getStatusCode() == 500)
-                        @include('errors.500_inframe' ,['message' => $e->getMessage(), 'debug_message' => $e->getMessage()])
-                    @else
-                        @include('errors.error_inframe' ,['message' => $e->getMessage(), 'debug_message' => $e->getMessage()])
-                    @endif
+                        @include('errors.500_inframe' ,['debug_message' => $e->getMessage()])
                     @php
                         }
                     @endphp

--- a/resources/views/core/cms_frame.blade.php
+++ b/resources/views/core/cms_frame.blade.php
@@ -121,8 +121,8 @@ if ($frame->isInvisiblePrivateFrame()) {
                         } catch (\Throwable $e) {
                             $plugin_instances[$frame->frame_id]->putLog($e);
                     @endphp
-                    {{-- debug_message は互換性のために残している。有効な活用方法は今後、検討 --}}
-                        @include('errors.500_inframe' ,['debug_message' => $e->getMessage()])
+                            {{-- debug_message は互換性のために残している。有効な活用方法は今後、検討 --}}
+                            @include('errors.500_inframe' ,['debug_message' => $e->getMessage()])
                     @php
                         }
                     @endphp
@@ -136,7 +136,7 @@ if ($frame->isInvisiblePrivateFrame()) {
                         } catch (\Throwable $e) {
                             $plugin_instances[$frame->frame_id]->putLog($e);
                     @endphp
-                        @include('errors.500_inframe' ,['debug_message' => $e->getMessage()])
+                            @include('errors.500_inframe' ,['debug_message' => $e->getMessage()])
                     @php
                         }
                     @endphp

--- a/resources/views/errors/error_inframe.blade.php
+++ b/resources/views/errors/error_inframe.blade.php
@@ -10,11 +10,11 @@
         <i class="fas fa-exclamation-triangle"></i>
         <span class="sr-only">Error:</span>
         @if ($e)
-            {{$e->getStatusCode()}}. 
+            {{$e->getCode()}}.
         @endif
         @if (isset($message))
             {{$message}}
-        @endif 
+        @endif
         <br />
         @if (Config::get('app.debug'))
             <div class="card mt-3">


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

プラグイン内で、プログラムミスなどによるシステムエラーが発生した場合、画面全体をシステムエラー表示にするのではなく、フレーム内にエラー表示を収める対応がありましたが、プラグインのactionを指定した処理では、画面全体のシステムエラーになっていたため、修正しました。

原因は、フレーム内にエラー表示時のバグで、フレーム内にエラー表示時にさらにシステムエラーが発生していたため「不要なエラーログ」が出て、原因のログが埋もれて原因が発見しずらい状態でした。


## 修正前

### 全画面システムエラー

![image](https://user-images.githubusercontent.com/2756509/189516006-bf7efc06-3e5b-4b92-abab-a9adaf1c7636.png)

### 不要なエラーログ

```log
[previous exception] [object] (Error(code: 0): Call to undefined method ErrorException::getStatusCode() at C:\\projects\\localhost\\htdocs\\storage\\framework\\views\\c3f41a66229ee7aac3e7c046275a5701e3f20ef3.php:7)
[stacktrace]
#0 C:\\projects\\localhost\\htdocs\\vendor\\laravel\\framework\\src\\Illuminate\\Filesystem\\Filesystem.php(107): require()
#1 C:\\projects\\localhost\\htdocs\\vendor\\laravel\\framework\\src\\Illuminate\\Filesystem\\Filesystem.php(108): Illuminate\\Filesystem\\Filesystem::Illuminate\\Filesystem\\{closure}()
#2 C:\\projects\\localhost\\htdocs\\vendor\\laravel\\framework\\src\\Illuminate\\View\\Engines\\PhpEngine.php(58): Illuminate\\Filesystem\\Filesystem->getRequire('C:\\\\projects\\\\lib...', Array)
#3 C:\\projects\\localhost\\htdocs\\vendor\\laravel\\framework\\src\\Illuminate\\View\\Engines\\CompilerEngine.php(61): Illuminate\\View\\Engines\\PhpEngine->evaluatePath('C:\\\\projects\\\\lib...', Array)

(省略)

#77 C:\\projects\\localhost\\htdocs\\vendor\\laravel\\framework\\src\\Illuminate\\Foundation\\Http\\Kernel.php(111): Illuminate\\Foundation\\Http\\Kernel->sendRequestThroughRouter(Object(Illuminate\\Http\\Request))
#78 C:\\projects\\localhost\\htdocs\\public\\index.php(59): Illuminate\\Foundation\\Http\\Kernel->handle(Object(Illuminate\\Http\\Request))
#79 {main}
"} 
```

## 修正後画面
### フレーム内システムエラー
![image](https://user-images.githubusercontent.com/2756509/189515770-082371b4-ee8c-4fb4-98b3-5f01af7f4d68.png)


## フレーム内にエラー表示時のバグ

https://github.com/opensource-workshop/connect-cms/pull/1425/files#diff-892fedbebd16393de2f10e8a658017daeaba442520879eafde0af87451400ab9L125

`$e.getStatusCode()` が原因。
どうもLaravelの`HttpException`がくることを期待した書き方だった。
`HttpException`は、getStatusCode()の取得が可能。

しかしプログラムエラーで飛んでくるエラーは、`ErrorException` &  [Throwable インターフェース](https://www.php.net/manual/ja/class.throwable.php) で、getStatusCode() メソッドは無いためエラーになっていた。


参考
https://minory.org/laravel-custom-errors-page.html
https://github.com/opensource-workshop/connect-cms/blob/master/app/Plugins/PluginBase.php#L42


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

ないけど、念のため社内確認する。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

https://www.php.net/manual/ja/class.errorexception.php




## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにラベルをつけました。