### PR TITLE
[データベース] default・カードタイプ２列・design-table-dlテンプレートの詳細画面で公開終了・公開前のタグ表示が抜けていたので追加

### DIFF
--- a/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
@@ -70,6 +70,14 @@
                 <span class="badge badge-warning align-bottom">一時保存</span>
             @endif
 
+            @if (!empty($inputs->expires_at) && $inputs->expires_at <= Carbon::now())
+                <span class="badge badge-secondary align-bottom">公開終了</span>
+            @endif
+
+            @if ($inputs->posted_at > Carbon::now())
+                <span class="badge badge-info align-bottom">公開前</span>
+            @endif
+
             <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}'">
                 <i class="far fa-edit"></i> 編集
             </button>

--- a/resources/views/plugins/user/databases/default/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_detail.blade.php
@@ -64,6 +64,14 @@
                 <span class="badge badge-warning align-bottom">一時保存</span>
             @endif
 
+            @if (!empty($inputs->expires_at) && $inputs->expires_at <= Carbon::now())
+                <span class="badge badge-secondary align-bottom">公開終了</span>
+            @endif
+
+            @if ($inputs->posted_at > Carbon::now())
+                <span class="badge badge-info align-bottom">公開前</span>
+            @endif
+
             <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}'">
                 <i class="far fa-edit"></i> 編集
             </button>

--- a/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
@@ -67,6 +67,14 @@
                 <span class="badge badge-warning align-bottom">一時保存</span>
             @endif
 
+            @if (!empty($inputs->expires_at) && $inputs->expires_at <= Carbon::now())
+                <span class="badge badge-secondary align-bottom">公開終了</span>
+            @endif
+
+            @if ($inputs->posted_at > Carbon::now())
+                <span class="badge badge-info align-bottom">公開前</span>
+            @endif
+
             <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}'">
                 <i class="far fa-edit"></i> 編集
             </button>


### PR DESCRIPTION

## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1207

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
