### PR TITLE
[nc3移行] 施設予約の移行対応（nc3-migrateブランチにマージ）

### DIFF
--- a/app/Models/Migration/Nc3/Nc3Category.php
+++ b/app/Models/Migration/Nc3/Nc3Category.php
@@ -22,12 +22,17 @@ class Nc3Category extends Model
      */
     public static function getCategoriesByBlockIds($block_ids): Collection
     {
-        return Nc3Category::select('categories.*', 'categories_languages.name')
+        return Nc3Category::select('categories.*', 'categories_languages.name', 'category_orders.weight as display_sequence')
             ->join('categories_languages', function ($join) {
                 $join->on('categories_languages.category_id', '=', 'categories.id')
                     ->where('categories_languages.language_id', Nc3Language::language_id_ja);
             })
+            ->join('category_orders', function ($join) {
+                $join->on('category_orders.category_key', '=', 'categories.key');
+            })
             ->whereIn('categories.block_id', $block_ids)
+            ->orderBy('category_orders.block_key')
+            ->orderBy('category_orders.weight')
             ->get();
     }
 }

--- a/app/Models/Migration/Nc3/Nc3ReservationEvent.php
+++ b/app/Models/Migration/Nc3/Nc3ReservationEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3ReservationEvent extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'reservation_events';
+}

--- a/app/Models/Migration/Nc3/Nc3ReservationLocation.php
+++ b/app/Models/Migration/Nc3/Nc3ReservationLocation.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3ReservationLocation extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'reservation_locations';
+}

--- a/app/Models/Migration/Nc3/Nc3ReservationLocationsApprovalUser.php
+++ b/app/Models/Migration/Nc3/Nc3ReservationLocationsApprovalUser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3ReservationLocationsApprovalUser extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'reservation_locations_approval_users';
+}

--- a/app/Models/Migration/Nc3/Nc3ReservationLocationsReservable.php
+++ b/app/Models/Migration/Nc3/Nc3ReservationLocationsReservable.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class Nc3ReservationLocationsReservable extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'reservation_location_reservable';
+
+    /**
+     * block_role_permissionsのvalueをblock_key,permission,role_keyで取得
+     */
+    public static function getReservableValue(Collection $reservation_location_reservables, string $location_key, string $role_key, ?string $default = '0'): string
+    {
+        $reservable = $reservation_location_reservables->where('location_key', $location_key)->firstWhere('role_key', $role_key) ?? new Nc3ReservationLocationsReservable();
+        return $reservable->value ?? $default;
+    }
+}

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -4267,14 +4267,13 @@ trait MigrationNc3ExportTrait
             ['{X-SUBJECT}',    '[[X-件名]]'],
             ['{X-USER}',       '[[' . NoticeEmbeddedTag::created_name . ']]'],
             ['{X-TO_DATE}',    '[[' . NoticeEmbeddedTag::created_at . ']]'],
-            ['{X-BODY}',       '[[' . NoticeEmbeddedTag::body . ']]'],
+            ['{X-BODY}',       '[[X-補足]]'],
             ['{X-URL}',        '[[' . NoticeEmbeddedTag::url . ']]'],
             ['開始日時:{X-START_TIME}', '利用日時:[[' . ReservationNoticeEmbeddedTag::booking_time . ']]'],
             ['{X-START_TIME}', '[[' . ReservationNoticeEmbeddedTag::booking_time . ']]'],
             ['{X-LOCATION}',   '[[' . ReservationNoticeEmbeddedTag::facility_name . ']]'],
             ['{X-CONTACT}',    '[[X-連絡先]]'],
             ['{X-RRULE}',      '[[' . ReservationNoticeEmbeddedTag::rrule . ']]'],
