### PR TITLE
[キャビネット]表示項目を追加しました（ダウンロード件数、更新者、作成者）

### DIFF
--- a/app/Enums/CabinetFrameConfig.php
+++ b/app/Enums/CabinetFrameConfig.php
@@ -11,9 +11,15 @@ final class CabinetFrameConfig extends EnumsBase
 {
     // 定数メンバ
     const sort = 'sort';
+    const show_download_count = 'show_download_count';
+    const show_created_name = 'show_created_name';
+    const show_updated_name = 'show_updated_name';
 
     // key/valueの連想配列
     const enum = [
         self::sort => '並び順',
+        self::show_download_count => 'ダウンロード件数',
+        self::show_created_name => '作成者',
+        self::show_updated_name => '更新者',
     ];
 }

--- a/app/Plugins/User/Cabinets/CabinetsPlugin.php
+++ b/app/Plugins/User/Cabinets/CabinetsPlugin.php
@@ -1092,32 +1092,10 @@ class CabinetsPlugin extends UserPluginBase
     public function saveView($request, $page_id, $frame_id, $cabinet_id)
     {
         // フレーム設定保存
-        $this->saveFrameConfigs($request, $frame_id, CabinetFrameConfig::getMemberKeys());
+        FrameConfig::saveFrameConfigs($request, $frame_id, CabinetFrameConfig::getMemberKeys());
         // 更新したので、frame_configsを設定しなおす
         $this->refreshFrameConfigs();
 
         return;
-    }
-
-    /**
-     * フレーム設定を保存する。
-     *
-     * @param Illuminate\Http\Request $request リクエスト
-     * @param int $frame_id フレームID
-     * @param array $frame_config_names フレーム設定のname配列
-     */
-    protected function saveFrameConfigs(\Illuminate\Http\Request $request, int $frame_id, array $frame_config_names)
-    {
-        foreach ($frame_config_names as $key => $value) {
-
-            if (empty($request->$value)) {
-                return;
-            }
-
-            FrameConfig::updateOrCreate(
-                ['frame_id' => $frame_id, 'name' => $value],
-                ['value' => $request->$value]
-            );
-        }
     }
 }

--- a/resources/views/plugins/user/cabinets/default/frame.blade.php
+++ b/resources/views/plugins/user/cabinets/default/frame.blade.php
@@ -44,6 +44,54 @@
             </div>
         </div>
 
+        {{-- ダウンロード件数の表示 --}}
+        @php
+            $show_download_count = FrameConfig::getConfigValueAndOld($frame_configs, CabinetFrameConfig::show_download_count, ShowType::not_show);
+        @endphp
+        <div class="form-group row">
+            <label class="{{$frame->getSettingLabelClass(true)}}">{{CabinetFrameConfig::getDescription(CabinetFrameConfig::show_download_count)}}</label>
+            <div class="{{$frame->getSettingInputClass(true)}}">
+                @foreach (ShowType::getMembers() as $sort_key => $sort_view)
+                <div class="custom-control custom-radio custom-control-inline">
+                        <input type="radio" value="{{$sort_key}}" id="show_download_count_{{$sort_key}}" name="show_download_count" class="custom-control-input" @if ($show_download_count == $sort_key) checked="checked" @endif>
+                        <label class="custom-control-label" for="show_download_count_{{$sort_key}}">{{$sort_view}}</label>
+                </div>
+                @endforeach
+            </div>
+        </div>
+
+        {{-- 作成者の表示 --}}
+        @php
+            $show_created_name = FrameConfig::getConfigValueAndOld($frame_configs, CabinetFrameConfig::show_created_name, ShowType::not_show);
+        @endphp
+        <div class="form-group row">
+            <label class="{{$frame->getSettingLabelClass(true)}}">{{CabinetFrameConfig::getDescription(CabinetFrameConfig::show_created_name)}}</label>
+            <div class="{{$frame->getSettingInputClass(true)}}">
+                @foreach (ShowType::getMembers() as $sort_key => $sort_view)
+                <div class="custom-control custom-radio custom-control-inline">
+                        <input type="radio" value="{{$sort_key}}" id="show_created_name_{{$sort_key}}" name="show_created_name" class="custom-control-input" @if ($show_created_name == $sort_key) checked="checked" @endif>
+                        <label class="custom-control-label" for="show_created_name_{{$sort_key}}">{{$sort_view}}</label>
+                </div>
+                @endforeach
+            </div>
+        </div>
+
+        {{-- 更新者の表示 --}}
+        @php
+            $show_updated_name = FrameConfig::getConfigValueAndOld($frame_configs, CabinetFrameConfig::show_updated_name, ShowType::not_show);
+        @endphp
+        <div class="form-group row">
+            <label class="{{$frame->getSettingLabelClass(true)}}">{{CabinetFrameConfig::getDescription(CabinetFrameConfig::show_updated_name)}}</label>
+            <div class="{{$frame->getSettingInputClass(true)}}">
+                @foreach (ShowType::getMembers() as $sort_key => $sort_view)
+                <div class="custom-control custom-radio custom-control-inline">
+                        <input type="radio" value="{{$sort_key}}" id="show_updated_name_{{$sort_key}}" name="show_updated_name" class="custom-control-input" @if ($show_updated_name == $sort_key) checked="checked" @endif>
+                        <label class="custom-control-label" for="show_updated_name_{{$sort_key}}">{{$sort_view}}</label>
+                </div>
+                @endforeach
+            </div>
+        </div>
+
         {{-- Submitボタン --}}
         <div class="text-center">
             <a class="btn btn-secondary mr-2" href="{{URL::to($page->permanent_link)}}#frame-{{$frame->id}}">

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -161,6 +161,14 @@
     @endcan
     <button class="btn btn-primary btn-sm btn-download" type="button" disabled><i class="fas fa-download"></i><span class="d-none d-sm-inline"> ダウンロード</span></button>
 </div>
