### PR TITLE
[スライドショー]PDFのアップロードに対応しました

### DIFF
--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -632,9 +632,6 @@ class SlideshowsPlugin extends UserPluginBase
             $slideshows_item->slideshows_id = $request->slideshows_id;
             $slideshows_item->image_path = $image_path;
             $slideshows_item->uploads_id = $image_upload->id;
-            $slideshows_item->link_url = $request->pdf_link_url;
-            $slideshows_item->link_target = $request->pdf_link_target;
-            $slideshows_item->caption = $request->pdf_caption;
             $slideshows_item->display_flag = ShowType::show;
             $slideshows_item->display_sequence = $max_display_sequence;
             $slideshows_item->save();

--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -21,6 +21,8 @@ use App\Enums\ShowType;
 use App\Enums\WidthOfPdfThumbnail;
 use App\Plugins\User\UserPluginBase;
 use App\Utilities\Curl\CurlUtils;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
 
 /**
  * スライドショー・プラグイン
@@ -521,82 +523,25 @@ class SlideshowsPlugin extends UserPluginBase
      */
     public function addPdf($request, $page_id, $frame_id, $id = null)
     {
-        // TODO: 異常系の処理　UploadController::postFile() の "if ($request->hasFile('pdf')) {" 以降を参考に
-        // TODO: 関数が長いのでリファクタリング
-        // TODO: addItem()と被っている処理を共通化
-        // TODO: PDFファイルサイズの上限チェック
-
         // エラーチェック
         $request->validate([
-            'pdf_file'  => 'required|mimes:pdf',
+            'pdf_file'  => 'required|mimes:pdf|file',
+            'pdf_image_size' => ['required',Rule::in(WidthOfPdfThumbnail::getMemberKeys())],
+            'pdf_password' => 'max:255',
             'pdf_link_url'    => [new CustomValiUrlMax()],
             'pdf_caption'     => 'max:255',
             'pdf_link_target' => 'max:255',
         ]);
 
-        if ($request->hasFile('pdf_file')) {
-            // API URL取得
-            $api_url = config('connect.PDF_THUMBNAIL_API_URL');
-
-            // 送信データを指定
-            $data = [
-                'api_key' => config('connect.PDF_THUMBNAIL_API_KEY'),
-                'pdf' => base64_encode($request->file('pdf_file')->get()),
-                'pdf_password' => '',
-                'scale_of_pdf_thumbnails' => WidthOfPdfThumbnail::getScale(WidthOfPdfThumbnail::middle),
-                'number_of_pdf_thumbnails' => NumberOfPdfThumbnail::all,
-            ];
-
-            $res = CurlUtils::execute($api_url, 'POST', $data);
-
-            $base64_thumbnails = json_decode($res['body'], true);
-
-            // エラーメッセージが有ったら、メッセージを出力して終了
-            if (isset($base64_thumbnails['errors']['message'])) {
-                // $msg_array['link_text'] .= '</a></p>';
-                // $msg_array['link_text'] .= '<p>サムネイル作成エラー：' . $base64_thumbnails['errors']['message'] . '</p>';
-                // return $msg_array;
-            }
-
-            $thumbnail_no = 1;
-            foreach ($base64_thumbnails as $base64_thumbnail) {
-
-                $thumbnail_name = $request->file('pdf_file')->getClientOriginalName() . '_' . $thumbnail_no;
-
-                $thumbnail_upload = Uploads::create([
-                    'client_original_name' => $thumbnail_name . '.png',
-                    'mimetype'             => 'image/png',
-                    'extension'            => 'png',
-                    'size'                 => 0,
-                    'page_id'              => $request->page_id,
-                    'plugin_name'          => $request->plugin_name,
-                ]);
-
-                $directory = $this->getDirectory($thumbnail_upload->id);
-                $thumbnail_path = storage_path('app/') . $directory . '/' . $thumbnail_upload->id . '.png';
-                File::put($thumbnail_path, base64_decode($base64_thumbnail));
-
-                // sizeはファイルにしてから取得する
-                $thumbnail_upload->size = File::size($thumbnail_path);
-                $thumbnail_upload->save();
-
-                // 新規登録時の表示順を設定
-                $max_display_sequence = SlideshowsItems::query()->where('slideshows_id', $request->slideshows_id)->max('display_sequence');
-                $max_display_sequence = $max_display_sequence ? $max_display_sequence + 1 : 1;
-
-                // 項目の登録処理
-                $slideshows_item = new SlideshowsItems();
-                $slideshows_item->slideshows_id = $request->slideshows_id;
-                $slideshows_item->image_path = $thumbnail_path;
-                $slideshows_item->uploads_id = $thumbnail_upload->id;
-                $slideshows_item->link_url = $request->pdf_link_url;
-                $slideshows_item->link_target = $request->pdf_link_target;
-                $slideshows_item->caption = $request->pdf_caption;
-                $slideshows_item->display_flag = ShowType::show;
-                $slideshows_item->display_sequence = $max_display_sequence;
-                $slideshows_item->save();
-            }
+        $base64_images = $this->pdfToImage($request->file('pdf_file')->get(), $request->pdf_image_size, $request->pdf_password);
+        // 変換失敗
+        if (empty($base64_images)) {
+            // フラッシュメッセージ設定
+            $request->merge(['flash_message' => 'PDFの追加に失敗しました。']);
+            return;
         }
+
+        $this->savePdfImages($request, $base64_images);
 
         // フラッシュメッセージ設定
         $request->merge([
@@ -604,6 +549,98 @@ class SlideshowsPlugin extends UserPluginBase
         ]);
 
         // リダイレクト設定はフォーム側で設定している為、return処理は省略
+    }
+
+    /**
+     * PDFファイルを画像に変換する
+     *
+     * @param string $pdf_file PDFファイル
+     * @param string $password PDFパスワード
+     * @param string $scale 変換後の画像サイズ
+     * @return array 画像(base64)
+     */
+    private function pdfToImage(string $pdf_file, string $scale, ?string $password) :array
+    {
+        // API URL取得
+        $api_url = config('connect.PDF_THUMBNAIL_API_URL');
+        if (empty($api_url)) {
+            // API URLを設定しないとこの処理は通らないため、通常ここに入らない想定。そのためシステム的なメッセージを表示
+            $error_message = 'error: 設定ファイル.envにPDF_THUMBNAIL_API_URLが設定されていません。';
+            Log::error($error_message);
+            return [];
+        }
+
+        // 送信データを指定
+        $data = [
+            'api_key' => config('connect.PDF_THUMBNAIL_API_KEY'),
+            'pdf' => base64_encode($pdf_file),
+            'pdf_password' => $password,
+            'scale_of_pdf_thumbnails' => $scale,
+            'number_of_pdf_thumbnails' => NumberOfPdfThumbnail::all,
+        ];
+
+        $res = CurlUtils::execute($api_url, 'POST', $data);
+        $base64_images = json_decode($res['body'], true);
+
+        // エラーメッセージが有ったら、メッセージを出力して終了
+        if (isset($base64_images['errors']['message'])) {
+            $error_message = '画像変換エラー：' . $base64_images['errors']['message'];
+            Log::error($error_message);
+            return [];
+        }
+
+        return $base64_images;
+    }
+
+    /**
+     * PDFの画像ファイルをスライドショーに登録する。
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param array $base64_images 画像(base64)
+     */
+    private function savePdfImages(\Illuminate\Http\Request $request, array $base64_images)
+    {
+        $index = 1;
+        foreach ($base64_images as $base64_image) {
+
+            // 画像をUploadsへ登録する
+            $image_name = $request->file('pdf_file')->getClientOriginalName() . '_' . $index;
+            $image_upload = Uploads::create([
+                'client_original_name' => $image_name . '.png',
+                'mimetype'             => 'image/png',
+                'extension'            => 'png',
+                'size'                 => 0,
+                'page_id'              => $request->page_id,
+                'plugin_name'          => $request->plugin_name,
+            ]);
+
+            // 画像をファイルとして保存する
+            $directory = $this->getDirectory($image_upload->id);
+            $image_path = storage_path('app/') . $directory . '/' . $image_upload->id . '.png';
+            File::put($image_path, base64_decode($base64_image));
+
+            // sizeはファイルにしてから取得する
+            $image_upload->size = File::size($image_path);
+            $image_upload->save();
+
+            // 新規登録時の表示順を設定
+            $max_display_sequence = SlideshowsItems::query()->where('slideshows_id', $request->slideshows_id)->max('display_sequence');
+            $max_display_sequence = $max_display_sequence ? $max_display_sequence + 1 : 1;
+
+            // 項目の登録処理
+            $slideshows_item = new SlideshowsItems();
+            $slideshows_item->slideshows_id = $request->slideshows_id;
+            $slideshows_item->image_path = $image_path;
+            $slideshows_item->uploads_id = $image_upload->id;
+            $slideshows_item->link_url = $request->pdf_link_url;
+            $slideshows_item->link_target = $request->pdf_link_target;
+            $slideshows_item->caption = $request->pdf_caption;
+            $slideshows_item->display_flag = ShowType::show;
+            $slideshows_item->display_sequence = $max_display_sequence;
+            $slideshows_item->save();
+
+            $index++;
+        }
     }
 
     /**

--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -537,7 +537,7 @@ class SlideshowsPlugin extends UserPluginBase
         // 変換失敗
         if (empty($base64_images)) {
             // フラッシュメッセージ設定
-            $request->merge(['flash_message' => 'PDFの追加に失敗しました。']);
+            session()->flash('slideshows_error_message', 'PDFの追加に失敗しました。PDFにパスワードが設定されている場合は、PDFパスワードを入力してください。PDFにパスワードが設定されていない、もしくは正しいPDFパスワードを入力しても変換に失敗する場合は、システム管理者に問い合わせてください。');
             return;
         }
 

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -164,12 +164,6 @@ return [
         'link_url'       => 'リンクURL',
         'caption'        => 'キャプション',
         'link_target'    => 'リンクターゲット',
-        'pdf_file' => 'PDF',
-        'pdf_image_size' => '画像の大きさ',
-        'pdf_password' => 'PDFパスワード',
-        'pdf_link_url' => 'リンクURL',
-        'pdf_caption' => 'キャプション',
-        'pdf_link_target' => 'リンクターゲット',
     ],
 
 ];

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -164,6 +164,12 @@ return [
         'link_url'       => 'リンクURL',
         'caption'        => 'キャプション',
         'link_target'    => 'リンクターゲット',
+        'pdf_file' => 'PDF',
+        'pdf_image_size' => '画像の大きさ',
+        'pdf_password' => 'PDFパスワード',
+        'pdf_link_url' => 'リンクURL',
+        'pdf_caption' => 'キャプション',
+        'pdf_link_target' => 'リンクターゲット',
     ],
 
 ];

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
@@ -46,8 +46,18 @@
 
                     {{-- メッセージエリア --}}
                     <div class="alert alert-info mt-2">
-                        <i class="fas fa-exclamation-circle"></i> {{ session('flash_message') ? session('flash_message') : 'スライドショーに表示させる画像やリンクを設定します。' }}
-                        <a href="https://manual.connect-cms.jp/user/slideshows/index.html" target="_brank"><i class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></i></a>
+                        @if (session('flash_message'))
+                            <i class="fas fa-exclamation-circle"></i>{{ session('flash_message') }}
+                            <a href="https://manual.connect-cms.jp/user/slideshows/index.html" target="_brank"><i class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></i></a>
+                        @else
+                            <ul>
+                                <li>
+                                    スライドショーに表示させる画像やリンクを設定します。
+                                    <a href="https://manual.connect-cms.jp/user/slideshows/index.html" target="_brank"><i class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></i></a>
+                                </li>
+                                <li>PDFを選択して追加することで、PDFの内容を画像に変換して登録できます。</li>
+                            </ul>
+                        @endif
                     </div>
 
                     {{-- 項目一覧 --}}

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
@@ -37,6 +37,13 @@
                     {{-- エラーメッセージエリア ※共通blade呼び出し --}}
                     @include('plugins.common.errors_form_line')
 
+                    {{-- エラーメッセージ --}}
+                    @if (session('slideshows_error_message'))
+                    <div class="alert alert-danger mt-2">
+                        <i class="fas fa-exclamation-circle"></i> {{ session('slideshows_error_message') }}
+                    </div>
+                    @endif
+
                     {{-- メッセージエリア --}}
                     <div class="alert alert-info mt-2">
                         <i class="fas fa-exclamation-circle"></i> {{ session('flash_message') ? session('flash_message') : 'スライドショーに表示させる画像やリンクを設定します。' }}

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
@@ -107,6 +107,14 @@
             }
 
             /**
+             * PDF選択の追加ボタン押下
+             */
+            function submit_add_pdf() {
+                slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/addPdf/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+                slideshow_items.submit();
+            }
+
+            /**
              * 項目の削除ボタン押下
              */
             function submit_delete_item(item_id) {

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
@@ -170,7 +170,8 @@
                         @endforeach
                         // 新規追加行用の変数
                         image_url_add:"",
-                        file_name_add:""
+                        file_name_add:"",
+                        selected_pdf:""
                     }
                 },
                 methods: {
@@ -180,6 +181,14 @@
                         // console.log(file);
                         eval("this.image_url_" + items_id + " = URL.createObjectURL(file);");
                         eval("this.file_name_" + items_id + " = file.name;");
+                    },
+                    // 選択中のPDFを表示する
+                    setPdfFile(event){
+                        let file = event.target.files[0];
+                        if (file === undefined) {
+                            this.selected_pdf = "";
+                        }
+                        this.selected_pdf = file.name;
                     }
                 }
             });

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
@@ -158,40 +158,11 @@
         </div>
     </td>
     {{-- リンクURL --}}
