### PR TITLE
[掲示板]枠なしテンプレートで詳細画面表示時のタイトル表示重複を改善しました

### DIFF
--- a/resources/views/plugins/user/bbses/default/index.blade.php
+++ b/resources/views/plugins/user/bbses/default/index.blade.php
@@ -67,10 +67,21 @@
                 {{-- no_frameテンプレート --}}
                 {{-- 根記事（スレッドの記事は古い順なので、根記事は最初） --}}
                 @include('plugins.user.bbses.default.post_title_div', ['view_post' => $post, 'current_post' => null, 'list_class' => $loop->first ? '' : 'mt-2'])
-                {{-- スレッド記事 --}}
-                @foreach ($children_posts->where("thread_root_id", $post->id) as $children_post)
-                    @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => null, 'list_class' => ''])
-                @endforeach
+                    @if (!isset($plugin_frame->view_format) || $plugin_frame->view_format == 0)
+                        {{-- フラット形式 --}}
+                        @foreach ($children_posts->where("thread_root_id", $post->id) as $children_post)
+                            @include('plugins.user.bbses.default.post_title_div', ['view_post' => $children_post, 'current_post' => null, 'list_class' => 'mb-2'])
+                        @endforeach
+                    @else
+                        {{-- ツリー形式 --}}
+                        @php
+                            $tree_posts = App\Models\User\Bbses\BbsPost::setDepth($children_posts->where("thread_root_id", $post->id));
+                        @endphp
+                        @foreach ($tree_posts as $tree_post)
+                            @include('plugins.user.bbses.default.post_title_div_tree', ['view_post' => $tree_post, 'current_post' => null, 'list_class' => 'tree'])
+                        @endforeach
+                    @endif
+
                 <div class="mb-2"></div>
             @else
                 {{-- defaultテンプレート --}}

--- a/resources/views/plugins/user/bbses/default/show.blade.php
+++ b/resources/views/plugins/user/bbses/default/show.blade.php
@@ -136,7 +136,13 @@
 </nav>
 
 {{-- スレッドの投稿一覧 --}}
-@include('plugins.user.bbses.default.thread_show')
+@if (isset($is_template_no_frame))
+    @include('plugins.user.bbses.no_frame.thread_show')
+@else
+    @include('plugins.user.bbses.default.thread_show')
+@endif
+
+
 
 {{-- / post がある想定の処理 --}}
 @endif

--- a/resources/views/plugins/user/bbses/default/thread_show.blade.php
+++ b/resources/views/plugins/user/bbses/default/thread_show.blade.php
@@ -25,15 +25,19 @@
         {{-- 詳細でのスレッド記事の展開方法：すべて閉じる --}}
         <div class="card mb-3 {{$view_format_name}}">
             {{-- 詳細でのスレッド記事の展開方法：すべて閉じるの場合は、card のヘッダに根記事のタイトルを表示 --}}
-            <div class="card-header">
-                {{$thread_root_post->title}}
-                @if ($thread_root_post->status == 1) <span class="badge badge-warning align-bottom">一時保存</span>
-                @elseif ($thread_root_post->status == 2) <span class="badge badge-warning align-bottom">承認待ち</span>
-                @endif
-                <span class="float-right">
-                    @include('plugins.user.bbses.default.post_created_at_and_name', ['post' => $thread_root_post])
-                </span>
-            </div>
+            @if (isset($is_template_no_frame))
+            @else
+                <div class="card-header">
+                    {{$thread_root_post->title}}
+                    @if ($thread_root_post->status == 1) <span class="badge badge-warning align-bottom">一時保存</span>
+                    @elseif ($thread_root_post->status == 2) <span class="badge badge-warning align-bottom">承認待ち</span>
+                    @endif
+                    <span class="float-right">
+                        @include('plugins.user.bbses.default.post_created_at_and_name', ['post' => $thread_root_post])
+                    </span>
+                </div>
+
+            @endif
             {{-- 詳細でのスレッド記事の展開方法：すべて閉じるの場合は、card のボディに根記事を含めた記事のタイトル一覧を表示 --}}
             <div class="card-body">
                 {{-- 根記事（スレッドの記事は古い順なので、根記事は最初） --}}
@@ -64,9 +68,11 @@
             {{-- 詳細でのスレッド記事の展開方法の判定 --}}
             @if ($plugin_frame->thread_format != 0)
                 {{-- 詳細でのスレッド記事の展開方法が詳細表示している記事のみ展開の場合 --}}
+
                 <div class="card-header">
                     @include('plugins.user.bbses.default.post_title', ['view_post' => $thread_root_post, 'current_post' => $post, 'list_class' => ''])
                 </div>
+
                 <div class="card-body">
                     {{-- 根記事（スレッドの記事は古い順なので、根記事は最初） --}}
                     {{-- 返信の場合は、親のpost を展開、詳細表示の場合は、自分のpost を展開 --}}

--- a/resources/views/plugins/user/bbses/no_frame/show.blade.php
+++ b/resources/views/plugins/user/bbses/no_frame/show.blade.php
@@ -1,0 +1,10 @@
+{{--
+ * 掲示板画面テンプレート。
+ *
+ * @author <horiguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category 掲示板プラグイン
+--}}
+
+{{-- defaultの詳細表示blade --}}
+@include('plugins.user.bbses.default.show', ['is_template_no_frame' => true])

--- a/resources/views/plugins/user/bbses/no_frame/thread_show.blade.php
+++ b/resources/views/plugins/user/bbses/no_frame/thread_show.blade.php
@@ -1,0 +1,10 @@
+{{--
+ * 掲示板画面テンプレート。
+ *
+ * @author <horiguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category 掲示板プラグイン
+--}}
+
+{{-- defaultのスレッド表示blade --}}
+@include('plugins.user.bbses.default.thread_show', ['is_template_no_frame' => true])


### PR DESCRIPTION
## 概要
[掲示板]枠なしテンプレートで詳細画面表示時のタイトル表示重複を改善しました

## レビュー完了希望日
軽微な改修なので急ぎません

## 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/issues/1474


## DB変更の有無
無し

## チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
