### PR TITLE
[ブログ] 一時保存で続きを表示する関連が登録されない不具合修正

### DIFF
--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -945,7 +945,6 @@ WHERE status = 0
 
         // エラーがあった場合は入力画面に戻る。
         if ($validator->fails()) {
-            // return ( $this->create($request, $page_id, $frame_id, $id, $validator->errors()) );
             return back()->withErrors($validator)->withInput();
         }
 
@@ -968,7 +967,7 @@ WHERE status = 0
         }
 
         // ブログ記事設定
-        $blogs_post->status = 1;
+        $blogs_post->status = StatusType::temporary;
         $blogs_post->blogs_id   = $request->blogs_id;
         $blogs_post->post_title = $request->post_title;
         $blogs_post->categories_id = $request->categories_id;
@@ -976,6 +975,9 @@ WHERE status = 0
         $blogs_post->posted_at  = $request->posted_at . ':00';
         $blogs_post->post_text  = $this->clean($request->post_text);
         $blogs_post->post_text2 = $this->clean($request->post_text2);
+        $blogs_post->read_more_flag = $request->read_more_flag ?? 0;
+        $blogs_post->read_more_button = $request->read_more_button;
+        $blogs_post->close_more_button = $request->close_more_button;
 
         $blogs_post->save();
 
@@ -988,7 +990,6 @@ WHERE status = 0
         $this->saveTag($request, $blogs_post);
 
         // 登録後は表示用の初期処理を呼ぶ。
-        // return $this->index($request, $page_id, $frame_id);
         return collect(['redirect_path' => url($this->page->permanent_link)]);
     }
 


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし


## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