-    <td class="d-block d-xl-table-cell align-middle">
-        <strong class="d-xl-none">リンクURL：</strong>
-        <input
-            type="text"
-            name="pdf_link_url"
-            class="form-control @if ($errors && $errors->has('pdf_link_url')) border-danger @endif"
-            value="{{ old('pdf_link_url') }}"
-            placeholder="例：https://connect-cms.jp/"
-        >
-        @include('common.errors_inline', ['name' => 'pdf_link_url'])
-    </td>
+    <td class="d-block d-xl-table-cell align-middle"></td>
     {{-- キャプション --}}
-    <td class="d-block d-xl-table-cell align-middle">
-        <strong class="d-xl-none">キャプション：</strong>
-        <input
-            type="text"
-            name="pdf_caption"
-            class="form-control @if ($errors && $errors->has('pdf_caption')) border-danger @endif"
-            value="{{ old('pdf_caption') }}"
-        >
-        @include('common.errors_inline', ['name' => 'pdf_caption'])
-    </td>
+    <td class="d-block d-xl-table-cell align-middle"></td>
     {{-- リンクターゲット --}}
-    <td class="d-block d-xl-table-cell align-middle">
-        <strong class="d-xl-none">リンクターゲット：</strong>
-        <input
-            type="text"
-            name="pdf_link_target"
-            class="form-control @if ($errors && $errors->has('pdf_link_target')) border-danger @endif"
-            value="{{ old('pdf_link_target') }}"
-            placeholder="例：_blank、_self等"
-        >
-        @include('common.errors_inline', ['name' => 'pdf_link_target'])
-    </td>
+    <td class="d-block d-xl-table-cell align-middle"></td>
     {{-- ＋ボタン --}}
     <td class="d-block d-xl-table-cell align-middle d-flex align-items-center justify-content-center">
         <button

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
@@ -139,13 +139,13 @@
                             <label for="pdf_image_size">画像の大きさ</label>
                             <select id="pdf_image_size" class="form-control" name="pdf_image_size">
                                 @foreach (WidthOfPdfThumbnail::getMembers() as $enum_value => $enum_label)
