### PR TITLE
[データベース] メール通知の埋め込みタグに全項目タグを追加

### DIFF
--- a/app/Enums/DatabaseNoticeEmbeddedTag.php
+++ b/app/Enums/DatabaseNoticeEmbeddedTag.php
@@ -18,8 +18,8 @@ final class DatabaseNoticeEmbeddedTag extends NoticeEmbeddedTag
     const enum = [
         self::site_name => 'サイト名',
         self::method => '処理名',
-        self::title => 'タイトル',
-        self::body => '本文',
+        self::title => 'タイトル（タイトル指定した項目）',
+        self::body => '本文（本文指定した項目）',
         self::posted_at => '公開日時',
         self::expires_at => '公開終了日時',
         self::display_sequence => '表示順',
@@ -40,6 +40,7 @@ final class DatabaseNoticeEmbeddedTag extends NoticeEmbeddedTag
         $embedded_tags[] = ['[[' . self::site_name . ']]',        self::getDescription(self::site_name)];
         $embedded_tags[] = ['[[' . self::method . ']]',           self::getDescription(self::method)];
         $embedded_tags[] = ['[[' . self::title . ']]',            self::getDescription(self::title)];
+        $embedded_tags[] = ['[[' . self::body . ']]',             self::getDescription(self::body)];
         $embedded_tags[] = ['[[' . self::posted_at . ']]',        self::getDescription(self::posted_at)];
         $embedded_tags[] = ['[[' . self::expires_at . ']]',       self::getDescription(self::expires_at)];
         $embedded_tags[] = ['[[' . self::display_sequence . ']]', self::getDescription(self::display_sequence)];

--- a/app/Enums/DatabaseNoticeEmbeddedTag.php
+++ b/app/Enums/DatabaseNoticeEmbeddedTag.php
@@ -10,6 +10,7 @@ use App\Enums\NoticeEmbeddedTag;
 final class DatabaseNoticeEmbeddedTag extends NoticeEmbeddedTag
 {
     // 定数メンバ
+    const all_items = 'all_items';
     const posted_at = 'posted_at';
     const expires_at = 'expires_at';
     const display_sequence = 'display_sequence';
@@ -20,6 +21,7 @@ final class DatabaseNoticeEmbeddedTag extends NoticeEmbeddedTag
         self::method => '処理名',
         self::title => 'タイトル（タイトル指定した項目）',
         self::body => '本文（本文指定した項目）',
+        self::all_items => '全項目',
         self::posted_at => '公開日時',
         self::expires_at => '公開終了日時',
         self::display_sequence => '表示順',
@@ -41,6 +43,7 @@ final class DatabaseNoticeEmbeddedTag extends NoticeEmbeddedTag
         $embedded_tags[] = ['[[' . self::method . ']]',           self::getDescription(self::method)];
         $embedded_tags[] = ['[[' . self::title . ']]',            self::getDescription(self::title)];
         $embedded_tags[] = ['[[' . self::body . ']]',             self::getDescription(self::body)];
+        $embedded_tags[] = ['[[' . self::all_items . ']]',        self::getDescription(self::all_items)];
         $embedded_tags[] = ['[[' . self::posted_at . ']]',        self::getDescription(self::posted_at)];
         $embedded_tags[] = ['[[' . self::expires_at . ']]',       self::getDescription(self::expires_at)];
         $embedded_tags[] = ['[[' . self::display_sequence . ']]', self::getDescription(self::display_sequence)];


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* NC3移行の汎用DBのメール通知移行に関連して、データベースプラグインのメール通知の埋め込みタグに、全項目タグを追加しました。
* 関連修正
    * [add: [データベース] メール通知の埋め込みに既に対応していたbodyを追加](https://github.com/opensource-workshop/connect-cms/pull/1487/commits/58c0dbeb9d62f68d2ce2445f5ad28611d9efb797)

## 修正後画面
### データベース＞メール通知設定
![image](https://user-images.githubusercontent.com/2756509/201843948-715f5c09-d129-4778-88f4-237edee7de72.png)

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし
## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし
## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
