### PR TITLE
[フォーム] 本登録後のメッセージをHTMLで記述できるようにする

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -1577,7 +1577,7 @@ class FormsPlugin extends UserPluginBase
         $forms->mail_subject        = $request->mail_subject;
         $forms->mail_format         = $request->mail_format;
         $forms->data_save_flag      = empty($request->data_save_flag) ? 0 : $request->data_save_flag;
-        $forms->after_message       = $request->after_message;
+        $forms->after_message       = $this->clean($request->after_message);
         $forms->numbering_use_flag  = empty($request->numbering_use_flag) ? 0 : $request->numbering_use_flag;
         $forms->numbering_prefix    = $request->numbering_prefix;
 

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -388,7 +388,10 @@
         <label class="{{$frame->getSettingLabelClass()}}">本登録後のメッセージ</label>
         <div class="{{$frame->getSettingInputClass()}}">
             <textarea name="after_message" class="form-control" rows=5 placeholder="（例）お申込みありがとうございます。&#13;&#10;受付番号は[[number]]になります。">{{old('after_message', $form->after_message)}}</textarea>
-            <small class="text-muted">※ [[number]] を記述すると該当部分に採番した番号が入ります。（採番機能の使用時）</small>
+            <small class="text-muted">
+                ※ HTMLでも記述できます。<br />
+                ※ [[number]] を記述すると該当部分に採番した番号が入ります。（採番機能の使用時）
+            </small>
         </div>
     </div>
 

--- a/resources/views/plugins/user/forms/default/forms_thanks.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_thanks.blade.php
@@ -8,5 +8,5 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
-{!! nl2br(e($after_message)) !!}
+{!! nl2br($after_message) !!}
 @endsection


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

本登録後のメッセージにHTMLを記述したい要望があり、その対応です。

## 設定画面例
### フォーム設定画面（本登録後のメッセージ　のみ）
![image](https://user-images.githubusercontent.com/2756509/193990954-d7efa79c-5184-40a6-9b5f-313a4a429223.png)
※ HTMLが使える旨のメッセージを追記しました。

### フォーム登録後
![image](https://user-images.githubusercontent.com/2756509/193990273-3135e54e-4a48-4294-bc61-72602939f95f.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

軽微な改修なので急ぎません

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