-                                    <option value="{{$enum_value}}">{{$enum_label}}</option>
+                                    <option value="{{$enum_value}}" @if (old('pdf_image_size') == $enum_value) selected @endif>{{$enum_label}}</option>
                                 @endforeach
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="pdf_password">PDFパスワード</label>
-                            <input type="text" class="form-control" id="pdf_password" name="pdf_password">
+                            <input type="text" class="form-control" id="pdf_password" name="pdf_password" value="{{ old('pdf_password') }}">
                             <small class="form-text text-muted">PDFにパスワードが設定されている場合に入力してください。</small>
                         </div>
                     </div>

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
@@ -99,3 +99,66 @@
         </button>
     </td>
 </tr>
+
+{{-- PDF選択 --}}
+{{-- TODO PDF選択後にサムネイルを表示する OR ファイル名を出す　など　選択しているファイルが画面でわかるようにする --}}
+{{-- TODO ダイアログ パスワード入力項目、画像の大きさ選択 --}}
+{{-- TODO アップロードファイルサイズの上限値　--}}
+
+@if (!empty(config('connect.PDF_THUMBNAIL_API_URL')))
+<tr>
+    <td class="d-none d-xl-display d-xl-table-cell"></td>
+    <td class="d-none d-xl-display d-xl-table-cell"></td>
+    <td class="d-block d-xl-table-cell align-middle">
+        <label class="input-group-btn d-flex align-items-center justify-content-center">
+            <span class="btn btn-primary text-nowrap" style="cursor: hand; cursor:pointer;">
+                PDF選択<input type="file" name="pdf_file" style="display:none" accept=".pdf">
+            </span>
+        </label>
+    </td>
+    {{-- リンクURL --}}
+    <td class="d-block d-xl-table-cell align-middle">
+        <strong class="d-xl-none">リンクURL：</strong>
+        <input
+            type="text"
+            name="pdf_link_url"
+            class="form-control @if ($errors && $errors->has('pdf_link_url')) border-danger @endif"
+            value="{{ old('pdf_link_url') }}"
+            placeholder="例：https://connect-cms.jp/"
+        >
+        @include('common.errors_inline', ['name' => 'pdf_link_url'])
+    </td>
+    {{-- キャプション --}}
+    <td class="d-block d-xl-table-cell align-middle">
+        <strong class="d-xl-none">キャプション：</strong>
+        <input
+            type="text"
+            name="pdf_caption"
+            class="form-control @if ($errors && $errors->has('pdf_caption')) border-danger @endif"
+            value="{{ old('pdf_caption') }}"
+        >
+        @include('common.errors_inline', ['name' => 'pdf_caption'])
+    </td>
+    {{-- リンクターゲット --}}
+    <td class="d-block d-xl-table-cell align-middle">
+        <strong class="d-xl-none">リンクターゲット：</strong>
+        <input
+            type="text"
+            name="pdf_link_target"
+            class="form-control @if ($errors && $errors->has('pdf_link_target')) border-danger @endif"
+            value="{{ old('pdf_link_target') }}"
+            placeholder="例：_blank、_self等"
+        >
+        @include('common.errors_inline', ['name' => 'pdf_link_target'])
+    </td>
+    {{-- ＋ボタン --}}
+    <td class="d-block d-xl-table-cell align-middle d-flex align-items-center justify-content-center">
+        <button
+            class="btn btn-success cc-font-90 text-nowrap"
+            onclick="javascript:submit_add_pdf();"
+        >
+            <i class="fas fa-plus"></i> 追加
+        </button>
+    </td>
+</tr>
+@endisset

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
@@ -101,20 +101,61 @@
 </tr>
 
 {{-- PDF選択 --}}
