### PR TITLE
[コア] メンテナンスモードに固定メッセージ表示に見直し

### DIFF
--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -8,6 +8,7 @@
  * @see resources\views\layouts\app.blade.php
  * @see vendor\laravel\framework\src\Illuminate\Foundation\Exceptions\views\503.blade.php
  * @see vendor\laravel\framework\src\Illuminate\Foundation\Exceptions\views\minimal.blade.php
+ * @see \App\Http\Middleware\CheckForMaintenanceMode::class
 --}}
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
@@ -36,6 +37,7 @@
 </div>
 ';
     @endphp
-    {!! __($exception->getMessage() ?: $default_html) !!}
+    {{-- {!! __($exception->getMessage() ?: $default_html) !!} --}}
+    {!! $default_html !!}
 </body>
 </html>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

Laravel6.x⇒Laravel8.xのアップデートにより、コマンドラインから任意のメッセージをセットできなくなったため、固定メッセージになりますが、表示を修正しました。

### 修正後表示

![image](https://user-images.githubusercontent.com/2756509/197539338-03de85c6-e698-4bf1-a4fd-f3a7cc33b155.png)

### ※参考：修正前

![image](https://user-images.githubusercontent.com/2756509/197539545-22acebab-03ba-4c20-b793-db85b8df9a11.png)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
