### PR TITLE
[nc3移行] 汎用DB移行に対応

### DIFF
--- a/app/Models/Migration/Nc2/Nc2User.php
+++ b/app/Models/Migration/Nc2/Nc2User.php
@@ -15,4 +15,14 @@ class Nc2User extends Model
      * テーブル名の指定
      */
     protected $table = 'users';
+
+    /**
+     * NC2ユーザIDからNC2ログインID取得
+     */
+    public static function getNc2LoginIdFromNc2UserId($nc2_users, $nc2_user_id)
+    {
+        $nc2_user = $nc2_users->firstWhere('user_id', $nc2_user_id);
+        $nc2_user = $nc2_user ?? new Nc2User();
+        return $nc2_user->login_id;
+    }
 }

--- a/app/Models/Migration/Nc3/Nc3MailSetting.php
+++ b/app/Models/Migration/Nc3/Nc3MailSetting.php
@@ -20,14 +20,18 @@ class Nc3MailSetting extends Model
     /**
      * block_keyでメール設定 取得
      */
-    public static function getMailSettingsByBlockKeys($block_keys): Collection
+    public static function getMailSettingsByBlockKeys($block_keys, string $plugin_key): Collection
     {
         return Nc3MailSetting::select('mail_settings.*', 'mail_setting_fixed_phrases.mail_fixed_phrase_subject', 'mail_setting_fixed_phrases.mail_fixed_phrase_body')
             ->join('mail_setting_fixed_phrases', function ($join) {
                 $join->on('mail_setting_fixed_phrases.mail_setting_id', '=', 'mail_settings.id')
                     ->where('mail_setting_fixed_phrases.language_id', Nc3Language::language_id_ja);
             })
-            ->whereIn('mail_settings.block_key', $block_keys)
+            ->where('mail_settings.plugin_key', $plugin_key)
+            ->where(function ($tmp_query) use ($block_keys) {
+                $tmp_query->whereIn('mail_settings.block_key', $block_keys)
+                    ->orWhere('mail_settings.block_key', null);     // block_key=nullで各プラグインのメール設定デフォルト値持ってる
+            })
             ->get();
     }
 }

--- a/app/Models/Migration/Nc3/Nc3MultidatabaseContent.php
+++ b/app/Models/Migration/Nc3/Nc3MultidatabaseContent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3MultidatabaseContent extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'multidatabase_contents';
+}

--- a/app/Models/Migration/Nc3/Nc3MultidatabaseFrameSetting.php
+++ b/app/Models/Migration/Nc3/Nc3MultidatabaseFrameSetting.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3MultidatabaseFrameSetting extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'multidatabase_frame_settings';
+}

--- a/app/Models/Migration/Nc3/Nc3MultidatabaseMetadata.php
+++ b/app/Models/Migration/Nc3/Nc3MultidatabaseMetadata.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3MultidatabaseMetadata extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'multidatabase_metadatas';
+}

--- a/app/Models/Migration/Nc3/Nc3User.php
+++ b/app/Models/Migration/Nc3/Nc3User.php
@@ -3,6 +3,7 @@
 namespace App\Models\Migration\Nc3;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 
 class Nc3User extends Model
 {
@@ -27,4 +28,22 @@ class Nc3User extends Model
      * テーブル名の指定
      */
     protected $table = 'users';
+
+    /**
+     * NC3ユーザIDからNC3ログインID取得
+     */
+    public static function getNc3LoginIdFromNc3UserId(Collection $nc3_users, ?int $nc3_user_id): ?string
+    {
+        $nc3_user = $nc3_users->firstWhere('id', $nc3_user_id) ?? new Nc3User();
+        return $nc3_user->username;
+    }
+
+    /**
+     * NC3ユーザIDからNC3ハンドル取得
+     */
+    public static function getNc3HandleFromNc3UserId(Collection $nc3_users, ?int $nc3_user_id): ?string
+    {
+        $nc3_user = $nc3_users->firstWhere('id', $nc3_user_id) ?? new Nc3User();
+        return $nc3_user->handlename;
+    }
 }

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -2503,7 +2503,7 @@ trait MigrationNc3ExportTrait
             $multidatabase_ini .= "mail_subject = \"" . $mail_subject . "\"\n";
             $multidatabase_ini .= "mail_body = \"" . $mail_body . "\"\n";
             $multidatabase_ini .= "approval_on = " . $mail_setting->is_mail_send_approval . "\n";
-            $multidatabase_ini .= "approval_admin_group = " . $use_workflow . "\n";              // 1:「管理者グループ」通知
+            $multidatabase_ini .= "approval_admin_group = 1\n";                                  // approval_onのON/OFFに関わらず通知先は1:「管理者グループ」をセット
             $multidatabase_ini .= "approval_subject = \"" . $approval_subject . "\"\n";
             $multidatabase_ini .= "approval_body = \"" . $approval_body . "\"\n";
             $multidatabase_ini .= "approved_on = 0\n";                                           // 承認完了通知はメール飛ばなかった

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -2456,7 +2456,7 @@ trait MigrationNc3ExportTrait
                 ['{X-SUBJECT}',   '[[' . NoticeEmbeddedTag::title . ']]'],
                 ['{X-USER}',      '[[' . NoticeEmbeddedTag::created_name . ']]'],
                 ['{X-TO_DATE}',   '[[' . NoticeEmbeddedTag::created_at . ']]'],
-                ['{X-DATA}',      '[[' . DatabaseNoticeEmbeddedTag::body . ']]'],
+                ['{X-DATA}',      '[[' . DatabaseNoticeEmbeddedTag::all_items . ']]'],
                 ['{X-URL}',       '[[' . NoticeEmbeddedTag::url . ']]'],
                 ['{X-PLUGIN_NAME}', 'データベース'],
                 // 除外

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -1513,7 +1513,6 @@ trait MigrationNc3ExportTrait
             $journals_ini .= "[source_info]\n";
             $journals_ini .= "journal_id = " . $nc3_blog->id . "\n";
             $journals_ini .= "room_id = " . $nc3_blog->room_id . "\n";
-            $journals_ini .= "space_id = " . $nc3_blog->space_id . "\n";
             $journals_ini .= "plugin_key = \"blogs\"\n";
             $journals_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_blog->created) . "\"\n";
             $journals_ini .= "created_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_blog->created_user) . "\"\n";
@@ -1853,7 +1852,6 @@ trait MigrationNc3ExportTrait
             $journals_ini .= "[source_info]\n";
             $journals_ini .= "journal_id = " . 'BBS_' . $nc3_bbs->id . "\n";
             $journals_ini .= "room_id = " . $nc3_bbs->room_id . "\n";
-            $journals_ini .= "space_id = " . $nc3_bbs->space_id . "\n";
             $journals_ini .= "plugin_key = \"bbses\"\n";
             $journals_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_bbs->created) . "\"\n";
             $journals_ini .= "created_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_bbs->created_user) . "\"\n";

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -326,24 +326,6 @@ trait MigrationNc3ExportTrait
     }
 
     /**
-     * NC3ユーザIDからNC3ログインID取得
-     */
-    private function getNc3LoginIdFromNc3UserId(Collection $nc3_users, ?int $nc3_user_id): ?string
-    {
-        $nc3_user = $nc3_users->firstWhere('id', $nc3_user_id) ?? new Nc3User();
-        return $nc3_user->username;
-    }
-
-    /**
-     * NC3ユーザIDからNC3ハンドル取得
-     */
-    private function getNc3HandleFromNc3UserId(Collection $nc3_users, ?int $nc3_user_id): ?string
-    {
-        $nc3_user = $nc3_users->firstWhere('id', $nc3_user_id) ?? new Nc3User();
-        return $nc3_user->handlename;
-    }
-
-    /**
      * ommit 設定を確認
      */
     private function isOmmit($section, $arg_name, $check_id)
@@ -1534,11 +1516,11 @@ trait MigrationNc3ExportTrait
             $journals_ini .= "space_id = " . $nc3_blog->space_id . "\n";
             $journals_ini .= "plugin_key = \"blogs\"\n";
             $journals_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_blog->created) . "\"\n";
-            $journals_ini .= "created_name    = \"" . $this->getNc3HandleFromNc3UserId($nc3_users, $nc3_blog->created_user) . "\"\n";
-            $journals_ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_blog->created_user) . "\"\n";
+            $journals_ini .= "created_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_blog->created_user) . "\"\n";
+            $journals_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_blog->created_user) . "\"\n";
             $journals_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_blog->modified) . "\"\n";
-            $journals_ini .= "updated_name    = \"" . $this->getNc3HandleFromNc3UserId($nc3_users, $nc3_blog->modified_user) . "\"\n";
-            $journals_ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_blog->modified_user) . "\"\n";
+            $journals_ini .= "updated_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_blog->modified_user) . "\"\n";
+            $journals_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_blog->modified_user) . "\"\n";
 
             // NC3日誌で使ってるカテゴリのみ移行する。
             $journals_ini .= "\n";
@@ -1592,11 +1574,11 @@ trait MigrationNc3ExportTrait
                 $journals_tsv .= $like->like_count                                              . "\t"; // [9] いいね数
                 $journals_tsv .=                                                                  "\t"; // [10]いいねのsession_id & user_id. nc3ない
                 $journals_tsv .= $this->getCCDatetime($nc3_blog_post->created)                                  . "\t";   // [11]
-                $journals_tsv .= $this->getNc3HandleFromNc3UserId($nc3_users, $nc3_blog->created_user)          . "\t";   // [12]
-                $journals_tsv .= $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_blog_post->created_user)    . "\t";   // [13]
+                $journals_tsv .= Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_blog->created_user)          . "\t";   // [12]
+                $journals_tsv .= Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_blog_post->created_user)    . "\t";   // [13]
                 $journals_tsv .= $this->getCCDatetime($nc3_blog_post->modified)                                 . "\t";   // [14]
-                $journals_tsv .= $this->getNc3HandleFromNc3UserId($nc3_users, $nc3_blog->modified_user)         . "\t";   // [15]
-                $journals_tsv .= $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_blog_post->modified_user);            // [16]
+                $journals_tsv .= Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_blog->modified_user)         . "\t";   // [15]
+                $journals_tsv .= Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_blog_post->modified_user);            // [16]
 
                 // 記事のタイトルの一覧
                 // タイトルに " あり
@@ -1874,11 +1856,11 @@ trait MigrationNc3ExportTrait
             $journals_ini .= "space_id = " . $nc3_bbs->space_id . "\n";
             $journals_ini .= "plugin_key = \"bbses\"\n";
             $journals_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_bbs->created) . "\"\n";
-            $journals_ini .= "created_name    = \"" . $this->getNc3HandleFromNc3UserId($nc3_users, $nc3_bbs->created_user) . "\"\n";
-            $journals_ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_bbs->created_user) . "\"\n";
+            $journals_ini .= "created_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_bbs->created_user) . "\"\n";
+            $journals_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_bbs->created_user) . "\"\n";
             $journals_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_bbs->modified) . "\"\n";
-            $journals_ini .= "updated_name    = \"" . $this->getNc3HandleFromNc3UserId($nc3_users, $nc3_bbs->modified_user) . "\"\n";
-            $journals_ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_bbs->modified_user) . "\"\n";
+            $journals_ini .= "updated_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_bbs->modified_user) . "\"\n";
+            $journals_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_bbs->modified_user) . "\"\n";
 
             // NC3掲示板の記事を移行する。
             $nc3_bbs_posts = Nc3BbsArticle::
@@ -1923,13 +1905,13 @@ trait MigrationNc3ExportTrait
                 $journals_tsv .= $nc3_bbs_post_parent->id                                   . "\t"; // 9:親記事ID
                 $journals_tsv .= $nc3_bbs_post_root->id                                     . "\t"; // 10:根記事ID（nc2だとトピックID）
                 $journals_tsv .= $this->getCCDatetime($nc3_bbs_post->created)                                   . "\t"; // 11:最新投稿日時
-                $journals_tsv .= $this->getNc3HandleFromNc3UserId($nc3_users, $nc3_bbs_post->created_user)      . "\t"; // 12:投稿者名
+                $journals_tsv .= Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_bbs_post->created_user)      . "\t"; // 12:投稿者名
                 $journals_tsv .= $like->like_count                                                              . "\t"; // 13:いいね数
                 $journals_tsv .=                                                                                  "\t"; // 14:いいねのsession_id & nc3 user_id
-                $journals_tsv .= $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_bbs_post->created_user)     . "\t"; // 15:投稿者ID
+                $journals_tsv .= Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_bbs_post->created_user)     . "\t"; // 15:投稿者ID
                 $journals_tsv .= $this->getCCDatetime($nc3_bbs_post->modified)                                  . "\t"; // 16:更新日時
-                $journals_tsv .= $this->getNc3HandleFromNc3UserId($nc3_users, $nc3_bbs_post->modified_user)     . "\t"; // 17:更新者名
-                $journals_tsv .= $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_bbs_post->modified_user)    . "\t"; // 18:更新者ID
+                $journals_tsv .= Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_bbs_post->modified_user)     . "\t"; // 17:更新者名
+                $journals_tsv .= Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_bbs_post->modified_user)    . "\t"; // 18:更新者ID
 
                 // 記事のタイトルの一覧
                 // タイトルに " あり
@@ -2178,10 +2160,10 @@ trait MigrationNc3ExportTrait
             $linklists_ini .= "plugin_key = \"linklist\"\n";
             $linklists_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_linklist->created) . "\"\n";
             $linklists_ini .= "created_name    = \"" . $nc3_linklist->insert_user_name . "\"\n";
-            $linklists_ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_linklist->created_user) . "\"\n";
+            $linklists_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_linklist->created_user) . "\"\n";
             $linklists_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_linklist->modified) . "\"\n";
             $linklists_ini .= "updated_name    = \"" . $nc3_linklist->update_user_name . "\"\n";
-            $linklists_ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_linklist->modified_user) . "\"\n";
+            $linklists_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_linklist->modified_user) . "\"\n";
 
             // NC3リンクリストで使っているカテゴリ（linklist_category）のみ移行する。
             $linklists_ini .= "\n";
@@ -2341,10 +2323,10 @@ trait MigrationNc3ExportTrait
             $multidatabase_ini .= "plugin_key = \"multidatabase\"\n";
             $multidatabase_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_multidatabase->created) . "\"\n";
             $multidatabase_ini .= "created_name    = \"" . $nc3_multidatabase->insert_user_name . "\"\n";
-            $multidatabase_ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_multidatabase->created_user) . "\"\n";
+            $multidatabase_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_multidatabase->created_user) . "\"\n";
             $multidatabase_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_multidatabase->modified) . "\"\n";
             $multidatabase_ini .= "updated_name    = \"" . $nc3_multidatabase->update_user_name . "\"\n";
-            $multidatabase_ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_multidatabase->modified_user) . "\"\n";
+            $multidatabase_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_multidatabase->modified_user) . "\"\n";
 
             // 汎用データベースのカラム情報
             $multidatabase_metadatas = Nc2MultidatabaseMetadata::where('multidatabase_id', $multidatabase_id)
@@ -2536,10 +2518,10 @@ trait MigrationNc3ExportTrait
                         // 登録日時、更新日時等
                         $tsv_record['created_at']      = $this->getCCDatetime($old_metadata_content->multidatabase_content_insert_time);
                         $tsv_record['created_name']    = $old_metadata_content->multidatabase_content_insert_user_name;
-                        $tsv_record['insert_login_id'] = $this->getNc3LoginIdFromNc3UserId($nc3_users, $old_metadata_content->multidatabase_content_insert_user_id);
+                        $tsv_record['insert_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $old_metadata_content->multidatabase_content_insert_user_id);
                         $tsv_record['updated_at']      = $this->getCCDatetime($old_metadata_content->multidatabase_content_update_time);
                         $tsv_record['updated_name']    = $old_metadata_content->multidatabase_content_update_user_name;
-                        $tsv_record['update_login_id'] = $this->getNc3LoginIdFromNc3UserId($nc3_users, $old_metadata_content->multidatabase_content_update_user_id);
+                        $tsv_record['update_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $old_metadata_content->multidatabase_content_update_user_id);
                         // NC3 レコードを示すID
                         $tsv_record['content_id'] = $old_metadata_content->content_id;
                         // データ行の書き出し
@@ -2604,10 +2586,10 @@ trait MigrationNc3ExportTrait
                 // 登録日時、更新日時等
                 $tsv_record['created_at']      = $this->getCCDatetime($old_metadata_content->multidatabase_content_insert_time);
                 $tsv_record['created_name']    = $old_metadata_content->multidatabase_content_insert_user_name;
-                $tsv_record['insert_login_id'] = $this->getNc3LoginIdFromNc3UserId($nc3_users, $old_metadata_content->multidatabase_content_insert_user_id);
+                $tsv_record['insert_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $old_metadata_content->multidatabase_content_insert_user_id);
                 $tsv_record['updated_at']      = $this->getCCDatetime($old_metadata_content->multidatabase_content_update_time);
                 $tsv_record['updated_name']    = $old_metadata_content->multidatabase_content_update_user_name;
-                $tsv_record['update_login_id'] = $this->getNc3LoginIdFromNc3UserId($nc3_users, $old_metadata_content->multidatabase_content_update_user_id);
+                $tsv_record['update_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $old_metadata_content->multidatabase_content_update_user_id);
                 $tsv_record['content_id'] = $old_metadata_content->content_id;
                 $tsv .= implode("\t", $tsv_record);
             }
@@ -2722,10 +2704,10 @@ trait MigrationNc3ExportTrait
             $registration_ini .= "plugin_key = \"registration\"\n";
             $registration_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_registration->created) . "\"\n";
             $registration_ini .= "created_name    = \"" . $nc3_registration->insert_user_name . "\"\n";
-            $registration_ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_registration->created_user) . "\"\n";
+            $registration_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_registration->created_user) . "\"\n";
             $registration_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_registration->modified) . "\"\n";
             $registration_ini .= "updated_name    = \"" . $nc3_registration->update_user_name . "\"\n";
-            $registration_ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_registration->modified_user) . "\"\n";
+            $registration_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_registration->modified_user) . "\"\n";
 
             // 登録フォームのカラム情報
             $registration_items = Nc2RegistrationItem::where('registration_id', $registration_id)
@@ -2835,10 +2817,10 @@ trait MigrationNc3ExportTrait
                         $registration_data .= "\n[" . $registration_item_data->data_id . "]\n";
                         $registration_data .= "created_at      = \"" . $this->getCCDatetime($registration_item_data->data_insert_time) . "\"\n";
                         $registration_data .= "created_name    = \"" . $registration_item_data->data_insert_user_name . "\"\n";
-                        $registration_data .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $registration_item_data->data_insert_user_id) . "\"\n";
+                        $registration_data .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $registration_item_data->data_insert_user_id) . "\"\n";
                         $registration_data .= "updated_at      = \"" . $this->getCCDatetime($registration_item_data->data_update_time) . "\"\n";
                         $registration_data .= "updated_name    = \"" . $registration_item_data->data_update_user_name . "\"\n";
-                        $registration_data .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $registration_item_data->data_update_user_id) . "\"\n";
+                        $registration_data .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $registration_item_data->data_update_user_id) . "\"\n";
                         $data_id = $registration_item_data->data_id;
                     }
                     $registration_data .= $registration_item_data->item_id . " = \"" . str_replace("\n", '\n', $registration_item_data->item_data_value) . "\"\n";
@@ -2932,10 +2914,10 @@ trait MigrationNc3ExportTrait
             $whatsnew_ini .= "plugin_key = \"whatsnew\"\n";
             $whatsnew_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_whatsnew_block->created) . "\"\n";
             $whatsnew_ini .= "created_name    = \"" . $nc3_whatsnew_block->insert_user_name . "\"\n";
-            $whatsnew_ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_whatsnew_block->created_user) . "\"\n";
+            $whatsnew_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_whatsnew_block->created_user) . "\"\n";
             $whatsnew_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_whatsnew_block->modified) . "\"\n";
             $whatsnew_ini .= "updated_name    = \"" . $nc3_whatsnew_block->update_user_name . "\"\n";
-            $whatsnew_ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_whatsnew_block->modified_user) . "\"\n";
+            $whatsnew_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_whatsnew_block->modified_user) . "\"\n";
 
             // 新着情報の設定を出力
             //Storage::put($this->getImportPath('whatsnews/whatsnew_') . $this->zeroSuppress($whatsnew_block_id) . '.ini', $whatsnew_ini);
@@ -2998,10 +2980,10 @@ trait MigrationNc3ExportTrait
             $ini .= "plugin_key = \"cabinet\"\n";
             $ini .= "created_at      = \"" . $this->getCCDatetime($cabinet_manage->created) . "\"\n";
             $ini .= "created_name    = \"" . $cabinet_manage->insert_user_name . "\"\n";
-            $ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $cabinet_manage->created_user) . "\"\n";
+            $ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $cabinet_manage->created_user) . "\"\n";
             $ini .= "updated_at      = \"" . $this->getCCDatetime($cabinet_manage->modified) . "\"\n";
             $ini .= "updated_name    = \"" . $cabinet_manage->update_user_name . "\"\n";
-            $ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $cabinet_manage->modified_user) . "\"\n";
+            $ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $cabinet_manage->modified_user) . "\"\n";
 
             // ファイル情報
             $cabinet_files = Nc2CabinetFile::select('cabinet_file.*', 'cabinet_comment.comment')
@@ -3031,10 +3013,10 @@ trait MigrationNc3ExportTrait
                 $tsv .= $cabinet_file['comment'] . "\t";
                 $tsv .= $this->getCCDatetime($cabinet_file->created)                             . "\t";    // [13]
                 $tsv .= $cabinet_file->insert_user_name                                              . "\t";    // [14]
-                $tsv .= $this->getNc3LoginIdFromNc3UserId($nc3_users, $cabinet_file->created_user) . "\t";    // [15]
+                $tsv .= Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $cabinet_file->created_user) . "\t";    // [15]
                 $tsv .= $this->getCCDatetime($cabinet_file->modified)                             . "\t";    // [16]
                 $tsv .= $cabinet_file->update_user_name                                              . "\t";    // [17]
-                $tsv .= $this->getNc3LoginIdFromNc3UserId($nc3_users, $cabinet_file->modified_user);           // [18]
+                $tsv .= Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $cabinet_file->modified_user);           // [18]
 
                 // 最終行は改行コード不要
                 if ($index !== ($cabinet_files->count() - 1)) {
@@ -3140,10 +3122,10 @@ trait MigrationNc3ExportTrait
             $ini .= "plugin_key = \"counter\"\n";
             $ini .= "created_at      = \"" . $this->getCCDatetime($nc3_counter->created) . "\"\n";
             $ini .= "created_name    = \"" . $nc3_counter->insert_user_name . "\"\n";
-            $ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_counter->created_user) . "\"\n";
+            $ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_counter->created_user) . "\"\n";
             $ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_counter->modified) . "\"\n";
             $ini .= "updated_name    = \"" . $nc3_counter->update_user_name . "\"\n";
-            $ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_counter->modified_user) . "\"\n";
+            $ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_counter->modified_user) . "\"\n";
 
             // カウンターの設定を出力
             $this->storagePut($this->getImportPath('counters/counter_') . $this->zeroSuppress($nc3_counter->block_id) . '.ini', $ini);
@@ -3355,10 +3337,10 @@ trait MigrationNc3ExportTrait
                 // NC3 calendar_plan 登録日・更新日等
                 $tsv_record['created_at']      = $this->getCCDatetime($calendar_plan->created);
                 $tsv_record['created_name']    = $calendar_plan->insert_user_name;
