### PR TITLE
[nc2移行] フォーム移行エクスポートでダブルクォーテーションを移行できるように対応、また改行の移行に対応

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -7667,8 +7667,8 @@ trait MigrationTrait
             $users_ini .= "email              = \"" . trim($nc2_user->email) . "\"\n";
             $users_ini .= "userid             = \"" . $nc2_user->login_id . "\"\n";
             $users_ini .= "password           = \"" . $nc2_user->password . "\"\n";
-            $users_ini .= "created_at      = \"" . $this->getCCDatetime($nc2_user->insert_time) . "\"\n";
-            $users_ini .= "updated_at      = \"" . $this->getCCDatetime($nc2_user->update_time) . "\"\n";
+            $users_ini .= "created_at         = \"" . $this->getCCDatetime($nc2_user->insert_time) . "\"\n";
+            $users_ini .= "updated_at         = \"" . $this->getCCDatetime($nc2_user->update_time) . "\"\n";
             if ($nc2_user->active_flag == 0) {
                 $users_ini .= "status             = " . UserStatus::not_active . "\n";
             } else {
@@ -7680,7 +7680,8 @@ trait MigrationTrait
                     $item_name = "item_{$nc2_any_item->item_id}";
                     // NC2システム固定値の置換
                     $item_value = rtrim(str_replace(array_keys($nc2_static_user_item_value), array_values($nc2_static_user_item_value), $nc2_user->$item_name), '|');// 最後のパイプは削除する
-                    $users_ini .= "{$item_name}            = \"" . $item_value . "\"\n";
+                    $item_value = str_replace('"', '\"', $item_value);
+                    $users_ini .= "{$item_name}            = \"{$item_value}\"\n";
                 }
             }
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -9625,7 +9625,8 @@ trait MigrationTrait
                         $registration_data .= "update_login_id = \"" . $this->getNc2LoginIdFromNc2UserId($nc2_users, $registration_item_data->data_update_user_id) . "\"\n";
                         $data_id = $registration_item_data->data_id;
                     }
-                    $registration_data .= $registration_item_data->item_id . " = \"" . str_replace("\n", '\n', $registration_item_data->item_data_value) . "\"\n";
+                    $value = str_replace('"', '\"', $registration_item_data->item_data_value);
+                    $registration_data .=  "{$registration_item_data->item_id} = \"{$value}\"\n";
                 }
                 // フォーム の登録データ
                 //Storage::put($this->getImportPath('forms/form_') . $this->zeroSuppress($registration_id) . '.txt', $registration_data_header . $registration_data);


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

公式掲示板より https://connect-cms.jp/plugin/bbses/show/106/233/687#frame-233

* [bugfix: [nc2移行] フォーム移行エクスポートでダブルクォーテーションを移行できるように対応、また改行の移行に対応](https://github.com/opensource-workshop/connect-cms/commit/80988c45678369604c695b5eb014db5ea16f2e84)
* 関連修正
    * [bugfix: [nc2移行] ユーザ移行エクスポートで任意項目でダブルクォーテーションを移行できるように対応](https://github.com/opensource-workshop/connect-cms/commit/2110d2e76fe569b31b991b46df5c1737c3c5b44a)

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://stackoverflow.com/questions/6684800/syntax-error-using-parse-ini-file-when-files-values-contain-exclamation-poin

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
