### PR TITLE
[コア] 本来のエラーログを出力するため、cc_configs未セットなら初期化するよう対応

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -35,18 +35,12 @@
     //$menu_pages = $page_obj::orderBy('display_sequence')->get();
     $menu_pages = $page_obj::defaultOrderWithDepth();
 */
-// move: app\Http\Middleware\ConnectInit.php で処理するように対応
-// if (! isset($cc_configs)) {
-    // seederを実行した場合、必ずconfigsにデータができ、データが無い場合は通常ありえないので、異常終了させる。
-    // うっかり操作ミスは誰にでもありえるのため、エラーメッセージで対応方法を表示する。
-    // ※ 新規インストール時、seederを実行しないと、なんでか Middleware の ConnectInit まで到達せず、cc_configsはセットされなかったため、ここで簡易チェックする。（実行されれば空のコレクションがセットされてエラーにならないんだけどねぇ）
-    // ↓
-    // 暫定対応：ページなしの場合、$cc_configsがセットされなかったため、exitしちゃだめ。（ページなし処理 ConnectController::__construct()から呼ばれる $this->checkPageNotFound() でabort() されるの、なんかあやしいかも。Middleware の ConnectInit が実行されない原因かも）
-    // echo('DBテーブルのconfigsにデータが１件もありません。<code>php artisan db:seed</code> コマンドを実行して初期データを登録してください。');
-    // exit;
-    // ↓
-    // $cc_configs = collect();
-// }
+if (! isset($cc_configs)) {
+    // cc_configsは app\Http\Middleware\ConnectInit.php で処理しているため、基本ここには入らない。
+    // .envのAPP_KEYに"xxxx"とダブルクォートで囲むと`php artisan key:generate`しても変換されない＋APP_DEBUG=falseで、cc_configsなしでここに到達する。
+    // その時に、正しいエラーログでエラー内容を追えるようにするため、cc_configsを初期化する。（初期化しないとcc_configs変数なしエラーになり本来のエラーにたどり着かない）
+    $cc_configs = collect();
+}
 ?>
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* cc_configsは app\Http\Middleware\ConnectInit.php で処理しているため、基本resources/views/layouts/app.blade.phpではセットされます。
* けど、.envのAPP_KEYに"xxxx"とダブルクォートで囲むと`php artisan key:generate`しても変換されない＋APP_DEBUG=falseで、cc_configsなしでここに到達する。
その時に、正しいエラーログでエラー内容を追えるようにするため、cc_configsを初期化する。（初期化しないとcc_configs変数なしエラーになり本来のエラーにたどり着かない）


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
