### PR TITLE
[nc2移行] ブログのタイトル・続きを読む・続きを隠すのタブ混入除去

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -9064,11 +9064,11 @@ trait MigrationTrait
                 $journals_tsv .= $category                          . "\t";
                 $journals_tsv .= $status                            . "\t";     // [2] ccステータス
                 $journals_tsv .= $nc2_journal_post->agree_flag      . "\t";     // [3] 使ってない
-                $journals_tsv .= $nc2_journal_post->title           . "\t";
+                $journals_tsv .= str_replace("\t", '',$nc2_journal_post->title)           . "\t";
                 $journals_tsv .= $content                           . "\t";
                 $journals_tsv .= $more_content                      . "\t";
-                $journals_tsv .= $nc2_journal_post->more_title      . "\t";
-                $journals_tsv .= $nc2_journal_post->hide_more_title . "\t";
+                $journals_tsv .= str_replace("\t", '',$nc2_journal_post->more_title)      . "\t";
+                $journals_tsv .= str_replace("\t", '',$nc2_journal_post->hide_more_title) . "\t";
                 $journals_tsv .= $like_count                        . "\t";     // [9] いいね数
                 $journals_tsv .= $nc2_journal_post->vote            . "\t";     // [10]いいねのsession_id & nc2 user_id
                 $journals_tsv .= $this->getCCDatetime($nc2_journal_post->insert_time)                             . "\t";   // [11]

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -9064,11 +9064,11 @@ trait MigrationTrait
                 $journals_tsv .= $category                          . "\t";
                 $journals_tsv .= $status                            . "\t";     // [2] ccステータス
                 $journals_tsv .= $nc2_journal_post->agree_flag      . "\t";     // [3] 使ってない
-                $journals_tsv .= str_replace("\t", '',$nc2_journal_post->title)           . "\t";
+                $journals_tsv .= str_replace("\t", '', $nc2_journal_post->title)           . "\t";
                 $journals_tsv .= $content                           . "\t";
                 $journals_tsv .= $more_content                      . "\t";
-                $journals_tsv .= str_replace("\t", '',$nc2_journal_post->more_title)      . "\t";
-                $journals_tsv .= str_replace("\t", '',$nc2_journal_post->hide_more_title) . "\t";
+                $journals_tsv .= str_replace("\t", '', $nc2_journal_post->more_title)      . "\t";
+                $journals_tsv .= str_replace("\t", '', $nc2_journal_post->hide_more_title) . "\t";
                 $journals_tsv .= $like_count                        . "\t";     // [9] いいね数
                 $journals_tsv .= $nc2_journal_post->vote            . "\t";     // [10]いいねのsession_id & nc2 user_id
                 $journals_tsv .= $this->getCCDatetime($nc2_journal_post->insert_time)                             . "\t";   // [11]


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

公式掲示板より
* https://connect-cms.jp/plugin/bbses/show/106/233/684#frame-233

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1384

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