-            ['{X-BODY}',       '[[X-補足]]'],
 
             ['{X-PLUGIN_NAME}', '施設予約'],
             // 除外

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -138,7 +138,6 @@ trait MigrationNc3ExportTrait
     protected $plugin_name = [
         // 'photo_albums'     => 'photoalbums',  // フォトアルバム
         // 'searches'         => 'searchs',      // 検索
-        // 'videos'           => 'Development',  // 動画
         'access_counters'  => 'counters',       // カウンター
         'announcements'    => 'contents',       // お知らせ
         'bbses'            => 'bbses',          // 掲示板

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -5968,8 +5968,6 @@ trait MigrationTrait
 
         // カレンダールームの情報取得
         if (!empty($nc2_calendar_room_id) && Storage::exists($this->getImportPath('calendars/calendar_room_') . $this->zeroSuppress($nc2_calendar_room_id) . '.ini')) {
-            // dd($nc2_calendar_room_id);
-
             $calendar_room_ini = parse_ini_file(storage_path() . '/app/' . $this->getImportPath('calendars/calendar_room_') . $this->zeroSuppress($nc2_calendar_room_id) . '.ini', true);
         }
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -4240,7 +4240,7 @@ trait MigrationTrait
                             ]);
 
                             // 開始日
-                            // ※ [要注意] NC2の reservation_reserve_details.rrule は DTSTART がないため、移行時は開始日の補完が必要。
+                            // ※ [要注意] NC2/NC3の rrule は DTSTART がないため、移行時は開始日の補完が必要。
                             //            DTSTART無指定だと、今日日付で処理される。
                             $dtstart = RRule::parseDate($reservation_tsv_cols[$tsv_idxs['start_time_full']]);
 

--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -106,7 +106,7 @@ nc3_export_plugins[] = "faqs"
 nc3_export_plugins[] = "linklists"
 nc3_export_plugins[] = "counters"
 nc3_export_plugins[] = "calendars"
-; nc3_export_plugins[] = "reservations"
+nc3_export_plugins[] = "reservations"
 ; nc3_export_plugins[] = "photoalbums"
 
 
@@ -122,7 +122,7 @@ cc_import_plugins[] = "faqs"
 cc_import_plugins[] = "linklists"
 cc_import_plugins[] = "counters"
 cc_import_plugins[] = "calendars"
-; cc_import_plugins[] = "reservations"
+cc_import_plugins[] = "reservations"
 ; cc_import_plugins[] = "photoalbums"
 
 
@@ -189,7 +189,7 @@ import_frame_plugins[] = "faqs"
 import_frame_plugins[] = "linklists"
 import_frame_plugins[] = "counters"
 import_frame_plugins[] = "calendars"
-; import_frame_plugins[] = "reservations"
+import_frame_plugins[] = "reservations"
 ; import_frame_plugins[] = "photoalbums"
 
 
@@ -368,3 +368,21 @@ export_clear_style[] = "font-family"
 ; nc3_export_private_room_calendar = 1
 
 ; --- インポート
+
+;------------------------------------------------
+;- 施設予約 オプション
+;------------------------------------------------
+[reservations]
+; --- エクスポート
+;エクスポート対象の施設予約フレームID（配置したフレーム（どう見せるか、だけ。ここ無くても予約データある））を絞る（指定がなければすべて対象）
+; nc3_export_where_reservation_frame_ids[] = 1
+
+;エクスポート対象の施設IDを絞る（指定がなければすべて対象）
+; nc3_export_where_reservation_location_ids[] = 1
+
+;エクスポート対象の施設予約名をページ名から取得する（指定がなければブロックタイトルがあればブロックタイトル。なければページ名）
+; nc3_export_reservation_name_is_page_name = true
+
+; --- インポート
+;インポート対象の表示施設カテゴリで、施設カテゴリ名とルーム名が同じものは表示する
+; import_is_show_reservations_category_name_and_room_name_are_the_same = true


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: [nc3移行エクスポート] 施設予約の移行対応](https://github.com/opensource-workshop/connect-cms/pull/1512/commits/e115a727609884baa55a9995afc36e2a03226491)
    * [add: [移行インポート] importPluginReservations() メールの承認通知/承認済み通知設定の移行対応](https://github.com/opensource-workshop/connect-cms/pull/1512/commits/21c581e15f8b03a1f04cf155bf76d844fedbb661)
    * [change: [nc2移行] 施設予約のカテゴリなし移行の見直し＆施設予約のカレンダー初期表示の移行設定を汎用的に見直し](https://github.com/opensource-workshop/connect-cms/pull/1512/commits/a238671023a2de50c0e3053c4ad89a0fd833b534)


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
