### PR TITLE
[nc3移行] カレンダーの移行対応（nc3-migrateブランチにマージ）

### DIFF
--- a/app/Models/Migration/Nc3/Nc3BlockSetting.php
+++ b/app/Models/Migration/Nc3/Nc3BlockSetting.php
@@ -20,7 +20,7 @@ class Nc3BlockSetting extends Model
     /**
      * block_settingsのvalueをblock_key,field_nameで取得
      */
-    public static function getNc3BlockSettingValue(Collection $block_settings, string $block_key, string $field_name, ?string $default = '0'): string
+    public static function getNc3BlockSettingValue(Collection $block_settings, ?string $block_key, string $field_name, ?string $default = '0'): string
     {
         $block_setting = $block_settings->where('block_key', $block_key)
             ->firstWhere('field_name', $field_name);

--- a/app/Models/Migration/Nc3/Nc3Calendar.php
+++ b/app/Models/Migration/Nc3/Nc3Calendar.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3Calendar extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'calendars';
+}

--- a/app/Models/Migration/Nc3/Nc3CalendarEvent.php
+++ b/app/Models/Migration/Nc3/Nc3CalendarEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3CalendarEvent extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'calendar_events';
+}

--- a/app/Models/Migration/Nc3/Nc3RoomRolePermission.php
+++ b/app/Models/Migration/Nc3/Nc3RoomRolePermission.php
@@ -3,6 +3,7 @@
 namespace App\Models\Migration\Nc3;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 
 class Nc3RoomRolePermission extends Model
 {
@@ -29,5 +30,27 @@ class Nc3RoomRolePermission extends Model
             ->where('roles_rooms.room_id', $room_id)
             ->where('roles_rooms.role_key', $role_key)
             ->first() ?? new Nc3RoomRolePermission();
+    }
+
+    /**
+     * room_idの配列 からルーム権限 を取得
+     */
+    public static function getRoomRolePermissionsByRoomIds($room_ids): Collection
+    {
+        return Nc3RolesRoom::
+            select(
+                'roles_rooms.room_id',
+                'roles_rooms.role_key',
+                'room_role_permissions.*',
+                'block_role_permissions.value as block_role_permission_value'
+            )
+            ->join('room_role_permissions', function ($join) {
+                $join->on('room_role_permissions.roles_room_id', '=', 'roles_rooms.id');
+            })
+            ->join('block_role_permissions', function ($join) {
+                $join->on('block_role_permissions.roles_room_id', '=', 'roles_rooms.id');
+            })
+            ->whereIn('roles_rooms.room_id', $room_ids)
+            ->get();
     }
 }

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -5784,7 +5784,7 @@ trait MigrationNc3ExportTrait
 
 
         $i = 0;
