### PR TITLE
[Opac]OpacBookLents 配送希望フラグのデフォルト値を設定し、OpacAPIからの貸出に対応する

### DIFF
--- a/database/migrations/2022_10_24_111729_change_delivery_request_opacs_books_lents.php
+++ b/database/migrations/2022_10_24_111729_change_delivery_request_opacs_books_lents.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeDeliveryRequestOpacsBooksLents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('opacs_books_lents', function (Blueprint $table) {
+            $table->integer('delivery_request_flag')->default(0)->change();
+        });    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('opacs_books_lents', function (Blueprint $table) {
+            $table->integer('delivery_request_flag')->default(NULL)->change();
+        });    }
+}


### PR DESCRIPTION
## 概要
OpacAPIで貸出処理を行った時、配送希望フラグを渡してこない。
配送希望フラグは、デフォルト値設定なしで、NULL入力NGである為、save処理でこける。
配送希望フラグのデフォルト値を0(希望なし)に設定

## レビュー完了希望日
なるはや

## 関連Pull requests/Issues
#1469 

## DB変更の有無
有り

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
