### PR TITLE
[データベース] 編集者は自分以外の「公開終了」した記事、投稿日前の記事は表示しない

### DIFF
--- a/resources/views/plugins/user/databases/card_02/databases.blade.php
+++ b/resources/views/plugins/user/databases/card_02/databases.blade.php
@@ -81,17 +81,18 @@
                                     </form>
                                 @endcan
                             @endif
-                            @can('posts.update',[[$input, $frame->plugin_name, $buckets]])
-                                @if ($input->status == 1)
-                                    <span class="badge badge-warning align-bottom">一時保存</span>
-                                @endif
-
+                            @can('role_update_or_approval',[[$input, $frame->plugin_name, $buckets]])
                                 @if (!empty($input->expires_at) && $input->expires_at <= Carbon::now())
                                     <span class="badge badge-secondary align-bottom">公開終了</span>
                                 @endif
 
                                 @if ($input->posted_at > Carbon::now())
                                     <span class="badge badge-info align-bottom">公開前</span>
+                                @endif
+                            @endcan
+                            @can('posts.update',[[$input, $frame->plugin_name, $buckets]])
+                                @if ($input->status == 1)
+                                    <span class="badge badge-warning align-bottom">一時保存</span>
                                 @endif
 
                                 <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}'">

--- a/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
@@ -65,17 +65,18 @@
                 </form>
             @endcan
         @endif
-        @can('posts.update',[[$inputs, $frame->plugin_name, $buckets]])
-            @if ($inputs->status == 1)
-                <span class="badge badge-warning align-bottom">一時保存</span>
-            @endif
-
+        @can('role_update_or_approval',[[$inputs, $frame->plugin_name, $buckets]])
             @if (!empty($inputs->expires_at) && $inputs->expires_at <= Carbon::now())
                 <span class="badge badge-secondary align-bottom">公開終了</span>
             @endif
 
             @if ($inputs->posted_at > Carbon::now())
                 <span class="badge badge-info align-bottom">公開前</span>
+            @endif
+        @endcan
+        @can('posts.update',[[$inputs, $frame->plugin_name, $buckets]])
+            @if ($inputs->status == 1)
+                <span class="badge badge-warning align-bottom">一時保存</span>
             @endif
 
             <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}'">

--- a/resources/views/plugins/user/databases/default/databases.blade.php
+++ b/resources/views/plugins/user/databases/default/databases.blade.php
@@ -76,17 +76,18 @@
                                 </form>
                             @endcan
                         @endif
-                        @can('posts.update',[[$input, $frame->plugin_name, $buckets]])
-                            @if ($input->status == 1)
-                                <span class="badge badge-warning align-bottom">一時保存</span>
-                            @endif
-
+                        @can('role_update_or_approval',[[$input, $frame->plugin_name, $buckets]])
                             @if (!empty($input->expires_at) && $input->expires_at <= Carbon::now())
                                 <span class="badge badge-secondary align-bottom">公開終了</span>
                             @endif
 
                             @if ($input->posted_at > Carbon::now())
                                 <span class="badge badge-info align-bottom">公開前</span>
+                            @endif
+                        @endcan
+                        @can('posts.update',[[$input, $frame->plugin_name, $buckets]])
+                            @if ($input->status == 1)
+                                <span class="badge badge-warning align-bottom">一時保存</span>
                             @endif
 
                             <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}'">

--- a/resources/views/plugins/user/databases/default/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_detail.blade.php
@@ -59,17 +59,18 @@
                 </form>
             @endcan
         @endif
-        @can('posts.update',[[$inputs, $frame->plugin_name, $buckets]])
-            @if ($inputs->status == 1)
-                <span class="badge badge-warning align-bottom">一時保存</span>
-            @endif
-
+        @can('role_update_or_approval',[[$inputs, $frame->plugin_name, $buckets]])
             @if (!empty($inputs->expires_at) && $inputs->expires_at <= Carbon::now())
                 <span class="badge badge-secondary align-bottom">公開終了</span>
             @endif
 
             @if ($inputs->posted_at > Carbon::now())
                 <span class="badge badge-info align-bottom">公開前</span>
+            @endif
+        @endcan
+        @can('posts.update',[[$inputs, $frame->plugin_name, $buckets]])
+            @if ($inputs->status == 1)
+                <span class="badge badge-warning align-bottom">一時保存</span>
             @endif
 
             <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}'">

--- a/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
@@ -62,17 +62,18 @@
                 </form>
             @endcan
         @endif
-        @can('posts.update',[[$inputs, $frame->plugin_name, $buckets]])
-            @if ($inputs->status == 1)
-                <span class="badge badge-warning align-bottom">一時保存</span>
-            @endif
-
+        @can('role_update_or_approval',[[$inputs, $frame->plugin_name, $buckets]])
             @if (!empty($inputs->expires_at) && $inputs->expires_at <= Carbon::now())
                 <span class="badge badge-secondary align-bottom">公開終了</span>
             @endif
 
             @if ($inputs->posted_at > Carbon::now())
                 <span class="badge badge-info align-bottom">公開前</span>
+            @endif
+        @endcan
+        @can('posts.update',[[$inputs, $frame->plugin_name, $buckets]])
+            @if ($inputs->status == 1)
+                <span class="badge badge-warning align-bottom">一時保存</span>
             @endif
 
             <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}'">


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

### 現状

* 未ログインで「公開終了」した記事、投稿日前の記事は表示しない。
* ログイン済みなら、「公開終了」した記事、投稿日前の記事は表示。

### 変更後

* 未ログインの動きは変更なし。
* ログイン済みで記事の編集権限ないなら、「公開終了」した記事、投稿日前の記事は表示しない。
* 承認者でも「公開終了」「公開前」タグを表示に見直し。

### ※補足：権限毎の動き

* コンテンツ管理者、モデレータ
  * 全記事編集できるため、「公開終了」した記事、投稿日前の記事は表示。
* 承認者
  * 「公開終了」した記事、投稿日前の記事も承認する事が設定できるため、表示。
* 編集者
  * 自分以外の記事を編集できないため、自分の「公開終了」した記事、投稿日前の記事は表示。
  * 他人の「公開終了」した記事、投稿日前の記事は、表示しない。
* 未ログイン
  * 「公開終了」した記事、投稿日前の記事は、表示しない。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

10/24の週中。けど急いでないです。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms-ideas/issues/135
  * https://github.com/opensource-workshop/connect-cms/issues/1207

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
