### PR TITLE
[コア] (サイトの負荷軽減対策) 画像キャッシュ対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,10 +19,7 @@ DB_PASSWORD=
 #SESSION_SECURE_COOKIE=true
 
 # Cache-Control default value.
-CACHE_CONTROL=no-store
-
-# HTTP Header Expires default value.
-EXPIRES="Thu, 01 Dec 1994 16:00:00 GMT"
+CACHE_CONTROL="max-age=604800"
 
 # Login link path
 LOGIN_PATH="login"

--- a/app/Http/Controllers/Core/UploadController.php
+++ b/app/Http/Controllers/Core/UploadController.php
@@ -171,7 +171,7 @@ class UploadController extends ConnectController
             }, config('connect.CACHE_MINUTS'), true); // 第3引数のtrue は戻り値にImage オブジェクトを返す意味。（false の場合は画像データ）
 
             $headers['Content-Disposition'] = 'inline; ' . $content_disposition;
-            return $this->setCachePrivate($img->response()->withHeaders($headers));
+            return $this->setCacheControlPrivate($img->response()->withHeaders($headers)->setEtag(md5($img->response()->getContent())));
         }
 
         if (in_array(strtolower($uploads->extension), $inline_extensions) && $request->response != 'download') {
@@ -181,7 +181,7 @@ class UploadController extends ConnectController
                 return response()->file($fullpath, $no_cache_headers);
             } else {
                 $headers['Content-Disposition'] = 'inline; ' . $content_disposition;
-                return $this->setCachePrivate(response()->file($fullpath, $headers));
+                return $this->setCacheControlPrivate(response()->file($fullpath, $headers)->setEtag(md5_file($fullpath)));
             }
         } else {
             $no_cache_headers['Content-Disposition'] = 'attachment; ' . $content_disposition;
@@ -190,12 +190,13 @@ class UploadController extends ConnectController
     }
 
     /**
-     * CACHE_CONTROLにprivateを含むならsetCache()でprivateをセット
+     * Cache-Controlにprivateを含むならprivateをセット
+     * @see \Symfony\Component\HttpFoundation\Response setPrivate()
      */
-    private function setCachePrivate($response)
+    private function setCacheControlPrivate($response)
     {
         if (strpos(config('connect.CACHE_CONTROL'), 'private') !== false) {
-            return $response->setCache(['private' => true]);
+            return $response->setPrivate();
         }
         return $response;
     }

--- a/app/Http/Controllers/Core/UploadController.php
+++ b/app/Http/Controllers/Core/UploadController.php
@@ -341,16 +341,6 @@ class UploadController extends ConnectController
      */
     public function getCss(Request $request, $page_id = null)
     {
-        // \Log::debug('[' . __METHOD__ . '] ' . __FILE__ . ' (line ' . __LINE__ . ')');
-
-        // config のgeneral カテゴリーを読み込んでおく。
-        // id のファイルを読んでhttp request に返す。
-        // $config_generals = array();
-        // $config_generals_rs = Configs::where('category', 'general')->get();
-        // foreach ($config_generals_rs as $config_general) {
-        //     $config_generals[$config_general['name']]['value'] = $config_general['value'];
-        //     $config_generals[$config_general['name']]['category'] = $config_general['category'];
-        // }
         $configs = Configs::getSharedConfigs();
 
         // 自分のページと親ページを遡って取得し、ページの背景色を探す。
@@ -380,15 +370,11 @@ class UploadController extends ConnectController
 
         // 背景色
         if (empty($background_color)) {
-            // $base_background_color = Configs::where('name', '=', 'base_background_color')->first();
-            // $background_color = $base_background_color->value;
             $background_color = Configs::getConfigsValue($configs, 'base_background_color', null);
         }
 
         // ヘッダーの背景色
         if (empty($header_color)) {
-            // $base_header_color = Configs::where('name', '=', 'base_header_color')->first();
-            // $header_color = $base_header_color->value;
             $header_color = Configs::getConfigsValue($configs, 'base_header_color', null);
         }
 
@@ -398,6 +384,8 @@ class UploadController extends ConnectController
         }
 
         header('Content-Type: text/css');
+        header("Content-Disposition: inline; filename={$page_id}.css");
+        header('Cache-Control: ' . config('connect.CACHE_CONTROL'));
 
         // 背景色
         if ($background_color) {
@@ -410,7 +398,6 @@ class UploadController extends ConnectController
         }
 
         // 画像の保存機能の無効化(スマホ長押し禁止)