-{{-- TODO PDF選択後にサムネイルを表示する OR ファイル名を出す　など　選択しているファイルが画面でわかるようにする --}}
-{{-- TODO ダイアログ パスワード入力項目、画像の大きさ選択 --}}
-{{-- TODO アップロードファイルサイズの上限値　--}}
 
 @if (!empty(config('connect.PDF_THUMBNAIL_API_URL')))
 <tr>
     <td class="d-none d-xl-display d-xl-table-cell"></td>
     <td class="d-none d-xl-display d-xl-table-cell"></td>
     <td class="d-block d-xl-table-cell align-middle">
-        <label class="input-group-btn d-flex align-items-center justify-content-center">
+        <label class="input-group-btn d-flex align-items-center justify-content-center" data-toggle="modal" data-target="#modalPdfAdd">
             <span class="btn btn-primary text-nowrap" style="cursor: hand; cursor:pointer;">
-                PDF選択<input type="file" name="pdf_file" style="display:none" accept=".pdf">
+                PDF選択
             </span>
         </label>
+        <div v-if="selected_pdf">@{{ selected_pdf }}</div>
+        @include('plugins.common.errors_inline', ['name' => 'pdf_file'])
+        @include('plugins.common.errors_inline', ['name' => 'pdf_image_size'])
+        @include('plugins.common.errors_inline', ['name' => 'pdf_password'])
+        {{-- PDF選択モーダル --}}
+        <div class="modal fade" id="modalPdfAdd" tabindex="-1" role="dialog" aria-labelledby="modalPdfAddTitle" aria-hidden="true">
+            {{-- モーダルサイズはXL --}}
+            <div class="modal-dialog modal-dialog-centered" role="document">
+                <div class="modal-content">
+                    {{-- ヘッダ --}}
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="modalPdfAddTitle">PDF選択</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    {{-- コンテンツ内容 --}}
+                    <div class="modal-body">
+                        <div class="form-group">
+                            <label for="pdf_file">ファイル</label>
+                            <input type="file" class="form-control-file" id="pdf_file" name="pdf_file" accept=".pdf" @change="setPdfFile(arguments[0])">
+                            <small id="upload-size-server-help" class="form-text text-muted">アップロードできる最大サイズ&nbsp;<span class="font-weight-bold">{{ini_get('upload_max_filesize')}}</span></small>
+                        </div>
+                        <div class="form-group">
+                            <label for="pdf_image_size">画像の大きさ</label>
+                            <select id="pdf_image_size" class="form-control" name="pdf_image_size">
+                                @foreach (WidthOfPdfThumbnail::getMembers() as $enum_value => $enum_label)
+                                    <option value="{{$enum_value}}">{{$enum_label}}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="pdf_password">PDFパスワード</label>
+                            <input type="text" class="form-control" id="pdf_password" name="pdf_password">
+                            <small class="form-text text-muted">PDFにパスワードが設定されている場合に入力してください。</small>
+                        </div>
+                    </div>
+                    {{-- フッター --}}
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-primary" data-dismiss="modal">保存</button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </td>
     {{-- リンクURL --}}
     <td class="d-block d-xl-table-cell align-middle">


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
PDFを画像に変換してスライドショーに登録します。

### 機能説明

#### 項目設定画面にPDFを登録する行を追加しました。
<img width="680" alt="image" src="https://user-images.githubusercontent.com/32890286/195317746-a275d713-30f4-43e0-b285-cf23dc8e4c05.png">

#### PDF選択ボタンでダイアログが表示されるので、必要な情報を入力します。
<img width="382" alt="image" src="https://user-images.githubusercontent.com/32890286/195318266-6c42f02e-f838-4129-98c4-f06846e218f4.png">

#### ＋追加ボタン押下で、スライドショーにPDFの内容を画像に変換して登録できます。

#### 特記事項

当機能の利用にはPDF Upload APIの実装＆設定が必要です。
https://github.com/opensource-workshop/connect-cms/wiki/PDF-Upload-API

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り / 無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
