### PR TITLE
[課題管理] どの科目をクリックしても同じ科目が表示される不具合修正 OW-1419

### DIFF
--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -242,8 +242,9 @@ class LearningtasksPlugin extends UserPluginBase
         // カテゴリのleftJoin
         $learningtasks_query = Categories::appendCategoriesLeftJoin($learningtasks_query, $this->frame->plugin_name, 'learningtasks_posts.categories_id', 'learningtasks.id');
 
-        // 履歴最新を取得するために、idをdesc指定（履歴を廃止しても過去データのため必要かも）
-        $this->post = $learningtasks_query->orderBy('id', 'desc')->first();
+        // 履歴の廃止による変更
+        // $this->post = $learningtasks_query->orderBy('id', 'desc')->firstOrNew(['learningtasks_posts.id' => $id]);
+        $this->post = $learningtasks_query->where('learningtasks_posts.id', $id)->first();
         $this->post = $this->post ?? new LearningtasksPosts();
 
         return $this->post;


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

https://github.com/opensource-workshop/connect-cms/commit/f767ac64da13fb50f715186952ac33544c563e54
上記でデグレードが発生していたので修正しました。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

本日10/5リリースしたいな。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし
## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
