### PR TITLE
[コア] 画像キャッシュを設定しても、画像キャッシュされない不具合修正

### DIFF
--- a/app/Http/Controllers/Core/UploadController.php
+++ b/app/Http/Controllers/Core/UploadController.php
@@ -113,8 +113,16 @@ class UploadController extends ConnectController
                 return response()->download(storage_path(config('connect.forbidden_image_path')));
             }
 
-            // キャッシュしない
-            $headers = $no_cache_headers;
+            // 閲覧パスワード設定あるか
+            if ($page->isRequestPasswordSetting($page_tree)) {
+                // キャッシュしない
+                $headers = $no_cache_headers;
+            }
+            // 表示制限設定あるか
+            if ($page->isViewLimitSetting()) {
+                // キャッシュしない
+                $headers = $no_cache_headers;
+            }
         }
 
         // ファイルに固有のチェック関数が設定されている場合は、チェック関数を呼ぶ

--- a/app/Models/Common/Page.php
+++ b/app/Models/Common/Page.php
@@ -323,6 +323,29 @@ class Page extends Model
     }
 
     /**
+     * 表示制限の設定ありか判断
+     */
+    public function isViewLimitSetting()
+    {
+        // IP アドレス制限
+        if ($this->ip_address) {
+            return true;
+        }
+
+        // ログインユーザ全員参加ページ
+        if ($this->membership_flag == 2) {
+            return true;
+        }
+
+        // メンバーシップページ
+        if ($this->membership_flag == 1) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * 親子ページを加味して 表示可否の判断
      */
     public function isVisibleAncestorsAndSelf(Collection $page_tree) : bool
@@ -535,6 +558,24 @@ class Page extends Model
 
         // 認証を要求
         return true;
+    }
+
+    /**
+     * 閲覧パスワード設定あるか
+     */
+    public function isRequestPasswordSetting($page_tree)
+    {
+        // 自分のページから親を遡って取得
+        $page_tree = $this->getPageTreeByGoingBackParent($page_tree);
+
+        // 自分及び先祖ページに閲覧パスワードが設定されていなければ戻る
+        foreach ($page_tree as $page) {
+            if ($page->password) {
+                // 設定あり
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/pull/1482

上記対応の不具合修正です。

症状：画像キャッシュを設定しても、画像キャッシュされない。
対応：ページの表示制限（パスワード設定等）の設定ありなら、キャッシュしないように修正

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