-                $tsv_record['insert_login_id'] = $this->getNc3LoginIdFromNc3UserId($nc3_users, $calendar_plan->created_user);
+                $tsv_record['insert_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $calendar_plan->created_user);
                 $tsv_record['updated_at']      = $this->getCCDatetime($calendar_plan->modified);
                 $tsv_record['updated_name']    = $calendar_plan->update_user_name;
-                $tsv_record['update_login_id'] = $this->getNc3LoginIdFromNc3UserId($nc3_users, $calendar_plan->modified_user);
+                $tsv_record['update_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $calendar_plan->modified_user);
 
                 // NC3カレンダー予定は公開のみ
                 $tsv_record['status'] = 0;
@@ -3534,10 +3516,10 @@ trait MigrationNc3ExportTrait
             $ini .= "plugin_key = \"slides\"\n";
             $ini .= "created_at      = \"" . $this->getCCDatetime($nc3_slideshow->created) . "\"\n";
             $ini .= "created_name    = \"" . $nc3_slideshow->insert_user_name . "\"\n";
-            $ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_slideshow->created_user) . "\"\n";
+            $ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_slideshow->created_user) . "\"\n";
             $ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_slideshow->modified) . "\"\n";
             $ini .= "updated_name    = \"" . $nc3_slideshow->update_user_name . "\"\n";
-            $ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_slideshow->modified_user) . "\"\n";
+            $ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_slideshow->modified_user) . "\"\n";
 
             // 付与情報を移行する。
             $nc3_slides_urls = Nc2SlidesUrl::where('slides_id', $nc3_slideshow->slides_id)->orderBy('slides_url_id')->get();
@@ -3876,10 +3858,10 @@ trait MigrationNc3ExportTrait
                 // NC3 reservation_reserve システム項目
                 $tsv_record['created_at'] = $this->getCCDatetime($reservation_reserve->created);
                 $tsv_record['created_name'] = $reservation_reserve->insert_user_name;
-                $tsv_record['insert_login_id'] = $this->getNc3LoginIdFromNc3UserId($nc3_users, $reservation_reserve->created_user);
+                $tsv_record['insert_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $reservation_reserve->created_user);
                 $tsv_record['updated_at'] = $this->getCCDatetime($reservation_reserve->modified);
                 $tsv_record['updated_name'] = $reservation_reserve->update_user_name;
-                $tsv_record['update_login_id'] = $this->getNc3LoginIdFromNc3UserId($nc3_users, $reservation_reserve->modified_user);
+                $tsv_record['update_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $reservation_reserve->modified_user);
 
                 // NC3施設予約予定は公開のみ
                 $tsv_record['status'] = 0;
@@ -4177,10 +4159,10 @@ trait MigrationNc3ExportTrait
             $photoalbum_ini .= "plugin_key = \"photoalbum\"\n";
             $photoalbum_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_photoalbum->created) . "\"\n";
             $photoalbum_ini .= "created_name    = \"" . $nc3_photoalbum->insert_user_name . "\"\n";
-            $photoalbum_ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum->created_user) . "\"\n";
+            $photoalbum_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum->created_user) . "\"\n";
             $photoalbum_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_photoalbum->modified) . "\"\n";
             $photoalbum_ini .= "updated_name    = \"" . $nc3_photoalbum->update_user_name . "\"\n";
-            $photoalbum_ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum->modified_user) . "\"\n";
+            $photoalbum_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum->modified_user) . "\"\n";
 
             // アルバム 情報
             $photoalbum_ini .= "\n";
@@ -4204,10 +4186,10 @@ trait MigrationNc3ExportTrait
                 $photoalbum_ini .= "height                     = "   . $nc3_photoalbum_alubum->height . "\n";
                 $photoalbum_ini .= "created_at                 = \"" . $this->getCCDatetime($nc3_photoalbum_alubum->created) . "\"\n";
                 $photoalbum_ini .= "created_name               = \"" . $nc3_photoalbum_alubum->insert_user_name . "\"\n";
-                $photoalbum_ini .= "insert_login_id            = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_alubum->created_user) . "\"\n";
+                $photoalbum_ini .= "insert_login_id            = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_alubum->created_user) . "\"\n";
                 $photoalbum_ini .= "updated_at                 = \"" . $this->getCCDatetime($nc3_photoalbum_alubum->modified) . "\"\n";
                 $photoalbum_ini .= "updated_name               = \"" . $nc3_photoalbum_alubum->update_user_name . "\"\n";
-                $photoalbum_ini .= "update_login_id            = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_alubum->modified_user) . "\"\n";
+                $photoalbum_ini .= "update_login_id            = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_alubum->modified_user) . "\"\n";
                 $photoalbum_ini .= "\n";
             }
 
@@ -4253,10 +4235,10 @@ trait MigrationNc3ExportTrait
                     $tsv_record['height']            = $nc3_photoalbum_photo->height;
                     $tsv_record['created_at']        = $this->getCCDatetime($nc3_photoalbum_photo->created);
                     $tsv_record['created_name']      = $nc3_photoalbum_photo->insert_user_name;
-                    $tsv_record['insert_login_id']   = $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_photo->created_user);
+                    $tsv_record['insert_login_id']   = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_photo->created_user);
                     $tsv_record['updated_at']        = $this->getCCDatetime($nc3_photoalbum_photo->modified);
                     $tsv_record['updated_name']      = $nc3_photoalbum_photo->update_user_name;
-                    $tsv_record['update_login_id']   = $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_photo->modified_user);
+                    $tsv_record['update_login_id']   = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_photo->modified_user);
 
                     $tsv .= implode("\t", $tsv_record) . "\n";
                 }
@@ -4302,10 +4284,10 @@ trait MigrationNc3ExportTrait
                 $slide_ini .= "plugin_key = \"photoalbum\"\n";
                 $slide_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_photoalbum_block->created) . "\"\n";
                 $slide_ini .= "created_name    = \"" . $nc3_photoalbum_block->insert_user_name . "\"\n";
-                $slide_ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_block->created_user) . "\"\n";
+                $slide_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_block->created_user) . "\"\n";
                 $slide_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_photoalbum_block->modified) . "\"\n";
                 $slide_ini .= "updated_name    = \"" . $nc3_photoalbum_block->update_user_name . "\"\n";
-                $slide_ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_block->modified_user) . "\"\n";
+                $slide_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_block->modified_user) . "\"\n";
 
                 // 写真
                 $nc3_photoalbum_photos = $nc3_photoalbum_photos_all->where('album_id', $nc3_photoalbum_block->display_album_id);
@@ -4929,11 +4911,11 @@ trait MigrationNc3ExportTrait
         $contents_ini = "[contents]\n";
         $contents_ini .= "contents_file   = \"" . $content_filename . "\"\n";
         $contents_ini .= "created_at      = \"" . $this->getCCDatetime($announcement->created) . "\"\n";
-        $contents_ini .= "created_name    = \"" . $this->getNc3HandleFromNc3UserId($nc3_users, $announcement->created_user) . "\"\n";
-        $contents_ini .= "insert_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $announcement->created_user) . "\"\n";
+        $contents_ini .= "created_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $announcement->created_user) . "\"\n";
+        $contents_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $announcement->created_user) . "\"\n";
         $contents_ini .= "updated_at      = \"" . $this->getCCDatetime($announcement->modified) . "\"\n";
