### PR TITLE
[nc2移行] 管理者グループの対象をコンテンツ管理者からシステム管理者に変更

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -2681,7 +2681,7 @@ trait MigrationTrait
         ]);
 
         // 管理者 group_users 作成
-        $admin_users_roles = UsersRoles::where('target', 'base')->where('role_name', 'role_article_admin')->get();
+        $admin_users_roles = UsersRoles::where('target', 'manage')->where('role_name', 'admin_system')->get();
         foreach ($admin_users_roles as $users_roles) {
             $group_user = GroupUser::updateOrCreate(
                 ['group_id' => $admin_group->id, 'user_id' => $users_roles->users_id],

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -8498,6 +8498,7 @@ trait MigrationTrait
             } elseif ($nc2_user->role_authority_id == 4) { // 4:一般
                 $users_ini .= "users_roles_base   = \"role_reporter\"\n";
             } elseif ($nc2_user->role_authority_id == 6) { // 6:事務局（デフォルト）
+                $users_ini .= "users_roles_manage = \"admin_page|admin_user\"\n";
                 $users_ini .= "users_roles_base   = \"role_article_admin\"\n";
             } elseif ($nc2_user->role_authority_id == 7) { // 7:管理者（デフォルト）
                 $users_ini .= "users_roles_manage = \"admin_system\"\n";


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [change: [nc2移行] 管理者グループの対象をコンテンツ管理者からシステム管理者に変更](https://github.com/opensource-workshop/connect-cms/commit/db38587d64af93cf62cc7d033af4513e415da29a)
* [bugfix: [nc2移行] 事務局ユーザにページとユーザの管理権限漏れていたため追加](https://github.com/opensource-workshop/connect-cms/commit/bf2f741a128c21bcf93a52b42b3c8cf73543aaca)

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし
## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
