### PR TITLE
[管理画面] storageに書き込み権限がなければエラーメッセージを管理画面に表示する

### DIFF
--- a/app/Plugins/Manage/IndexManage/IndexManage.php
+++ b/app/Plugins/Manage/IndexManage/IndexManage.php
@@ -86,6 +86,7 @@ class IndexManage extends ManagePluginBase
             "plugin_name"  => "index",
             "rss_xml"      => $rss_xml,
             "errors"       => $errors,
+            "storage_disabled_label" => is_writable(storage_path()) ? '' : 'disabled',
         ]);
     }
 

--- a/app/Plugins/Manage/IndexManage/IndexManage.php
+++ b/app/Plugins/Manage/IndexManage/IndexManage.php
@@ -86,7 +86,7 @@ class IndexManage extends ManagePluginBase
             "plugin_name"  => "index",
             "rss_xml"      => $rss_xml,
             "errors"       => $errors,
-            "storage_disabled_label" => is_writable(storage_path()) ? '' : 'disabled',
+            "is_writable_storage" => is_writable(storage_path()),
         ]);
     }
 

--- a/resources/views/plugins/manage/index/index.blade.php
+++ b/resources/views/plugins/manage/index/index.blade.php
@@ -11,6 +11,12 @@
 {{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
 @section('manage_content')
 
+@if ($storage_disabled_label)
+    <div class="alert alert-danger">
+        <i class="fas fa-exclamation-circle"></i> アップロードするディレクトリに書込権限がありません。対象ディレクトリ：<code>storage</code><br />
+    </div>
+@endif
+
 {{-- バージョン情報 --}}
 @if (config('version.show_cc_version'))
 <div class="card mb-2">

--- a/resources/views/plugins/manage/index/index.blade.php
+++ b/resources/views/plugins/manage/index/index.blade.php
@@ -11,7 +11,7 @@
 {{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
 @section('manage_content')
 
-@if ($storage_disabled_label)
+@if (!$is_writable_storage)
     <div class="alert alert-danger">
         <i class="fas fa-exclamation-circle"></i> アップロードするディレクトリに書込権限がありません。対象ディレクトリ：<code>storage</code><br />
     </div>


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

storageディレクトリのパーミッション設定ミスをしても管理画面で気付けるように対応

## 変更後画面
### 管理初期画面
![image](https://user-images.githubusercontent.com/2756509/199201516-f8a3324f-91aa-4535-9d40-b559db9cfe9a.png)

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし
## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし
## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし
## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
