### PR TITLE
PHP8.1でインポートが出来ないバグ修正

### DIFF
--- a/app/Plugins/Manage/CodeManage/CodeManage.php
+++ b/app/Plugins/Manage/CodeManage/CodeManage.php
@@ -851,7 +851,7 @@ class CodeManage extends ManagePluginBase
                 'required',
                 'file',
                 'mimes:csv,txt', // mimesの都合上text/csvなのでtxtも許可が必要
-                'mimetypes:application/csv,text/plain',
+                'mimetypes:application/csv,text/plain,text/csv',
             ],
         ];
 

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1483,7 +1483,7 @@ class UserManage extends ManagePluginBase
                 'required',
                 'file',
                 'mimes:csv,txt', // mimesの都合上text/csvなのでtxtも許可が必要
-                'mimetypes:application/csv,text/plain',
+                'mimetypes:application/csv,text/plain,text/csv',
             ],
         ];
 

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3051,7 +3051,7 @@ class DatabasesPlugin extends UserPluginBase
                     'required',
                     'file',
                     'mimes:csv,txt,zip,html', // mimesの都合上text/csvなのでtxtも許可が必要. ウィジウィグのHTMLがcsvに含まれているとhtmlと判定されるため、ファイル拡張子チェックでhtmlを許可
-                    'mimetypes:application/csv,text/plain,application/zip,text/html',
+                    'mimetypes:application/csv,text/plain,text/csv,application/zip,text/html',
                 ],
             ];
             // csvを通すため、txt,htmlを追加しているため、メッセージをカスタマイズする。
@@ -3066,7 +3066,7 @@ class DatabasesPlugin extends UserPluginBase
                     'required',
                     'file',
                     'mimes:csv,txt,html', // mimesの都合上text/csvなのでtxtも許可が必要. ウィジウィグのHTMLがcsvに含まれているとhtmlと判定されるため、ファイル拡張子チェックでhtmlを許可
-                    'mimetypes:application/csv,text/plain,text/html',
+                    'mimetypes:application/csv,text/plain,text/csv,text/html',
                 ],
             ];
             // csvを通すため、txt,htmlを追加しているため、メッセージをカスタマイズする。

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -2632,7 +2632,7 @@ class LearningtasksPlugin extends UserPluginBase
                 'required',
                 'file',
                 'mimes:csv,txt', // mimesの都合上text/csvなのでtxtも許可が必要
-                'mimetypes:application/csv,text/plain',
+                'mimetypes:application/csv,text/plain,text/csv',
             ],
         ];
 


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1417
* 関連修正
    * [bugfix: PHP8.1でインポートが出来ないバグ修正](https://github.com/opensource-workshop/connect-cms/pull/1509/commits/d52b6e39d3668ffcfb7ffc6ff95730e32c0dac9e)
        * ユーザ管理インポート
        * データベースインポート
        * 課題管理インポート

エラーになっていた、php8.1のコード管理インポート処理でエラーが出なくなりました。
https://github.com/opensource-workshop/connect-cms/actions/runs/3560808368/jobs/5981133473
（ブランチを指定してduskテスト。指定したブランチはどっかでわかるのかな？）

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