-        while (!isset($headers[$i])) {
+        while (isset($headers[$i])) {
             if (stripos($headers[$i], "200") !== false) {
                 // OK
                 return true;

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -25,6 +25,8 @@ use App\Models\Migration\Nc3\Nc3Blog;
 use App\Models\Migration\Nc3\Nc3BlogEntry;
 use App\Models\Migration\Nc3\Nc3Cabinet;
 use App\Models\Migration\Nc3\Nc3CabinetFile;
+use App\Models\Migration\Nc3\Nc3Calendar;
+use App\Models\Migration\Nc3\Nc3CalendarEvent;
 use App\Models\Migration\Nc3\Nc3CalendarFrameSetting;
 use App\Models\Migration\Nc3\Nc3Category;
 use App\Models\Migration\Nc3\Nc3Faq;
@@ -52,6 +54,7 @@ use App\Models\Migration\Nc3\Nc3RegistrationPage;
 use App\Models\Migration\Nc3\Nc3RegistrationQuestion;
 use App\Models\Migration\Nc3\Nc3ReservationFrameSetting;
 use App\Models\Migration\Nc3\Nc3Room;
+use App\Models\Migration\Nc3\Nc3RoomRolePermission;
 use App\Models\Migration\Nc3\Nc3PhotoAlbum;
 use App\Models\Migration\Nc3\Nc3PhotoAlbumFrameSetting;
 use App\Models\Migration\Nc3\Nc3SiteSetting;
@@ -128,7 +131,6 @@ trait MigrationNc3ExportTrait
      * 廃止のものは 'Abolition' にする。
      */
     protected $plugin_name = [
-        // 'calendars'        => 'calendars',    // カレンダー
         // 'photo_albums'     => 'photoalbums',  // フォトアルバム
         // 'reservations'     => 'reservations', // 施設予約
         // 'searches'         => 'searchs',      // 検索
@@ -138,7 +140,7 @@ trait MigrationNc3ExportTrait
         'bbses'            => 'bbses',          // 掲示板
         'blogs'            => 'blogs',          // ブログ
         'cabinets'         => 'cabinets',       // キャビネット
-        'calendars'        => 'Development',    // カレンダー
+        'calendars'        => 'calendars',      // カレンダー
         'circular_notices' => 'Development',    // 回覧板
         'faqs'             => 'faqs',           // FAQ
         'iframes'          => 'Development',    // iFrame
@@ -480,14 +482,14 @@ trait MigrationNc3ExportTrait
             $this->nc3ExportCounter($redo);
         }
 
+        // NC3 カレンダー（calendars）データのエクスポート
+        if ($this->isTarget('nc3_export', 'plugins', 'calendars')) {
+            $this->nc3ExportCalendar($redo);
+        }
+
         //////////////////
         // [TODO] まだ
         //////////////////
-
-        // // NC3 カレンダー（calendar）データのエクスポート
-        // if ($this->isTarget('nc3_export', 'plugins', 'calendars')) {
-        //     $this->nc3ExportCalendar($redo);
-        // }
 
         // // NC3 スライダー（slides）データのエクスポート
         // if ($this->isTarget('nc3_export', 'plugins', 'slideshows')) {
@@ -3432,7 +3434,7 @@ trait MigrationNc3ExportTrait
     }
 
     /**
-     * NC3：カレンダー（カレンダー）の移行
+     * NC3：カレンダー（calendars）の移行
      */
     private function nc3ExportCalendar($redo)
     {
@@ -3446,40 +3448,56 @@ trait MigrationNc3ExportTrait
 
         // ・NC3ルーム一覧とって、NC3予定データを移行する
         //   ※ ルームなしはありえない（必ずパブリックルームがあるため）
-        // ・NC3カレンダーブロック（モジュール配置したブロック（どう見せるか、だけ。ここ無くても予定データある））を移行する。
 
-        // NC3ルーム一覧を移行する。
+        // NC3全会員 （communityのルートroom_idが全会員のroom_id）
+        $nc3_space = Nc3Space::find(Nc3Space::COMMUNITY_SPACE_ID);
+        $all_users_room_id = $nc3_space->room_id_root;
+
+        // NC3ルーム一覧を移行する。（全会員は除外）
+        $nc3_rooms_query = Nc3Room::select('rooms.*', 'rooms_languages.name as room_name')
+            ->join('rooms_languages', function ($join) {
+                $join->on('rooms_languages.room_id', 'rooms.id')
+                    ->where('rooms_languages.language_id', Nc3Language::language_id_ja);
+            })
+            ->where('rooms.id', '!=', $all_users_room_id)
+            ->orderBy('rooms.id');
+
         $nc3_export_private_room_calendar = $this->getMigrationConfig('calendars', 'nc3_export_private_room_calendar');
         if (empty($nc3_export_private_room_calendar)) {
             // プライベートルームをエクスポート（=移行）しない
-            $nc3_page_rooms = Nc2Page::whereColumn('page_id', 'room_id')
-                ->whereIn('space_type', [1, 2])     // 1:パブリックスペース, 2:グループスペース
-                ->where('room_id', '!=', 2)         // 2:グループスペースを除外（枠だけでグループルームじゃないので除外）
-                ->where('private_flag', 0)          // 0:プライベートルーム以外
-                ->orderBy('room_id')
-                ->get();
+            $nc3_rooms_query = $nc3_rooms_query->whereIn('space_id', [Nc3Space::PUBLIC_SPACE_ID, Nc3Space::COMMUNITY_SPACE_ID]);
+
         } else {
             // プライベートルームをエクスポート（=移行）する
-            $nc3_page_rooms = Nc2Page::whereColumn('page_id', 'room_id')
-                ->whereIn('space_type', [1, 2])     // 1:パブリックスペース, 2:グループスペース
-                ->where('room_id', '!=', 2)         // 2:グループスペースを除外（枠だけでグループルームじゃないので除外）
-                ->orderBy('room_id')
-                ->get();
-        }
+            $nc3_rooms_query = $nc3_rooms_query->whereIn('space_id', [Nc3Space::PUBLIC_SPACE_ID, Nc3Space::COMMUNITY_SPACE_ID, Nc3Space::PRIVATE_SPACE_ID]);
 
-        // NC3権限設定（サイト全体で１設定のみ）. インストール時は空。権限設定でOK押さないとデータできない。
-        $nc3_calendar_manages = Nc2CalendarManage::orderBy('room_id')->get();
+        }
+        $nc3_rooms = $nc3_rooms_query->get();
+
+        // (nc3) calendarsはなぜかblock_key=1ルームとして設定を保持しているため取得
+        $nc3_calendars = Nc3Calendar::select('calendars.*', 'blocks.room_id')
+            ->join('blocks', function ($join) {
+                $join->on('blocks.key', 'calendars.block_key')
+                    ->where('blocks.plugin_key', 'calendars');
+            })
+            ->get();
 
         $nc3_export_room_ids = $this->getMigrationConfig('basic', 'nc3_export_room_ids');
 
         // nc3の全ユーザ取得
-        $nc3_users = Nc2User::get();
+        $nc3_users = Nc3User::get();
+
+        // NC3権限設定
+        $nc3_room_role_permissions = Nc3RoomRolePermission::getRoomRolePermissionsByRoomIds($nc3_rooms->pluck('id'));
+
+        // ブロック設定
+        $block_settings = Nc3BlockSetting::whereIn('block_key', $nc3_calendars->pluck('block_key'))->get();
 
         // ルームでループ（NC3カレンダーはルーム単位でエクスポート）
-        foreach ($nc3_page_rooms as $nc3_page_room) {
+        foreach ($nc3_rooms as $nc3_room) {
 
             // ルーム指定があれば、指定されたルームのみ処理する。
-            if (!empty($nc3_export_room_ids) && !in_array($nc3_page_room->room_id, $nc3_export_room_ids)) {
+            if (!empty($nc3_export_room_ids) && !in_array($nc3_room->id, $nc3_export_room_ids)) {
                 // ルーム指定あり。条件に合致せず。移行しない。
                 continue;
             }
@@ -3488,46 +3506,60 @@ trait MigrationNc3ExportTrait
             $ini = "";
             $ini .= "[calendar_base]\n";
 
-            // NC3 権限設定
-            $nc3_calendar_manage = $nc3_calendar_manages->firstWhere('room_id', $nc3_page_room->room_id);
+            // 権限設定
+            // ----------------------------------------------------
+            // ※ユーザ (nc3)一般 => (cc)編集者
+            // カレンダーの権限はサイトで１セット。だけどなぜか 一般の権限設定は block_role_permission にあるためそっちも見る。
+            $nc3_room_role_permission = $nc3_room_role_permissions->where('permission', 'content_creatable')
+                ->where('role_key', 'general_user')
+                ->firstWhere('room_id', $nc3_room->id);
+
+            $article_post_flag = 1;     // 投稿権限はnc3編集者まで常時チェックON
+            $reporter_post_flag = 0;
+
+            if (empty($nc3_room_role_permission)) {
+                $reporter_post_flag = 0;
+            } else {
+                $reporter_post_flag = $nc3_room_role_permission->block_role_permission_value ? $nc3_room_role_permission->block_role_permission_value : $nc3_room_role_permission->value;
+            }
+
+            // 承認あり
+            // パブリック　：デフォ承認ありっぽい
+            // コミュニティ：デフォ承認なしっぽい
+            // 全会員　　　：デフォ承認ありっぽい。（全会員は room_id=3, Nc3Space::COMMUNITY_SPACE_IDのルートroom_id）
+            // $roomBlock[$this->alias]['use_workflow'] = Hash::get($roomBlock, 'Room.need_approval'); がデフォ値。
+            // 記事承認（content_publishable）はルーム管理者・編集長固定. 編集者は承認必要
+
+            // room_idからcalendarsのblock_keyを取り出し
+            $nc3_calendar = $nc3_calendars->firstWhere('room_id', $nc3_room->id) ?? new Nc3Calendar();
+            $use_workflow = Nc3BlockSetting::getNc3BlockSettingValue($block_settings, $nc3_calendar->block_key, 'use_workflow', $nc3_room->need_approval);
+
             $ini .= "\n";
             $ini .= "[calendar_manage]\n";
-            if (is_null($nc3_calendar_manage)) {
-                // データなしは 4:主担。 ここに全会員ルームのデータは入ってこないため、これでOK
-                $ini .= "add_authority_id = 4\n";
-                // フラグは必ず1
-                // $ini .= "use_flag = 1\n";
-            } else {
-                // 予定を追加できる権限. 2:主担,モデレータ,一般  3:主担,モデレータ  4:主担  5:なし（全会員のみ設定可能）
-                $ini .= "add_authority_id = " . $nc3_calendar_manage->add_authority_id . "\n";
-                // フラグ. 1:使う
-                // $ini .= "use_flag = " . $nc3_calendar_manage->use_flag . "\n";
-            }
+            $ini .= "article_post_flag      = {$article_post_flag}\n";
+            $ini .= "article_approval_flag  = 0\n";                                 // 編集長=モデは承認不要
+            $ini .= "reporter_post_flag     = {$reporter_post_flag}\n";
+            $ini .= "reporter_approval_flag = {$use_workflow}\n";                   // 承認ありなら編集者承認ON
 
             // NC3 情報
             $ini .= "\n";
             $ini .= "[source_info]\n";
-            $ini .= "room_id = " . $nc3_page_room->room_id . "\n";
+            $ini .= "room_id = " . $nc3_room->id . "\n";
             // ルーム名
-            $ini .= "room_name = '" . $nc3_page_room->page_name . "'\n";
-            // プライベートフラグ, 1:プライベートルーム, 0:プライベートルーム以外
-            $ini .= "private_flag = " . $nc3_page_room->private_flag . "\n";
+            $ini .= "room_name = '" . $nc3_room->room_name . "'\n";
             // スペースID
-            $ini .= "space_id = " . $nc3_page_room->space_id . "\n";
-            $ini .= "plugin_key = \"calendar\"\n";
+            $ini .= "space_id = " . $nc3_room->space_id . "\n";
+            $ini .= "plugin_key = \"calendars\"\n";
 
 
             // カラムのヘッダー及びTSV 行毎の枠準備
             $tsv_header = "calendar_id" . "\t" . "plan_id" . "\t" . "user_id" . "\t" . "user_name" . "\t" . "title" . "\t" .
                 "allday_flag" . "\t" . "start_date" . "\t" . "start_time" . "\t" . "end_date" . "\t" . "end_time" . "\t" .
-                // NC3 calendar_plan_details
                 "location" . "\t" . "contact" . "\t" . "body" . "\t" . "rrule" . "\t" .
-                // NC3 calendar_plan 登録日・更新日等
                 "created_at" . "\t" . "created_name" . "\t" . "insert_login_id" . "\t" . "updated_at" . "\t" . "updated_name" . "\t" . "update_login_id" . "\t" .
                 // CC 状態
                 "status";
 
-            // NC3 calendar_plan
             $tsv_cols['calendar_id'] = "";
             $tsv_cols['plan_id'] = "";
             $tsv_cols['user_id'] = "";
@@ -3539,7 +3571,6 @@ trait MigrationNc3ExportTrait
             $tsv_cols['end_date'] = "";
             $tsv_cols['end_time'] = "";
 
-            // NC3 calendar_plan_details
             // 場所
             $tsv_cols['location'] = "";
             // 連絡先
@@ -3549,7 +3580,7 @@ trait MigrationNc3ExportTrait
             // 繰り返し条件
             $tsv_cols['rrule'] = "";
 
-            // NC3 calendar_plan 登録日・更新日等
+            // 登録日・更新日等
             $tsv_cols['created_at'] = "";
             $tsv_cols['created_name'] = "";
             $tsv_cols['insert_login_id'] = "";
@@ -3560,45 +3591,44 @@ trait MigrationNc3ExportTrait
             // CC 状態
             $tsv_cols['status'] = "";
 
-            // カレンダーの予定 calendar_plan
-            $calendar_plans = Nc2CalendarPlan::
-                leftjoin('calendar_plan_details', function ($join) {
-                    $join->on('calendar_plan.plan_id', '=', 'calendar_plan_details.plan_id')
-                        ->whereColumn('calendar_plan.room_id', 'calendar_plan_details.room_id');
+            // カレンダーの予定
+            $calendar_events = Nc3CalendarEvent::select('calendar_events.*', 'calendar_rrules.rrule')
+                ->leftJoin('calendar_rrules', function ($join) {
+                    $join->on('calendar_rrules.id', '=', 'calendar_events.calendar_rrule_id');
                 })
-                ->where('calendar_plan.room_id', $nc3_page_room->room_id)
-                ->orderBy('calendar_plan.calendar_id', 'asc')
+                ->where('calendar_events.is_latest', 1)
+                ->where('calendar_events.room_id', $nc3_room->id)
+                ->orderBy('calendar_events.room_id', 'asc')
                 ->get();
 
             // カラムデータのループ
-            Storage::delete($this->getImportPath('calendars/calendar_room_') . $this->zeroSuppress($nc3_page_room->room_id) . '.tsv');
+            Storage::delete($this->getImportPath('calendars/calendar_room_') . $this->zeroSuppress($nc3_room->id) . '.tsv');
 
             $tsv = '';
             $tsv .= $tsv_header . "\n";
 
-            foreach ($calendar_plans as $calendar_plan) {
+            foreach ($calendar_events as $calendar_event) {
 
                 // 初期化
                 $tsv_record = $tsv_cols;
 
-                // NC3 calendar_plan
-                $tsv_record['calendar_id'] = $calendar_plan->calendar_id;
-                $tsv_record['plan_id'] = $calendar_plan->plan_id;
-                $tsv_record['user_id'] = $calendar_plan->user_id;
-                $tsv_record['user_name'] = $calendar_plan->user_name;
-                $tsv_record['title'] = $calendar_plan->title;
-                $tsv_record['allday_flag'] = $calendar_plan->allday_flag;
+                // $tsv_record['calendar_id'] = $calendar_event->id;
+                // $tsv_record['plan_id']     = $calendar_event->calendar_rrule_id;
+                // $tsv_record['user_id']     = $calendar_event->user_id;
+                // $tsv_record['user_name']   = $calendar_event->user_name;
+                $tsv_record['title']       = $calendar_event->title;
+                $tsv_record['allday_flag'] = $calendar_event->is_allday;
 
                 // 予定開始日時
                 // Carbon()で処理。必須値のため基本値がある想定で、timezone_offset で時間加算して予定時間を算出
-                $start_time_full = (new Carbon($calendar_plan->start_time_full))->addHour($calendar_plan->timezone_offset);
-                $tsv_record['start_date'] = $start_time_full->format('Y-m-d');
-                $tsv_record['start_time'] = $start_time_full->format('H:i:s');
+                $dtstart = (new Carbon($calendar_event->dtstart))->addHour($calendar_event->timezone_offset);
+                $tsv_record['start_date'] = $dtstart->format('Y-m-d');
+                $tsv_record['start_time'] = $dtstart->format('H:i:s');
 
                 // 予定終了日時
                 // Carbon()で処理。必須値のため基本値がある想定で、timezone_offset で時間加算して予定時間を算出
-                $end_time_full = (new Carbon($calendar_plan->end_time_full))->addHour($calendar_plan->timezone_offset);
-                if ($calendar_plan->allday_flag == 1) {
+                $dtend = (new Carbon($calendar_event->dtend))->addHour($calendar_event->timezone_offset);
+                if ($calendar_event->is_allday == 1) {
                     // 全日で終了日時の変換対応. -1日する。
                     //
                     // ・NC3 で登録できる開始時間：0:00～23:55 （24:00ないため、こっちは対応不要）
@@ -3611,153 +3641,98 @@ trait MigrationNc3ExportTrait
                     //    そのため、2021/08/11 0:00～2021/08/12 0:00 を 2021/08/11 0:00～2021/08/11 0:00に変換する。
 
                     // -1日
-                    $end_time_full = $end_time_full->subDay();
-                } elseif ($end_time_full->format('H:i:s') == '00:00:00') {
+                    $dtend = $dtend->subDay();
+                } elseif ($dtend->format('H:i:s') == '00:00:00') {
                     // 全日以外で終了日時が0:00の変換対応. -1分する。
                     // ※ 例えばNC3の「時間指定」で10:00～24:00という予定に対応して、10:00～23:59に終了時間を変換する
 
                     // -1分
-                    $end_time_full = $end_time_full->subMinute();
+                    $dtend = $dtend->subMinute();
                 }
-                $tsv_record['end_date'] = $end_time_full->format('Y-m-d');
-                $tsv_record['end_time'] = $end_time_full->format('H:i:s');
+                $tsv_record['end_date'] = $dtend->format('Y-m-d');
+                $tsv_record['end_time'] = $dtend->format('H:i:s');
 
-                // NC3 calendar_plan_details（plan_id, room_idあり）
                 // 場所
-                $tsv_record['location'] = $calendar_plan->location;
+                $tsv_record['location'] = $calendar_event->location;
                 // 連絡先
-                $tsv_record['contact'] = $calendar_plan->contact;
+                $tsv_record['contact'] = $calendar_event->contact;
                 // 内容 [WYSIWYG]
-                $tsv_record['body'] = $this->nc3Wysiwyg(null, null, null, null, $calendar_plan->description, 'calendar');
-
+                $tsv_record['body'] = $this->nc3Wysiwyg(null, null, null, null, $calendar_event->description, 'calendars');
                 // 繰り返し条件
-                $tsv_record['rrule'] = $calendar_plan->rrule;
-
-                // NC3 calendar_plan 登録日・更新日等
-                $tsv_record['created_at']      = $this->getCCDatetime($calendar_plan->created);
-                $tsv_record['created_name']    = $calendar_plan->insert_user_name;
-                $tsv_record['insert_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $calendar_plan->created_user);
-                $tsv_record['updated_at']      = $this->getCCDatetime($calendar_plan->modified);
-                $tsv_record['updated_name']    = $calendar_plan->update_user_name;
-                $tsv_record['update_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $calendar_plan->modified_user);
-
-                // NC3カレンダー予定は公開のみ
-                $tsv_record['status'] = 0;
+                $tsv_record['rrule'] = $calendar_event->rrule;
+                // 登録日・更新日等
+                $tsv_record['created_at']      = $this->getCCDatetime($calendar_event->created);
+                $tsv_record['created_name']    = Nc3User::getNc3HandleFromNc3UserId($nc3_users, $calendar_event->created_user);
+                $tsv_record['insert_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $calendar_event->created_user);
+                $tsv_record['updated_at']      = $this->getCCDatetime($calendar_event->modified);
+                $tsv_record['updated_name']    = Nc3User::getNc3HandleFromNc3UserId($nc3_users, $calendar_event->modified_user);
+                $tsv_record['update_login_id'] = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $calendar_event->modified_user);
+                $tsv_record['status']          = $calendar_event->status;
 
                 $tsv .= implode("\t", $tsv_record) . "\n";
             }
 
             // データ行の書き出し
             $tsv = $this->exportStrReplace($tsv, 'calendars');
-            $this->storageAppend($this->getImportPath('calendars/calendar_room_') . $this->zeroSuppress($nc3_page_room->room_id) . '.tsv', $tsv);
+            $this->storageAppend($this->getImportPath('calendars/calendar_room_') . $this->zeroSuppress($nc3_room->id) . '.tsv', $tsv);
 
             // カレンダーの設定を出力
-            $this->storagePut($this->getImportPath('calendars/calendar_room_') . $this->zeroSuppress($nc3_page_room->room_id) . '.ini', $ini);
+            $this->storagePut($this->getImportPath('calendars/calendar_room_') . $this->zeroSuppress($nc3_room->id) . '.ini', $ini);
         }
 
 
-        // NC3全会員 room_id=0（nc3_page にデータないため手動で設定）
-        $all_users_room_id = 0;
+        // NC3全会員
 
         // ルーム指定があれば、指定されたルームのみ処理する。
         if (empty($nc3_export_room_ids) || in_array($all_users_room_id, $nc3_export_room_ids)) {
 
+            // NC3ルーム（全会員）
+            $nc3_room = Nc3Room::find($all_users_room_id);
+
+            // 権限設定
+            // ----------------------------------------------------
+            // ※ユーザ (nc3)一般 => (cc)編集者
+            // カレンダーの権限はサイトで１セット。だけどなぜか 一般の権限設定は block_role_permission にあるためそっちも見る。
+            $nc3_room_role_permission = $nc3_room_role_permissions->where('permission', 'content_creatable')
+                ->where('role_key', 'general_user')
+                ->firstWhere('room_id', $nc3_room->id);
+
+            $article_post_flag = 1;     // 投稿権限はnc3編集者まで常時チェックON
+            $reporter_post_flag = 0;
+
+            if (empty($nc3_room_role_permission)) {
+                $reporter_post_flag = 0;
+            } else {
+                $reporter_post_flag = $nc3_room_role_permission->block_role_permission_value ? $nc3_room_role_permission->block_role_permission_value : $nc3_room_role_permission->value;
+            }
+
+            // 承認あり
+            // room_idからcalendarsのblock_keyを取り出し
+            $nc3_calendar = $nc3_calendars->firstWhere('room_id', $nc3_room->id) ?? new Nc3Calendar();
+            $use_workflow = Nc3BlockSetting::getNc3BlockSettingValue($block_settings, $nc3_calendar->block_key, 'use_workflow', $nc3_room->need_approval);
+
             // カレンダー設定
             $ini = "";
             $ini .= "[calendar_base]\n";
-
-            // NC3 権限設定
-            $nc3_calendar_manage = $nc3_calendar_manages->firstWhere('room_id', $all_users_room_id);
             $ini .= "\n";
             $ini .= "[calendar_manage]\n";
-            if (is_null($nc3_calendar_manage)) {
-                // 全会員のデータなしは 5:なし（全会員のみ設定可能）
-                $ini .= "add_authority_id = 5\n";
-                // フラグは必ず1
-                // $ini .= "use_flag = 1\n";
-            } else {
-                // 予定を追加できる権限. 2:主担,モデレータ,一般  3:主担,モデレータ  4:主担  5:なし（全会員のみ設定可能）
-                $ini .= "add_authority_id = " . $nc3_calendar_manage->add_authority_id . "\n";
-                // フラグ. 1:使う
-                // $ini .= "use_flag = " . $nc3_calendar_manage->use_flag . "\n";
-            }
+            $ini .= "article_post_flag      = {$article_post_flag}\n";
+            $ini .= "article_approval_flag  = 0\n";                                 // 編集長=モデは承認不要
+            $ini .= "reporter_post_flag     = {$reporter_post_flag}\n";
+            $ini .= "reporter_approval_flag = {$use_workflow}\n";                   // 承認ありなら編集者承認ON
 
             // NC3 情報
             $ini .= "\n";
             $ini .= "[source_info]\n";
-            $ini .= "room_id = " . $all_users_room_id . "\n";
+            $ini .= "room_id = " . $nc3_room->id . "\n";
             // ルーム名
-            $ini .= "room_name = 全会員\n";
-            // プライベートフラグ, 1:プライベートルーム
-            $ini .= "private_flag = 0\n";
-            // スペースタイプ, 1:パブリックスペース, 2:グループスペース
-            $ini .= "space_type =\n";
-            $ini .= "plugin_key = \"calendar\"\n";
+            $ini .= "room_name = '全会員'\n";
+            // スペースID
+            $ini .= "space_id = " . $nc3_room->space_id . "\n";
+            $ini .= "plugin_key = \"calendars\"\n";
 
             // カレンダーの設定を出力
             $this->storagePut($this->getImportPath('calendars/calendar_room_') . $this->zeroSuppress($all_users_room_id) . '.ini', $ini);
-        }
-
-
-        // NC3カレンダーブロック（モジュール配置したブロック（どう見せるか、だけ。ここ無くても予定データある））を移行する。
-        $where_calendar_block_ids = $this->getMigrationConfig('calendars', 'nc3_export_where_calendar_block_ids');
-        if (empty($where_calendar_block_ids)) {
-            $nc3_calendar_blocks = Nc2CalendarBlock::orderBy('block_id')->get();
-        } else {
-            $nc3_calendar_blocks = Nc2CalendarBlock::whereIn('block_id', $where_calendar_block_ids)->orderBy('block_id')->get();
-        }
-
-        // 空なら戻る
-        if ($nc3_calendar_blocks->isEmpty()) {
-            return;
-        }
-
-        // NC3 指定ルームのみ表示 nc3_calendar_select_room
-        // if (empty($where_calendar_block_ids)) {
-        //     $nc3_calendar_select_rooms = Nc2CalendarSelectRoom::orderBy('block_id')->get();
-        // } else {
-        //     $nc3_calendar_select_rooms = Nc2CalendarSelectRoom::whereIn('block_id', $where_calendar_block_ids)->orderBy('block_id')->get();
-        // }
-
-        // NC3カレンダーブロックのループ
-        foreach ($nc3_calendar_blocks as $nc3_calendar_block) {
-
-            // ルーム指定があれば、指定されたルームのみ処理する。
-            if (!empty($nc3_export_room_ids) && !in_array($nc3_page_room->room_id, $nc3_export_room_ids)) {
-                // ルーム指定あり。条件に合致せず。移行しない。
-                continue;
-            }
-
-            // NC3 カレンダーブロック（表示方法）設定
-            $ini = "";
-            $ini .= "[calendar_block]\n";
-            // 表示方法
-            $ini .= "display_type = " . $nc3_calendar_block->display_type . "\n";
-            // 開始位置
-            // $ini .= "start_pos = " .  $nc3_calendar_block->start_pos . "\n";
-            // 表示日数
-            // $ini .= "display_count = " . $nc3_calendar_block->display_count . "\n";
-            // 指定したルームのみ表示する 1:ルーム指定する 0:指定しない
-            // $ini .= "select_room = " . $nc3_calendar_block->select_room . "\n";
-            // [不明] 画面に該当項目なし。プライベートルームにカレンダー配置しても 0 だった。
-            // $ini .= "myroom_flag = " . $nc3_calendar_block->myroom_flag . "\n";
-
-            // NC3 指定ルームのみ表示
-            // $ini .= "\n";
-            // $ini .= "[calendar_select_room]\n";
-            // foreach ($nc3_calendar_select_rooms as $nc3_calendar_select_room) {
-            //     $ini .= "room_id[] = " . $nc3_calendar_select_room->room_id . "\n";
-            // }
-
-            // NC3 情報
-            $ini .= "\n";
-            $ini .= "[source_info]\n";
-            $ini .= "calendar_block_id = " . $nc3_calendar_block->block_id . "\n";
-            $ini .= "room_id = " . $nc3_calendar_block->room_id . "\n";
-            $ini .= "plugin_key = \"calendar\"\n";
-
-            // カレンダーの設定を出力
-            $this->storagePut($this->getImportPath('calendars/calendar_block_') . $this->zeroSuppress($nc3_calendar_block->block_id) . '.ini', $ini);
         }
     }
 
@@ -4840,37 +4815,6 @@ trait MigrationNc3ExportTrait
                 $frame_ini .= "frame_col = " . $nc3_frame->frame_col . "\n";
             }
 
-            // 各項目
-            // [TODO] 未対応
-            // if ($nc3_frame->plugin_key == 'calendars') {
-            //     $calendar_block_ini = null;
-            //     $calendar_display_type = null;
-
-            //     // カレンダーブロックの情報取得
-            //     if (Storage::exists($this->getImportPath('calendars/calendar_block_') . $this->zeroSuppress($nc3_frame->block_id) . '.ini')) {
-            //         $calendar_block_ini = parse_ini_file(storage_path() . '/app/' . $this->getImportPath('calendars/calendar_block_') . $this->zeroSuppress($nc3_frame->block_id) . '.ini', true);
-            //     }
-
-            //     if (!empty($calendar_block_ini) && array_key_exists('calendar_block', $calendar_block_ini) && array_key_exists('display_type', $calendar_block_ini['calendar_block'])) {
-            //         // NC3 のcalendar の display_type
-            //         $calendar_display_type = MigrationUtils::getArrayValue($calendar_block_ini, 'calendar_block', 'display_type', null);
-            //     }
-
-            //     // frame_design 変換 (key:nc3)display_type => (value:cc)template
-            //     // (NC3)初期値 = 月表示（縮小）= 2
-            //     // (CC) 初期値 = 月表示（大）= default
-            //     $display_type_to_frame_designs = [
-            //         1 => 'default',     // 1:年間表示
-            //         2 => 'small_month', // 2:月表示（縮小）
-            //         3 => 'default',     // 3:月表示（拡大）
-            //         4 => 'default',     // 4:週表示
-            //         5 => 'day',         // 5:日表示
-            //         6 => 'day',         // 6:スケジュール（時間順）
-            //         7 => 'day',         // 7:スケジュール（会員順）
-            //     ];
-            //     $frame_design = $display_type_to_frame_designs[$calendar_display_type] ?? 'default';
-            //     $frame_ini .= "template = \"" . $frame_design . "\"\n";
-            // }
             if (!empty($nc3_frame->template)) {
                 // overrideNc3Frame()関連設定 があれば最優先で設定
                 $frame_ini .= "template = \"" . $nc3_frame->template . "\"\n";
@@ -4894,6 +4838,24 @@ trait MigrationNc3ExportTrait
                 ];
                 $template = $convert_templates[$nc3_menu_frame_setting->display_type] ?? 'default';
                 $frame_ini .= "template = \"{$template}\"\n";
+
+            } elseif ($nc3_frame->plugin_key == 'calendars') {
+                // NC3カレンダーフレーム（どう見せるか、だけ。ここ無くても予定データある）を移行する。
+                $nc3_calendar_frame_setting = Nc3CalendarFrameSetting::where('frame_key', $nc3_frame->key)->first();
+
+                // frame_design 変換 (key:nc3)display_type => (value:cc)template
+                // (NC3)初期値 = 月表示（縮小）= 1
+                // (CC) 初期値 = 月表示（大）= default
+                $display_type_to_frame_designs = [
+                    1 => 'small_month', // 1:月表示（縮小）
+                    2 => 'default',     // 2:月表示（拡大）
+                    3 => 'default',     // 3:週表示
+                    4 => 'day',         // 4:日表示
+                    5 => 'day',         // 5:スケジュール（時間順）
+                    6 => 'day',         // 6:スケジュール（会員順）
+                ];
+                $frame_design = $display_type_to_frame_designs[$nc3_calendar_frame_setting->display_type] ?? 'default';
+                $frame_ini .= "template = \"" . $frame_design . "\"\n";
             } else {
                 $frame_ini .= "template = \"default\"\n";
             }

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -3553,17 +3553,13 @@ trait MigrationNc3ExportTrait
 
 
             // カラムのヘッダー及びTSV 行毎の枠準備
-            $tsv_header = "calendar_id" . "\t" . "plan_id" . "\t" . "user_id" . "\t" . "user_name" . "\t" . "title" . "\t" .
-                "allday_flag" . "\t" . "start_date" . "\t" . "start_time" . "\t" . "end_date" . "\t" . "end_time" . "\t" .
+            $tsv_header = "post_id" . "\t" . "title" . "\t" . "allday_flag" . "\t" . "start_date" . "\t" . "start_time" . "\t" . "end_date" . "\t" . "end_time" . "\t" .
                 "location" . "\t" . "contact" . "\t" . "body" . "\t" . "rrule" . "\t" .
                 "created_at" . "\t" . "created_name" . "\t" . "insert_login_id" . "\t" . "updated_at" . "\t" . "updated_name" . "\t" . "update_login_id" . "\t" .
                 // CC 状態
                 "status";
 
-            $tsv_cols['calendar_id'] = "";
-            $tsv_cols['plan_id'] = "";
-            $tsv_cols['user_id'] = "";
-            $tsv_cols['user_name'] = "";
+            $tsv_cols['post_id'] = "";
             $tsv_cols['title'] = "";
             $tsv_cols['allday_flag'] = "";
             $tsv_cols['start_date'] = "";
@@ -3612,10 +3608,7 @@ trait MigrationNc3ExportTrait
                 // 初期化
                 $tsv_record = $tsv_cols;
 
-                // $tsv_record['calendar_id'] = $calendar_event->id;
-                // $tsv_record['plan_id']     = $calendar_event->calendar_rrule_id;
-                // $tsv_record['user_id']     = $calendar_event->user_id;
-                // $tsv_record['user_name']   = $calendar_event->user_name;
+                $tsv_record['post_id'] = $calendar_event->id;
                 $tsv_record['title']       = $calendar_event->title;
                 $tsv_record['allday_flag'] = $calendar_event->is_allday;
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -10304,13 +10304,8 @@ trait MigrationTrait
         }
 
 
-        // NC2カレンダーブロック（モジュール配置したブロック（どう見せるか、だけ。ここ無くても予定データある））を移行する。
-        $where_calendar_block_ids = $this->getMigrationConfig('calendars', 'nc2_export_where_calendar_block_ids');
-        if (empty($where_calendar_block_ids)) {
-            $nc2_calendar_blocks = Nc2CalendarBlock::orderBy('block_id')->get();
-        } else {
-            $nc2_calendar_blocks = Nc2CalendarBlock::whereIn('block_id', $where_calendar_block_ids)->orderBy('block_id')->get();
-        }
+        // NC2カレンダーブロック（インポート時にblock_idからroom_idを取得するために出力）
+        $nc2_calendar_blocks = Nc2CalendarBlock::orderBy('block_id')->get();
 
         // 空なら戻る
         if ($nc2_calendar_blocks->isEmpty()) {

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -3617,19 +3617,13 @@ trait MigrationTrait
                 // 行ループで使用する各種変数
                 $header_skip = true;       // ヘッダースキップフラグ（1行目はカラム名の行）
 
-                // NC2 calendar_plan
-                $tsv_idxs['calendar_id'] = 0;
-                $tsv_idxs['plan_id'] = 0;
-                $tsv_idxs['user_id'] = 0;
-                $tsv_idxs['user_name'] = 0;
+                $tsv_idxs['post_id'] = 0;
                 $tsv_idxs['title'] = 0;
                 $tsv_idxs['allday_flag'] = 0;
                 $tsv_idxs['start_date'] = 0;
                 $tsv_idxs['start_time'] = 0;
                 $tsv_idxs['end_date'] = 0;
                 $tsv_idxs['end_time'] = 0;
-
-                // NC2 calendar_plan_details
                 // 場所
                 $tsv_idxs['location'] = 0;
                 // 連絡先
@@ -3638,18 +3632,15 @@ trait MigrationTrait
                 $tsv_idxs['body'] = 0;
                 // 繰り返し条件
                 $tsv_idxs['rrule'] = 0;
-
-                // NC2 calendar_plan 登録日・更新日等
+                // 登録日・更新日等
                 $tsv_idxs['created_at'] = 0;
                 $tsv_idxs['created_name'] = 0;
                 $tsv_idxs['insert_login_id'] = 0;
                 $tsv_idxs['updated_at'] = 0;
                 $tsv_idxs['updated_name'] = 0;
                 $tsv_idxs['update_login_id'] = 0;
-
                 // CC 状態
                 $tsv_idxs['status'] = 0;
-
 
                 // 改行で記事毎に分割（行の処理）
                 $calendar_tsv_lines = explode("\n", $calendar_tsv);
@@ -3706,7 +3697,7 @@ trait MigrationTrait
                     // 記事のマッピングテーブルの追加
                     $mapping = MigrationMapping::create([
                         'target_source_table'  => 'calendars_post',
-                        'source_key'           => $calendar_tsv_cols[$tsv_idxs['calendar_id']],
+                        'source_key'           => $calendar_tsv_cols[$tsv_idxs['post_id']],
                         'destination_key'      => $calendar_post->id,
                     ]);
 
@@ -10110,20 +10101,15 @@ trait MigrationTrait
 
 
             // カラムのヘッダー及びTSV 行毎の枠準備
-            $tsv_header = "calendar_id" . "\t" . "plan_id" . "\t" . "user_id" . "\t" . "user_name" . "\t" . "title" . "\t" .
-                "allday_flag" . "\t" . "start_date" . "\t" . "start_time" . "\t" . "end_date" . "\t" . "end_time" . "\t" .
-                // NC2 calendar_plan_details
+            $tsv_header = "post_id" . "\t" . "title" . "\t" . "allday_flag" . "\t" . "start_date" . "\t" . "start_time" . "\t" . "end_date" . "\t" . "end_time" . "\t" .
                 "location" . "\t" . "contact" . "\t" . "body" . "\t" . "rrule" . "\t" .
-                // NC2 calendar_plan 登録日・更新日等
+                // 登録日・更新日等
                 "created_at" . "\t" . "created_name" . "\t" . "insert_login_id" . "\t" . "updated_at" . "\t" . "updated_name" . "\t" . "update_login_id" . "\t" .
                 // CC 状態
                 "status";
 
             // NC2 calendar_plan
-            $tsv_cols['calendar_id'] = "";
-            $tsv_cols['plan_id'] = "";
-            $tsv_cols['user_id'] = "";
-            $tsv_cols['user_name'] = "";
+            $tsv_cols['post_id'] = "";
             $tsv_cols['title'] = "";
             $tsv_cols['allday_flag'] = "";
             $tsv_cols['start_date'] = "";
@@ -10173,11 +10159,7 @@ trait MigrationTrait
                 // 初期化
                 $tsv_record = $tsv_cols;
 
-                // NC2 calendar_plan
-                $tsv_record['calendar_id'] = $calendar_plan->calendar_id;
-                $tsv_record['plan_id'] = $calendar_plan->plan_id;
-                $tsv_record['user_id'] = $calendar_plan->user_id;
-                $tsv_record['user_name'] = $calendar_plan->user_name;
+                $tsv_record['post_id'] = $calendar_plan->calendar_id;
                 $tsv_record['title'] = trim($calendar_plan->title);
                 $tsv_record['allday_flag'] = $calendar_plan->allday_flag;
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -12438,7 +12438,7 @@ trait MigrationTrait
 
 
         $i = 0;
-        while (!isset($headers[$i])) {
+        while (isset($headers[$i])) {
             if (stripos($headers[$i], "200") !== false) {
                 // OK
                 return true;

--- a/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
@@ -372,9 +372,6 @@ img_fluid_min_width = 200
 [calendars]
 
 ; --- エクスポート
-;エクスポート対象のカレンダーブロックID（モジュール配置したブロック（どう見せるか、だけ。ここ無くても予定データある））を絞る（指定がなければすべて対象）
-; nc2_export_where_calendar_block_ids[] = 1
-
 ;プライベートルームのカレンダーをエクスポートする
 ; nc2_export_private_room_calendar = 1
 

--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -105,7 +105,7 @@ nc3_export_plugins[] = "forms"
 nc3_export_plugins[] = "faqs"
 nc3_export_plugins[] = "linklists"
 nc3_export_plugins[] = "counters"
-; nc3_export_plugins[] = "calendars"
+nc3_export_plugins[] = "calendars"
 ; nc3_export_plugins[] = "reservations"
 ; nc3_export_plugins[] = "photoalbums"
 
@@ -121,7 +121,7 @@ cc_import_plugins[] = "forms"
 cc_import_plugins[] = "faqs"
 cc_import_plugins[] = "linklists"
 cc_import_plugins[] = "counters"
-; cc_import_plugins[] = "calendars"
+cc_import_plugins[] = "calendars"
 ; cc_import_plugins[] = "reservations"
 ; cc_import_plugins[] = "photoalbums"
 
@@ -188,7 +188,7 @@ import_frame_plugins[] = "forms"
 import_frame_plugins[] = "faqs"
 import_frame_plugins[] = "linklists"
 import_frame_plugins[] = "counters"
-; import_frame_plugins[] = "calendars"
+import_frame_plugins[] = "calendars"
 ; import_frame_plugins[] = "reservations"
 ; import_frame_plugins[] = "photoalbums"
 
@@ -357,3 +357,14 @@ export_clear_style[] = "font-family"
 [counters]
 ;エクスポート対象のカウンターブロックIDを絞る（指定がなければすべて対象）
 ; nc3_export_where_counter_ids[] = 1
+
+;------------------------------------------------
+;- カレンダー オプション
+;------------------------------------------------
+[calendars]
+
+; --- エクスポート
+;プライベートルームのカレンダーをエクスポートする
+; nc3_export_private_room_calendar = 1
+
+; --- インポート


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: [nc3移行エクスポート] カレンダー移行対応](https://github.com/opensource-workshop/connect-cms/pull/1511/commits/76caafb0d53a77d08f16e26701004cffb61188f1)
    * [add: [移行インポート] カレンダーの権限設定を個別設定で移行できるよう対応](https://github.com/opensource-workshop/connect-cms/pull/1511/commits/4ccfc20b98e25131d6436226e7c509642ae62a5e)
* 関連修正
    * [change: [nc2移行] カレンダー権限設定移行の汎用化対応](https://github.com/opensource-workshop/connect-cms/pull/1511/commits/c9bda080de576b2a71e36142c9ac1d56096e2d22)
    * [change: [nc2移行] カレンダー予定の移行カラム見直し](https://github.com/opensource-workshop/connect-cms/pull/1511/commits/36ea856550753fb83e05a2df3766c32df8f9ab7b)
    * [refactor: [nc2移行エクスポート] カレンダーの表示方法移行の処理見直し](https://github.com/opensource-workshop/connect-cms/pull/1511/commits/bf8597e411e7713150e69cbc5fb2fb875055f0a6)
    * [delete: [nc2移行エクスポート] カレンダーの移行オプション nc2_export_where_calendar_block_ids の廃止](https://github.com/opensource-workshop/connect-cms/pull/1511/commits/254df15407a7b5f0087def2e88c76e519fbf96aa) 
    * [bugfix: [nc2/nc3移行エクスポート] 外部リンクチェックができてない不具合の修正](https://github.com/opensource-workshop/connect-cms/pull/1511/commits/f25edac17651f49bb7e92b1f9f0157bedbe66ca5)

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
