### PR TITLE
[nc3移行] カレンダーの予定の状態/施設予約の予約の状態・予定時間・連絡先・補足の移行ミス修正（nc3-migrateブランチにマージ）

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -4134,9 +4134,9 @@ trait MigrationNc3ExportTrait
                 $tsv_record['title']              = $reservation_event->title;
                 $tsv_record['allday_flag']        = $reservation_event->is_allday;
                 // 予定開始日時
-                $tsv_record['start_time_full']    = new Carbon($reservation_event->dtstart, $reservation_event->timezone);
+                $tsv_record['start_time_full']    = (new Carbon($reservation_event->dtstart, 'UTC'))->timezone($reservation_event->timezone);
                 // 予定終了日時
-                $tsv_record['end_time_full']      = new Carbon($reservation_event->dtend, $reservation_event->timezone);
+                $tsv_record['end_time_full']      = (new Carbon($reservation_event->dtend, 'UTC'))->timezone($reservation_event->timezone);
                 // 連絡先
                 $tsv_record['contact']            = $reservation_event->contact;
                 // 内容 [WYSIWYG]

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -4208,27 +4208,24 @@ trait MigrationTrait
                         $column_contact = $columns->firstWhere('column_name', '連絡先');
                         $column_description = $columns->firstWhere('column_name', '補足');
 
-                        // bulk insert
-                        $reservations_inputs_columns = ReservationsInputsColumn::insert(
-                            // 件名
-                            [
-                                'inputs_parent_id' => $reservation_post->inputs_parent_id,
-                                'column_id' => $column_title->id,
-                                'value' => $reservation_tsv_cols[$tsv_idxs['title']],
-                            ],
-                            // 連絡先
-                            [
-                                'inputs_parent_id' => $reservation_post->inputs_parent_id,
-                                'column_id' => $column_contact->id,
-                                'value' => $reservation_tsv_cols[$tsv_idxs['contact']],
-                            ],
-                            // 補足
-                            [
-                                'inputs_parent_id' => $reservation_post->inputs_parent_id,
-                                'column_id' => $column_description->id,
-                                'value' => $this->changeWYSIWYG($reservation_tsv_cols[$tsv_idxs['description']]),
-                            ],
-                        );
+                        // 件名
+                        $reservations_inputs_column = ReservationsInputsColumn::create([
+                            'inputs_parent_id' => $reservation_post->inputs_parent_id,
+                            'column_id' => $column_title->id,
+                            'value' => $reservation_tsv_cols[$tsv_idxs['title']],
+                        ]);
+                        // 連絡先
+                        $reservations_inputs_column = ReservationsInputsColumn::create([
+                            'inputs_parent_id' => $reservation_post->inputs_parent_id,
+                            'column_id' => $column_contact->id,
+                            'value' => $reservation_tsv_cols[$tsv_idxs['contact']],
+                        ]);
+                        // 補足
+                        $reservations_inputs_column = ReservationsInputsColumn::create([
+                            'inputs_parent_id' => $reservation_post->inputs_parent_id,
+                            'column_id' => $column_description->id,
+                            'value' => $this->changeWYSIWYG($reservation_tsv_cols[$tsv_idxs['description']]),
+                        ]);
 
                         // rruleあれば登録
                         $rrule_setting = $reservation_tsv_cols[$tsv_idxs['rrule']];

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -3707,7 +3707,7 @@ trait MigrationTrait
             if (CalendarPost::where('calendar_id', $calendar->id)->count() == 0) {
                 // カレンダー予定の移行なし
 
-                $this->putMonitor(3, 'カレンダー予定なし', "カレンダー名={$calendar->name}, ini_path={$ini_path}");
+                $this->putMonitor(3, 'カレンダー予定なしで移行しない', "カレンダー名={$calendar->name}, ini_path={$ini_path}");
 
                 // 予定空のカレンダーは移行せず、ログ出力する。
                 Calendar::destroy($calendar->id);

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -4278,7 +4278,7 @@ trait MigrationTrait
 
             if (ReservationsInput::where('facility_id', $reservations_facility->id)->count() == 0) {
                 // 施設予約の予約の移行なし
-                $this->putError(3, '施設予約の予約なし', "施設名={$reservations_facility->facility_name}, ini_path={$ini_path}");
+                $this->putMonitor(1, '施設予約の予約なし', "施設名={$reservations_facility->facility_name}, ini_path={$ini_path}");
             }
 
             // マッピングテーブルの追加


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [bugfix: [nc3移行エクスポート] カレンダーの予定/施設予約の予定の状態移行ミス修正](https://github.com/opensource-workshop/connect-cms/commit/052ed5bbfe045a794046d132c9c487659fa2b442)
* [bugfix: [nc3移行エクスポート] 施設予約の予定時間の移行ミス修正](https://github.com/opensource-workshop/connect-cms/pull/1516/commits/bad87a82698c6da94ce6dd0d3b4de181e17ffa29)
* [bugfix: [移行インポート] 施設予約の予定の連絡先/補足が移行されないバグ修正](https://github.com/opensource-workshop/connect-cms/pull/1516/commits/e3683b984c9b44c8c6f5f755f6e0346a485b5176)
* 関連修正
    * [change: [移行インポート] カレンダーで予定空のエラー時のコンソールログ表示を修正](https://github.com/opensource-workshop/connect-cms/commit/3df8245b49902cf212653138f46aa8c2e1e1ac51)
    * [change: [移行インポート] 施設予約で予定空は、エラーではなく通知のみのため、ログ出力レベルを修正](https://github.com/opensource-workshop/connect-cms/commit/5982cad91379d1db48eff304ef72c09f075accd1)

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