+
+@php
+    //　表示設定
+    $show_download_count = FrameConfig::getConfigValueAndOld($frame_configs, CabinetFrameConfig::show_download_count, ShowType::not_show) == ShowType::show;
+    $show_created_name = FrameConfig::getConfigValueAndOld($frame_configs, CabinetFrameConfig::show_created_name, ShowType::not_show) == ShowType::show;
+    $show_updated_name = FrameConfig::getConfigValueAndOld($frame_configs, CabinetFrameConfig::show_updated_name, ShowType::not_show) == ShowType::show;
+@endphp
+
 <table class="table text-break">
     <thead>
         <tr class="d-none d-md-table-row">
@@ -168,6 +176,8 @@
             <th>名前</th>
             <th>サイズ</th>
             <th>更新日</th>
+            @if ($show_created_name)<th>作成者</th>@endif
+            @if ($show_updated_name)<th>更新者</th>@endif
         </tr>
     </thead>
     <tbody>
@@ -197,18 +207,30 @@
                             <small class="form-text text-muted d-block d-md-none">
                                 - | {{$cabinet_content->created_at}}
                             </small>
+                            <small class="form-text text-muted d-block d-md-none">
+                                @if ($show_created_name)作成者 : {{$cabinet_content->created_name}}@endif
+                            </small>
                         </td>
                         <td class="d-none d-md-table-cell">-</td>
                         <td class="d-none d-md-table-cell">{{$cabinet_content->created_at}}</td>
+                        @if ($show_created_name)<td class="d-none d-md-table-cell">{{$cabinet_content->created_name}}</td>@endif
+                        @if ($show_updated_name)<td class="d-none d-md-table-cell">{{$cabinet_content->updated_name}}</td>@endif
                     @else
                         <td>
                             <i class="far fa-file mr-1 text-secondary"></i><a href="{{url('/')}}/file/{{$cabinet_content->upload_id}}" target="_blank">{{$cabinet_content->displayName}}</a>
+                            @if ($show_download_count)<span class="badge badge-pill badge-secondary" title="ダウンロード数">{{$cabinet_content->upload->download_count}}</span>@endif
                             <small class="form-text text-muted d-block d-md-none">
                                 {{$cabinet_content->upload->getFormatSize()}} | {{$cabinet_content->created_at}}
+                            </small>
+                            <small class="form-text text-muted d-block d-md-none">
+                                @if ($show_created_name)作成者 : {{$cabinet_content->created_name}}@endif
+                                @if ($show_updated_name) @if ($show_created_name && $show_updated_name) |  @endif 更新者 : {{$cabinet_content->updated_name}} @endif
                             </small>
                         </td>
                         <td class="d-none d-md-table-cell">{{$cabinet_content->upload->getFormatSize()}}</td>
                         <td class="d-none d-md-table-cell">{{$cabinet_content->updated_at}}</td>
+                        @if ($show_created_name)<td class="d-none d-md-table-cell">{{$cabinet_content->created_name}}</td>@endif
+                        @if ($show_updated_name)<td class="d-none d-md-table-cell">{{$cabinet_content->updated_name}}</td>@endif
                     @endif
                 </tr>
             @endforeach


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
キャビネットに以下の項目を追加しました。

- ダウンロード件数
- 更新者
- 作成者

### 一覧画面
<img width="300" alt="image" src="https://user-images.githubusercontent.com/32890286/189609433-56a9a3ff-92e6-42ad-b47c-dfa098bded83.png">
※灰色のバッジがダウンロード件数

### 設定画面
<img width="300" alt="image" src="https://user-images.githubusercontent.com/32890286/189609283-2415d9b7-2e39-4d0f-b3c4-3fc4f3e2338c.png">

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
9/20くらい

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] オンラインマニュアルの更新 https://connect-cms.jp/manual
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにラベルをつけました。