### PR TITLE
[キャビネット]一覧のコンテンツ選択チェックボックスの全選択機能を追加しました。

### DIFF
--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -48,7 +48,16 @@
         @endcan
 
         $('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]').on('change', function(){
+            // 選択リスト（selected-contents）の更新＆ボタンの活性化制御
             controlSelectedContentsAndButtons{{$frame_id}}();
+            // 全選択チェックボックスの制御
+            if ($('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:checked').length == $('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:input').length) {
+                // （コンテンツチェックボックスのチェック済み = チェックボックス全件の場合）全選択のチェックをONにする
+                $('#app_{{$frame_id}} #select_all_{{$frame_id}}').prop('checked', true);
+            } else {
+                // （コンテンツチェックボックスのチェック済み ≠ チェックボックス全件の場合）全選択のチェックをOFFにする
+                $('#app_{{$frame_id}} #select_all_{{$frame_id}}').prop('checked', false);
+            }
         });
 
         // 全選択チェックボックスの押下時

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -48,23 +48,14 @@
         @endcan
 
         $('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]').on('change', function(){
+            controlSelectedContentsAndButtons{{$frame_id}}();
+        });
 
-            $('#selected-contents{{$frame_id}}').html('');
-
-            if ($('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:checked').length > 0){
-                $('#app_{{$frame_id}} .btn-download').prop('disabled', false);
-                $('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:checked').each(function(){
-                    $('#selected-contents{{$frame_id}}').append('<li>' + $(this).data('name') + '</li>');
-                })
-                @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
-                $('#app_{{$frame_id}} .btn-delete').prop('disabled', false);
-                @endcan
-            } else {
-                $('#app_{{$frame_id}} .btn-download').prop('disabled', true);
-                @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
-                $('#app_{{$frame_id}} .btn-delete').prop('disabled', true);
-                @endcan
-            }
+        // 全選択チェックボックスの押下時
+        $('#app_{{$frame_id}} #select_all_{{$frame_id}}').on("click",function(){
+            // フレーム配下のチェックボックスすべてON/OFF
+            $('#app_{{$frame_id}} input[type=checkbox][id^=customCheck]').prop("checked", $(this).prop("checked"));
+            controlSelectedContentsAndButtons{{$frame_id}}();
         });
 
         $('#app_{{$frame_id}} .btn-download').on('click', function(){
@@ -85,6 +76,29 @@
         }
     }
     @endcan
+
+    // 選択リスト（selected-contents）の更新＆ボタンの活性化制御
+    function controlSelectedContentsAndButtons{{$frame_id}}() {
+        // 選択リストを初期化
+        $('#selected-contents{{$frame_id}}').html('');
+
+        if ($('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:checked').length > 0){
+            // 選択済みコンテンツが1件以上ある場合：ボタン活性化＆選択リストにコンテンツを詰める
+            $('#app_{{$frame_id}} .btn-download').prop('disabled', false);
+            $('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:checked').each(function(){
+                $('#selected-contents{{$frame_id}}').append('<li>' + $(this).data('name') + '</li>');
+            })
+            @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
+            $('#app_{{$frame_id}} .btn-delete').prop('disabled', false);
+            @endcan
+        } else {
+            // 選択済みコンテンツが0件の場合：ボタンdisable化
+            $('#app_{{$frame_id}} .btn-download').prop('disabled', true);
+            @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
+            $('#app_{{$frame_id}} .btn-delete').prop('disabled', true);
+            @endcan
+        }
+    }
 </script>
 <div id="app_{{$frame_id}}">
 @can('posts.create', [[null, $frame->plugin_name, $buckets]])
@@ -172,7 +186,13 @@
 <table class="table text-break">
     <thead>
         <tr class="d-none d-md-table-row">
-            <th>&nbsp;</th>
+            <th>
+                {{-- 全選択チェック --}}
+                <div class="custom-control custom-checkbox">
+                    <input type="checkbox" class="custom-control-input" id="select_all_{{$frame_id}}">
+                    <label class="custom-control-label" for="select_all_{{$frame_id}}"></label>
+                </div>
+            </th>
             <th>名前</th>
             <th>サイズ</th>
             <th>更新日</th>

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -51,7 +51,7 @@
             // 選択リスト（selected-contents）の更新＆ボタンの活性化制御
             controlSelectedContentsAndButtons{{$frame_id}}();
             // 全選択チェックボックスの制御
-            if ($('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:checked').length == $('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:input').length) {
+            if ($('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]:checked').length == $('#app_{{$frame_id}} input[type="checkbox"][name="cabinet_content_id[]"]').length) {
                 // （コンテンツチェックボックスのチェック済み = チェックボックス全件の場合）全選択のチェックをONにする
                 $('#app_{{$frame_id}} #select_all_{{$frame_id}}').prop('checked', true);
             } else {


### PR DESCRIPTION
## 概要
 - ファイルが多い場合に個別に選択するのが大変だった為、１アクションで全選択ON/OFF指定ができる機能を追加しました。
 - 付随してjQuery処理の一部共通化（削除押下時のファイル名列挙時に参照するリストの更新処理＆ボタンの活性化制御）を行いました。
![image](https://user-images.githubusercontent.com/13323806/196609029-aa7d08ff-7623-4475-b536-b1f5ed4faeef.png)



## レビュー完了希望日
今日から2週間程度で11/2（水）。急がないです。

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms-ideas/issues/136

## 参考
なし

## DB変更の有無
なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