-        $contents_ini .= "updated_name    = \"" . $this->getNc3HandleFromNc3UserId($nc3_users, $announcement->modified_user) . "\"\n";
-        $contents_ini .= "update_login_id = \"" . $this->getNc3LoginIdFromNc3UserId($nc3_users, $announcement->modified_user) . "\"\n";
+        $contents_ini .= "updated_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $announcement->modified_user) . "\"\n";
+        $contents_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $announcement->modified_user) . "\"\n";
         $this->storageAppend($save_folder . "/" . $ini_filename, $contents_ini);
     }
 

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -253,893 +253,6 @@ trait MigrationNc3ExportTrait
     }
 
     /**
-     * NC3のリンク切れチェック
-     */
-    private function checkDeadLinkNc2($url, $nc3_plugin_key = null, $nc3_block = null)
-    {
-        $scheme = parse_url($url, PHP_URL_SCHEME);
-
-        if (in_array($scheme, ['http', 'https'])) {
-
-            $nc3_base_url = $this->getMigrationConfig('basic', 'check_deadlink_nc3_base_url', '');
-            if (empty($nc3_base_url)) {
-                $this->putLinkCheck(3, 'check_deadlink_nc3_base_url未設定', 'migration_config.iniの [basic] check_deadlink_nc3_base_url を設定してください');
-            }
-
-            $domain = str_replace("https://", "", $nc3_base_url);
-            $domain = str_replace("http://", "", $domain);
-
-            // 先頭がNC3のベースURL
-            if (preg_match("/^http:\/\/{$domain}|^https:\/\/{$domain}/", $url)) {
-                // 内部リンク
-                $this->checkDeadLinkInsideNc2($url, $nc3_plugin_key, $nc3_block);
-            } else {
-                // 外部リンク
-                $this->checkDeadLinkOutside($url, $nc3_plugin_key, $nc3_block);
-            }
-
-        } elseif (is_null($scheme)) {
-            // "{{CORE_BASE_URL}}/images/comp/textarea/titleicon/icon-weather9.gif" 等はここで処理
-
-            // 内部リンク
-            $this->checkDeadLinkInsideNc2($url, $nc3_plugin_key, $nc3_block);
-        } else {
-            // 対象外
-            $this->putLinkCheck(3, $nc3_plugin_key . '|リンク切れチェック対象外', $url, $nc3_block);
-        }
-    }
-
-    /**
-     * 外部URLのリンク切れチェック
-     */
-    private function checkDeadLinkOutside($url, $nc3_plugin_key, $nc3_block): bool
-    {
-        // タイムアウト(秒)を変更
-        ini_set('default_socket_timeout', 3);
-
-        stream_context_set_default([
-            'ssl' => [
-                'verify_peer' => false,
-                'verify_peer_name' => false,
-            ],
-        ]);
-
-        // 独自でエラーをcatchする
-        set_error_handler(function ($severity, $message) {
-            throw new \Exception($message);
-        });
-
-        try {
-            $headers = get_headers($url, true);
-        } catch (\Exception $e) {
-            // NG
-            $this->putLinkCheck(3, $nc3_plugin_key . '|外部リンク|リンク切れ|' . $e->getMessage(), $url, $nc3_block);
-            return false;
-
-        } finally {
-            // エラーハンドリングを元に戻す
-            restore_error_handler();
-
-            // タイムアウト(秒)を元に戻す
-            ini_restore('default_socket_timeout');
-        }
-
-
-        $i = 0;
-        while (!isset($headers[$i])) {
-            if (stripos($headers[$i], "200") !== false) {
-                // OK
-                return true;
-            } elseif (stripos($headers[$i], "301") !== false) {
-                // 301リダイレクトのため、次要素の $header でチェック
-            } elseif (stripos($headers[$i], "302") !== false) {
-                // OK
-                return true;
-            } else {
-                // NG
-                $this->putLinkCheck(3, $nc3_plugin_key . '|外部リンク|リンク切れ|' . $headers[$i], $url, $nc3_block);
-                return false;
-            }
-            $i++;
-        }
-
-        // NG. 基本ここには到達しない想定
-        $this->putLinkCheck(3, $nc3_plugin_key . '|外部リンク|リンク切れ', $url, $nc3_block);
-        return false;
-    }
-
-    /**
-     * 内部URL(nc3)のリンク切れチェック
-     */
-    private function checkDeadLinkInsideNc2($url, $nc3_plugin_key = null, $nc3_block = null)
-    {
-
-        // >>> parse_url("http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42")
-        // => [
-        //      "scheme" => "http",
-        //      "host" => "localhost",
-        //      "port" => 8080,
-        //      "path" => "/index.php",
-        //      "query" => "action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2",
-        //      "fragment" => "_active_center_42",
-        //    ]
-        //
-        // >>> parse_url("http://localhost:8080/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/")
-        // => [
-        //      "scheme" => "http",
-        //      "host" => "localhost",
-        //      "port" => 8080,
-        //      "path" => "/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/",
-        //    ]
-
-        $nc3_base_url = $this->getMigrationConfig('basic', 'check_deadlink_nc3_base_url', '');
-
-        // &amp; => & 等のデコード
-        $check_url = htmlspecialchars_decode($url);
-        // {{CORE_BASE_URL}} 置換
-        $check_url = str_replace("{{CORE_BASE_URL}}", $nc3_base_url, $check_url);
-
-        $check_url_path = parse_url($check_url, PHP_URL_PATH);
-        $check_url_query = parse_url($check_url, PHP_URL_QUERY);
-
-        // トップページ
-        // ---------------------------------
-        // http://localhost:8080/
-        // http://localhost:8080
-        // /
-        // ./
-        // /index.php
-        // ./index.php
-        // http://localhost:8080/index.php
-        // ---------------------------------
-        // (pathがトップページに該当するもの＋queryなし)は、OK扱いにする
-        if (in_array($check_url_path, [null, '/', './', '/index.php', './index.php']) && is_null($check_url_query)) {
-            return;
-        }
-        // ---------------------------------
-        // http://localhost:8080/?lang=japanese
-        // http://localhost:8080/?lang=english
-        // http://localhost:8080/?lang=chinese
-        // ---------------------------------
-        // queryあり＋pathがトップページに該当するもの＋queryはlang１つだけ、はOK扱いにする
-        parse_str($check_url_query, $check_url_query_array);
-        if ($check_url_query_array) {
-            $lang = MigrationUtils::getArrayValue($check_url_query_array, 'lang', null, null);
-            if (in_array($check_url_path, ['/', './', '/index.php', './index.php']) && count($check_url_query_array) === 1 && $lang) {
-                if (in_array($lang, ['japanese', 'english', 'chinese'])) {
-                    // OK
-                } else {
-                    // NG
-                    $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|lang値の間違い', $url, $nc3_block);
-                }
-                return;
-            }
-        }
-        // 以下 check_url_path は値が存在する
-
-        // ページ＋mod_rewrite
-        // ---------------------------------
-        // http://localhost:8080/カウンター/
-        // http://localhost:8080/group/グループ１/
-        // http://localhost:8080/group/グループ１/サブグループ１/
-        // http://localhost:8080/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/
-        // ---------------------------------
-        $check_page_permalink = trim($check_url_path, '/');
-        if ($check_page_permalink) {
-            // 頭とお尻の/を取り除いたpath + 空以外 の permalink でページの存在チェック
-            $nc3_page = Nc2Page::where('permalink', trim($check_url_path, '/'))->where('permalink', '!=', '')->first();
-            if ($nc3_page) {
-                // ページデータあり. チェックOK
-                return;
-            }
-        }
-
-        // ページ（mod_rewriteなし. page_id指定）
-        // ---------------------------------
-        // http://localhost:8080/?page_id=16
-        // ---------------------------------
-        if ($check_url_query_array) {
-            // >>> parse_str("page_id=16", $result)
-            // >>> $result
-            // => [
-            //      "page_id" => "16",
-            //    ]
-            //
-            // >>> parse_str("action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2", $result)
-            // >>> $result
-            // => [
-            //      "action" => "pages_view_main",
-            //      "active_center" => "reservation_view_main_init",
-            //      "reserve_details_id" => "19",
-            //      "active_block_id" => "42",
-            //      "page_id" => "0",
-            //      "display_type" => "2",
-            //    ]
-            $page_id = MigrationUtils::getArrayValue($check_url_query_array, 'page_id', null, null);
-            if ($page_id) {
-                $nc3_page = Nc2Page::where('page_id', $page_id)->first();
-                if ($nc3_page) {
-                    // ページデータあり. チェックOK
-                } else {
-                    // NG
-                    $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|ページデータなし', $url, $nc3_block);
-                }
-                return;
-            }
-        }
-
-        // ダウンロードURL（ファイル・画像）
-        // ---------------------------------
-        // (画像) ./?action=common_download_main&upload_id=10
-        // (添付) ./?action=common_download_main&upload_id=11
-        // ---------------------------------
-        if ($check_url_query_array) {
-            $action = MigrationUtils::getArrayValue($check_url_query_array, 'action', null, null);
-            if ($action == 'common_download_main') {
-                $upload_id = MigrationUtils::getArrayValue($check_url_query_array, 'upload_id', null, null);
-                if ($upload_id) {
-                    $nc3_upload = Nc2Upload::where('upload_id', $upload_id)->first();
-                    if ($nc3_upload) {
-                        // アップロードデータあり. チェックOK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|アップロードデータなし', $url, $nc3_block);
-                    }
-                } else {
-                    // NG
-                    $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|common_download_mainでアップロードIDなし', $url, $nc3_block);
-                }
-                return;
-            }
-        }
-
-        // ---------------------------------
-        // 新着表示の各リンク
-        // ---------------------------------
-        // (中央エリアに表示)
-        //   (action)active_center & active_block_id(任意)
-        //
-        //   (施設予約)       http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42
-        //   (カレンダー)     http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=5#_active_center_11
-        //   active_block_idなしでも表示できる
-        //   (施設予約)       http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=0&display_type=2#_active_center_42
-        //   (カレンダー)     http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&page_id=1&display_type=5#_active_center_11
-        //   (検索)          ./index.php?action=pages_view_main&active_center=search_view_main_center
-        //
-        //   (手動で active_center 入れてリンク作成)
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
-        // active_center でblock_id無でもトップページとして表示できる
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=#_69
-        // active_center で存在しないblock_idは「データの取得失敗」エラーで表示できない
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=699999#_69
-        // ---------------------------------
-        // (通常モジュール)
-        //   (action)active_action & block_id(必須)
-        //
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
-        //   (掲示板)        http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
-        //   (フォトアルバム) http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=1&block_id=68#photoalbum_album_68_1
-        //
-        //   (手動で block_id など修正してリンク作成)
-        // active_action でblock_id無は「キャビネット削除された可能性」エラーで表示できない
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=#_69
-        // active_action で存在しないblock_idは「キャビネット削除された可能性」エラーで表示できない
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=699999#_69
-        //
-        //   (pages_view_main 内での active_action処理の調査)
-        //   $blocks[$count]['full_path'] = BASE_URL.INDEX_FILE_NAME."?action=".$block['action_name']."&block_id=".$block['block_id']."&page_id=".$block['page_id'];    //絶対座標に変換
-        //   (掲示板ページ表示)       http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
-        //                           ↓
-        //   (掲示板ブロックだけ表示)  http://localhost:8080/index.php?action=bbs_view_main_post&post_id=9&block_id=56&page_id=33#_56
-        //   (掲示板ブロックだけ表示)  http://localhost:8080/index.php?action=bbs_view_main_post&post_id=9&block_id=56#_56    // page_idなくても表示できた
-        //
-        // ---------------------------------
-        // 検索結果の各リンク
-        // ---------------------------------
-        // (お知らせ)   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50&active_action=announcement_view_main_init#_72
-        // (掲示板)     http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=3&post_id=9#_56
-        // (カレンダー) http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&current_time=000000&display_type=5
-        // ---------------------------------
-        //
-        // NC3モジュール名| 新着 | 検索 | リンクチェック対象
-        // お知らせ         o      o     o
-        // アンケート       o      -     o
-        // Todo            o      o     o
-        // カレンダー       o      o     o
-        // 掲示板           o      o     o
-        // キャビネット     o      o     o
-        // レポート         o      o     o
-        // 小テスト         o      -     o
-        // 施設予約         o      o     o
-        // 日誌             o      o     o
-        // フォトアルバム    o      -     o
-        // 汎用データベース  o      o     o
-        // 回覧板           o      o     o
-        // FAQ              -      o     o
-        // 検索             -      -     o
-        // ---------------------------------
-
-        if ($check_url_query_array) {
-
-            $action = MigrationUtils::getArrayValue($check_url_query_array, 'action', null, null);
-            if ($action == 'pages_view_main') {
-
-                // (通常モジュール)
-                //   (action)active_action & block_id(必須)         例：掲示板, お知らせ, キャビネット等
-                // (中央エリアに表示)
-                //   (action)active_center & active_block_id(任意)  例：カレンダー, 施設予約, 検索
-                $active_action = MigrationUtils::getArrayValue($check_url_query_array, 'active_action', null, null);
-                $active_center = MigrationUtils::getArrayValue($check_url_query_array, 'active_center', null, null);
-
-                if ($active_action) {
-                    // block存在チェック(必須)
-                    $block_id = MigrationUtils::getArrayValue($check_url_query_array, 'block_id', null, null);
-                    $check_nc3_block = Nc2Block::where('block_id', $block_id)->first();
-                    if ($check_nc3_block) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|blockデータなし', $url, $nc3_block);
-                        return;
-                    }
-                }
-
-                if ($active_action || $active_center) {
-                    // page_id存在チェック(任意)
-                    $page_id = MigrationUtils::getArrayValue($check_url_query_array, 'page_id', null, null);
-                    if ($page_id) {
-                        $check_nc3_page = Nc2Page::where('page_id', $page_id)->first();
-                        if ($check_nc3_page) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|pageデータなし', $url, $nc3_block);
-                            return;
-                        }
-                    }
-                }
-
-                // (通常モジュール) active_action
-                // --------------------------------
-                if ($active_action == 'bbs_view_main_post') {
-                    // (掲示板パラメータ)
-                    //   block_id 必須
-                    //   post_id  必須
-                    //   bbs_id   任意. あれば存在チェック
-                    //
-                    // (掲示板-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
-                    // block_idを存在しないIDにすると、「該当ページに配置してある掲示板が削除された可能性があります。」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56999999999999#_56
-                    // post_idを存在しないIDにすると、ページは開けて、掲示板の箇所が「入力値が不正です。不正にアクセスされた可能性があります。」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=99999999999999&block_id=56#_56
-                    //
-                    // (掲示板-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=3&post_id=9#_56
-                    // bbs_idなくても表示できた
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&post_id=9#_56
-                    // bbs_idを存在しないIDにすると、ページは開けて、掲示板の箇所が「入力値が不正です。不正にアクセスされた可能性があります。」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=39999999&post_id=9#_56
-                    //
-                    // (掲示板-active_center, 手動でリンク作成を想定)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_block_id=56&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
-                    // active_block_idを存在しないID, active_block_id設定なしにしても、詳細表示部分が空白なだけで、エラーにはならない。
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_block_id=56999999999&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
-
-                    // bbs_post存在チェック
-                    $post_id = MigrationUtils::getArrayValue($check_url_query_array, 'post_id', null, null);
-                    $check_nc3_bbs_post = Nc2BbsPost::where('post_id', $post_id)->first();
-                    if ($check_nc3_bbs_post) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|bbs_postデータなし', $url, $nc3_block);
-                        return;
-                    }
-
-                    // bbs_id存在チェック(任意)
-                    $bbs_id = MigrationUtils::getArrayValue($check_url_query_array, 'bbs_id', null, null);
-                    if ($bbs_id) {
-                        $check_nc3_bbs = Nc2Bbs::where('bbs_id', $bbs_id)->first();
-                        if ($check_nc3_bbs) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|bbsデータなし', $url, $nc3_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'announcement_view_main_init') {
-                    // (お知らせパラメータ)
-                    //   block_id 必須
-                    //   page_id  任意. あれば存在チェック
-                    //
-                    // (お知らせ-新着)
-                    // http://localhost:8080/index.php?action=pages_view_main&&block_id=72#_72
-                    //
-                    // (お知らせ-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50&active_action=announcement_view_main_init#_72
-                    // page_idなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&active_action=announcement_view_main_init#_72
-                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50999999&active_action=announcement_view_main_init#_72
-                    // block_idがない or 存在しないIDにすると、「該当ページに配置してある掲示板が削除された可能性があります。」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=50&active_action=announcement_view_main_init#_72
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=7299999&page_id=50&active_action=announcement_view_main_init#_72
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'journal_view_main_detail') {
-                    // (日誌パラメータ)
-                    //   block_id       必須
-                    //   post_id        必須
-                    //   comment_flag   任意. (チェック不要). 1:コメント入力あり 1以外:コメント入力なし
-                    //
-                    // (日誌-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&comment_flag=1&block_id=34#_34
-                    // post_idなし or 存在しないIDにすると「記事は存在しいません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&comment_flag=1&block_id=34#_34
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=49999&comment_flag=1&block_id=34#_34
-                    // comment_flagなし or 変な値でも記事表示できる＋コメント入力なし
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&block_id=34#_34
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&comment_flag=199999&block_id=34#_34
-                    //
-                    // (日誌-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=34&active_action=journal_view_main_detail&post_id=4#_34
-
-                    // journal_post存在チェック
-                    $post_id = MigrationUtils::getArrayValue($check_url_query_array, 'post_id', null, null);
-                    $check_nc3_journal_post = Nc2JournalPost::where('post_id', $post_id)->first();
-                    if ($check_nc3_journal_post) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|journal_postデータなし', $url, $nc3_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'multidatabase_view_main_detail') {
-                    // (汎用DBパラメータ)
-                    //   block_id          必須
-                    //   multidatabase_id  必須
-                    //   content_id        必須
-                    //
-                    // (汎用DB-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=1&block_id=51#_51
-                    // multidatabase_idなし or IDが存在しないと「入力値が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&block_id=51#_51
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=19999&block_id=51#_51
-                    // content_idなし or IDが存在しないとコンテンツが存在しません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&multidatabase_id=1&block_id=51#_51
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=499999&multidatabase_id=1&block_id=51#_51
-                    //
-                    // (汎用DB-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=51&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=1&block_id=51#_51
-
-                    // multidatabase存在チェック
-                    $multidatabase_id = MigrationUtils::getArrayValue($check_url_query_array, 'multidatabase_id', null, null);
-                    $check_nc3_multidatabase = Nc2Multidatabase::where('multidatabase_id', $multidatabase_id)->first();
-                    if ($check_nc3_multidatabase) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|multidatabaseデータなし', $url, $nc3_block);
-                        return;
-                    }
-
-                    // multidatabase_content存在チェック
-                    $content_id = MigrationUtils::getArrayValue($check_url_query_array, 'content_id', null, null);
-                    $check_nc3_multidatabase_content = Nc2MultidatabaseContent::where('content_id', $content_id)->first();
-                    if ($check_nc3_multidatabase_content) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|multidatabase_contentデータなし', $url, $nc3_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'cabinet_view_main_init') {
-                    // (キャビネットパラメータ)
-                    //   block_id          必須
-                    //   cabinet_id        任意.
-                    //   folder_id         任意.
-                    //
-                    // (キャビネット-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&block_id=69#_69
-                    // cabinet_idなしは表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&folder_id=&block_id=69#_69
-                    // cabinet_idのIDが存在しないと「公開されているキャビネットはありません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2999999&folder_id=&block_id=69#_69
-                    // folder_idなしは表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&block_id=69#_69
-                    // folder_idのIDが存在しないと「権限が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=99999&block_id=69#_69
-                    //
-                    // (キャビネット-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=69&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=0#_69
-
-                    // cabinet_manage存在チェック(任意)
-                    $cabinet_id = MigrationUtils::getArrayValue($check_url_query_array, 'cabinet_id', null, null);
-                    if ($cabinet_id) {
-                        $check_nc3_cabinet_manage = Nc2CabinetManage::where('cabinet_id', $cabinet_id)->first();
-                        if ($check_nc3_cabinet_manage) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|cabinet_manageデータなし', $url, $nc3_block);
-                            return;
-                        }
-                    }
-
-                    // folder_id(=file_id)のcabinet_file存在チェック(任意)
-                    $folder_id = MigrationUtils::getArrayValue($check_url_query_array, 'folder_id', null, null);
-                    if ($folder_id) {
-                        $check_nc3_cabinet_file = Nc2CabinetFile::where('file_id', $folder_id)->first();
-                        if ($check_nc3_cabinet_file) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|cabinet_fileデータなし.folder_id=file_id', $url, $nc3_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'faq_view_main_init') {
-                    // (FAQパラメータ)
-                    //   block_id          必須
-                    //   question_id       任意.（チェック不要）
-                    //
-                    // (FAQ-検索-のみ)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init&question_id=4#_faq_answer_4
-                    // question_idなし or 存在しないIDでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init#_faq_answer_4
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init&question_id=4999#_faq_answer_4
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'photoalbum_view_main_init') {
-                    // (フォトアルバムパラメータ)
-                    //   block_id          必須
-                    //   album_id          任意.（チェック不要）
-                    //
-                    // (フォトアルバム-新着-のみ)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=1&block_id=68#photoalbum_album_68_1
-                    // album_idなし or 存在しないIDでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&block_id=68#photoalbum_album_68_1
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=19999999999999&block_id=68#photoalbum_album_68_1
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'assignment_view_main_whatsnew' || $active_action == 'assignment_view_main_init') {
-                    // (レポートパラメータ)
-                    //   block_id          必須
-                    //   (新着：assignment_view_main_whatsnew) assignment_id     必須
-                    //   (検索：assignment_view_main_init)     assignment_id     任意.
-                    //
-                    // (レポート-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&assignment_id=1&block_id=74#_74
-                    // assignment_idなし or 存在しないIDだと「入力値が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&block_id=74#_74
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&assignment_id=1999999&block_id=74#_74
-                    //
-                    // (レポート-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init&assignment_id=1#_74
-                    // assignment_idなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init#_74
-                    // assignment_idで存在しないIDだと「公開されている課題はありません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init&assignment_id=1999999#_74
-
-
-                    if ($active_action == 'assignment_view_main_whatsnew') {
-                        // (レポート-新着)
-                        // assignment存在チェック（必須）
-                        $assignment_id = MigrationUtils::getArrayValue($check_url_query_array, 'assignment_id', null, null);
-                        $check_nc3_assignment = Nc2Assignment::where('assignment_id', $assignment_id)->first();
-                        if ($check_nc3_assignment) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|assignmentデータなし', $url, $nc3_block);
-                            return;
-                        }
-
-                    } elseif ($active_action == 'assignment_view_main_init') {
-                        // (レポート-検索)
-                        // assignment存在チェック（任意）
-                        $assignment_id = MigrationUtils::getArrayValue($check_url_query_array, 'assignment_id', null, null);
-                        if ($assignment_id) {
-                            $check_nc3_assignment = Nc2Assignment::where('assignment_id', $assignment_id)->first();
-                            if ($check_nc3_assignment) {
-                                // OK
-                            } else {
-                                // NG
-                                $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|assignmentデータなし', $url, $nc3_block);
-                                return;
-                            }
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'questionnaire_view_main_whatsnew') {
-                    // (アンケートパラメータ)
-                    //   block_id          必須
-                    //   questionnaire_id  必須
-                    //
-                    // (アンケート-新着-のみ)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&questionnaire_id=1&block_id=75#_75
-                    // questionnaire_idなし or 存在しないIDだと「入力値が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&block_id=75#_75
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&questionnaire_id=19999999&block_id=75#_75
-
-                    // questionnaire存在チェック
-                    $questionnaire_id = MigrationUtils::getArrayValue($check_url_query_array, 'questionnaire_id', null, null);
-                    $check_nc3_questionnaire = Nc2Questionnaire::where('questionnaire_id', $questionnaire_id)->first();
-                    if ($check_nc3_questionnaire) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|questionnaireデータなし', $url, $nc3_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'quiz_view_main_whatsnew') {
-                    // (小テストパラメータ)
-                    //   block_id          必須
-                    //   quiz_id           必須
-                    //
-                    // (小テスト-新着-のみ)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&quiz_id=1&block_id=77#_77
-                    // quiz_idなし or 存在しないIDだと「入力値が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&block_id=77#_77
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&quiz_id=1999999&block_id=77#_77
-
-                    // quiz存在チェック
-                    $quiz_id = MigrationUtils::getArrayValue($check_url_query_array, 'quiz_id', null, null);
-                    $check_nc3_quiz = Nc2Quiz::where('quiz_id', $quiz_id)->first();
-                    if ($check_nc3_quiz) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|quizデータなし', $url, $nc3_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'todo_view_main_init') {
-                    // (Todoパラメータ)
-                    //   block_id          必須
-                    //   todo_id           任意
-                    //   page_id           任意
-                    //
-                    // (Todo-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&todo_id=11&block_id=76#_76
-                    // todo_idなし だと表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&block_id=76#_76
-                    // todo_idが存在しないID だと「公開されているTodoリストはありません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&todo_id=11999999&block_id=76#_76
-                    //
-                    // (Todo-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=76&page_id=55&active_action=todo_view_main_init#_76
-
-                    // todo存在チェック（任意）
-                    $todo_id = MigrationUtils::getArrayValue($check_url_query_array, 'todo_id', null, null);
-                    if ($todo_id) {
-                        $check_nc3_todo = Nc2Todo::where('todo_id', $todo_id)->first();
-                        if ($check_nc3_todo) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|todoデータなし', $url, $nc3_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'circular_view_main_detail') {
-                    // (回覧板パラメータ)
-                    //   block_id          必須
-                    //   circular_id       必須
-                    //   page_id           任意
-                    //   room_id           任意（チェック不要）
-                    //
-                    // (回覧板-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&circular_id=2&page_id=53&block_id=78#_78
-                    // circular_idなし or 存在しないID だと「既に削除されています」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&page_id=53&block_id=78#_78
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&circular_id=299999&page_id=53&block_id=78#_78
-                    //
-                    // (回覧板-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&room_id=1&circular_id=2#_78
-                    // room_idなし or 存在しないID でも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&circular_id=2#_78
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&room_id=19999&circular_id=2#_78
-
-                    // circular存在チェック
-                    $circular_id = MigrationUtils::getArrayValue($check_url_query_array, 'circular_id', null, null);
-                    $check_nc3_circular = Nc2Circular::where('circular_id', $circular_id)->first();
-                    if ($check_nc3_circular) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|circularデータなし', $url, $nc3_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-                }
-
-
-                // (中央エリアに表示) active_center
-                // --------------------------------
-                if ($active_center == 'search_view_main_center') {
-                    // （検索-初期インストール配置のヘッダー検索お知らせ）
-                    //   ./index.php?action=pages_view_main&active_center=search_view_main_center
-                    // （検索-active_action, 手動でリンク作成を想定
-                    //   → 対応しない
-                    //   block_idがないと、「該当ページに配置してある検索が削除された可能性があります。」エラー
-                    //   ./index.php?action=pages_view_main&active_action=search_view_main_center
-
-                    // OK
-                    return;
-
-                } elseif ($active_center == 'reservation_view_main_init') {
-                    // (施設予約-新着)
-                    //   active_block_id      任意. (チェック不要)
-                    //   page_id              任意. あれば存在チェック
-                    //   reserve_details_id   任意. (チェック不要)
-                    //   display_type         任意. あれば値チェック=1|2|3
-                    //   reserve_id           任意. (チェック不要)
-                    //
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init
-                    // active_block_idなしでも, 存在しないIDでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=0&display_type=2#_active_center_42
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=4299999999999999&page_id=0&display_type=2#_active_center_42
-                    // page_idなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&display_type=2#_active_center_42
-                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=9999999&display_type=2#_active_center_42
-                    // reserve_details_idなし or 存在しないIDでも表示できる. あれば該当日の一覧を表示
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=1999999999&active_block_id=42&page_id=0&display_type=2#_active_center_42
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&active_block_id=42&page_id=0&display_type=2#_active_center_42
-                    // display_typeなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0#_active_center_42
-                    // display_typeの「入力値が不正です」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=999#_active_center_42
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=4#_active_center_42
-                    //
-                    // >>> parse_str("action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2", $result)
-                    // >>> $result
-                    // => [
-                    //      "action" => "pages_view_main",
-                    //      "active_center" => "reservation_view_main_init",
-                    //      "reserve_details_id" => "19",
-                    //      "active_block_id" => "42",
-                    //      "page_id" => "0",
-                    //      "display_type" => "2",
-                    //    ]
-                    //
-                    // (施設予約-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=reservation_view_main_init&reserve_id=74
-                    // reserve_id が存在しないIDでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=reservation_view_main_init&reserve_id=74999999
-
-                    // display_typeの有効値チェック(任意)
-                    $display_type = MigrationUtils::getArrayValue($check_url_query_array, 'display_type', null, null);
-                    if ($display_type) {
-                        if ((int)$display_type <= 3) {
-                            // OK 1|2|3, ※ イレギュラーだけど0,-1,-2...でも表示可
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|display_type対象外', $url, $nc3_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_center == 'calendar_view_main_init') {
-                    // (カレンダー-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=5#_active_center_11
-                    // page_idなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&display_type=5#_active_center_11
-                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=19999999999&display_type=5#_active_center_11
-                    // display_typeなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1#_active_center_11
-                    // display_type=0|-1|-2...は表示できちゃう
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=-1#_active_center_11
-                    // display_typeの「入力値が不正です」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=8#_active_center_11
-                    // plan_id なし or ID存在しなくても表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&active_block_id=11&page_id=1&display_type=5#_active_center_11
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42999&active_block_id=11&page_id=1&display_type=5#_active_center_11
-                    //
-                    // http://localhost:8080/index.php?
-                    //   - action=pages_view_main
-                    //   - active_center=calendar_view_main_init
-                    //   - plan_id=42           任意. (チェック不要)
-                    //   - active_block_id=11
-                    //   - page_id=1            上にチェック処理あり
-                    //   o display_type=5       任意. あれば値チェック=1～8
-                    //   - #_active_center_11
-                    //
-                    // (カレンダー-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&current_time=000000&display_type=5
-                    // date|current_time なし or 値が変な値でも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&display_type=5
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=202108119999&current_time=0000009999&display_type=5
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&display_type=5
-                    //
-                    // http://localhost:8080/index.php?
-                    //   - date=20210811        任意. (チェック不要)
-                    //   - current_time=000000  任意. (チェック不要)
-                    //   o display_type=5       任意. あれば値チェック=1～8
-
-                    // display_typeの有効値チェック(任意)
-                    $display_type = MigrationUtils::getArrayValue($check_url_query_array, 'display_type', null, null);
-                    if ($display_type) {
-                        if ((int)$display_type <= 8) {
-                            // OK ※イレギュラーだけど0,-1,-2...でも表示可
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|display_type対象外', $url, $nc3_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-                }
-
-            }
-        }
-
-        // 外部リンク
-        // 内部リンクの直ファイル指定の存在チェック。例）http://localhost:8080/htdocs/install/logo.gif
-        // if ($this->checkDeadLinkOutside($check_url, $nc3_plugin_key, $nc3_block)) {
-        //     // 外部OK=移行対象外 (link_checkログには吐かない)
-        //     $this->putMonitor(3, $nc3_plugin_key . '|内部リンク＋外部リンクチェックOK|移行対象外URL', $url, $nc3_block);
-        // } else {
-        //     // 外部NG
-        //     $header = get_headers($check_url, true);
-        //     $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク＋外部リンクチェックNG|未対応URL|' . $header[0], $url, $nc3_block);
-        // }
-
-        // 移行対象外 (link_checkログには吐かない)
-        $this->putMonitor(3, $nc3_plugin_key . '|内部リンク|移行対象外URL', $url, $nc3_block);
-    }
-
-    /**
      * エクスポート・インポートの初期処理
      */
     private function migrationInit()
@@ -6208,5 +5321,892 @@ trait MigrationNc3ExportTrait
             4 => StatusType::approval_pending,  // 差し戻しは承認待ちへ
         ];
         return $convert_statuses[$nc3_status] ?? StatusType::active;
+    }
+
+    /**
+     * NC3のリンク切れチェック
+     */
+    private function checkDeadLinkNc2($url, $nc3_plugin_key = null, $nc3_block = null)
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        if (in_array($scheme, ['http', 'https'])) {
+
+            $nc3_base_url = $this->getMigrationConfig('basic', 'check_deadlink_nc3_base_url', '');
+            if (empty($nc3_base_url)) {
+                $this->putLinkCheck(3, 'check_deadlink_nc3_base_url未設定', 'migration_config.iniの [basic] check_deadlink_nc3_base_url を設定してください');
+            }
+
+            $domain = str_replace("https://", "", $nc3_base_url);
+            $domain = str_replace("http://", "", $domain);
+
+            // 先頭がNC3のベースURL
+            if (preg_match("/^http:\/\/{$domain}|^https:\/\/{$domain}/", $url)) {
+                // 内部リンク
+                $this->checkDeadLinkInsideNc2($url, $nc3_plugin_key, $nc3_block);
+            } else {
+                // 外部リンク
+                $this->checkDeadLinkOutside($url, $nc3_plugin_key, $nc3_block);
+            }
+
+        } elseif (is_null($scheme)) {
+            // "{{CORE_BASE_URL}}/images/comp/textarea/titleicon/icon-weather9.gif" 等はここで処理
+
+            // 内部リンク
+            $this->checkDeadLinkInsideNc2($url, $nc3_plugin_key, $nc3_block);
+        } else {
+            // 対象外
+            $this->putLinkCheck(3, $nc3_plugin_key . '|リンク切れチェック対象外', $url, $nc3_block);
+        }
+    }
+
+    /**
+     * 外部URLのリンク切れチェック
+     */
+    private function checkDeadLinkOutside($url, $nc3_plugin_key, $nc3_block): bool
+    {
+        // タイムアウト(秒)を変更
+        ini_set('default_socket_timeout', 3);
+
+        stream_context_set_default([
+            'ssl' => [
+                'verify_peer' => false,
+                'verify_peer_name' => false,
+            ],
+        ]);
+
+        // 独自でエラーをcatchする
+        set_error_handler(function ($severity, $message) {
+            throw new \Exception($message);
+        });
+
+        try {
+            $headers = get_headers($url, true);
+        } catch (\Exception $e) {
+            // NG
+            $this->putLinkCheck(3, $nc3_plugin_key . '|外部リンク|リンク切れ|' . $e->getMessage(), $url, $nc3_block);
+            return false;
+
+        } finally {
+            // エラーハンドリングを元に戻す
+            restore_error_handler();
+
+            // タイムアウト(秒)を元に戻す
+            ini_restore('default_socket_timeout');
+        }
+
+
+        $i = 0;
+        while (!isset($headers[$i])) {
+            if (stripos($headers[$i], "200") !== false) {
+                // OK
+                return true;
+            } elseif (stripos($headers[$i], "301") !== false) {
+                // 301リダイレクトのため、次要素の $header でチェック
+            } elseif (stripos($headers[$i], "302") !== false) {
+                // OK
+                return true;
+            } else {
+                // NG
+                $this->putLinkCheck(3, $nc3_plugin_key . '|外部リンク|リンク切れ|' . $headers[$i], $url, $nc3_block);
+                return false;
+            }
+            $i++;
+        }
+
+        // NG. 基本ここには到達しない想定
+        $this->putLinkCheck(3, $nc3_plugin_key . '|外部リンク|リンク切れ', $url, $nc3_block);
+        return false;
+    }
+
+    /**
+     * 内部URL(nc3)のリンク切れチェック
+     */
+    private function checkDeadLinkInsideNc2($url, $nc3_plugin_key = null, $nc3_block = null)
+    {
+
+        // >>> parse_url("http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42")
+        // => [
+        //      "scheme" => "http",
+        //      "host" => "localhost",
+        //      "port" => 8080,
+        //      "path" => "/index.php",
+        //      "query" => "action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2",
+        //      "fragment" => "_active_center_42",
+        //    ]
+        //
+        // >>> parse_url("http://localhost:8080/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/")
+        // => [
+        //      "scheme" => "http",
+        //      "host" => "localhost",
+        //      "port" => 8080,
+        //      "path" => "/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/",
+        //    ]
+
+        $nc3_base_url = $this->getMigrationConfig('basic', 'check_deadlink_nc3_base_url', '');
+
+        // &amp; => & 等のデコード
+        $check_url = htmlspecialchars_decode($url);
+        // {{CORE_BASE_URL}} 置換
+        $check_url = str_replace("{{CORE_BASE_URL}}", $nc3_base_url, $check_url);
+
+        $check_url_path = parse_url($check_url, PHP_URL_PATH);
+        $check_url_query = parse_url($check_url, PHP_URL_QUERY);
+
+        // トップページ
+        // ---------------------------------
+        // http://localhost:8080/
+        // http://localhost:8080
+        // /
+        // ./
+        // /index.php
+        // ./index.php
+        // http://localhost:8080/index.php
+        // ---------------------------------
+        // (pathがトップページに該当するもの＋queryなし)は、OK扱いにする
+        if (in_array($check_url_path, [null, '/', './', '/index.php', './index.php']) && is_null($check_url_query)) {
+            return;
+        }
+        // ---------------------------------
+        // http://localhost:8080/?lang=japanese
+        // http://localhost:8080/?lang=english
+        // http://localhost:8080/?lang=chinese
+        // ---------------------------------
+        // queryあり＋pathがトップページに該当するもの＋queryはlang１つだけ、はOK扱いにする
+        parse_str($check_url_query, $check_url_query_array);
+        if ($check_url_query_array) {
+            $lang = MigrationUtils::getArrayValue($check_url_query_array, 'lang', null, null);
+            if (in_array($check_url_path, ['/', './', '/index.php', './index.php']) && count($check_url_query_array) === 1 && $lang) {
+                if (in_array($lang, ['japanese', 'english', 'chinese'])) {
+                    // OK
+                } else {
+                    // NG
+                    $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|lang値の間違い', $url, $nc3_block);
+                }
+                return;
+            }
+        }
+        // 以下 check_url_path は値が存在する
+
+        // ページ＋mod_rewrite
+        // ---------------------------------
+        // http://localhost:8080/カウンター/
+        // http://localhost:8080/group/グループ１/
+        // http://localhost:8080/group/グループ１/サブグループ１/
+        // http://localhost:8080/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/
+        // ---------------------------------
+        $check_page_permalink = trim($check_url_path, '/');
+        if ($check_page_permalink) {
+            // 頭とお尻の/を取り除いたpath + 空以外 の permalink でページの存在チェック
+            $nc3_page = Nc2Page::where('permalink', trim($check_url_path, '/'))->where('permalink', '!=', '')->first();
+            if ($nc3_page) {
+                // ページデータあり. チェックOK
+                return;
+            }
+        }
+
+        // ページ（mod_rewriteなし. page_id指定）
+        // ---------------------------------
+        // http://localhost:8080/?page_id=16
+        // ---------------------------------
+        if ($check_url_query_array) {
+            // >>> parse_str("page_id=16", $result)
+            // >>> $result
+            // => [
+            //      "page_id" => "16",
+            //    ]
+            //
+            // >>> parse_str("action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2", $result)
+            // >>> $result
+            // => [
+            //      "action" => "pages_view_main",
+            //      "active_center" => "reservation_view_main_init",
+            //      "reserve_details_id" => "19",
+            //      "active_block_id" => "42",
+            //      "page_id" => "0",
+            //      "display_type" => "2",
+            //    ]
+            $page_id = MigrationUtils::getArrayValue($check_url_query_array, 'page_id', null, null);
+            if ($page_id) {
+                $nc3_page = Nc2Page::where('page_id', $page_id)->first();
+                if ($nc3_page) {
+                    // ページデータあり. チェックOK
+                } else {
+                    // NG
+                    $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|ページデータなし', $url, $nc3_block);
+                }
+                return;
+            }
+        }
+
+        // ダウンロードURL（ファイル・画像）
+        // ---------------------------------
+        // (画像) ./?action=common_download_main&upload_id=10
+        // (添付) ./?action=common_download_main&upload_id=11
+        // ---------------------------------
+        if ($check_url_query_array) {
+            $action = MigrationUtils::getArrayValue($check_url_query_array, 'action', null, null);
+            if ($action == 'common_download_main') {
+                $upload_id = MigrationUtils::getArrayValue($check_url_query_array, 'upload_id', null, null);
+                if ($upload_id) {
+                    $nc3_upload = Nc2Upload::where('upload_id', $upload_id)->first();
+                    if ($nc3_upload) {
+                        // アップロードデータあり. チェックOK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|アップロードデータなし', $url, $nc3_block);
+                    }
+                } else {
+                    // NG
+                    $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|common_download_mainでアップロードIDなし', $url, $nc3_block);
+                }
+                return;
+            }
+        }
+
+        // ---------------------------------
+        // 新着表示の各リンク
+        // ---------------------------------
+        // (中央エリアに表示)
+        //   (action)active_center & active_block_id(任意)
+        //
+        //   (施設予約)       http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42
+        //   (カレンダー)     http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=5#_active_center_11
+        //   active_block_idなしでも表示できる
+        //   (施設予約)       http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=0&display_type=2#_active_center_42
+        //   (カレンダー)     http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&page_id=1&display_type=5#_active_center_11
+        //   (検索)          ./index.php?action=pages_view_main&active_center=search_view_main_center
+        //
+        //   (手動で active_center 入れてリンク作成)
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
+        // active_center でblock_id無でもトップページとして表示できる
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=#_69
+        // active_center で存在しないblock_idは「データの取得失敗」エラーで表示できない
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=699999#_69
+        // ---------------------------------
+        // (通常モジュール)
+        //   (action)active_action & block_id(必須)
+        //
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
+        //   (掲示板)        http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
+        //   (フォトアルバム) http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=1&block_id=68#photoalbum_album_68_1
+        //
+        //   (手動で block_id など修正してリンク作成)
+        // active_action でblock_id無は「キャビネット削除された可能性」エラーで表示できない
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=#_69
+        // active_action で存在しないblock_idは「キャビネット削除された可能性」エラーで表示できない
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=699999#_69
+        //
+        //   (pages_view_main 内での active_action処理の調査)
+        //   $blocks[$count]['full_path'] = BASE_URL.INDEX_FILE_NAME."?action=".$block['action_name']."&block_id=".$block['block_id']."&page_id=".$block['page_id'];    //絶対座標に変換
+        //   (掲示板ページ表示)       http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
+        //                           ↓
+        //   (掲示板ブロックだけ表示)  http://localhost:8080/index.php?action=bbs_view_main_post&post_id=9&block_id=56&page_id=33#_56
+        //   (掲示板ブロックだけ表示)  http://localhost:8080/index.php?action=bbs_view_main_post&post_id=9&block_id=56#_56    // page_idなくても表示できた
+        //
+        // ---------------------------------
+        // 検索結果の各リンク
+        // ---------------------------------
+        // (お知らせ)   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50&active_action=announcement_view_main_init#_72
+        // (掲示板)     http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=3&post_id=9#_56
+        // (カレンダー) http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&current_time=000000&display_type=5
+        // ---------------------------------
+        //
+        // NC3モジュール名| 新着 | 検索 | リンクチェック対象
+        // お知らせ         o      o     o
+        // アンケート       o      -     o
+        // Todo            o      o     o
+        // カレンダー       o      o     o
+        // 掲示板           o      o     o
+        // キャビネット     o      o     o
+        // レポート         o      o     o
+        // 小テスト         o      -     o
+        // 施設予約         o      o     o
+        // 日誌             o      o     o
+        // フォトアルバム    o      -     o
+        // 汎用データベース  o      o     o
+        // 回覧板           o      o     o
+        // FAQ              -      o     o
+        // 検索             -      -     o
+        // ---------------------------------
+
+        if ($check_url_query_array) {
+
+            $action = MigrationUtils::getArrayValue($check_url_query_array, 'action', null, null);
+            if ($action == 'pages_view_main') {
+
+                // (通常モジュール)
+                //   (action)active_action & block_id(必須)         例：掲示板, お知らせ, キャビネット等
+                // (中央エリアに表示)
+                //   (action)active_center & active_block_id(任意)  例：カレンダー, 施設予約, 検索
+                $active_action = MigrationUtils::getArrayValue($check_url_query_array, 'active_action', null, null);
+                $active_center = MigrationUtils::getArrayValue($check_url_query_array, 'active_center', null, null);
+
+                if ($active_action) {
+                    // block存在チェック(必須)
+                    $block_id = MigrationUtils::getArrayValue($check_url_query_array, 'block_id', null, null);
+                    $check_nc3_block = Nc2Block::where('block_id', $block_id)->first();
+                    if ($check_nc3_block) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|blockデータなし', $url, $nc3_block);
+                        return;
+                    }
+                }
+
+                if ($active_action || $active_center) {
+                    // page_id存在チェック(任意)
+                    $page_id = MigrationUtils::getArrayValue($check_url_query_array, 'page_id', null, null);
+                    if ($page_id) {
+                        $check_nc3_page = Nc2Page::where('page_id', $page_id)->first();
+                        if ($check_nc3_page) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|pageデータなし', $url, $nc3_block);
+                            return;
+                        }
+                    }
+                }
+
+                // (通常モジュール) active_action
+                // --------------------------------
+                if ($active_action == 'bbs_view_main_post') {
+                    // (掲示板パラメータ)
+                    //   block_id 必須
+                    //   post_id  必須
+                    //   bbs_id   任意. あれば存在チェック
+                    //
+                    // (掲示板-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
+                    // block_idを存在しないIDにすると、「該当ページに配置してある掲示板が削除された可能性があります。」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56999999999999#_56
+                    // post_idを存在しないIDにすると、ページは開けて、掲示板の箇所が「入力値が不正です。不正にアクセスされた可能性があります。」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=99999999999999&block_id=56#_56
+                    //
+                    // (掲示板-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=3&post_id=9#_56
+                    // bbs_idなくても表示できた
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&post_id=9#_56
+                    // bbs_idを存在しないIDにすると、ページは開けて、掲示板の箇所が「入力値が不正です。不正にアクセスされた可能性があります。」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=39999999&post_id=9#_56
+                    //
+                    // (掲示板-active_center, 手動でリンク作成を想定)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_block_id=56&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
+                    // active_block_idを存在しないID, active_block_id設定なしにしても、詳細表示部分が空白なだけで、エラーにはならない。
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_block_id=56999999999&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
+
+                    // bbs_post存在チェック
+                    $post_id = MigrationUtils::getArrayValue($check_url_query_array, 'post_id', null, null);
+                    $check_nc3_bbs_post = Nc2BbsPost::where('post_id', $post_id)->first();
+                    if ($check_nc3_bbs_post) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|bbs_postデータなし', $url, $nc3_block);
+                        return;
+                    }
+
+                    // bbs_id存在チェック(任意)
+                    $bbs_id = MigrationUtils::getArrayValue($check_url_query_array, 'bbs_id', null, null);
+                    if ($bbs_id) {
+                        $check_nc3_bbs = Nc2Bbs::where('bbs_id', $bbs_id)->first();
+                        if ($check_nc3_bbs) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|bbsデータなし', $url, $nc3_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'announcement_view_main_init') {
+                    // (お知らせパラメータ)
+                    //   block_id 必須
+                    //   page_id  任意. あれば存在チェック
+                    //
+                    // (お知らせ-新着)
+                    // http://localhost:8080/index.php?action=pages_view_main&&block_id=72#_72
+                    //
+                    // (お知らせ-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50&active_action=announcement_view_main_init#_72
+                    // page_idなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&active_action=announcement_view_main_init#_72
+                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50999999&active_action=announcement_view_main_init#_72
+                    // block_idがない or 存在しないIDにすると、「該当ページに配置してある掲示板が削除された可能性があります。」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=50&active_action=announcement_view_main_init#_72
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=7299999&page_id=50&active_action=announcement_view_main_init#_72
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'journal_view_main_detail') {
+                    // (日誌パラメータ)
+                    //   block_id       必須
+                    //   post_id        必須
+                    //   comment_flag   任意. (チェック不要). 1:コメント入力あり 1以外:コメント入力なし
+                    //
+                    // (日誌-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&comment_flag=1&block_id=34#_34
+                    // post_idなし or 存在しないIDにすると「記事は存在しいません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&comment_flag=1&block_id=34#_34
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=49999&comment_flag=1&block_id=34#_34
+                    // comment_flagなし or 変な値でも記事表示できる＋コメント入力なし
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&block_id=34#_34
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&comment_flag=199999&block_id=34#_34
+                    //
+                    // (日誌-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=34&active_action=journal_view_main_detail&post_id=4#_34
+
+                    // journal_post存在チェック
+                    $post_id = MigrationUtils::getArrayValue($check_url_query_array, 'post_id', null, null);
+                    $check_nc3_journal_post = Nc2JournalPost::where('post_id', $post_id)->first();
+                    if ($check_nc3_journal_post) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|journal_postデータなし', $url, $nc3_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'multidatabase_view_main_detail') {
+                    // (汎用DBパラメータ)
+                    //   block_id          必須
+                    //   multidatabase_id  必須
+                    //   content_id        必須
+                    //
+                    // (汎用DB-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=1&block_id=51#_51
+                    // multidatabase_idなし or IDが存在しないと「入力値が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&block_id=51#_51
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=19999&block_id=51#_51
+                    // content_idなし or IDが存在しないとコンテンツが存在しません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&multidatabase_id=1&block_id=51#_51
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=499999&multidatabase_id=1&block_id=51#_51
+                    //
+                    // (汎用DB-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=51&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=1&block_id=51#_51
+
+                    // multidatabase存在チェック
+                    $multidatabase_id = MigrationUtils::getArrayValue($check_url_query_array, 'multidatabase_id', null, null);
+                    $check_nc3_multidatabase = Nc2Multidatabase::where('multidatabase_id', $multidatabase_id)->first();
+                    if ($check_nc3_multidatabase) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|multidatabaseデータなし', $url, $nc3_block);
+                        return;
+                    }
+
+                    // multidatabase_content存在チェック
+                    $content_id = MigrationUtils::getArrayValue($check_url_query_array, 'content_id', null, null);
+                    $check_nc3_multidatabase_content = Nc2MultidatabaseContent::where('content_id', $content_id)->first();
+                    if ($check_nc3_multidatabase_content) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|multidatabase_contentデータなし', $url, $nc3_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'cabinet_view_main_init') {
+                    // (キャビネットパラメータ)
+                    //   block_id          必須
+                    //   cabinet_id        任意.
+                    //   folder_id         任意.
+                    //
+                    // (キャビネット-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&block_id=69#_69
+                    // cabinet_idなしは表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&folder_id=&block_id=69#_69
+                    // cabinet_idのIDが存在しないと「公開されているキャビネットはありません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2999999&folder_id=&block_id=69#_69
+                    // folder_idなしは表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&block_id=69#_69
+                    // folder_idのIDが存在しないと「権限が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=99999&block_id=69#_69
+                    //
+                    // (キャビネット-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=69&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=0#_69
+
+                    // cabinet_manage存在チェック(任意)
+                    $cabinet_id = MigrationUtils::getArrayValue($check_url_query_array, 'cabinet_id', null, null);
+                    if ($cabinet_id) {
+                        $check_nc3_cabinet_manage = Nc2CabinetManage::where('cabinet_id', $cabinet_id)->first();
+                        if ($check_nc3_cabinet_manage) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|cabinet_manageデータなし', $url, $nc3_block);
+                            return;
+                        }
+                    }
+
+                    // folder_id(=file_id)のcabinet_file存在チェック(任意)
+                    $folder_id = MigrationUtils::getArrayValue($check_url_query_array, 'folder_id', null, null);
+                    if ($folder_id) {
+                        $check_nc3_cabinet_file = Nc2CabinetFile::where('file_id', $folder_id)->first();
+                        if ($check_nc3_cabinet_file) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|cabinet_fileデータなし.folder_id=file_id', $url, $nc3_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'faq_view_main_init') {
+                    // (FAQパラメータ)
+                    //   block_id          必須
+                    //   question_id       任意.（チェック不要）
+                    //
+                    // (FAQ-検索-のみ)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init&question_id=4#_faq_answer_4
+                    // question_idなし or 存在しないIDでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init#_faq_answer_4
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init&question_id=4999#_faq_answer_4
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'photoalbum_view_main_init') {
+                    // (フォトアルバムパラメータ)
+                    //   block_id          必須
+                    //   album_id          任意.（チェック不要）
+                    //
+                    // (フォトアルバム-新着-のみ)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=1&block_id=68#photoalbum_album_68_1
+                    // album_idなし or 存在しないIDでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&block_id=68#photoalbum_album_68_1
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=19999999999999&block_id=68#photoalbum_album_68_1
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'assignment_view_main_whatsnew' || $active_action == 'assignment_view_main_init') {
+                    // (レポートパラメータ)
+                    //   block_id          必須
+                    //   (新着：assignment_view_main_whatsnew) assignment_id     必須
+                    //   (検索：assignment_view_main_init)     assignment_id     任意.
+                    //
+                    // (レポート-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&assignment_id=1&block_id=74#_74
+                    // assignment_idなし or 存在しないIDだと「入力値が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&block_id=74#_74
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&assignment_id=1999999&block_id=74#_74
+                    //
+                    // (レポート-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init&assignment_id=1#_74
+                    // assignment_idなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init#_74
+                    // assignment_idで存在しないIDだと「公開されている課題はありません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init&assignment_id=1999999#_74
+
+
+                    if ($active_action == 'assignment_view_main_whatsnew') {
+                        // (レポート-新着)
+                        // assignment存在チェック（必須）
+                        $assignment_id = MigrationUtils::getArrayValue($check_url_query_array, 'assignment_id', null, null);
+                        $check_nc3_assignment = Nc2Assignment::where('assignment_id', $assignment_id)->first();
+                        if ($check_nc3_assignment) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|assignmentデータなし', $url, $nc3_block);
+                            return;
+                        }
+
+                    } elseif ($active_action == 'assignment_view_main_init') {
+                        // (レポート-検索)
+                        // assignment存在チェック（任意）
+                        $assignment_id = MigrationUtils::getArrayValue($check_url_query_array, 'assignment_id', null, null);
+                        if ($assignment_id) {
+                            $check_nc3_assignment = Nc2Assignment::where('assignment_id', $assignment_id)->first();
+                            if ($check_nc3_assignment) {
+                                // OK
+                            } else {
+                                // NG
+                                $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|assignmentデータなし', $url, $nc3_block);
+                                return;
+                            }
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'questionnaire_view_main_whatsnew') {
+                    // (アンケートパラメータ)
+                    //   block_id          必須
+                    //   questionnaire_id  必須
+                    //
+                    // (アンケート-新着-のみ)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&questionnaire_id=1&block_id=75#_75
+                    // questionnaire_idなし or 存在しないIDだと「入力値が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&block_id=75#_75
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&questionnaire_id=19999999&block_id=75#_75
+
+                    // questionnaire存在チェック
+                    $questionnaire_id = MigrationUtils::getArrayValue($check_url_query_array, 'questionnaire_id', null, null);
+                    $check_nc3_questionnaire = Nc2Questionnaire::where('questionnaire_id', $questionnaire_id)->first();
+                    if ($check_nc3_questionnaire) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|questionnaireデータなし', $url, $nc3_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'quiz_view_main_whatsnew') {
+                    // (小テストパラメータ)
+                    //   block_id          必須
+                    //   quiz_id           必須
+                    //
+                    // (小テスト-新着-のみ)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&quiz_id=1&block_id=77#_77
+                    // quiz_idなし or 存在しないIDだと「入力値が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&block_id=77#_77
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&quiz_id=1999999&block_id=77#_77
+
+                    // quiz存在チェック
+                    $quiz_id = MigrationUtils::getArrayValue($check_url_query_array, 'quiz_id', null, null);
+                    $check_nc3_quiz = Nc2Quiz::where('quiz_id', $quiz_id)->first();
+                    if ($check_nc3_quiz) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|quizデータなし', $url, $nc3_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'todo_view_main_init') {
+                    // (Todoパラメータ)
+                    //   block_id          必須
+                    //   todo_id           任意
+                    //   page_id           任意
+                    //
+                    // (Todo-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&todo_id=11&block_id=76#_76
+                    // todo_idなし だと表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&block_id=76#_76
+                    // todo_idが存在しないID だと「公開されているTodoリストはありません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&todo_id=11999999&block_id=76#_76
+                    //
+                    // (Todo-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=76&page_id=55&active_action=todo_view_main_init#_76
+
+                    // todo存在チェック（任意）
+                    $todo_id = MigrationUtils::getArrayValue($check_url_query_array, 'todo_id', null, null);
+                    if ($todo_id) {
+                        $check_nc3_todo = Nc2Todo::where('todo_id', $todo_id)->first();
+                        if ($check_nc3_todo) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|todoデータなし', $url, $nc3_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'circular_view_main_detail') {
+                    // (回覧板パラメータ)
+                    //   block_id          必須
+                    //   circular_id       必須
+                    //   page_id           任意
+                    //   room_id           任意（チェック不要）
+                    //
+                    // (回覧板-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&circular_id=2&page_id=53&block_id=78#_78
+                    // circular_idなし or 存在しないID だと「既に削除されています」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&page_id=53&block_id=78#_78
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&circular_id=299999&page_id=53&block_id=78#_78
+                    //
+                    // (回覧板-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&room_id=1&circular_id=2#_78
+                    // room_idなし or 存在しないID でも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&circular_id=2#_78
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&room_id=19999&circular_id=2#_78
+
+                    // circular存在チェック
+                    $circular_id = MigrationUtils::getArrayValue($check_url_query_array, 'circular_id', null, null);
+                    $check_nc3_circular = Nc2Circular::where('circular_id', $circular_id)->first();
+                    if ($check_nc3_circular) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|circularデータなし', $url, $nc3_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+                }
+
+
+                // (中央エリアに表示) active_center
+                // --------------------------------
+                if ($active_center == 'search_view_main_center') {
+                    // （検索-初期インストール配置のヘッダー検索お知らせ）
+                    //   ./index.php?action=pages_view_main&active_center=search_view_main_center
+                    // （検索-active_action, 手動でリンク作成を想定
+                    //   → 対応しない
+                    //   block_idがないと、「該当ページに配置してある検索が削除された可能性があります。」エラー
+                    //   ./index.php?action=pages_view_main&active_action=search_view_main_center
+
+                    // OK
+                    return;
+
+                } elseif ($active_center == 'reservation_view_main_init') {
+                    // (施設予約-新着)
+                    //   active_block_id      任意. (チェック不要)
+                    //   page_id              任意. あれば存在チェック
+                    //   reserve_details_id   任意. (チェック不要)
+                    //   display_type         任意. あれば値チェック=1|2|3
+                    //   reserve_id           任意. (チェック不要)
+                    //
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init
+                    // active_block_idなしでも, 存在しないIDでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=0&display_type=2#_active_center_42
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=4299999999999999&page_id=0&display_type=2#_active_center_42
+                    // page_idなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&display_type=2#_active_center_42
+                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=9999999&display_type=2#_active_center_42
+                    // reserve_details_idなし or 存在しないIDでも表示できる. あれば該当日の一覧を表示
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=1999999999&active_block_id=42&page_id=0&display_type=2#_active_center_42
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&active_block_id=42&page_id=0&display_type=2#_active_center_42
+                    // display_typeなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0#_active_center_42
+                    // display_typeの「入力値が不正です」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=999#_active_center_42
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=4#_active_center_42
+                    //
+                    // >>> parse_str("action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2", $result)
+                    // >>> $result
+                    // => [
+                    //      "action" => "pages_view_main",
+                    //      "active_center" => "reservation_view_main_init",
+                    //      "reserve_details_id" => "19",
+                    //      "active_block_id" => "42",
+                    //      "page_id" => "0",
+                    //      "display_type" => "2",
+                    //    ]
+                    //
+                    // (施設予約-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=reservation_view_main_init&reserve_id=74
+                    // reserve_id が存在しないIDでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=reservation_view_main_init&reserve_id=74999999
+
+                    // display_typeの有効値チェック(任意)
+                    $display_type = MigrationUtils::getArrayValue($check_url_query_array, 'display_type', null, null);
+                    if ($display_type) {
+                        if ((int)$display_type <= 3) {
+                            // OK 1|2|3, ※ イレギュラーだけど0,-1,-2...でも表示可
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|display_type対象外', $url, $nc3_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_center == 'calendar_view_main_init') {
+                    // (カレンダー-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=5#_active_center_11
+                    // page_idなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&display_type=5#_active_center_11
+                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=19999999999&display_type=5#_active_center_11
+                    // display_typeなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1#_active_center_11
+                    // display_type=0|-1|-2...は表示できちゃう
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=-1#_active_center_11
+                    // display_typeの「入力値が不正です」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=8#_active_center_11
+                    // plan_id なし or ID存在しなくても表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&active_block_id=11&page_id=1&display_type=5#_active_center_11
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42999&active_block_id=11&page_id=1&display_type=5#_active_center_11
+                    //
+                    // http://localhost:8080/index.php?
+                    //   - action=pages_view_main
+                    //   - active_center=calendar_view_main_init
+                    //   - plan_id=42           任意. (チェック不要)
+                    //   - active_block_id=11
+                    //   - page_id=1            上にチェック処理あり
+                    //   o display_type=5       任意. あれば値チェック=1～8
+                    //   - #_active_center_11
+                    //
+                    // (カレンダー-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&current_time=000000&display_type=5
+                    // date|current_time なし or 値が変な値でも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&display_type=5
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=202108119999&current_time=0000009999&display_type=5
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&display_type=5
+                    //
+                    // http://localhost:8080/index.php?
+                    //   - date=20210811        任意. (チェック不要)
+                    //   - current_time=000000  任意. (チェック不要)
+                    //   o display_type=5       任意. あれば値チェック=1～8
+
+                    // display_typeの有効値チェック(任意)
+                    $display_type = MigrationUtils::getArrayValue($check_url_query_array, 'display_type', null, null);
+                    if ($display_type) {
+                        if ((int)$display_type <= 8) {
+                            // OK ※イレギュラーだけど0,-1,-2...でも表示可
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク|display_type対象外', $url, $nc3_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+                }
+
+            }
+        }
+
+        // 外部リンク
+        // 内部リンクの直ファイル指定の存在チェック。例）http://localhost:8080/htdocs/install/logo.gif
+        // if ($this->checkDeadLinkOutside($check_url, $nc3_plugin_key, $nc3_block)) {
+        //     // 外部OK=移行対象外 (link_checkログには吐かない)
+        //     $this->putMonitor(3, $nc3_plugin_key . '|内部リンク＋外部リンクチェックOK|移行対象外URL', $url, $nc3_block);
+        // } else {
+        //     // 外部NG
+        //     $header = get_headers($check_url, true);
+        //     $this->putLinkCheck(3, $nc3_plugin_key . '|内部リンク＋外部リンクチェックNG|未対応URL|' . $header[0], $url, $nc3_block);
+        // }
+
+        // 移行対象外 (link_checkログには吐かない)
+        $this->putMonitor(3, $nc3_plugin_key . '|内部リンク|移行対象外URL', $url, $nc3_block);
     }
 }

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -4739,7 +4739,7 @@ trait MigrationNc3ExportTrait
             $nc3_block = Nc3Block::find($nc3_frame->block_id);
             // ブロックがあり、リンクリストがない場合は対象外
             if (!empty($nc3_block)) {
-                // NC3カウンターにプラグイン固有のデータまとめテーブルがないため、block_idをセット
+                // NC3リンクリストにプラグイン固有のデータまとめテーブルがないため、block_idをセット
                 // [TODO] id名と値ズレ
                 $ret = "linklist_id = \"" . $this->zeroSuppress($nc3_block->id) . "\"\n";
             }

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -4982,7 +4982,7 @@ trait MigrationNc3ExportTrait
             $view_format = $convert_view_formats[$nc3_bbs_frame_setting->display_type];
         } else {
             $view_format = '';
-            $this->putError(3, '掲示板の表示形式が未対応の形式', "nc3_bbs_frame_setting = " . $nc3_frame->key);
+            $this->putError(3, '掲示板の表示形式が未対応の形式', "nc3_bbs_frame_setting = " . $nc3_bbs_frame_setting->frame_key);
         }
 
         $frame_ini = "[bbs]\n";

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -1279,7 +1279,7 @@ trait MigrationNc3ExportTrait
         $block_role_permissions = Nc3BlockRolePermission::getBlockRolePermissionsByBlockKeys($nc3_blogs->pluck('block_key'));
 
         // メール設定
-        $mail_settings = Nc3MailSetting::getMailSettingsByBlockKeys($nc3_blogs->pluck('block_key'));
+        $mail_settings = Nc3MailSetting::getMailSettingsByBlockKeys($nc3_blogs->pluck('block_key'), 'blogs');
 
         // サイト設定
         $site_settings = Nc3SiteSetting::where('language_id', Nc3Language::language_id_ja)->get();
@@ -1392,8 +1392,8 @@ trait MigrationNc3ExportTrait
                 $notice_admin_group = 1;
             }
 
-            // 通知メール
-            $mail_setting = $mail_settings->firstWhere('block_key', $nc3_blog->block_key) ?? new Nc3MailSetting();
+            // 通知メール（データなければblock_key=nullの初期設定取得）
+            $mail_setting = $mail_settings->firstWhere('block_key', $nc3_blog->block_key) ?? $mail_settings->firstWhere('block_key', null);
             $mail_subject = $mail_setting->mail_fixed_phrase_subject;
             $mail_body = $mail_setting->mail_fixed_phrase_body;
 
@@ -1638,7 +1638,7 @@ trait MigrationNc3ExportTrait
         $block_role_permissions = Nc3BlockRolePermission::getBlockRolePermissionsByBlockKeys($nc3_bbses->pluck('block_key'));
 
         // メール設定
-        $mail_settings = Nc3MailSetting::getMailSettingsByBlockKeys($nc3_bbses->pluck('block_key'));
+        $mail_settings = Nc3MailSetting::getMailSettingsByBlockKeys($nc3_bbses->pluck('block_key'), 'bbses');
 
         // サイト設定
         $site_settings = Nc3SiteSetting::where('language_id', Nc3Language::language_id_ja)->get();
@@ -1756,8 +1756,8 @@ trait MigrationNc3ExportTrait
                 $notice_admin_group = 1;
             }
 
-            // 通知メール
-            $mail_setting = $mail_settings->firstWhere('block_key', $nc3_bbs->block_key) ?? new Nc3MailSetting();
+            // 通知メール（データなければblock_key=nullの初期設定取得）
+            $mail_setting = $mail_settings->firstWhere('block_key', $nc3_bbs->block_key) ?? $mail_settings->firstWhere('block_key', null);
             $mail_subject = $mail_setting->mail_fixed_phrase_subject;
             $mail_body = $mail_setting->mail_fixed_phrase_body;
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -8863,6 +8863,7 @@ trait MigrationTrait
                 $multidatabase_cols_rows[$metadata_id]["sort_flag"]        = $multidatabase_metadata->sort_flag;
                 $multidatabase_cols_rows[$metadata_id]["search_flag"]      = $multidatabase_metadata->search_flag;
                 $multidatabase_cols_rows[$metadata_id]["select_flag"]      = ($multidatabase_metadata->type == 4 || $multidatabase_metadata->type == 12) ? 1 : 0;
+                $multidatabase_cols_rows[$metadata_id]["display_sequence"] = null;  // 後処理で連番セット
                 $multidatabase_cols_rows[$metadata_id]["row_group"]        = null;
                 $multidatabase_cols_rows[$metadata_id]["column_group"]     = null;
                 if ($multidatabase_metadata->display_pos == 1) {

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -159,6 +159,7 @@ use App\Utilities\Migration\MigrationUtils;
 use App\Enums\BlogFrameConfig;
 use App\Enums\CounterDesignType;
 use App\Enums\ContentOpenType;
+use App\Enums\DatabaseSortFlag;
 use App\Enums\DayOfWeek;
 use App\Enums\FacilityDisplayType;
 use App\Enums\LinklistType;
@@ -11523,9 +11524,9 @@ trait MigrationTrait
         if ($nc2_multidatabase_block->default_sort == 'seq') {
             $this->putError(3, 'データベースのソートが未対応順（カスタマイズ順）', "nc2_multidatabase_block = " . $nc2_multidatabase_block->block_id);
         } elseif ($nc2_multidatabase_block->default_sort == 'date') {
-            $default_sort_flag = 'created_desc';
+            $default_sort_flag = DatabaseSortFlag::created_desc;
         } elseif ($nc2_multidatabase_block->default_sort == 'date_asc') {
-            $default_sort_flag = 'created_asc';
+            $default_sort_flag = DatabaseSortFlag::created_asc;
         } else {
             $this->putError(3, 'データベースのソートが未対応順', "nc2_multidatabase_block = " . $nc2_multidatabase_block->block_id);
         }

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -8909,7 +8909,7 @@ trait MigrationTrait
 
             // multidatabase_block の取得
             // 1DB で複数ブロックがあるので、Join せずに、個別に読む
-            $nc2_multidatabase_block = Nc2MultidatabaseBlock::where('multidatabase_id', $nc2_multidatabase->multidatabase_id)->orderBy('block_id', 'asc')->first();
+            $nc2_multidatabase_block = Nc2MultidatabaseBlock::where('multidatabase_id', $multidatabase_id)->orderBy('block_id', 'asc')->first();
 
             // この汎用データベースが配置されている最初のページオブジェクトを取得しておく
             // WYSIWYG で相対パスを絶対パスに変換する際に、ページの固定URL が必要になるため。
@@ -8924,7 +8924,7 @@ trait MigrationTrait
             // NC2 情報
             $multidatabase_ini .= "\n";
             $multidatabase_ini .= "[source_info]\n";
-            $multidatabase_ini .= "multidatabase_id = " . $nc2_multidatabase->multidatabase_id . "\n";
+            $multidatabase_ini .= "multidatabase_id = " . $multidatabase_id . "\n";
             $multidatabase_ini .= "room_id = " . $nc2_multidatabase->room_id . "\n";
             $multidatabase_ini .= "module_name = \"multidatabase\"\n";
             $multidatabase_ini .= "created_at      = \"" . $this->getCCDatetime($nc2_multidatabase->insert_time) . "\"\n";

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -8760,11 +8760,6 @@ trait MigrationTrait
             // multidatabase_block の取得
             // 1DB で複数ブロックがあるので、Join せずに、個別に読む
             $nc2_multidatabase_block = Nc2MultidatabaseBlock::where('multidatabase_id', $nc2_multidatabase->multidatabase_id)->orderBy('block_id', 'asc')->first();
-            if (empty($nc2_multidatabase_block)) {
-                $multidatabase_ini .= "view_count = 10\n";  // 初期値
-            } else {
-                $multidatabase_ini .= "view_count = " . $nc2_multidatabase_block->visible_item . "\n";
-            }
 
             // この汎用データベースが配置されている最初のページオブジェクトを取得しておく
             // WYSIWYG で相対パスを絶対パスに変換する際に、ページの固定URL が必要になるため。

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -8017,7 +8017,6 @@ trait MigrationTrait
             $journals_ini .= "[source_info]\n";
             $journals_ini .= "journal_id = " . $nc2_journal->journal_id . "\n";
             $journals_ini .= "room_id = " . $nc2_journal->room_id . "\n";
-            $journals_ini .= "space_type = " . $nc2_journal->space_type . "\n";   // スペースタイプ, 1:パブリックスペース, 2:グループスペース
             $journals_ini .= "module_name = \"journal\"\n";
             $journals_ini .= "created_at      = \"" . $this->getCCDatetime($nc2_journal->insert_time) . "\"\n";
             $journals_ini .= "created_name    = \"" . $nc2_journal->insert_user_name . "\"\n";
@@ -8342,7 +8341,6 @@ trait MigrationTrait
             $journals_ini .= "[source_info]\n";
             $journals_ini .= "journal_id = " . 'BBS_' . $nc2_bbs->bbs_id . "\n";
             $journals_ini .= "room_id = " . $nc2_bbs->room_id . "\n";
-            $journals_ini .= "space_type = " . $nc2_bbs->space_type . "\n";   // スペースタイプ, 1:パブリックスペース, 2:グループスペース
             $journals_ini .= "module_name = \"bbs\"\n";
             $journals_ini .= "created_at      = \"" . $this->getCCDatetime($nc2_bbs->insert_time) . "\"\n";
             $journals_ini .= "created_name    = \"" . $nc2_bbs->insert_user_name . "\"\n";

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -795,9 +795,7 @@ trait MigrationTrait
      */
     private function getNc2LoginIdFromNc2UserId($nc2_users, $nc2_user_id)
     {
-        $nc2_user = $nc2_users->firstWhere('user_id', $nc2_user_id);
-        $nc2_user = $nc2_user ?? new Nc2User();
-        return $nc2_user->login_id;
+        return Nc2User::getNc2LoginIdFromNc2UserId($nc2_users, $nc2_user_id);
     }
 
     /**

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -2594,6 +2594,10 @@ trait MigrationTrait
                     }
                     // 行データをタブで項目に分割
                     $database_tsv_cols = explode("\t", trim($database_tsv_line, "\n\r"));
+                    if (!isset($database_tsv_cols[1])) {
+                        // タブ区切りで１番目がセットされないのは、末尾空行と判断してスルーする。
+                        continue;
+                    }
 
                     $created_id   = $this->getUserIdFromLoginId($users, $database_tsv_cols[$tsv_idxs['insert_login_id']]);
                     $created_name = $database_tsv_cols[$tsv_idxs['created_name']];

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -8856,6 +8856,13 @@ trait MigrationTrait
                 } elseif ($multidatabase_metadata->type == 11) {
                     $column_type = "updated";
                 }
+                $select_flag = 0;
+                // (nc) 絞り込みは、select|checkboxで一覧表示の時に表示
+                if ($multidatabase_metadata->type == 4 || $multidatabase_metadata->type == 12) {
+                    if ($multidatabase_metadata->list_flag == 1) {
+                        $select_flag = 1;
+                    }
+                }
                 $metadata_id = $multidatabase_metadata->metadata_id;
                 $multidatabase_cols_rows[$metadata_id]["column_type"]      = $column_type;
                 $multidatabase_cols_rows[$metadata_id]["column_name"]      = $multidatabase_metadata->name;
@@ -8866,7 +8873,7 @@ trait MigrationTrait
                 $multidatabase_cols_rows[$metadata_id]["detail_hide_flag"] = ($multidatabase_metadata->detail_flag == 0) ? 1 : 0;
                 $multidatabase_cols_rows[$metadata_id]["sort_flag"]        = $multidatabase_metadata->sort_flag;
                 $multidatabase_cols_rows[$metadata_id]["search_flag"]      = $multidatabase_metadata->search_flag;
-                $multidatabase_cols_rows[$metadata_id]["select_flag"]      = ($multidatabase_metadata->type == 4 || $multidatabase_metadata->type == 12) ? 1 : 0;
+                $multidatabase_cols_rows[$metadata_id]["select_flag"]      = $select_flag;
                 $multidatabase_cols_rows[$metadata_id]["display_sequence"] = null;  // 後処理で連番セット
                 $multidatabase_cols_rows[$metadata_id]["row_group"]        = null;
                 $multidatabase_cols_rows[$metadata_id]["column_group"]     = null;

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -8863,7 +8863,6 @@ trait MigrationTrait
                 $multidatabase_cols_rows[$metadata_id]["sort_flag"]        = $multidatabase_metadata->sort_flag;
                 $multidatabase_cols_rows[$metadata_id]["search_flag"]      = $multidatabase_metadata->search_flag;
                 $multidatabase_cols_rows[$metadata_id]["select_flag"]      = ($multidatabase_metadata->type == 4 || $multidatabase_metadata->type == 12) ? 1 : 0;
-                $multidatabase_cols_rows[$metadata_id]["display_sequence"] = $multidatabase_metadata->display_sequence;
                 $multidatabase_cols_rows[$metadata_id]["row_group"]        = null;
                 $multidatabase_cols_rows[$metadata_id]["column_group"]     = null;
                 if ($multidatabase_metadata->display_pos == 1) {

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -611,987 +611,6 @@ trait MigrationTrait
     }
 
     /**
-     * NC2のリンク切れチェック
-     */
-    private function checkDeadLinkNc2($url, $nc2_module_name = null, $nc2_block = null)
-    {
-        // リンクチェックしない場合は返却
-        $check_deadlink_nc2 = $this->getMigrationConfig('basic', 'check_deadlink_nc2', '');
-        if (empty($check_deadlink_nc2)) {
-            return;
-        }
-
-        $scheme = parse_url($url, PHP_URL_SCHEME);
-
-        if (in_array($scheme, ['http', 'https'])) {
-
-            $nc2_base_url = $this->getMigrationConfig('basic', 'check_deadlink_nc2_base_url', '');
-            if (empty($nc2_base_url)) {
-                $this->putLinkCheck(3, 'check_deadlink_nc2_base_url未設定', 'migration_config.iniの [basic] check_deadlink_nc2_base_url を設定してください');
-            }
-
-            $domain = str_replace("https://", "", $nc2_base_url);
-            $domain = str_replace("http://", "", $domain);
-
-            // 先頭がNC2のベースURL
-            if (preg_match("/^http:\/\/{$domain}|^https:\/\/{$domain}/", $url)) {
-                // 内部リンク
-                $this->checkDeadLinkInsideNc2($url, $nc2_module_name, $nc2_block);
-            } else {
-                // 外部リンク
-                $this->checkDeadLinkOutside($url, $nc2_module_name, $nc2_block);
-            }
-
-        } elseif (is_null($scheme)) {
-            // "{{CORE_BASE_URL}}/images/comp/textarea/titleicon/icon-weather9.gif" 等はここで処理
-
-            // 内部リンク
-            $this->checkDeadLinkInsideNc2($url, $nc2_module_name, $nc2_block);
-        } else {
-            // 対象外
-            $this->putLinkCheck(3, $nc2_module_name . '|リンク切れチェック対象外', $url, $nc2_block);
-        }
-    }
-
-    /**
-     * 外部URLのリンク切れチェック
-     */
-    private function checkDeadLinkOutside($url, $nc2_module_name, $nc2_block): bool
-    {
-        // タイムアウト(秒)を変更
-        ini_set('default_socket_timeout', 3);
-
-        stream_context_set_default([
-            'ssl' => [
-                'verify_peer' => false,
-                'verify_peer_name' => false,
-            ],
-        ]);
-
-        // 独自でエラーをcatchする
-        set_error_handler(function ($severity, $message) {
-            throw new \Exception($message);
-        });
-
-        try {
-            $headers = get_headers($url, true);
-        } catch (\Exception $e) {
-            // NG
-            $this->putLinkCheck(3, $nc2_module_name . '|外部リンク|リンク切れ|' . $e->getMessage(), $url, $nc2_block);
-            return false;
-
-        } finally {
-            // エラーハンドリングを元に戻す
-            restore_error_handler();
-
-            // タイムアウト(秒)を元に戻す
-            ini_restore('default_socket_timeout');
-        }
-
-
-        $i = 0;
-        while (!isset($headers[$i])) {
-            if (stripos($headers[$i], "200") !== false) {
-                // OK
-                return true;
-            } elseif (stripos($headers[$i], "301") !== false) {
-                // 301リダイレクトのため、次要素の $header でチェック
-            } elseif (stripos($headers[$i], "302") !== false) {
-                // OK
-                return true;
-            } else {
-                // NG
-                $this->putLinkCheck(3, $nc2_module_name . '|外部リンク|リンク切れ|' . $headers[$i], $url, $nc2_block);
-                return false;
-            }
-            $i++;
-        }
-
-        // NG. 基本ここには到達しない想定
-        $this->putLinkCheck(3, $nc2_module_name . '|外部リンク|リンク切れ', $url, $nc2_block);
-        return false;
-    }
-
-    /**
-     * 内部URL(nc2)のリンク切れチェック
-     */
-    private function checkDeadLinkInsideNc2($url, $nc2_module_name = null, $nc2_block = null)
-    {
-
-        // >>> parse_url("http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42")
-        // => [
-        //      "scheme" => "http",
-        //      "host" => "localhost",
-        //      "port" => 8080,
-        //      "path" => "/index.php",
-        //      "query" => "action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2",
-        //      "fragment" => "_active_center_42",
-        //    ]
-        //
-        // >>> parse_url("http://localhost:8080/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/")
-        // => [
-        //      "scheme" => "http",
-        //      "host" => "localhost",
-        //      "port" => 8080,
-        //      "path" => "/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/",
-        //    ]
-
-        $nc2_base_url = $this->getMigrationConfig('basic', 'check_deadlink_nc2_base_url', '');
-
-        // &amp; => & 等のデコード
-        $check_url = htmlspecialchars_decode($url);
-        // {{CORE_BASE_URL}} 置換
-        $check_url = str_replace("{{CORE_BASE_URL}}", $nc2_base_url, $check_url);
-
-        $check_url_path = parse_url($check_url, PHP_URL_PATH);
-        $check_url_query = parse_url($check_url, PHP_URL_QUERY);
-
-        // トップページ
-        // ---------------------------------
-        // http://localhost:8080/
-        // http://localhost:8080
-        // /
-        // ./
-        // /index.php
-        // ./index.php
-        // http://localhost:8080/index.php
-        // ---------------------------------
-        // (pathがトップページに該当するもの＋queryなし)は、OK扱いにする
-        if (in_array($check_url_path, [null, '/', './', '/index.php', './index.php']) && is_null($check_url_query)) {
-            return;
-        }
-        // ---------------------------------
-        // http://localhost:8080/?lang=japanese
-        // http://localhost:8080/?lang=english
-        // http://localhost:8080/?lang=chinese
-        // ---------------------------------
-        // queryあり＋pathがトップページに該当するもの＋queryはlang１つだけ、はOK扱いにする
-        parse_str($check_url_query, $check_url_query_array);
-        if ($check_url_query_array) {
-            $lang = $this->getArrayValue($check_url_query_array, 'lang', null, null);
-            if (in_array($check_url_path, ['/', './', '/index.php', './index.php']) && count($check_url_query_array) === 1 && $lang) {
-                if (in_array($lang, ['japanese', 'english', 'chinese'])) {
-                    // OK
-                } else {
-                    // NG
-                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|lang値の間違い', $url, $nc2_block);
-                }
-                return;
-            }
-        }
-        // 以下 check_url_path は値が存在する
-
-        $check_url_array = explode('/', $check_url_path);
-        // array_filter()でarrayの空要素削除. array_values()で添え字振り直し
-        $check_url_array = array_values(array_filter($check_url_array));
-
-        // NC2固定URLチェック. 例）mu4bpil7b-1312  explodeで0要素は必ずある.
-        // ---------------------------------
-        // (掲示板) http://localhost:8080/bb7flt02n-57/#_57
-        // (汎用DB) http://localhost:8080/muwoibbvq-51/#_51
-        // (日誌)   http://localhost:8080/jojo6xnz5-34/#_34
-        // (日誌)   http://localhost:8080/index.php?key=jojo6xnz5-34#_34
-        // ---------------------------------
-        if (!isset($check_url_array[0])) {
-            return;
-        }
-        $short_url_array = explode('-', $check_url_array[0]);
-        $key = $this->getArrayValue($check_url_query_array, 'key', null, null);
-        $key_array = explode('-', $key);
-
-        $nc2_abbreviate_url = Nc2AbbreviateUrl::
-            where(function ($query) use ($short_url_array, $key_array) {
-                $query->where('short_url', $short_url_array[0])
-                    ->orWhere('short_url', $key_array[0]);
-            })->first();
-
-        if ($nc2_abbreviate_url) {
-            if ($nc2_abbreviate_url->dir_name == 'multidatabase') {
-                // 汎用DB
-
-                // [Abbreviateurl]
-                // block_sql = "SELECT {blocks}.block_id FROM {blocks},{multidatabase_block},{multidatabase_content},{abbreviate_url} WHERE {blocks}.block_id={multidatabase_block}.block_id AND {multidatabase_block}.multidatabase_id={multidatabase_content}.multidatabase_id AND {multidatabase_content}.multidatabase_id={abbreviate_url}.contents_id AND {multidatabase_content}.content_id={abbreviate_url}.unique_id"
-                $abbreviate_block = Nc2Block::join('multidatabase_block', 'multidatabase_block.block_id', '=', 'blocks.block_id')
-                    ->join('multidatabase_content', 'multidatabase_content.multidatabase_id', '=', 'multidatabase_block.multidatabase_id')
-                    ->join('abbreviate_url', function ($join) {
-                        $join->on('abbreviate_url.contents_id', '=', 'multidatabase_content.multidatabase_id')
-                            ->whereColumn('abbreviate_url.unique_id', 'multidatabase_content.content_id');
-                    })
-                    ->first();
-
-                // var_dump($abbreviate_block);
-                if (!$abbreviate_block) {
-                    // NG
-                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|DBデータなし', $url, $nc2_block);
-                }
-
-            } elseif ($nc2_abbreviate_url->dir_name == 'bbs') {
-                // 掲示板
-
-                // [Abbreviateurl]
-                // block_sql = "SELECT {blocks}.block_id FROM {blocks},{bbs_block},{bbs_post},{abbreviate_url} WHERE {blocks}.block_id={bbs_block}.block_id AND {bbs_block}.bbs_id={bbs_post}.bbs_id AND {bbs_post}.bbs_id={abbreviate_url}.contents_id AND {bbs_post}.post_id={abbreviate_url}.unique_id"
-                $abbreviate_block = Nc2Block::join('bbs_block', 'bbs_block.block_id', '=', 'blocks.block_id')
-                    ->join('bbs_post', 'bbs_post.bbs_id', '=', 'bbs_block.bbs_id')
-                    ->join('abbreviate_url', function ($join) {
-                        $join->on('abbreviate_url.contents_id', '=', 'bbs_post.bbs_id')
-                            ->whereColumn('abbreviate_url.unique_id', 'bbs_post.post_id');
-                    })
-                    ->first();
-
-                // var_dump($abbreviate_block);
-                if (!$abbreviate_block) {
-                    // NG
-                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|DBデータなし', $url, $nc2_block);
-                }
-
-            } elseif ($nc2_abbreviate_url->dir_name == 'journal') {
-                // 日誌
-
-                // [Abbreviateurl]
-                // block_sql = "SELECT {blocks}.block_id FROM {blocks},{journal_block},{journal_post},{abbreviate_url} WHERE {blocks}.block_id={journal_block}.block_id AND {journal_block}.journal_id={journal_post}.journal_id AND {journal_post}.journal_id={abbreviate_url}.contents_id AND {journal_post}.post_id={abbreviate_url}.unique_id"
-                $abbreviate_block = Nc2Block::join('journal_block', 'journal_block.block_id', '=', 'blocks.block_id')
-                    ->join('journal_post', 'journal_post.journal_id', '=', 'journal_block.journal_id')
-                    ->join('abbreviate_url', function ($join) {
-                        $join->on('abbreviate_url.contents_id', '=', 'journal_post.journal_id')
-                            ->whereColumn('abbreviate_url.unique_id', 'journal_post.post_id');
-                    })
-                    ->first();
-
-                // var_dump($abbreviate_block);
-                if (!$abbreviate_block) {
-                    // NG
-                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|DBデータなし', $url, $nc2_block);
-                }
-
-            } else {
-                $this->putError(3, '固定URLの未対応モジュール', "nc2_abbreviate_url->dir_name = " . $nc2_abbreviate_url->dir_name);
-            }
-            return;
-        }
-
-        // ページ＋mod_rewrite
-        // ---------------------------------
-        // http://localhost:8080/カウンター/
-        // http://localhost:8080/group/グループ１/
-        // http://localhost:8080/group/グループ１/サブグループ１/
-        // http://localhost:8080/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/
-        // ---------------------------------
-        $check_page_permalink = trim($check_url_path, '/');
-        if ($check_page_permalink) {
-            // 頭とお尻の/を取り除いたpath + 空以外 の permalink でページの存在チェック
-            $nc2_page = Nc2Page::where('permalink', trim($check_url_path, '/'))->where('permalink', '!=', '')->first();
-            if ($nc2_page) {
-                // ページデータあり. チェックOK
-                return;
-            }
-        }
-
-        // ページ（mod_rewriteなし. page_id指定）
-        // ---------------------------------
-        // http://localhost:8080/?page_id=16
-        // ---------------------------------
-        if ($check_url_query_array) {
-            // >>> parse_str("page_id=16", $result)
-            // >>> $result
-            // => [
-            //      "page_id" => "16",
-            //    ]
-            //
-            // >>> parse_str("action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2", $result)
-            // >>> $result
-            // => [
-            //      "action" => "pages_view_main",
-            //      "active_center" => "reservation_view_main_init",
-            //      "reserve_details_id" => "19",
-            //      "active_block_id" => "42",
-            //      "page_id" => "0",
-            //      "display_type" => "2",
-            //    ]
-            $page_id = $this->getArrayValue($check_url_query_array, 'page_id', null, null);
-            if ($page_id) {
-                $nc2_page = Nc2Page::where('page_id', $page_id)->first();
-                if ($nc2_page) {
-                    // ページデータあり. チェックOK
-                } else {
-                    // NG
-                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|ページデータなし', $url, $nc2_block);
-                }
-                return;
-            }
-        }
-
-        // ダウンロードURL（ファイル・画像）
-        // ---------------------------------
-        // (画像) ./?action=common_download_main&upload_id=10
-        // (添付) ./?action=common_download_main&upload_id=11
-        // ---------------------------------
-        if ($check_url_query_array) {
-            $action = $this->getArrayValue($check_url_query_array, 'action', null, null);
-            if ($action == 'common_download_main') {
-                $upload_id = $this->getArrayValue($check_url_query_array, 'upload_id', null, null);
-                if ($upload_id) {
-                    $nc2_upload = Nc2Upload::where('upload_id', $upload_id)->first();
-                    if ($nc2_upload) {
-                        // アップロードデータあり. チェックOK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|アップロードデータなし', $url, $nc2_block);
-                    }
-                } else {
-                    // NG
-                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|common_download_mainでアップロードIDなし', $url, $nc2_block);
-                }
-                return;
-            }
-        }
-
-        // ---------------------------------
-        // 新着表示の各リンク
-        // ---------------------------------
-        // (中央エリアに表示)
-        //   (action)active_center & active_block_id(任意)
-        //
-        //   (施設予約)       http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42
-        //   (カレンダー)     http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=5#_active_center_11
-        //   active_block_idなしでも表示できる
-        //   (施設予約)       http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=0&display_type=2#_active_center_42
-        //   (カレンダー)     http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&page_id=1&display_type=5#_active_center_11
-        //   (検索)          ./index.php?action=pages_view_main&active_center=search_view_main_center
-        //
-        //   (手動で active_center 入れてリンク作成)
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
-        // active_center でblock_id無でもトップページとして表示できる
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=#_69
-        // active_center で存在しないblock_idは「データの取得失敗」エラーで表示できない
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=699999#_69
-        // ---------------------------------
-        // (通常モジュール)
-        //   (action)active_action & block_id(必須)
-        //
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
-        //   (掲示板)        http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
-        //   (フォトアルバム) http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=1&block_id=68#photoalbum_album_68_1
-        //
-        //   (手動で block_id など修正してリンク作成)
-        // active_action でblock_id無は「キャビネット削除された可能性」エラーで表示できない
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=#_69
-        // active_action で存在しないblock_idは「キャビネット削除された可能性」エラーで表示できない
-        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=699999#_69
-        //
-        //   (pages_view_main 内での active_action処理の調査)
-        //   $blocks[$count]['full_path'] = BASE_URL.INDEX_FILE_NAME."?action=".$block['action_name']."&block_id=".$block['block_id']."&page_id=".$block['page_id'];    //絶対座標に変換
-        //   (掲示板ページ表示)       http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
-        //                           ↓
-        //   (掲示板ブロックだけ表示)  http://localhost:8080/index.php?action=bbs_view_main_post&post_id=9&block_id=56&page_id=33#_56
-        //   (掲示板ブロックだけ表示)  http://localhost:8080/index.php?action=bbs_view_main_post&post_id=9&block_id=56#_56    // page_idなくても表示できた
-        //
-        // ---------------------------------
-        // 検索結果の各リンク
-        // ---------------------------------
-        // (お知らせ)   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50&active_action=announcement_view_main_init#_72
-        // (掲示板)     http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=3&post_id=9#_56
-        // (カレンダー) http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&current_time=000000&display_type=5
-        // ---------------------------------
-        //
-        // NC2モジュール名| 新着 | 検索 | リンクチェック対象
-        // お知らせ         o      o     o
-        // アンケート       o      -     o
-        // Todo            o      o     o
-        // カレンダー       o      o     o
-        // 掲示板           o      o     o
-        // キャビネット     o      o     o
-        // レポート         o      o     o
-        // 小テスト         o      -     o
-        // 施設予約         o      o     o
-        // 日誌             o      o     o
-        // フォトアルバム    o      -     o
-        // 汎用データベース  o      o     o
-        // 回覧板           o      o     o
-        // FAQ              -      o     o
-        // 検索             -      -     o
-        // ---------------------------------
-
-        if ($check_url_query_array) {
-
-            $action = $this->getArrayValue($check_url_query_array, 'action', null, null);
-            if ($action == 'pages_view_main') {
-
-                // (通常モジュール)
-                //   (action)active_action & block_id(必須)         例：掲示板, お知らせ, キャビネット等
-                // (中央エリアに表示)
-                //   (action)active_center & active_block_id(任意)  例：カレンダー, 施設予約, 検索
-                $active_action = $this->getArrayValue($check_url_query_array, 'active_action', null, null);
-                $active_center = $this->getArrayValue($check_url_query_array, 'active_center', null, null);
-
-                if ($active_action) {
-                    // block存在チェック(必須)
-                    $block_id = $this->getArrayValue($check_url_query_array, 'block_id', null, null);
-                    $check_nc2_block = Nc2Block::where('block_id', $block_id)->first();
-                    if ($check_nc2_block) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|blockデータなし', $url, $nc2_block);
-                        return;
-                    }
-                }
-
-                if ($active_action || $active_center) {
-                    // page_id存在チェック(任意)
-                    $page_id = $this->getArrayValue($check_url_query_array, 'page_id', null, null);
-                    if ($page_id) {
-                        $check_nc2_page = Nc2Page::where('page_id', $page_id)->first();
-                        if ($check_nc2_page) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|pageデータなし', $url, $nc2_block);
-                            return;
-                        }
-                    }
-                }
-
-                // (通常モジュール) active_action
-                // --------------------------------
-                if ($active_action == 'bbs_view_main_post') {
-                    // (掲示板パラメータ)
-                    //   block_id 必須
-                    //   post_id  必須
-                    //   bbs_id   任意. あれば存在チェック
-                    //
-                    // (掲示板-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
-                    // block_idを存在しないIDにすると、「該当ページに配置してある掲示板が削除された可能性があります。」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56999999999999#_56
-                    // post_idを存在しないIDにすると、ページは開けて、掲示板の箇所が「入力値が不正です。不正にアクセスされた可能性があります。」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=99999999999999&block_id=56#_56
-                    //
-                    // (掲示板-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=3&post_id=9#_56
-                    // bbs_idなくても表示できた
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&post_id=9#_56
-                    // bbs_idを存在しないIDにすると、ページは開けて、掲示板の箇所が「入力値が不正です。不正にアクセスされた可能性があります。」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=39999999&post_id=9#_56
-                    //
-                    // (掲示板-active_center, 手動でリンク作成を想定)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_block_id=56&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
-                    // active_block_idを存在しないID, active_block_id設定なしにしても、詳細表示部分が空白なだけで、エラーにはならない。
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_block_id=56999999999&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
-
-                    // bbs_post存在チェック
-                    $post_id = $this->getArrayValue($check_url_query_array, 'post_id', null, null);
-                    $check_nc2_bbs_post = Nc2BbsPost::where('post_id', $post_id)->first();
-                    if ($check_nc2_bbs_post) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|bbs_postデータなし', $url, $nc2_block);
-                        return;
-                    }
-
-                    // bbs_id存在チェック(任意)
-                    $bbs_id = $this->getArrayValue($check_url_query_array, 'bbs_id', null, null);
-                    if ($bbs_id) {
-                        $check_nc2_bbs = Nc2Bbs::where('bbs_id', $bbs_id)->first();
-                        if ($check_nc2_bbs) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|bbsデータなし', $url, $nc2_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'announcement_view_main_init') {
-                    // (お知らせパラメータ)
-                    //   block_id 必須
-                    //   page_id  任意. あれば存在チェック
-                    //
-                    // (お知らせ-新着)
-                    // http://localhost:8080/index.php?action=pages_view_main&&block_id=72#_72
-                    //
-                    // (お知らせ-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50&active_action=announcement_view_main_init#_72
-                    // page_idなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&active_action=announcement_view_main_init#_72
-                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50999999&active_action=announcement_view_main_init#_72
-                    // block_idがない or 存在しないIDにすると、「該当ページに配置してある掲示板が削除された可能性があります。」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=50&active_action=announcement_view_main_init#_72
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=7299999&page_id=50&active_action=announcement_view_main_init#_72
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'journal_view_main_detail') {
-                    // (日誌パラメータ)
-                    //   block_id       必須
-                    //   post_id        必須
-                    //   comment_flag   任意. (チェック不要). 1:コメント入力あり 1以外:コメント入力なし
-                    //
-                    // (日誌-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&comment_flag=1&block_id=34#_34
-                    // post_idなし or 存在しないIDにすると「記事は存在しいません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&comment_flag=1&block_id=34#_34
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=49999&comment_flag=1&block_id=34#_34
-                    // comment_flagなし or 変な値でも記事表示できる＋コメント入力なし
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&block_id=34#_34
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&comment_flag=199999&block_id=34#_34
-                    //
-                    // (日誌-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=34&active_action=journal_view_main_detail&post_id=4#_34
-
-                    // journal_post存在チェック
-                    $post_id = $this->getArrayValue($check_url_query_array, 'post_id', null, null);
-                    $check_nc2_journal_post = Nc2JournalPost::where('post_id', $post_id)->first();
-                    if ($check_nc2_journal_post) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|journal_postデータなし', $url, $nc2_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'multidatabase_view_main_detail') {
-                    // (汎用DBパラメータ)
-                    //   block_id          必須
-                    //   multidatabase_id  必須
-                    //   content_id        必須
-                    //
-                    // (汎用DB-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=1&block_id=51#_51
-                    // multidatabase_idなし or IDが存在しないと「入力値が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&block_id=51#_51
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=19999&block_id=51#_51
-                    // content_idなし or IDが存在しないとコンテンツが存在しません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&multidatabase_id=1&block_id=51#_51
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=499999&multidatabase_id=1&block_id=51#_51
-                    //
-                    // (汎用DB-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=51&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=1&block_id=51#_51
-
-                    // multidatabase存在チェック
-                    $multidatabase_id = $this->getArrayValue($check_url_query_array, 'multidatabase_id', null, null);
-                    $check_nc2_multidatabase = Nc2Multidatabase::where('multidatabase_id', $multidatabase_id)->first();
-                    if ($check_nc2_multidatabase) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|multidatabaseデータなし', $url, $nc2_block);
-                        return;
-                    }
-
-                    // multidatabase_content存在チェック
-                    $content_id = $this->getArrayValue($check_url_query_array, 'content_id', null, null);
-                    $check_nc2_multidatabase_content = Nc2MultidatabaseContent::where('content_id', $content_id)->first();
-                    if ($check_nc2_multidatabase_content) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|multidatabase_contentデータなし', $url, $nc2_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'cabinet_view_main_init') {
-                    // (キャビネットパラメータ)
-                    //   block_id          必須
-                    //   cabinet_id        任意.
-                    //   folder_id         任意.
-                    //
-                    // (キャビネット-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&block_id=69#_69
-                    // cabinet_idなしは表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&folder_id=&block_id=69#_69
-                    // cabinet_idのIDが存在しないと「公開されているキャビネットはありません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2999999&folder_id=&block_id=69#_69
-                    // folder_idなしは表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&block_id=69#_69
-                    // folder_idのIDが存在しないと「権限が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=99999&block_id=69#_69
-                    //
-                    // (キャビネット-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=69&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=0#_69
-
-                    // cabinet_manage存在チェック(任意)
-                    $cabinet_id = $this->getArrayValue($check_url_query_array, 'cabinet_id', null, null);
-                    if ($cabinet_id) {
-                        $check_nc2_cabinet_manage = Nc2CabinetManage::where('cabinet_id', $cabinet_id)->first();
-                        if ($check_nc2_cabinet_manage) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|cabinet_manageデータなし', $url, $nc2_block);
-                            return;
-                        }
-                    }
-
-                    // folder_id(=file_id)のcabinet_file存在チェック(任意)
-                    $folder_id = $this->getArrayValue($check_url_query_array, 'folder_id', null, null);
-                    if ($folder_id) {
-                        $check_nc2_cabinet_file = Nc2CabinetFile::where('file_id', $folder_id)->first();
-                        if ($check_nc2_cabinet_file) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|cabinet_fileデータなし.folder_id=file_id', $url, $nc2_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'faq_view_main_init') {
-                    // (FAQパラメータ)
-                    //   block_id          必須
-                    //   question_id       任意.（チェック不要）
-                    //
-                    // (FAQ-検索-のみ)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init&question_id=4#_faq_answer_4
-                    // question_idなし or 存在しないIDでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init#_faq_answer_4
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init&question_id=4999#_faq_answer_4
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'photoalbum_view_main_init') {
-                    // (フォトアルバムパラメータ)
-                    //   block_id          必須
-                    //   album_id          任意.（チェック不要）
-                    //
-                    // (フォトアルバム-新着-のみ)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=1&block_id=68#photoalbum_album_68_1
-                    // album_idなし or 存在しないIDでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&block_id=68#photoalbum_album_68_1
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=19999999999999&block_id=68#photoalbum_album_68_1
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'assignment_view_main_whatsnew' || $active_action == 'assignment_view_main_init') {
-                    // (レポートパラメータ)
-                    //   block_id          必須
-                    //   (新着：assignment_view_main_whatsnew) assignment_id     必須
-                    //   (検索：assignment_view_main_init)     assignment_id     任意.
-                    //
-                    // (レポート-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&assignment_id=1&block_id=74#_74
-                    // assignment_idなし or 存在しないIDだと「入力値が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&block_id=74#_74
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&assignment_id=1999999&block_id=74#_74
-                    //
-                    // (レポート-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init&assignment_id=1#_74
-                    // assignment_idなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init#_74
-                    // assignment_idで存在しないIDだと「公開されている課題はありません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init&assignment_id=1999999#_74
-
-
-                    if ($active_action == 'assignment_view_main_whatsnew') {
-                        // (レポート-新着)
-                        // assignment存在チェック（必須）
-                        $assignment_id = $this->getArrayValue($check_url_query_array, 'assignment_id', null, null);
-                        $check_nc2_assignment = Nc2Assignment::where('assignment_id', $assignment_id)->first();
-                        if ($check_nc2_assignment) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|assignmentデータなし', $url, $nc2_block);
-                            return;
-                        }
-
-                    } elseif ($active_action == 'assignment_view_main_init') {
-                        // (レポート-検索)
-                        // assignment存在チェック（任意）
-                        $assignment_id = $this->getArrayValue($check_url_query_array, 'assignment_id', null, null);
-                        if ($assignment_id) {
-                            $check_nc2_assignment = Nc2Assignment::where('assignment_id', $assignment_id)->first();
-                            if ($check_nc2_assignment) {
-                                // OK
-                            } else {
-                                // NG
-                                $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|assignmentデータなし', $url, $nc2_block);
-                                return;
-                            }
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'questionnaire_view_main_whatsnew') {
-                    // (アンケートパラメータ)
-                    //   block_id          必須
-                    //   questionnaire_id  必須
-                    //
-                    // (アンケート-新着-のみ)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&questionnaire_id=1&block_id=75#_75
-                    // questionnaire_idなし or 存在しないIDだと「入力値が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&block_id=75#_75
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&questionnaire_id=19999999&block_id=75#_75
-
-                    // questionnaire存在チェック
-                    $questionnaire_id = $this->getArrayValue($check_url_query_array, 'questionnaire_id', null, null);
-                    $check_nc2_questionnaire = Nc2Questionnaire::where('questionnaire_id', $questionnaire_id)->first();
-                    if ($check_nc2_questionnaire) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|questionnaireデータなし', $url, $nc2_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'quiz_view_main_whatsnew') {
-                    // (小テストパラメータ)
-                    //   block_id          必須
-                    //   quiz_id           必須
-                    //
-                    // (小テスト-新着-のみ)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&quiz_id=1&block_id=77#_77
-                    // quiz_idなし or 存在しないIDだと「入力値が不正」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&block_id=77#_77
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&quiz_id=1999999&block_id=77#_77
-
-                    // quiz存在チェック
-                    $quiz_id = $this->getArrayValue($check_url_query_array, 'quiz_id', null, null);
-                    $check_nc2_quiz = Nc2Quiz::where('quiz_id', $quiz_id)->first();
-                    if ($check_nc2_quiz) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|quizデータなし', $url, $nc2_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'todo_view_main_init') {
-                    // (Todoパラメータ)
-                    //   block_id          必須
-                    //   todo_id           任意
-                    //   page_id           任意
-                    //
-                    // (Todo-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&todo_id=11&block_id=76#_76
-                    // todo_idなし だと表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&block_id=76#_76
-                    // todo_idが存在しないID だと「公開されているTodoリストはありません」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&todo_id=11999999&block_id=76#_76
-                    //
-                    // (Todo-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=76&page_id=55&active_action=todo_view_main_init#_76
-
-                    // todo存在チェック（任意）
-                    $todo_id = $this->getArrayValue($check_url_query_array, 'todo_id', null, null);
-                    if ($todo_id) {
-                        $check_nc2_todo = Nc2Todo::where('todo_id', $todo_id)->first();
-                        if ($check_nc2_todo) {
-                            // OK
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|todoデータなし', $url, $nc2_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_action == 'circular_view_main_detail') {
-                    // (回覧板パラメータ)
-                    //   block_id          必須
-                    //   circular_id       必須
-                    //   page_id           任意
-                    //   room_id           任意（チェック不要）
-                    //
-                    // (回覧板-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&circular_id=2&page_id=53&block_id=78#_78
-                    // circular_idなし or 存在しないID だと「既に削除されています」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&page_id=53&block_id=78#_78
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&circular_id=299999&page_id=53&block_id=78#_78
-                    //
-                    // (回覧板-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&room_id=1&circular_id=2#_78
-                    // room_idなし or 存在しないID でも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&circular_id=2#_78
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&room_id=19999&circular_id=2#_78
-
-                    // circular存在チェック
-                    $circular_id = $this->getArrayValue($check_url_query_array, 'circular_id', null, null);
-                    $check_nc2_circular = Nc2Circular::where('circular_id', $circular_id)->first();
-                    if ($check_nc2_circular) {
-                        // OK
-                    } else {
-                        // NG
-                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|circularデータなし', $url, $nc2_block);
-                        return;
-                    }
-
-                    // OK
-                    return;
-                }
-
-
-                // (中央エリアに表示) active_center
-                // --------------------------------
-                if ($active_center == 'search_view_main_center') {
-                    // （検索-初期インストール配置のヘッダー検索お知らせ）
-                    //   ./index.php?action=pages_view_main&active_center=search_view_main_center
-                    // （検索-active_action, 手動でリンク作成を想定
-                    //   → 対応しない
-                    //   block_idがないと、「該当ページに配置してある検索が削除された可能性があります。」エラー
-                    //   ./index.php?action=pages_view_main&active_action=search_view_main_center
-
-                    // OK
-                    return;
-
-                } elseif ($active_center == 'reservation_view_main_init') {
-                    // (施設予約-新着)
-                    //   active_block_id      任意. (チェック不要)
-                    //   page_id              任意. あれば存在チェック
-                    //   reserve_details_id   任意. (チェック不要)
-                    //   display_type         任意. あれば値チェック=1|2|3
-                    //   reserve_id           任意. (チェック不要)
-                    //
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init
-                    // active_block_idなしでも, 存在しないIDでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=0&display_type=2#_active_center_42
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=4299999999999999&page_id=0&display_type=2#_active_center_42
-                    // page_idなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&display_type=2#_active_center_42
-                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=9999999&display_type=2#_active_center_42
-                    // reserve_details_idなし or 存在しないIDでも表示できる. あれば該当日の一覧を表示
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=1999999999&active_block_id=42&page_id=0&display_type=2#_active_center_42
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&active_block_id=42&page_id=0&display_type=2#_active_center_42
-                    // display_typeなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0#_active_center_42
-                    // display_typeの「入力値が不正です」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=999#_active_center_42
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=4#_active_center_42
-                    //
-                    // >>> parse_str("action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2", $result)
-                    // >>> $result
-                    // => [
-                    //      "action" => "pages_view_main",
-                    //      "active_center" => "reservation_view_main_init",
-                    //      "reserve_details_id" => "19",
-                    //      "active_block_id" => "42",
-                    //      "page_id" => "0",
-                    //      "display_type" => "2",
-                    //    ]
-                    //
-                    // (施設予約-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=reservation_view_main_init&reserve_id=74
-                    // reserve_id が存在しないIDでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=reservation_view_main_init&reserve_id=74999999
-
-                    // display_typeの有効値チェック(任意)
-                    $display_type = $this->getArrayValue($check_url_query_array, 'display_type', null, null);
-                    if ($display_type) {
-                        if ((int)$display_type <= 3) {
-                            // OK 1|2|3, ※ イレギュラーだけど0,-1,-2...でも表示可
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|display_type対象外', $url, $nc2_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-
-                } elseif ($active_center == 'calendar_view_main_init') {
-                    // (カレンダー-新着)
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=5#_active_center_11
-                    // page_idなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&display_type=5#_active_center_11
-                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=19999999999&display_type=5#_active_center_11
-                    // display_typeなしでも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1#_active_center_11
-                    // display_type=0|-1|-2...は表示できちゃう
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=-1#_active_center_11
-                    // display_typeの「入力値が不正です」エラー
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=8#_active_center_11
-                    // plan_id なし or ID存在しなくても表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&active_block_id=11&page_id=1&display_type=5#_active_center_11
-                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42999&active_block_id=11&page_id=1&display_type=5#_active_center_11
-                    //
-                    // http://localhost:8080/index.php?
-                    //   - action=pages_view_main
-                    //   - active_center=calendar_view_main_init
-                    //   - plan_id=42           任意. (チェック不要)
-                    //   - active_block_id=11
-                    //   - page_id=1            上にチェック処理あり
-                    //   o display_type=5       任意. あれば値チェック=1～8
-                    //   - #_active_center_11
-                    //
-                    // (カレンダー-検索)
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&current_time=000000&display_type=5
-                    // date|current_time なし or 値が変な値でも表示できる
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&display_type=5
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=202108119999&current_time=0000009999&display_type=5
-                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&display_type=5
-                    //
-                    // http://localhost:8080/index.php?
-                    //   - date=20210811        任意. (チェック不要)
-                    //   - current_time=000000  任意. (チェック不要)
-                    //   o display_type=5       任意. あれば値チェック=1～8
-
-                    // display_typeの有効値チェック(任意)
-                    $display_type = $this->getArrayValue($check_url_query_array, 'display_type', null, null);
-                    if ($display_type) {
-                        if ((int)$display_type <= 8) {
-                            // OK ※イレギュラーだけど0,-1,-2...でも表示可
-                        } else {
-                            // NG
-                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|display_type対象外', $url, $nc2_block);
-                            return;
-                        }
-                    }
-
-                    // OK
-                    return;
-                }
-
-            }
-        }
-
-        // 外部リンク
-        // 内部リンクの直ファイル指定の存在チェック。例）http://localhost:8080/htdocs/install/logo.gif
-        // if ($this->checkDeadLinkOutside($check_url, $nc2_module_name, $nc2_block)) {
-        //     // 外部OK=移行対象外 (link_checkログには吐かない)
-        //     $this->putMonitor(3, $nc2_module_name . '|内部リンク＋外部リンクチェックOK|移行対象外URL', $url, $nc2_block);
-        // } else {
-        //     // 外部NG
-        //     $header = get_headers($check_url, true);
-        //     $this->putLinkCheck(3, $nc2_module_name . '|内部リンク＋外部リンクチェックNG|未対応URL|' . $header[0], $url, $nc2_block);
-        // }
-
-        // 移行対象外 (link_checkログには吐かない)
-        $this->putMonitor(3, $nc2_module_name . '|内部リンク|移行対象外URL', $url, $nc2_block);
-    }
-
-    /**
      * 配列の値の取得
      */
     private function getArrayValue($array, $key1, $key2 = null, $default = "")
@@ -12909,5 +11928,986 @@ trait MigrationTrait
             return null;
         }
         return  date('Y-m-d H:i:s', $time + (60 * 60 * 9));
+    }
+
+    /**
+     * NC2のリンク切れチェック
+     */
+    private function checkDeadLinkNc2($url, $nc2_module_name = null, $nc2_block = null)
+    {
+        // リンクチェックしない場合は返却
+        $check_deadlink_nc2 = $this->getMigrationConfig('basic', 'check_deadlink_nc2', '');
+        if (empty($check_deadlink_nc2)) {
+            return;
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        if (in_array($scheme, ['http', 'https'])) {
+
+            $nc2_base_url = $this->getMigrationConfig('basic', 'check_deadlink_nc2_base_url', '');
+            if (empty($nc2_base_url)) {
+                $this->putLinkCheck(3, 'check_deadlink_nc2_base_url未設定', 'migration_config.iniの [basic] check_deadlink_nc2_base_url を設定してください');
+            }
+
+            $domain = str_replace("https://", "", $nc2_base_url);
+            $domain = str_replace("http://", "", $domain);
+
+            // 先頭がNC2のベースURL
+            if (preg_match("/^http:\/\/{$domain}|^https:\/\/{$domain}/", $url)) {
+                // 内部リンク
+                $this->checkDeadLinkInsideNc2($url, $nc2_module_name, $nc2_block);
+            } else {
+                // 外部リンク
+                $this->checkDeadLinkOutside($url, $nc2_module_name, $nc2_block);
+            }
+
+        } elseif (is_null($scheme)) {
+            // "{{CORE_BASE_URL}}/images/comp/textarea/titleicon/icon-weather9.gif" 等はここで処理
+
+            // 内部リンク
+            $this->checkDeadLinkInsideNc2($url, $nc2_module_name, $nc2_block);
+        } else {
+            // 対象外
+            $this->putLinkCheck(3, $nc2_module_name . '|リンク切れチェック対象外', $url, $nc2_block);
+        }
+    }
+
+    /**
+     * 外部URLのリンク切れチェック
+     */
+    private function checkDeadLinkOutside($url, $nc2_module_name, $nc2_block): bool
+    {
+        // タイムアウト(秒)を変更
+        ini_set('default_socket_timeout', 3);
+
+        stream_context_set_default([
+            'ssl' => [
+                'verify_peer' => false,
+                'verify_peer_name' => false,
+            ],
+        ]);
+
+        // 独自でエラーをcatchする
+        set_error_handler(function ($severity, $message) {
+            throw new \Exception($message);
+        });
+
+        try {
+            $headers = get_headers($url, true);
+        } catch (\Exception $e) {
+            // NG
+            $this->putLinkCheck(3, $nc2_module_name . '|外部リンク|リンク切れ|' . $e->getMessage(), $url, $nc2_block);
+            return false;
+
+        } finally {
+            // エラーハンドリングを元に戻す
+            restore_error_handler();
+
+            // タイムアウト(秒)を元に戻す
+            ini_restore('default_socket_timeout');
+        }
+
+
+        $i = 0;
+        while (!isset($headers[$i])) {
+            if (stripos($headers[$i], "200") !== false) {
+                // OK
+                return true;
+            } elseif (stripos($headers[$i], "301") !== false) {
+                // 301リダイレクトのため、次要素の $header でチェック
+            } elseif (stripos($headers[$i], "302") !== false) {
+                // OK
+                return true;
+            } else {
+                // NG
+                $this->putLinkCheck(3, $nc2_module_name . '|外部リンク|リンク切れ|' . $headers[$i], $url, $nc2_block);
+                return false;
+            }
+            $i++;
+        }
+
+        // NG. 基本ここには到達しない想定
+        $this->putLinkCheck(3, $nc2_module_name . '|外部リンク|リンク切れ', $url, $nc2_block);
+        return false;
+    }
+
+    /**
+     * 内部URL(nc2)のリンク切れチェック
+     */
+    private function checkDeadLinkInsideNc2($url, $nc2_module_name = null, $nc2_block = null)
+    {
+
+        // >>> parse_url("http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42")
+        // => [
+        //      "scheme" => "http",
+        //      "host" => "localhost",
+        //      "port" => 8080,
+        //      "path" => "/index.php",
+        //      "query" => "action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2",
+        //      "fragment" => "_active_center_42",
+        //    ]
+        //
+        // >>> parse_url("http://localhost:8080/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/")
+        // => [
+        //      "scheme" => "http",
+        //      "host" => "localhost",
+        //      "port" => 8080,
+        //      "path" => "/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/",
+        //    ]
+
+        $nc2_base_url = $this->getMigrationConfig('basic', 'check_deadlink_nc2_base_url', '');
+
+        // &amp; => & 等のデコード
+        $check_url = htmlspecialchars_decode($url);
+        // {{CORE_BASE_URL}} 置換
+        $check_url = str_replace("{{CORE_BASE_URL}}", $nc2_base_url, $check_url);
+
+        $check_url_path = parse_url($check_url, PHP_URL_PATH);
+        $check_url_query = parse_url($check_url, PHP_URL_QUERY);
+
+        // トップページ
+        // ---------------------------------
+        // http://localhost:8080/
+        // http://localhost:8080
+        // /
+        // ./
+        // /index.php
+        // ./index.php
+        // http://localhost:8080/index.php
+        // ---------------------------------
+        // (pathがトップページに該当するもの＋queryなし)は、OK扱いにする
+        if (in_array($check_url_path, [null, '/', './', '/index.php', './index.php']) && is_null($check_url_query)) {
+            return;
+        }
+        // ---------------------------------
+        // http://localhost:8080/?lang=japanese
+        // http://localhost:8080/?lang=english
+        // http://localhost:8080/?lang=chinese
+        // ---------------------------------
+        // queryあり＋pathがトップページに該当するもの＋queryはlang１つだけ、はOK扱いにする
+        parse_str($check_url_query, $check_url_query_array);
+        if ($check_url_query_array) {
+            $lang = $this->getArrayValue($check_url_query_array, 'lang', null, null);
+            if (in_array($check_url_path, ['/', './', '/index.php', './index.php']) && count($check_url_query_array) === 1 && $lang) {
+                if (in_array($lang, ['japanese', 'english', 'chinese'])) {
+                    // OK
+                } else {
+                    // NG
+                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|lang値の間違い', $url, $nc2_block);
+                }
+                return;
+            }
+        }
+        // 以下 check_url_path は値が存在する
+
+        $check_url_array = explode('/', $check_url_path);
+        // array_filter()でarrayの空要素削除. array_values()で添え字振り直し
+        $check_url_array = array_values(array_filter($check_url_array));
+
+        // NC2固定URLチェック. 例）mu4bpil7b-1312  explodeで0要素は必ずある.
+        // ---------------------------------
+        // (掲示板) http://localhost:8080/bb7flt02n-57/#_57
+        // (汎用DB) http://localhost:8080/muwoibbvq-51/#_51
+        // (日誌)   http://localhost:8080/jojo6xnz5-34/#_34
+        // (日誌)   http://localhost:8080/index.php?key=jojo6xnz5-34#_34
+        // ---------------------------------
+        if (!isset($check_url_array[0])) {
+            return;
+        }
+        $short_url_array = explode('-', $check_url_array[0]);
+        $key = $this->getArrayValue($check_url_query_array, 'key', null, null);
+        $key_array = explode('-', $key);
+
+        $nc2_abbreviate_url = Nc2AbbreviateUrl::
+            where(function ($query) use ($short_url_array, $key_array) {
+                $query->where('short_url', $short_url_array[0])
+                    ->orWhere('short_url', $key_array[0]);
+            })->first();
+
+        if ($nc2_abbreviate_url) {
+            if ($nc2_abbreviate_url->dir_name == 'multidatabase') {
+                // 汎用DB
+
+                // [Abbreviateurl]
+                // block_sql = "SELECT {blocks}.block_id FROM {blocks},{multidatabase_block},{multidatabase_content},{abbreviate_url} WHERE {blocks}.block_id={multidatabase_block}.block_id AND {multidatabase_block}.multidatabase_id={multidatabase_content}.multidatabase_id AND {multidatabase_content}.multidatabase_id={abbreviate_url}.contents_id AND {multidatabase_content}.content_id={abbreviate_url}.unique_id"
+                $abbreviate_block = Nc2Block::join('multidatabase_block', 'multidatabase_block.block_id', '=', 'blocks.block_id')
+                    ->join('multidatabase_content', 'multidatabase_content.multidatabase_id', '=', 'multidatabase_block.multidatabase_id')
+                    ->join('abbreviate_url', function ($join) {
+                        $join->on('abbreviate_url.contents_id', '=', 'multidatabase_content.multidatabase_id')
+                            ->whereColumn('abbreviate_url.unique_id', 'multidatabase_content.content_id');
+                    })
+                    ->first();
+
+                // var_dump($abbreviate_block);
+                if (!$abbreviate_block) {
+                    // NG
+                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|DBデータなし', $url, $nc2_block);
+                }
+
+            } elseif ($nc2_abbreviate_url->dir_name == 'bbs') {
+                // 掲示板
+
+                // [Abbreviateurl]
+                // block_sql = "SELECT {blocks}.block_id FROM {blocks},{bbs_block},{bbs_post},{abbreviate_url} WHERE {blocks}.block_id={bbs_block}.block_id AND {bbs_block}.bbs_id={bbs_post}.bbs_id AND {bbs_post}.bbs_id={abbreviate_url}.contents_id AND {bbs_post}.post_id={abbreviate_url}.unique_id"
+                $abbreviate_block = Nc2Block::join('bbs_block', 'bbs_block.block_id', '=', 'blocks.block_id')
+                    ->join('bbs_post', 'bbs_post.bbs_id', '=', 'bbs_block.bbs_id')
+                    ->join('abbreviate_url', function ($join) {
+                        $join->on('abbreviate_url.contents_id', '=', 'bbs_post.bbs_id')
+                            ->whereColumn('abbreviate_url.unique_id', 'bbs_post.post_id');
+                    })
+                    ->first();
+
+                // var_dump($abbreviate_block);
+                if (!$abbreviate_block) {
+                    // NG
+                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|DBデータなし', $url, $nc2_block);
+                }
+
+            } elseif ($nc2_abbreviate_url->dir_name == 'journal') {
+                // 日誌
+
+                // [Abbreviateurl]
+                // block_sql = "SELECT {blocks}.block_id FROM {blocks},{journal_block},{journal_post},{abbreviate_url} WHERE {blocks}.block_id={journal_block}.block_id AND {journal_block}.journal_id={journal_post}.journal_id AND {journal_post}.journal_id={abbreviate_url}.contents_id AND {journal_post}.post_id={abbreviate_url}.unique_id"
+                $abbreviate_block = Nc2Block::join('journal_block', 'journal_block.block_id', '=', 'blocks.block_id')
+                    ->join('journal_post', 'journal_post.journal_id', '=', 'journal_block.journal_id')
+                    ->join('abbreviate_url', function ($join) {
+                        $join->on('abbreviate_url.contents_id', '=', 'journal_post.journal_id')
+                            ->whereColumn('abbreviate_url.unique_id', 'journal_post.post_id');
+                    })
+                    ->first();
+
+                // var_dump($abbreviate_block);
+                if (!$abbreviate_block) {
+                    // NG
+                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|DBデータなし', $url, $nc2_block);
+                }
+
+            } else {
+                $this->putError(3, '固定URLの未対応モジュール', "nc2_abbreviate_url->dir_name = " . $nc2_abbreviate_url->dir_name);
+            }
+            return;
+        }
+
+        // ページ＋mod_rewrite
+        // ---------------------------------
+        // http://localhost:8080/カウンター/
+        // http://localhost:8080/group/グループ１/
+        // http://localhost:8080/group/グループ１/サブグループ１/
+        // http://localhost:8080/新規カテゴリ2/新規カテゴリ2-1/新規カテゴリ2-1-1/
+        // ---------------------------------
+        $check_page_permalink = trim($check_url_path, '/');
+        if ($check_page_permalink) {
+            // 頭とお尻の/を取り除いたpath + 空以外 の permalink でページの存在チェック
+            $nc2_page = Nc2Page::where('permalink', trim($check_url_path, '/'))->where('permalink', '!=', '')->first();
+            if ($nc2_page) {
+                // ページデータあり. チェックOK
+                return;
+            }
+        }
+
+        // ページ（mod_rewriteなし. page_id指定）
+        // ---------------------------------
+        // http://localhost:8080/?page_id=16
+        // ---------------------------------
+        if ($check_url_query_array) {
+            // >>> parse_str("page_id=16", $result)
+            // >>> $result
+            // => [
+            //      "page_id" => "16",
+            //    ]
+            //
+            // >>> parse_str("action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2", $result)
+            // >>> $result
+            // => [
+            //      "action" => "pages_view_main",
+            //      "active_center" => "reservation_view_main_init",
+            //      "reserve_details_id" => "19",
+            //      "active_block_id" => "42",
+            //      "page_id" => "0",
+            //      "display_type" => "2",
+            //    ]
+            $page_id = $this->getArrayValue($check_url_query_array, 'page_id', null, null);
+            if ($page_id) {
+                $nc2_page = Nc2Page::where('page_id', $page_id)->first();
+                if ($nc2_page) {
+                    // ページデータあり. チェックOK
+                } else {
+                    // NG
+                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|ページデータなし', $url, $nc2_block);
+                }
+                return;
+            }
+        }
+
+        // ダウンロードURL（ファイル・画像）
+        // ---------------------------------
+        // (画像) ./?action=common_download_main&upload_id=10
+        // (添付) ./?action=common_download_main&upload_id=11
+        // ---------------------------------
+        if ($check_url_query_array) {
+            $action = $this->getArrayValue($check_url_query_array, 'action', null, null);
+            if ($action == 'common_download_main') {
+                $upload_id = $this->getArrayValue($check_url_query_array, 'upload_id', null, null);
+                if ($upload_id) {
+                    $nc2_upload = Nc2Upload::where('upload_id', $upload_id)->first();
+                    if ($nc2_upload) {
+                        // アップロードデータあり. チェックOK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|アップロードデータなし', $url, $nc2_block);
+                    }
+                } else {
+                    // NG
+                    $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|common_download_mainでアップロードIDなし', $url, $nc2_block);
+                }
+                return;
+            }
+        }
+
+        // ---------------------------------
+        // 新着表示の各リンク
+        // ---------------------------------
+        // (中央エリアに表示)
+        //   (action)active_center & active_block_id(任意)
+        //
+        //   (施設予約)       http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42
+        //   (カレンダー)     http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=5#_active_center_11
+        //   active_block_idなしでも表示できる
+        //   (施設予約)       http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=0&display_type=2#_active_center_42
+        //   (カレンダー)     http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&page_id=1&display_type=5#_active_center_11
+        //   (検索)          ./index.php?action=pages_view_main&active_center=search_view_main_center
+        //
+        //   (手動で active_center 入れてリンク作成)
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
+        // active_center でblock_id無でもトップページとして表示できる
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=#_69
+        // active_center で存在しないblock_idは「データの取得失敗」エラーで表示できない
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_center=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=699999#_69
+        // ---------------------------------
+        // (通常モジュール)
+        //   (action)active_action & block_id(必須)
+        //
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
+        //   (掲示板)        http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
+        //   (フォトアルバム) http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=1&block_id=68#photoalbum_album_68_1
+        //
+        //   (手動で block_id など修正してリンク作成)
+        // active_action でblock_id無は「キャビネット削除された可能性」エラーで表示できない
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=#_69
+        // active_action で存在しないblock_idは「キャビネット削除された可能性」エラーで表示できない
+        //   (キャビネット)   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=699999#_69
+        //
+        //   (pages_view_main 内での active_action処理の調査)
+        //   $blocks[$count]['full_path'] = BASE_URL.INDEX_FILE_NAME."?action=".$block['action_name']."&block_id=".$block['block_id']."&page_id=".$block['page_id'];    //絶対座標に変換
+        //   (掲示板ページ表示)       http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
+        //                           ↓
+        //   (掲示板ブロックだけ表示)  http://localhost:8080/index.php?action=bbs_view_main_post&post_id=9&block_id=56&page_id=33#_56
+        //   (掲示板ブロックだけ表示)  http://localhost:8080/index.php?action=bbs_view_main_post&post_id=9&block_id=56#_56    // page_idなくても表示できた
+        //
+        // ---------------------------------
+        // 検索結果の各リンク
+        // ---------------------------------
+        // (お知らせ)   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50&active_action=announcement_view_main_init#_72
+        // (掲示板)     http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=3&post_id=9#_56
+        // (カレンダー) http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&current_time=000000&display_type=5
+        // ---------------------------------
+        //
+        // NC2モジュール名| 新着 | 検索 | リンクチェック対象
+        // お知らせ         o      o     o
+        // アンケート       o      -     o
+        // Todo            o      o     o
+        // カレンダー       o      o     o
+        // 掲示板           o      o     o
+        // キャビネット     o      o     o
+        // レポート         o      o     o
+        // 小テスト         o      -     o
+        // 施設予約         o      o     o
+        // 日誌             o      o     o
+        // フォトアルバム    o      -     o
+        // 汎用データベース  o      o     o
+        // 回覧板           o      o     o
+        // FAQ              -      o     o
+        // 検索             -      -     o
+        // ---------------------------------
+
+        if ($check_url_query_array) {
+
+            $action = $this->getArrayValue($check_url_query_array, 'action', null, null);
+            if ($action == 'pages_view_main') {
+
+                // (通常モジュール)
+                //   (action)active_action & block_id(必須)         例：掲示板, お知らせ, キャビネット等
+                // (中央エリアに表示)
+                //   (action)active_center & active_block_id(任意)  例：カレンダー, 施設予約, 検索
+                $active_action = $this->getArrayValue($check_url_query_array, 'active_action', null, null);
+                $active_center = $this->getArrayValue($check_url_query_array, 'active_center', null, null);
+
+                if ($active_action) {
+                    // block存在チェック(必須)
+                    $block_id = $this->getArrayValue($check_url_query_array, 'block_id', null, null);
+                    $check_nc2_block = Nc2Block::where('block_id', $block_id)->first();
+                    if ($check_nc2_block) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|blockデータなし', $url, $nc2_block);
+                        return;
+                    }
+                }
+
+                if ($active_action || $active_center) {
+                    // page_id存在チェック(任意)
+                    $page_id = $this->getArrayValue($check_url_query_array, 'page_id', null, null);
+                    if ($page_id) {
+                        $check_nc2_page = Nc2Page::where('page_id', $page_id)->first();
+                        if ($check_nc2_page) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|pageデータなし', $url, $nc2_block);
+                            return;
+                        }
+                    }
+                }
+
+                // (通常モジュール) active_action
+                // --------------------------------
+                if ($active_action == 'bbs_view_main_post') {
+                    // (掲示板パラメータ)
+                    //   block_id 必須
+                    //   post_id  必須
+                    //   bbs_id   任意. あれば存在チェック
+                    //
+                    // (掲示板-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56#_56
+                    // block_idを存在しないIDにすると、「該当ページに配置してある掲示板が削除された可能性があります。」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=9&block_id=56999999999999#_56
+                    // post_idを存在しないIDにすると、ページは開けて、掲示板の箇所が「入力値が不正です。不正にアクセスされた可能性があります。」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=bbs_view_main_post&post_id=99999999999999&block_id=56#_56
+                    //
+                    // (掲示板-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=3&post_id=9#_56
+                    // bbs_idなくても表示できた
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&post_id=9#_56
+                    // bbs_idを存在しないIDにすると、ページは開けて、掲示板の箇所が「入力値が不正です。不正にアクセスされた可能性があります。」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=56&active_action=bbs_view_main_post&bbs_id=39999999&post_id=9#_56
+                    //
+                    // (掲示板-active_center, 手動でリンク作成を想定)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_block_id=56&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
+                    // active_block_idを存在しないID, active_block_id設定なしにしても、詳細表示部分が空白なだけで、エラーにはならない。
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_block_id=56999999999&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=bbs_view_main_post&bbs_id=3&post_id=9#_56
+
+                    // bbs_post存在チェック
+                    $post_id = $this->getArrayValue($check_url_query_array, 'post_id', null, null);
+                    $check_nc2_bbs_post = Nc2BbsPost::where('post_id', $post_id)->first();
+                    if ($check_nc2_bbs_post) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|bbs_postデータなし', $url, $nc2_block);
+                        return;
+                    }
+
+                    // bbs_id存在チェック(任意)
+                    $bbs_id = $this->getArrayValue($check_url_query_array, 'bbs_id', null, null);
+                    if ($bbs_id) {
+                        $check_nc2_bbs = Nc2Bbs::where('bbs_id', $bbs_id)->first();
+                        if ($check_nc2_bbs) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|bbsデータなし', $url, $nc2_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'announcement_view_main_init') {
+                    // (お知らせパラメータ)
+                    //   block_id 必須
+                    //   page_id  任意. あれば存在チェック
+                    //
+                    // (お知らせ-新着)
+                    // http://localhost:8080/index.php?action=pages_view_main&&block_id=72#_72
+                    //
+                    // (お知らせ-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50&active_action=announcement_view_main_init#_72
+                    // page_idなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&active_action=announcement_view_main_init#_72
+                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=72&page_id=50999999&active_action=announcement_view_main_init#_72
+                    // block_idがない or 存在しないIDにすると、「該当ページに配置してある掲示板が削除された可能性があります。」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=50&active_action=announcement_view_main_init#_72
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=7299999&page_id=50&active_action=announcement_view_main_init#_72
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'journal_view_main_detail') {
+                    // (日誌パラメータ)
+                    //   block_id       必須
+                    //   post_id        必須
+                    //   comment_flag   任意. (チェック不要). 1:コメント入力あり 1以外:コメント入力なし
+                    //
+                    // (日誌-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&comment_flag=1&block_id=34#_34
+                    // post_idなし or 存在しないIDにすると「記事は存在しいません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&comment_flag=1&block_id=34#_34
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=49999&comment_flag=1&block_id=34#_34
+                    // comment_flagなし or 変な値でも記事表示できる＋コメント入力なし
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&block_id=34#_34
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=journal_view_main_detail&post_id=4&comment_flag=199999&block_id=34#_34
+                    //
+                    // (日誌-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=34&active_action=journal_view_main_detail&post_id=4#_34
+
+                    // journal_post存在チェック
+                    $post_id = $this->getArrayValue($check_url_query_array, 'post_id', null, null);
+                    $check_nc2_journal_post = Nc2JournalPost::where('post_id', $post_id)->first();
+                    if ($check_nc2_journal_post) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|journal_postデータなし', $url, $nc2_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'multidatabase_view_main_detail') {
+                    // (汎用DBパラメータ)
+                    //   block_id          必須
+                    //   multidatabase_id  必須
+                    //   content_id        必須
+                    //
+                    // (汎用DB-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=1&block_id=51#_51
+                    // multidatabase_idなし or IDが存在しないと「入力値が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&block_id=51#_51
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=19999&block_id=51#_51
+                    // content_idなし or IDが存在しないとコンテンツが存在しません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&multidatabase_id=1&block_id=51#_51
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=multidatabase_view_main_detail&content_id=499999&multidatabase_id=1&block_id=51#_51
+                    //
+                    // (汎用DB-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=51&active_action=multidatabase_view_main_detail&content_id=4&multidatabase_id=1&block_id=51#_51
+
+                    // multidatabase存在チェック
+                    $multidatabase_id = $this->getArrayValue($check_url_query_array, 'multidatabase_id', null, null);
+                    $check_nc2_multidatabase = Nc2Multidatabase::where('multidatabase_id', $multidatabase_id)->first();
+                    if ($check_nc2_multidatabase) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|multidatabaseデータなし', $url, $nc2_block);
+                        return;
+                    }
+
+                    // multidatabase_content存在チェック
+                    $content_id = $this->getArrayValue($check_url_query_array, 'content_id', null, null);
+                    $check_nc2_multidatabase_content = Nc2MultidatabaseContent::where('content_id', $content_id)->first();
+                    if ($check_nc2_multidatabase_content) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|multidatabase_contentデータなし', $url, $nc2_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'cabinet_view_main_init') {
+                    // (キャビネットパラメータ)
+                    //   block_id          必須
+                    //   cabinet_id        任意.
+                    //   folder_id         任意.
+                    //
+                    // (キャビネット-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=&block_id=69#_69
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&block_id=69#_69
+                    // cabinet_idなしは表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&folder_id=&block_id=69#_69
+                    // cabinet_idのIDが存在しないと「公開されているキャビネットはありません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2999999&folder_id=&block_id=69#_69
+                    // folder_idなしは表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&block_id=69#_69
+                    // folder_idのIDが存在しないと「権限が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=99999&block_id=69#_69
+                    //
+                    // (キャビネット-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=69&active_action=cabinet_view_main_init&cabinet_id=2&folder_id=0#_69
+
+                    // cabinet_manage存在チェック(任意)
+                    $cabinet_id = $this->getArrayValue($check_url_query_array, 'cabinet_id', null, null);
+                    if ($cabinet_id) {
+                        $check_nc2_cabinet_manage = Nc2CabinetManage::where('cabinet_id', $cabinet_id)->first();
+                        if ($check_nc2_cabinet_manage) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|cabinet_manageデータなし', $url, $nc2_block);
+                            return;
+                        }
+                    }
+
+                    // folder_id(=file_id)のcabinet_file存在チェック(任意)
+                    $folder_id = $this->getArrayValue($check_url_query_array, 'folder_id', null, null);
+                    if ($folder_id) {
+                        $check_nc2_cabinet_file = Nc2CabinetFile::where('file_id', $folder_id)->first();
+                        if ($check_nc2_cabinet_file) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|cabinet_fileデータなし.folder_id=file_id', $url, $nc2_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'faq_view_main_init') {
+                    // (FAQパラメータ)
+                    //   block_id          必須
+                    //   question_id       任意.（チェック不要）
+                    //
+                    // (FAQ-検索-のみ)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init&question_id=4#_faq_answer_4
+                    // question_idなし or 存在しないIDでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init#_faq_answer_4
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=35&active_action=faq_view_main_init&question_id=4999#_faq_answer_4
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'photoalbum_view_main_init') {
+                    // (フォトアルバムパラメータ)
+                    //   block_id          必須
+                    //   album_id          任意.（チェック不要）
+                    //
+                    // (フォトアルバム-新着-のみ)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=1&block_id=68#photoalbum_album_68_1
+                    // album_idなし or 存在しないIDでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&block_id=68#photoalbum_album_68_1
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=photoalbum_view_main_init&album_id=19999999999999&block_id=68#photoalbum_album_68_1
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'assignment_view_main_whatsnew' || $active_action == 'assignment_view_main_init') {
+                    // (レポートパラメータ)
+                    //   block_id          必須
+                    //   (新着：assignment_view_main_whatsnew) assignment_id     必須
+                    //   (検索：assignment_view_main_init)     assignment_id     任意.
+                    //
+                    // (レポート-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&assignment_id=1&block_id=74#_74
+                    // assignment_idなし or 存在しないIDだと「入力値が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&block_id=74#_74
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=assignment_view_main_whatsnew&assignment_id=1999999&block_id=74#_74
+                    //
+                    // (レポート-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init&assignment_id=1#_74
+                    // assignment_idなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init#_74
+                    // assignment_idで存在しないIDだと「公開されている課題はありません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=74&active_action=assignment_view_main_init&assignment_id=1999999#_74
+
+
+                    if ($active_action == 'assignment_view_main_whatsnew') {
+                        // (レポート-新着)
+                        // assignment存在チェック（必須）
+                        $assignment_id = $this->getArrayValue($check_url_query_array, 'assignment_id', null, null);
+                        $check_nc2_assignment = Nc2Assignment::where('assignment_id', $assignment_id)->first();
+                        if ($check_nc2_assignment) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|assignmentデータなし', $url, $nc2_block);
+                            return;
+                        }
+
+                    } elseif ($active_action == 'assignment_view_main_init') {
+                        // (レポート-検索)
+                        // assignment存在チェック（任意）
+                        $assignment_id = $this->getArrayValue($check_url_query_array, 'assignment_id', null, null);
+                        if ($assignment_id) {
+                            $check_nc2_assignment = Nc2Assignment::where('assignment_id', $assignment_id)->first();
+                            if ($check_nc2_assignment) {
+                                // OK
+                            } else {
+                                // NG
+                                $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|assignmentデータなし', $url, $nc2_block);
+                                return;
+                            }
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'questionnaire_view_main_whatsnew') {
+                    // (アンケートパラメータ)
+                    //   block_id          必須
+                    //   questionnaire_id  必須
+                    //
+                    // (アンケート-新着-のみ)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&questionnaire_id=1&block_id=75#_75
+                    // questionnaire_idなし or 存在しないIDだと「入力値が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&block_id=75#_75
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=questionnaire_view_main_whatsnew&questionnaire_id=19999999&block_id=75#_75
+
+                    // questionnaire存在チェック
+                    $questionnaire_id = $this->getArrayValue($check_url_query_array, 'questionnaire_id', null, null);
+                    $check_nc2_questionnaire = Nc2Questionnaire::where('questionnaire_id', $questionnaire_id)->first();
+                    if ($check_nc2_questionnaire) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|questionnaireデータなし', $url, $nc2_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'quiz_view_main_whatsnew') {
+                    // (小テストパラメータ)
+                    //   block_id          必須
+                    //   quiz_id           必須
+                    //
+                    // (小テスト-新着-のみ)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&quiz_id=1&block_id=77#_77
+                    // quiz_idなし or 存在しないIDだと「入力値が不正」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&block_id=77#_77
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=quiz_view_main_whatsnew&quiz_id=1999999&block_id=77#_77
+
+                    // quiz存在チェック
+                    $quiz_id = $this->getArrayValue($check_url_query_array, 'quiz_id', null, null);
+                    $check_nc2_quiz = Nc2Quiz::where('quiz_id', $quiz_id)->first();
+                    if ($check_nc2_quiz) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|quizデータなし', $url, $nc2_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'todo_view_main_init') {
+                    // (Todoパラメータ)
+                    //   block_id          必須
+                    //   todo_id           任意
+                    //   page_id           任意
+                    //
+                    // (Todo-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&todo_id=11&block_id=76#_76
+                    // todo_idなし だと表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&block_id=76#_76
+                    // todo_idが存在しないID だと「公開されているTodoリストはありません」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=todo_view_main_init&todo_id=11999999&block_id=76#_76
+                    //
+                    // (Todo-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&block_id=76&page_id=55&active_action=todo_view_main_init#_76
+
+                    // todo存在チェック（任意）
+                    $todo_id = $this->getArrayValue($check_url_query_array, 'todo_id', null, null);
+                    if ($todo_id) {
+                        $check_nc2_todo = Nc2Todo::where('todo_id', $todo_id)->first();
+                        if ($check_nc2_todo) {
+                            // OK
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|todoデータなし', $url, $nc2_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_action == 'circular_view_main_detail') {
+                    // (回覧板パラメータ)
+                    //   block_id          必須
+                    //   circular_id       必須
+                    //   page_id           任意
+                    //   room_id           任意（チェック不要）
+                    //
+                    // (回覧板-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&circular_id=2&page_id=53&block_id=78#_78
+                    // circular_idなし or 存在しないID だと「既に削除されています」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&page_id=53&block_id=78#_78
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&circular_id=299999&page_id=53&block_id=78#_78
+                    //
+                    // (回覧板-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&room_id=1&circular_id=2#_78
+                    // room_idなし or 存在しないID でも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&circular_id=2#_78
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_action=circular_view_main_detail&block_id=78&room_id=19999&circular_id=2#_78
+
+                    // circular存在チェック
+                    $circular_id = $this->getArrayValue($check_url_query_array, 'circular_id', null, null);
+                    $check_nc2_circular = Nc2Circular::where('circular_id', $circular_id)->first();
+                    if ($check_nc2_circular) {
+                        // OK
+                    } else {
+                        // NG
+                        $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|circularデータなし', $url, $nc2_block);
+                        return;
+                    }
+
+                    // OK
+                    return;
+                }
+
+
+                // (中央エリアに表示) active_center
+                // --------------------------------
+                if ($active_center == 'search_view_main_center') {
+                    // （検索-初期インストール配置のヘッダー検索お知らせ）
+                    //   ./index.php?action=pages_view_main&active_center=search_view_main_center
+                    // （検索-active_action, 手動でリンク作成を想定
+                    //   → 対応しない
+                    //   block_idがないと、「該当ページに配置してある検索が削除された可能性があります。」エラー
+                    //   ./index.php?action=pages_view_main&active_action=search_view_main_center
+
+                    // OK
+                    return;
+
+                } elseif ($active_center == 'reservation_view_main_init') {
+                    // (施設予約-新着)
+                    //   active_block_id      任意. (チェック不要)
+                    //   page_id              任意. あれば存在チェック
+                    //   reserve_details_id   任意. (チェック不要)
+                    //   display_type         任意. あれば値チェック=1|2|3
+                    //   reserve_id           任意. (チェック不要)
+                    //
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2#_active_center_42
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init
+                    // active_block_idなしでも, 存在しないIDでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=0&display_type=2#_active_center_42
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=4299999999999999&page_id=0&display_type=2#_active_center_42
+                    // page_idなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&display_type=2#_active_center_42
+                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&page_id=9999999&display_type=2#_active_center_42
+                    // reserve_details_idなし or 存在しないIDでも表示できる. あれば該当日の一覧を表示
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=1999999999&active_block_id=42&page_id=0&display_type=2#_active_center_42
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&active_block_id=42&page_id=0&display_type=2#_active_center_42
+                    // display_typeなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0#_active_center_42
+                    // display_typeの「入力値が不正です」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=999#_active_center_42
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=4#_active_center_42
+                    //
+                    // >>> parse_str("action=pages_view_main&active_center=reservation_view_main_init&reserve_details_id=19&active_block_id=42&page_id=0&display_type=2", $result)
+                    // >>> $result
+                    // => [
+                    //      "action" => "pages_view_main",
+                    //      "active_center" => "reservation_view_main_init",
+                    //      "reserve_details_id" => "19",
+                    //      "active_block_id" => "42",
+                    //      "page_id" => "0",
+                    //      "display_type" => "2",
+                    //    ]
+                    //
+                    // (施設予約-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=reservation_view_main_init&reserve_id=74
+                    // reserve_id が存在しないIDでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=reservation_view_main_init&reserve_id=74999999
+
+                    // display_typeの有効値チェック(任意)
+                    $display_type = $this->getArrayValue($check_url_query_array, 'display_type', null, null);
+                    if ($display_type) {
+                        if ((int)$display_type <= 3) {
+                            // OK 1|2|3, ※ イレギュラーだけど0,-1,-2...でも表示可
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|display_type対象外', $url, $nc2_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+
+                } elseif ($active_center == 'calendar_view_main_init') {
+                    // (カレンダー-新着)
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=5#_active_center_11
+                    // page_idなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&display_type=5#_active_center_11
+                    // page_idを存在しないIDにすると「データ取得に失敗」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=19999999999&display_type=5#_active_center_11
+                    // display_typeなしでも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1#_active_center_11
+                    // display_type=0|-1|-2...は表示できちゃう
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=-1#_active_center_11
+                    // display_typeの「入力値が不正です」エラー
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42&active_block_id=11&page_id=1&display_type=8#_active_center_11
+                    // plan_id なし or ID存在しなくても表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&active_block_id=11&page_id=1&display_type=5#_active_center_11
+                    //   http://localhost:8080/index.php?action=pages_view_main&active_center=calendar_view_main_init&plan_id=42999&active_block_id=11&page_id=1&display_type=5#_active_center_11
+                    //
+                    // http://localhost:8080/index.php?
+                    //   - action=pages_view_main
+                    //   - active_center=calendar_view_main_init
+                    //   - plan_id=42           任意. (チェック不要)
+                    //   - active_block_id=11
+                    //   - page_id=1            上にチェック処理あり
+                    //   o display_type=5       任意. あれば値チェック=1～8
+                    //   - #_active_center_11
+                    //
+                    // (カレンダー-検索)
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&current_time=000000&display_type=5
+                    // date|current_time なし or 値が変な値でも表示できる
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&display_type=5
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=202108119999&current_time=0000009999&display_type=5
+                    //   http://localhost:8080/index.php?action=pages_view_main&page_id=13&active_center=calendar_view_main_init&date=20210811&display_type=5
+                    //
+                    // http://localhost:8080/index.php?
+                    //   - date=20210811        任意. (チェック不要)
+                    //   - current_time=000000  任意. (チェック不要)
+                    //   o display_type=5       任意. あれば値チェック=1～8
+
+                    // display_typeの有効値チェック(任意)
+                    $display_type = $this->getArrayValue($check_url_query_array, 'display_type', null, null);
+                    if ($display_type) {
+                        if ((int)$display_type <= 8) {
+                            // OK ※イレギュラーだけど0,-1,-2...でも表示可
+                        } else {
+                            // NG
+                            $this->putLinkCheck(3, $nc2_module_name . '|内部リンク|display_type対象外', $url, $nc2_block);
+                            return;
+                        }
+                    }
+
+                    // OK
+                    return;
+                }
+
+            }
+        }
+
+        // 外部リンク
+        // 内部リンクの直ファイル指定の存在チェック。例）http://localhost:8080/htdocs/install/logo.gif
+        // if ($this->checkDeadLinkOutside($check_url, $nc2_module_name, $nc2_block)) {
+        //     // 外部OK=移行対象外 (link_checkログには吐かない)
+        //     $this->putMonitor(3, $nc2_module_name . '|内部リンク＋外部リンクチェックOK|移行対象外URL', $url, $nc2_block);
+        // } else {
+        //     // 外部NG
+        //     $header = get_headers($check_url, true);
+        //     $this->putLinkCheck(3, $nc2_module_name . '|内部リンク＋外部リンクチェックNG|未対応URL|' . $header[0], $url, $nc2_block);
+        // }
+
+        // 移行対象外 (link_checkログには吐かない)
+        $this->putMonitor(3, $nc2_module_name . '|内部リンク|移行対象外URL', $url, $nc2_block);
     }
 }

--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -99,7 +99,7 @@ cc_import_groups = true
 nc3_export_plugins[] = "menus"
 nc3_export_plugins[] = "blogs"
 nc3_export_plugins[] = "bbses"
-; nc3_export_plugins[] = "databases"
+nc3_export_plugins[] = "databases"
 ;nc3_export_plugins[] = "faqs"
 ; nc3_export_plugins[] = "forms"
 ; nc3_export_plugins[] = "linklists"
@@ -115,7 +115,7 @@ nc3_export_plugins[] = "bbses"
 ;cc_import_plugins[] = "menus" 07/11 メニューはここには関係ない
 cc_import_plugins[] = "blogs"
 cc_import_plugins[] = "bbses"
-; cc_import_plugins[] = "databases"
+cc_import_plugins[] = "databases"
 ; cc_import_plugins[] = "faqs"
 ; cc_import_plugins[] = "forms"
 ; cc_import_plugins[] = "linklists"
@@ -182,7 +182,7 @@ import_frame_plugins[] = "menus"
 import_frame_plugins[] = "contents"
 import_frame_plugins[] = "blogs"
 import_frame_plugins[] = "bbses"
-; import_frame_plugins[] = "databases"
+import_frame_plugins[] = "databases"
 ; import_frame_plugins[] = "faqs"
 ; import_frame_plugins[] = "forms"
 ; import_frame_plugins[] = "linklists"
@@ -283,3 +283,27 @@ export_clear_style[] = "font-family"
 ; --- インポート
 ; 掲示板のいいねを全てOFF
 ;import_bbs_all_like_not_use = true
+
+;------------------------------------------------
+;- データベースプラグイン・オプション
+;------------------------------------------------
+[databases]
+
+; --- エクスポート
+; エクスポート対象のNC2汎用データベースIDを絞る（指定がなければすべて対象）
+;nc3_export_where_multidatabase_ids[] = 11
+;nc3_export_where_multidatabase_ids[] = 22
+
+; WYSIWYG で装飾された文章をクリーニングする場合に使用します。
+export_clear_style[] = "font-family"
+;export_clear_style[] = "font-size"
+;export_clear_style[] = "color"
+;export_clear_style[] = "background-color"
+
+; 変換したい文字や、取り除きたい文字(キー部分 = 探したい値, 値部分 = 置き換える値)
+;nc3_export_str_replace[''] = ''
+
+; --- インポート
+; インポートするデータベースを絞る
+;cc_import_where_database_ids[] = 11
+;cc_import_where_database_ids[] = 22


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [nc3移行] 汎用DB移行に対応
* 関連修正
    * [add: [移行インポート] データベースのメール通知設定・権限設定のインポートに対応](https://github.com/opensource-workshop/connect-cms/pull/1488/commits/ec430ed6875794789ca6c5ac2ce0eeb3d98447f0)
    * [add: [移行インポート] データベースの任意項目のソート移行に対応](https://github.com/opensource-workshop/connect-cms/pull/1488/commits/cf1602aa05d3a25eaae3e0af94efc90a28c77194)
    * [add: [移行インポート] データベースの行データで末尾空行があってもエラーにならないよう対応](https://github.com/opensource-workshop/connect-cms/pull/1488/commits/60eab085debd98e13b8e7981973e51f2893027cc)
    * [add: [nc2移行] 汎用DBのメール通知設定/権限設定のエクスポートに対応](https://github.com/opensource-workshop/connect-cms/pull/1488/commits/2d4f1dc7d8f3b817b4e84aa58d6901740d0617de)
    * [change: [nc2移行] 汎用DBの絞り込み項目の移行条件をnc2仕様に見直し](https://github.com/opensource-workshop/connect-cms/pull/1488/commits/cf6c7d03867f778dab4acea2f8554d0198774926)
    * [delete: [nc2移行] multidatabase_iniの[database_base]view_countは使わず、nc2BlockExportDatabases()でview_countを別途出力しているため削除](https://github.com/opensource-workshop/connect-cms/pull/1488/commits/f27487861a4c03205a7d833fab01c5f7d91cd360) 
    * [add: [nc3移行] 通知メール設定で、設定なければblock_key=nullの初期設定取得に対応](https://github.com/opensource-workshop/connect-cms/pull/1488/commits/e51d3e03d7b2c7fd93bc23c0201fc9e705d363e5)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