-        // if ($config_generals['base_touch_callout']['value'] == '1') {
         if (Configs::getConfigsValue($configs, 'base_touch_callout') == '1') {
             echo <<<EOD
 img {

--- a/app/Http/Controllers/Core/UploadController.php
+++ b/app/Http/Controllers/Core/UploadController.php
@@ -191,6 +191,8 @@ class UploadController extends ConnectController
 
     /**
      * Cache-Controlにprivateを含むならprivateをセット
+     * - Laravel特有対応
+     *   - headerでCache-Control にprivateを指定しても、Laravelだと自動的にpublicが付き２重定義になったため、setPrivate()で対応
      * @see \Symfony\Component\HttpFoundation\Response setPrivate()
      */
     private function setCacheControlPrivate($response)

--- a/app/Http/Middleware/ResponseHeader.php
+++ b/app/Http/Middleware/ResponseHeader.php
@@ -19,7 +19,10 @@ class ResponseHeader
     {
         $response = $next($request);
 
-        if (Route::currentRouteName() != 'get_file') {
+        // 除外ルート名
+        $exclude_route_names = ['get_file', 'get_userfile'];
+
+        if (!in_array(Route::currentRouteName(), $exclude_route_names)) {
             // セキュリティ設定でHTTP ヘッダを指定する。
             $response->headers->set('Cache-Control', 'no-store');
             $response->headers->set('Expires', 'Thu, 01 Dec 1994 16:00:00 GMT');

--- a/app/Http/Middleware/ResponseHeader.php
+++ b/app/Http/Middleware/ResponseHeader.php
@@ -20,7 +20,7 @@ class ResponseHeader
         $response = $next($request);
 
         // 除外ルート名
-        $exclude_route_names = ['get_file', 'get_userfile'];
+        $exclude_route_names = ['get_file', 'get_userfile', 'get_css'];
 
         if (!in_array(Route::currentRouteName(), $exclude_route_names)) {
             // セキュリティ設定でHTTP ヘッダを指定する。

--- a/app/Http/Middleware/ResponseHeader.php
+++ b/app/Http/Middleware/ResponseHeader.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Middleware;
 
+use Illuminate\Support\Facades\Route;
+
 use Closure;
 
 class ResponseHeader
@@ -17,9 +19,11 @@ class ResponseHeader
     {
         $response = $next($request);
 
-        // セキュリティ設定でHTTP ヘッダを指定する。
-        $response->headers->set('Cache-Control', config('connect.CACHE_CONTROL'));
-        $response->headers->set('Expires', config('connect.EXPIRES'));
+        if (Route::currentRouteName() != 'get_file') {
+            // セキュリティ設定でHTTP ヘッダを指定する。
+            $response->headers->set('Cache-Control', 'no-store');
+            $response->headers->set('Expires', 'Thu, 01 Dec 1994 16:00:00 GMT');
+        }
 
         return $response;
     }

--- a/config/connect.php
+++ b/config/connect.php
@@ -69,10 +69,7 @@ return [
     // 'OSWS_TRANSLATE_AGREEMENT' => env('OSWS_TRANSLATE_AGREEMENT', false),
 
     // Cache-Control
-    'CACHE_CONTROL' => env('CACHE_CONTROL', 'no-store'),
-
-    // Expires
-    'EXPIRES' => env('EXPIRES', 'Thu, 01 Dec 1994 16:00:00 GMT'),
+    'CACHE_CONTROL' => env('CACHE_CONTROL', 'max-age=604800'),
 
     // Login link path
     'LOGIN_PATH' => env('LOGIN_PATH', 'login'),

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -125,9 +125,9 @@ if (! isset($cc_configs)) {
 
     <!-- Connect-CMS Page CSS -->
 @if (isset($page) && !empty($page->id))
-    <link href="{{url('/')}}/file/css/{{$page->id}}.css" rel="stylesheet">
+    <link href="{{url('/')}}/file/css/{{$page->id}}.css?version={{ md5_file(url('/') . '/file/css/' . $page->id . '.css') }}" rel="stylesheet">
 @else
-    <link href="{{url('/')}}/file/css/0.css" rel="stylesheet">
+    <link href="{{url('/')}}/file/css/0.css?version={{ md5_file(url('/') . '/file/css/0.css') }}" rel="stylesheet">
 @endif
 
     <!-- Context -->


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

サイトの負荷軽減対策です。

* 画像キャッシュ対応
  * 対応内容
    * 公開されている画像等, /file/css/999.cssをキャッシュする。対象は以下。
      * /file/{id?}
      * /file/user/{dir}/{filename}
      * /file/css/{page_id?}.css
    * 公開されない画像等はキャッシュしない。（例：ログインが必要なページ、メンバーシップページ、パスワードページの画像）
    * PDFはキャッシュしない。（Googleから参照されたPDFの削除依頼がそこそこあるため）
    * その他はキャッシュしない。
  * .env設定
    * キャッシュは.envのCACHE_CONTROLで設定可能
      * 設定例）`CACHE_CONTROL="max-age=604800"`
    * .envのEXPIRESは廃止（キャッシュしない設定にのみ使われていたため）
* 関連修正
  * /file/{id?}, /file/user/{dir}/{filename}のヘッダー対応
    * Content-Disposition の最適化
    * Etag対応
  * /file/css/{page_id?}.css に変更あったらクエリストリングで即時反映

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

追加機能の改修なので急ぎません

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* #1429

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* 調査したら [キャッシュコントロール・ミドルウェア](https://readouble.com/laravel/8.x/ja/responses.html#cache-control-middleware) はファイルキャッシュには使えなかった。 https://github.com/opensource-workshop/connect-cms/issues/1429#issuecomment-1299792273
* https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Cache-Control
* https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/ETag
* $response->setCache()参考 https://syuntech.net/php/laravel/laravel-http/



## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
