### PR TITLE
[ブログ][FAQ][新着情報]一部の文字を入力するとRSSが正常に取得できない問題を修正しました

### DIFF
--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1415,7 +1415,7 @@ EOD;
 
         $blogs_posts = $this->getPosts($blog_frame, $blog_frame->rss_count);
         foreach ($blogs_posts as $blogs_post) {
-            $title = $blogs_post->post_title;
+            $title = htmlspecialchars($blogs_post->post_title, ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1);
             $link = url("/plugin/blogs/show/" . $page_id . "/" . $frame_id . "/" . $blogs_post->id);
             if (mb_strlen(strip_tags($blogs_post->post_text)) > 100) {
                 $description = mb_substr(strip_tags($blogs_post->post_text), 0, 100) . "...";
@@ -1427,7 +1427,7 @@ EOD;
                 $description = str_replace($replaceTarget, '', $description);
             }
             $pub_date = date(DATE_RSS, strtotime($blogs_post->posted_at));
-            $content = strip_tags(html_entity_decode($blogs_post->post_text));
+            $content = htmlspecialchars(strip_tags(html_entity_decode($blogs_post->post_text)), ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1);
             echo <<<EOD
 
 <item>

--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -1126,7 +1126,7 @@ EOD;
 
         $faqs_posts = $this->getPosts($faq_frame, $faq_frame->rss_count);
         foreach ($faqs_posts as $faqs_post) {
-            $title = $faqs_post->post_title;
+            $title = htmlspecialchars($faqs_post->post_title, ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1);
             $link = url("/plugin/faqs/show/" . $page_id . "/" . $frame_id . "/" . $faqs_post->id);
             if (mb_strlen(strip_tags($faqs_post->post_text)) > 100) {
                 $description = mb_substr(strip_tags($faqs_post->post_text), 0, 100) . "...";
@@ -1138,7 +1138,7 @@ EOD;
                 $description = str_replace($replaceTarget, '', $description);
             }
             $pub_date = date(DATE_RSS, strtotime($faqs_post->posted_at));
-            $content = strip_tags(html_entity_decode($faqs_post->post_text));
+            $content = htmlspecialchars(strip_tags(html_entity_decode($faqs_post->post_text)), ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1);
             echo <<<EOD
 
 <item>

--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -848,11 +848,11 @@ EOD;
         list($whatsnews, $link_pattern, $link_base) = $this->getWhatsnews($whatsnews_frame, 'rss');
 
         foreach ($whatsnews as $whatsnew) {
-            $title = $whatsnew->post_title;
+            $title = htmlspecialchars($whatsnew->post_title, ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1);
             $link = url($link_base[$whatsnew->plugin_name] . '/' . $whatsnew->page_id . '/' . $whatsnew->frame_id . '/' . $whatsnew->post_id);
 //            $description = strip_tags(mb_substr($blogs_post->post_text, 0, 20));
             $pub_date = date(DATE_RSS, strtotime($whatsnew->posted_at));
-            $content = strip_tags(html_entity_decode($whatsnew->post_title));
+            $content = htmlspecialchars(strip_tags(html_entity_decode($whatsnew->post_title)), ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1);;
             echo <<<EOD
 
 <item>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
タイトルと本文に&（アンパサンド）が含まれていると、RSSのXMLがパースエラーとなります。
そのため、RSSが正常に読み込めない事象が発生していました。

&はXMLで特殊文字であるため、エスケープの必要がありました。
なお、XML内の<description>には、TinyMCEでエスケープされた文字列がそのまま入るため、修正していません。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なるはやでお願いします。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
#1451 

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
