### PR TITLE
[nc3移行] フォトアルバムの移行対応（nc3-migrateブランチにマージ）

### DIFF
--- a/app/Models/Migration/Nc3/Nc3PhotoAlbumDisplayAlbum.php
+++ b/app/Models/Migration/Nc3/Nc3PhotoAlbumDisplayAlbum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3PhotoAlbumDisplayAlbum extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'photo_album_display_albums';
+}

--- a/app/Models/Migration/Nc3/Nc3PhotoAlbumFrameSetting.php
+++ b/app/Models/Migration/Nc3/Nc3PhotoAlbumFrameSetting.php
@@ -6,13 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class Nc3PhotoAlbumFrameSetting extends Model
 {
-    // アルバム一覧表示
-    const DISPLAY_ALBUM_LIST = 1;
-    // 写真一覧表示
-    const DISPLAY_PHOTO_LIST = 2;
-    // アルバムのスライド表示
-    const DISPLAY_SLIDESHOW = 3;
-
     /**
      * 使用するDB Connection
      */
@@ -22,4 +15,20 @@ class Nc3PhotoAlbumFrameSetting extends Model
      * テーブル名の指定
      */
     protected $table = 'photo_album_frame_settings';
+
+    // アルバム一覧表示
+    const DISPLAY_ALBUM_LIST = 1;
+    // 写真一覧表示
+    const DISPLAY_PHOTO_LIST = 2;
+    // アルバムのスライド表示
+    const DISPLAY_SLIDESHOW = 3;
+
+    // アルバムの表示順
+    const albums_order_new  = 'PhotoAlbum.modified desc',       // 新着順
+        albums_order_create = 'PhotoAlbum.created asc',         // 登録順
+        albums_order_title  = 'PhotoAlbum.name asc';            // タイトル順
+
+    // 写真の表示順
+    const photos_order_new  = 'PhotoAlbumPhoto.modified desc',  // 新着順
+        photos_order_create = 'PhotoAlbumPhoto.created asc';    // 登録順
 }

--- a/app/Models/Migration/Nc3/Nc3PhotoAlbumPhoto.php
+++ b/app/Models/Migration/Nc3/Nc3PhotoAlbumPhoto.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc3;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc3PhotoAlbumPhoto extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc3';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'photo_album_photos';
+}

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -3468,12 +3468,10 @@ trait MigrationNc3ExportTrait
         $nc3_export_private_room_calendar = $this->getMigrationConfig('calendars', 'nc3_export_private_room_calendar');
         if (empty($nc3_export_private_room_calendar)) {
             // プライベートルームをエクスポート（=移行）しない
-            $nc3_rooms_query = $nc3_rooms_query->whereIn('space_id', [Nc3Space::PUBLIC_SPACE_ID, Nc3Space::COMMUNITY_SPACE_ID]);
-
+            $nc3_rooms_query = $nc3_rooms_query->whereIn('rooms.space_id', [Nc3Space::PUBLIC_SPACE_ID, Nc3Space::COMMUNITY_SPACE_ID]);
         } else {
             // プライベートルームをエクスポート（=移行）する
-            $nc3_rooms_query = $nc3_rooms_query->whereIn('space_id', [Nc3Space::PUBLIC_SPACE_ID, Nc3Space::COMMUNITY_SPACE_ID, Nc3Space::PRIVATE_SPACE_ID]);
-
+            $nc3_rooms_query = $nc3_rooms_query->whereIn('rooms.space_id', [Nc3Space::PUBLIC_SPACE_ID, Nc3Space::COMMUNITY_SPACE_ID, Nc3Space::PRIVATE_SPACE_ID]);
         }
         $nc3_rooms = $nc3_rooms_query->get();
 

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -673,7 +673,7 @@ trait MigrationNc3ExportTrait
                      'destination_key'     => $this->zeroSuppress($new_page_index)]
                 );
 
-                // ブロック処理
+                // フレーム処理
                 $this->nc3Frame($nc3_sort_page, $new_page_index, $nc3_top_page);
             }
 
@@ -4709,7 +4709,7 @@ trait MigrationNc3ExportTrait
             ->orderBy('frames.weight')
             ->get();
 
-        // ブロックをループ
+        // フレームをループ
         $frame_index = 0; // フレームの連番
 
         // [Connect出力] 割り切り実装

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -4398,7 +4398,7 @@ trait MigrationNc3ExportTrait
                 $photoalbum_ini .= "album_name                 = \"" . $nc3_photoalbum_alubum->name . "\"\n";
                 $photoalbum_ini .= "album_description          = \"" . $nc3_photoalbum_alubum->description . "\"\n";
                 $photoalbum_ini .= "public_flag                = 1\n";   // 1:公開
-                $photoalbum_ini .= "nc2_upload_id              = "   . $album_upload->id . "\n";    // [TODO] 今後upload_idにリネームしたいな
+                $photoalbum_ini .= "upload_id                  = "   . $album_upload->id . "\n";
                 $photoalbum_ini .= "width                      = {$image_width}\n";
                 $photoalbum_ini .= "height                     = {$image_height}\n";
                 $photoalbum_ini .= "created_at                 = \"" . $this->getCCDatetime($nc3_photoalbum_alubum->created) . "\"\n";
@@ -4414,12 +4414,11 @@ trait MigrationNc3ExportTrait
             $this->storagePut($this->getImportPath('photoalbums/photoalbum_') . $this->zeroSuppress($nc3_room->id) . '.ini', $photoalbum_ini);
 
             // カラムのヘッダー及びTSV 行毎の枠準備
-            // [TODO] 今後upload_idにリネームしたいな
-            $tsv_header = "photo_id" . "\t" . "nc2_upload_id" . "\t" . "photo_name" . "\t" . "photo_description" . "\t" . "width" . "\t" ."height" . "\t" .
+            $tsv_header = "photo_id" . "\t" . "upload_id" . "\t" . "photo_name" . "\t" . "photo_description" . "\t" . "width" . "\t" ."height" . "\t" .
                 "created_at" . "\t" . "created_name" . "\t" . "insert_login_id" . "\t" . "updated_at" . "\t" . "updated_name" . "\t" . "update_login_id";
 
             $tsv_cols['photo_id'] = "";
-            $tsv_cols['nc2_upload_id'] = "";
+            $tsv_cols['upload_id'] = "";
             $tsv_cols['photo_name'] = "";
             $tsv_cols['photo_description'] = "";
             $tsv_cols['width'] = "";
@@ -4458,7 +4457,7 @@ trait MigrationNc3ExportTrait
                     }
 
                     $tsv_record['photo_id']          = $nc3_photoalbum_photo->id;
-                    $tsv_record['nc2_upload_id']     = $photo_upload->id;
+                    $tsv_record['upload_id']         = $photo_upload->id;
                     $tsv_record['photo_name']        = $nc3_photoalbum_photo->title;
                     $tsv_record['photo_description'] = $nc3_photoalbum_photo->description;
                     $tsv_record['width']             = $image_width;

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -4660,7 +4660,7 @@ trait MigrationNc3ExportTrait
      */
     private function nc3Frame(Nc3Page $nc3_page, int $new_page_index, Nc3Page $nc3_top_page)
     {
-        // 指定されたページ内のブロックを取得
+        // 指定されたページ内のフレームを取得
         $nc3_frames_query = Nc3Frame::
             select(
                 'frames.*',
@@ -5406,7 +5406,7 @@ trait MigrationNc3ExportTrait
      */
     private function nc3FrameExportCounters(Nc3Frame $nc3_frame, int $new_page_index, string $frame_index_str): void
     {
-        // NC3 フレーム設定の取得（データなければ、badge_secondaryを指定）
+        // NC3 フレーム設定の取得
         $access_counter_frame_setting = Nc3AccessCounterFrameSetting::where('frame_key', $nc3_frame->key)->firstOrNew([]);
 
         $ini_filename = "frame_" . $frame_index_str . '.ini';

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -60,7 +60,9 @@ use App\Models\Migration\Nc3\Nc3ReservationLocationsReservable;
 use App\Models\Migration\Nc3\Nc3Room;
 use App\Models\Migration\Nc3\Nc3RoomRolePermission;
 use App\Models\Migration\Nc3\Nc3PhotoAlbum;
+use App\Models\Migration\Nc3\Nc3PhotoAlbumDisplayAlbum;
 use App\Models\Migration\Nc3\Nc3PhotoAlbumFrameSetting;
+use App\Models\Migration\Nc3\Nc3PhotoAlbumPhoto;
 use App\Models\Migration\Nc3\Nc3SiteSetting;
 use App\Models\Migration\Nc3\Nc3Space;
 use App\Models\Migration\Nc3\Nc3UploadFile;
@@ -83,6 +85,7 @@ use App\Enums\FaqSequenceConditionType;
 use App\Enums\FormColumnType;
 use App\Enums\LinklistType;
 use App\Enums\NoticeEmbeddedTag;
+use App\Enums\PhotoalbumSort;
 use App\Enums\ReservationCalendarDisplayType;
 use App\Enums\ReservationLimitedByRole;
 use App\Enums\ReservationNoticeEmbeddedTag;
@@ -136,7 +139,6 @@ trait MigrationNc3ExportTrait
      * 廃止のものは 'Abolition' にする。
      */
     protected $plugin_name = [
-        // 'photo_albums'     => 'photoalbums',  // フォトアルバム
         // 'searches'         => 'searchs',      // 検索
         'access_counters'  => 'counters',       // カウンター
         'announcements'    => 'contents',       // お知らせ
@@ -150,7 +152,7 @@ trait MigrationNc3ExportTrait
         'links'            => 'linklists',      // リンクリスト
         'menus'            => 'menus',          // メニュー
         'multidatabases'   => 'databases',      // データベース
-        'photo_albums'     => 'Development',    // フォトアルバム
+        'photo_albums'     => 'photoalbums',    // フォトアルバム
         'questionnaires'   => 'Development',    // アンケート
         'quizzes'          => 'Development',    // 小テスト
         'registrations'    => 'forms',          // フォーム
@@ -487,6 +489,11 @@ trait MigrationNc3ExportTrait
             $this->nc3ExportReservation($redo);
         }
 
+        // NC3 フォトアルバム（photoalbums）データのエクスポート
+        if ($this->isTarget('nc3_export', 'plugins', 'photoalbums')) {
+            $this->nc3ExportPhotoalbum($redo);
+        }
+
         //////////////////
         // [TODO] まだ
         //////////////////
@@ -499,11 +506,6 @@ trait MigrationNc3ExportTrait
         // // NC3 シンプル動画（simplemovie）データのエクスポート
         // if ($this->isTarget('nc3_export', 'plugins', 'simplemovie')) {
         //     $this->nc3ExportSimplemovie($redo);
-        // }
-
-        // // NC3 フォトアルバム（photoalbum）データのエクスポート
-        // if ($this->isTarget('nc3_export', 'plugins', 'photoalbums')) {
-        //     $this->nc3ExportPhotoalbum($redo);
         // }
 
         // pages データとファイルのエクスポート
@@ -4435,7 +4437,7 @@ trait MigrationNc3ExportTrait
     }
 
     /**
-     * NC3：フォトアルバム（Photoalbum）の移行
+     * NC3：フォトアルバム（Photoalbums）の移行
      */
     private function nc3ExportPhotoalbum($redo)
     {
@@ -4447,14 +4449,34 @@ trait MigrationNc3ExportTrait
             Storage::deleteDirectory($this->getImportPath('photoalbums/'));
         }
 
-        // NC3フォトアルバム（Photoalbum）を移行する。
-        $nc3_export_where_photoalbum_ids = $this->getMigrationConfig('photoalbums', 'nc3_export_where_photoalbum_ids');
+        // NC3ルーム一覧
+        $nc3_rooms = Nc3Room::select('rooms.*', 'rooms_languages.name as room_name')
+            ->join('rooms_languages', function ($join) {
+                $join->on('rooms_languages.room_id', 'rooms.id')
+                    ->where('rooms_languages.language_id', Nc3Language::language_id_ja);
+            })
+            ->whereIn('rooms.space_id', [Nc3Space::PUBLIC_SPACE_ID, Nc3Space::COMMUNITY_SPACE_ID])
+            ->orderBy('rooms.id')
+            ->get();
 
-        if (empty($nc3_export_where_photoalbum_ids)) {
-            $nc3_photoalbums = Nc2Photoalbum::orderBy('photoalbum_id')->get();
-        } else {
-            $nc3_photoalbums = Nc2Photoalbum::whereIn('photoalbum_id', $nc3_export_where_photoalbum_ids)->orderBy('photoalbum_id')->get();
+        // NC3フォトアルバム（Photoalbums）を移行する。
+        $nc3_photoalbums_query = Nc3Photoalbum::select('photo_albums.*', 'blocks.key as block_key', 'blocks.room_id', 'rooms.space_id')
+            ->join('blocks', function ($join) {
+                $join->on('blocks.id', '=', 'photo_albums.block_id')
+                    ->where('blocks.plugin_key', 'photo_albums');
+            })
+            ->join('rooms', function ($join) {
+                $join->on('rooms.id', '=', 'blocks.room_id')
+                    ->whereIn('rooms.space_id', [Nc3Space::PUBLIC_SPACE_ID, Nc3Space::COMMUNITY_SPACE_ID]);
+            })
+            ->where('photo_albums.is_latest', 1)
+            ->orderBy('photo_albums.id');
+
+        $nc3_export_where_photoalbum_ids = $this->getMigrationConfig('photoalbums', 'nc3_export_where_photoalbum_ids');
+        if ($nc3_export_where_photoalbum_ids) {
+            $nc3_photoalbums_query = $nc3_photoalbums_query->whereIn('photo_albums.id', $nc3_export_where_photoalbum_ids);
         }
+        $nc3_photoalbums = $nc3_photoalbums_query->get();
 
         // 空なら戻る
         if ($nc3_photoalbums->isEmpty()) {
@@ -4463,80 +4485,103 @@ trait MigrationNc3ExportTrait
 
 
         // nc3の全ユーザ取得
-        $nc3_users = Nc2User::get();
+        $nc3_users = Nc3User::get();
 
-        $nc3_photoalbum_alubums_all = Nc2PhotoalbumAlbum::orderBy('photoalbum_id')->orderBy('album_sequence')->get();
-        $nc3_photoalbum_photos_all = Nc2PhotoalbumPhoto::orderBy('photoalbum_id')->orderBy('album_id')->orderBy('photo_sequence')->get();
+        $nc3_photoalbum_photos_all = Nc3PhotoAlbumPhoto::where('is_latest', 1)->orderBy('id')->get();
 
-        // NC3フォトアルバム（Photoalbum）のループ
-        foreach ($nc3_photoalbums as $nc3_photoalbum) {
+        // アップロードファイル
+        $photoalbum_uploads_all = Nc3UploadFile::where('plugin_key', 'photo_albums')->get();
+
+        // 表示アルバム
+        $photo_album_display_albums_all = Nc3PhotoAlbumDisplayAlbum::get();
+
+        // nc3 uploads_path の取得
+        $nc3_uploads_path = $this->getExportUploadsPath();
+
+        // nc3はフォトアルバムのバケツがないため、ルーム単位で出力する
+        // 例）name=パブリックルームのフォトアルバム
+
+        // ルーム単位で出力
+        foreach ($nc3_rooms as $nc3_room) {
             $room_ids = $this->getMigrationConfig('basic', 'nc3_export_room_ids');
             // ルーム指定があれば、指定されたルームのみ処理する。
             if (empty($room_ids)) {
                 // ルーム指定なし。全データの移行
-            } elseif (!empty($room_ids) && in_array($nc3_photoalbum->room_id, $room_ids)) {
+            } elseif (!empty($room_ids) && in_array($nc3_room->id, $room_ids)) {
                 // ルーム指定あり。指定ルームに合致する。
             } else {
                 // ルーム指定あり。条件に合致せず。移行しない。
                 continue;
             }
 
+            // 空なら移行しない
+            $nc3_photoalbum_alubums = $nc3_photoalbums->where('room_id', $nc3_room->id);
+            if ($nc3_photoalbum_alubums->isEmpty()) {
+                continue;
+            }
+
             // データベース設定
             $photoalbum_ini = "";
             $photoalbum_ini .= "[photoalbum_base]\n";
-            $photoalbum_ini .= "photoalbum_name = \"" . $nc3_photoalbum->photoalbum_name . "\"\n";
+            $photoalbum_ini .= "photoalbum_name = \"" . $nc3_room->room_name . "のフォトアルバム\"\n";
 
             // NC3 情報
             $photoalbum_ini .= "\n";
             $photoalbum_ini .= "[source_info]\n";
-            $photoalbum_ini .= "photoalbum_id = " . $nc3_photoalbum->photoalbum_id . "\n";
-            $photoalbum_ini .= "room_id = " . $nc3_photoalbum->room_id . "\n";
-            $photoalbum_ini .= "plugin_key = \"photoalbum\"\n";
-            $photoalbum_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_photoalbum->created) . "\"\n";
-            $photoalbum_ini .= "created_name    = \"" . $nc3_photoalbum->insert_user_name . "\"\n";
-            $photoalbum_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum->created_user) . "\"\n";
-            $photoalbum_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_photoalbum->modified) . "\"\n";
-            $photoalbum_ini .= "updated_name    = \"" . $nc3_photoalbum->update_user_name . "\"\n";
-            $photoalbum_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum->modified_user) . "\"\n";
+            $photoalbum_ini .= "photoalbum_id   = " . $nc3_room->id . "\n";
+            $photoalbum_ini .= "room_id         = " . $nc3_room->id . "\n";
+            $photoalbum_ini .= "plugin_key      = \"photoalbums\"\n";
 
             // アルバム 情報
             $photoalbum_ini .= "\n";
             $photoalbum_ini .= "[albums]\n";
 
-            $nc3_photoalbum_alubums = $nc3_photoalbum_alubums_all->where('photoalbum_id', $nc3_photoalbum->photoalbum_id);
             foreach ($nc3_photoalbum_alubums as $nc3_photoalbum_alubum) {
-                $photoalbum_ini .= "album[" . $nc3_photoalbum_alubum->album_id . "] = \"" . $nc3_photoalbum_alubum->album_name . "\"\n";
+                $photoalbum_ini .= "album[" . $nc3_photoalbum_alubum->id . "] = \"" . $nc3_photoalbum_alubum->name . "\"\n";
             }
             $photoalbum_ini .= "\n";
 
             // アルバム詳細 情報
             foreach ($nc3_photoalbum_alubums as $nc3_photoalbum_alubum) {
-                $photoalbum_ini .= "[" . $nc3_photoalbum_alubum->album_id . "]" . "\n";
-                $photoalbum_ini .= "album_id                   = \"" . $nc3_photoalbum_alubum->album_id . "\"\n";
-                $photoalbum_ini .= "album_name                 = \"" . $nc3_photoalbum_alubum->album_name . "\"\n";
-                $photoalbum_ini .= "album_description          = \"" . $nc3_photoalbum_alubum->album_description . "\"\n";
-                $photoalbum_ini .= "public_flag                = "   . $nc3_photoalbum_alubum->public_flag . "\n";
-                $photoalbum_ini .= "nc3_upload_id              = "   . $nc3_photoalbum_alubum->upload_id . "\n";
-                $photoalbum_ini .= "width                      = "   . $nc3_photoalbum_alubum->width . "\n";
-                $photoalbum_ini .= "height                     = "   . $nc3_photoalbum_alubum->height . "\n";
+                $album_upload = $photoalbum_uploads_all->where('field_name', 'jacket')->firstWhere('content_key', $nc3_photoalbum_alubum->key) ?? new Nc3UploadFile();
+
+                // 画像：原寸
+                $image_file_path = $nc3_uploads_path . $album_upload->path . $album_upload->id . '/' . $album_upload->real_file_name;
+                $image_width = 0;
+                $image_height = 0;
+                if (File::exists($image_file_path)) {
+                    list($image_width, $image_height) = getimagesize($image_file_path);
+                } else {
+                    $this->putError(3, "Image file not exists: " . $nc3_uploads_path . $album_upload->path . $album_upload->id . '/' . $album_upload->real_file_name);
+                }
+
+                $photoalbum_ini .= "[" . $nc3_photoalbum_alubum->id . "]" . "\n";
+                $photoalbum_ini .= "album_id                   = \"" . $nc3_photoalbum_alubum->id . "\"\n";
+                $photoalbum_ini .= "album_name                 = \"" . $nc3_photoalbum_alubum->name . "\"\n";
+                $photoalbum_ini .= "album_description          = \"" . $nc3_photoalbum_alubum->description . "\"\n";
+                $photoalbum_ini .= "public_flag                = 1\n";   // 1:公開
+                $photoalbum_ini .= "nc2_upload_id              = "   . $album_upload->id . "\n";    // [TODO] 今後upload_idにリネームしたいな
+                $photoalbum_ini .= "width                      = {$image_width}\n";
+                $photoalbum_ini .= "height                     = {$image_height}\n";
                 $photoalbum_ini .= "created_at                 = \"" . $this->getCCDatetime($nc3_photoalbum_alubum->created) . "\"\n";
-                $photoalbum_ini .= "created_name               = \"" . $nc3_photoalbum_alubum->insert_user_name . "\"\n";
+                $photoalbum_ini .= "created_name               = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_photoalbum_alubum->created_user) . "\"\n";
                 $photoalbum_ini .= "insert_login_id            = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_alubum->created_user) . "\"\n";
                 $photoalbum_ini .= "updated_at                 = \"" . $this->getCCDatetime($nc3_photoalbum_alubum->modified) . "\"\n";
-                $photoalbum_ini .= "updated_name               = \"" . $nc3_photoalbum_alubum->update_user_name . "\"\n";
+                $photoalbum_ini .= "updated_name               = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_photoalbum_alubum->modified_user) . "\"\n";
                 $photoalbum_ini .= "update_login_id            = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_alubum->modified_user) . "\"\n";
                 $photoalbum_ini .= "\n";
             }
 
             // フォトアルバム の設定
-            $this->storagePut($this->getImportPath('photoalbums/photoalbum_') . $this->zeroSuppress($nc3_photoalbum->photoalbum_id) . '.ini', $photoalbum_ini);
+            $this->storagePut($this->getImportPath('photoalbums/photoalbum_') . $this->zeroSuppress($nc3_room->id) . '.ini', $photoalbum_ini);
 
             // カラムのヘッダー及びTSV 行毎の枠準備
-            $tsv_header = "photo_id" . "\t" . "nc3_upload_id" . "\t" . "photo_name" . "\t" . "photo_description" . "\t" . "width" . "\t" ."height" . "\t" .
+            // [TODO] 今後upload_idにリネームしたいな
+            $tsv_header = "photo_id" . "\t" . "nc2_upload_id" . "\t" . "photo_name" . "\t" . "photo_description" . "\t" . "width" . "\t" ."height" . "\t" .
                 "created_at" . "\t" . "created_name" . "\t" . "insert_login_id" . "\t" . "updated_at" . "\t" . "updated_name" . "\t" . "update_login_id";
 
             $tsv_cols['photo_id'] = "";
-            $tsv_cols['nc3_upload_id'] = "";
+            $tsv_cols['nc2_upload_id'] = "";
             $tsv_cols['photo_name'] = "";
             $tsv_cols['photo_description'] = "";
             $tsv_cols['width'] = "";
@@ -4551,28 +4596,40 @@ trait MigrationNc3ExportTrait
             // 写真 情報
             foreach ($nc3_photoalbum_alubums as $nc3_photoalbum_alubum) {
 
-                Storage::delete($this->getImportPath('photoalbums/photoalbum_') . $this->zeroSuppress($nc3_photoalbum->photoalbum_id) . '_' . $this->zeroSuppress($nc3_photoalbum_alubum->album_id) . '.tsv');
+                Storage::delete($this->getImportPath('photoalbums/photoalbum_') . $this->zeroSuppress($nc3_room->id) . '_' . $this->zeroSuppress($nc3_photoalbum_alubum->id) . '.tsv');
 
                 $tsv = '';
                 $tsv .= $tsv_header . "\n";
 
-                $nc3_photoalbum_photos = $nc3_photoalbum_photos_all->where('album_id', $nc3_photoalbum_alubum->album_id);
+                $nc3_photoalbum_photos = $nc3_photoalbum_photos_all->where('album_key', $nc3_photoalbum_alubum->key);
                 foreach ($nc3_photoalbum_photos as $nc3_photoalbum_photo) {
 
                     // 初期化
                     $tsv_record = $tsv_cols;
 
-                    $tsv_record['photo_id']          = $nc3_photoalbum_photo->photo_id;
-                    $tsv_record['nc3_upload_id']     = $nc3_photoalbum_photo->upload_id;
-                    $tsv_record['photo_name']        = $nc3_photoalbum_photo->photo_name;
-                    $tsv_record['photo_description'] = $nc3_photoalbum_photo->photo_description;
-                    $tsv_record['width']             = $nc3_photoalbum_photo->width;
-                    $tsv_record['height']            = $nc3_photoalbum_photo->height;
+                    $photo_upload = $photoalbum_uploads_all->where('field_name', 'photo')->firstWhere('content_key', $nc3_photoalbum_photo->key) ?? new Nc3UploadFile();
+
+                    // 画像：原寸
+                    $image_file_path = $nc3_uploads_path . $photo_upload->path . $photo_upload->id . '/' . $photo_upload->real_file_name;
+                    $image_width = 0;
+                    $image_height = 0;
+                    if (File::exists($image_file_path)) {
+                        list($image_width, $image_height) = getimagesize($image_file_path);
+                    } else {
+                        $this->putError(3, "Image file not exists: " . $nc3_uploads_path . $photo_upload->path . $photo_upload->id . '/' . $photo_upload->real_file_name);
+                    }
+
+                    $tsv_record['photo_id']          = $nc3_photoalbum_photo->id;
+                    $tsv_record['nc2_upload_id']     = $photo_upload->id;
+                    $tsv_record['photo_name']        = $nc3_photoalbum_photo->title;
+                    $tsv_record['photo_description'] = $nc3_photoalbum_photo->description;
+                    $tsv_record['width']             = $image_width;
+                    $tsv_record['height']            = $image_height;
                     $tsv_record['created_at']        = $this->getCCDatetime($nc3_photoalbum_photo->created);
-                    $tsv_record['created_name']      = $nc3_photoalbum_photo->insert_user_name;
+                    $tsv_record['created_name']      = Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_photoalbum_photo->created_user);
                     $tsv_record['insert_login_id']   = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_photo->created_user);
                     $tsv_record['updated_at']        = $this->getCCDatetime($nc3_photoalbum_photo->modified);
-                    $tsv_record['updated_name']      = $nc3_photoalbum_photo->update_user_name;
+                    $tsv_record['updated_name']      = Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_photoalbum_photo->modified_user);
                     $tsv_record['update_login_id']   = Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_photo->modified_user);
 
                     $tsv .= implode("\t", $tsv_record) . "\n";
@@ -4580,52 +4637,64 @@ trait MigrationNc3ExportTrait
 
                 // データ行の書き出し
                 $tsv = $this->exportStrReplace($tsv, 'photoalbums');
-                $this->storageAppend($this->getImportPath('photoalbums/photoalbum_') . $this->zeroSuppress($nc3_photoalbum->photoalbum_id) . '_' . $this->zeroSuppress($nc3_photoalbum_alubum->album_id) . '.tsv', $tsv);
+                $this->storageAppend($this->getImportPath('photoalbums/photoalbum_') . $this->zeroSuppress($nc3_room->id) . '_' . $this->zeroSuppress($nc3_photoalbum_alubum->id) . '.tsv', $tsv);
             }
 
             // スライド表示はスライダーにも移行
 
-            // photoalbum_block の取得
-            // 1DB で複数ブロックがあるので、Join せずに、個別に読む
-            $nc3_photoalbum_blocks = Nc2PhotoalbumBlock::where('photoalbum_id', $nc3_photoalbum->photoalbum_id)
-                ->where('display', Nc2PhotoalbumBlock::DISPLAY_SLIDESHOW)
-                ->orderBy('block_id', 'asc')->get();
+            $nc3_photoalbum_frame_settings = Nc3Frame::select('photo_album_frame_settings.*', 'frames.id as frame_id')
+                ->join('photo_album_frame_settings', function ($join) {
+                    $join->on('photo_album_frame_settings.frame_key', '=', 'frames.key');
+                })
+                ->where('photo_album_frame_settings.display_type', Nc3PhotoAlbumFrameSetting::DISPLAY_SLIDESHOW)
+                ->whereIn('frames.block_id', $nc3_photoalbum_alubums->pluck('block_id'))
+                ->get();
 
             // NC3スライダー（Slideshow）のループ
-            foreach ($nc3_photoalbum_blocks as $nc3_photoalbum_block) {
+            foreach ($nc3_photoalbum_frame_settings as $nc3_photoalbum_frame_setting) {
                 // アルバム
-                $nc3_photoalbum_alubum = $nc3_photoalbum_alubums_all->firstWhere('album_id', $nc3_photoalbum_block->display_album_id);
-                $nc3_photoalbum_alubum = $nc3_photoalbum_alubum ?? new Nc2PhotoalbumAlbum();
+                $photo_album_display_album = $photo_album_display_albums_all->firstWhere('frame_key', $nc3_photoalbum_frame_setting->frame_key) ?? new Nc3PhotoAlbumDisplayAlbum();
+                $nc3_photoalbum_alubum = $nc3_photoalbum_alubums->firstWhere('key', $photo_album_display_album->album_key) ?? new Nc3Photoalbum();
 
-                // (nc)秒 => (cc)ミリ秒
-                $image_interval = $nc3_photoalbum_block->slide_time * 1000;
+                // (nc3)5000ミリ秒固定 => (cc)ミリ秒
+                // @see (nc3) app\Plugin\PhotoAlbums\View\PhotoAlbumPhotos\slide.ctp
+                $image_interval = 5000;
 
-                $height = $nc3_photoalbum_block->size_flag ? $nc3_photoalbum_block->height : null;
+                $height = $nc3_photoalbum_frame_setting->slide_height;
+                if ($height == 0) {
+                    // height=0(自動)の場合、固定値をセット
+                    $height = $this->getMigrationConfig('photoalbums', 'nc3_export_slideshow_convert_auto_height_value', 250);
+                }
 
                 // スライダー設定
                 $slide_ini = "";
                 $slide_ini .= "[slideshow_base]\n";
-                $slide_ini .= "slideshows_name = \"{$nc3_photoalbum_alubum->album_name}\"\n";
-                $slide_ini .= "image_interval = {$image_interval}\n";
-                $slide_ini .= "height = {$height}\n";
+                $slide_ini .= "slideshows_name = \"{$nc3_photoalbum_alubum->name}\"\n";
+                $slide_ini .= "image_interval  = {$image_interval}\n";
+                $slide_ini .= "height          = {$height}\n";
 
                 // NC3 情報
                 $slide_ini .= "\n";
                 $slide_ini .= "[source_info]\n";
-                $slide_ini .= "slideshows_block_id = " . $nc3_photoalbum_block->block_id . "\n";
-                $slide_ini .= "photoalbum_id = " . $nc3_photoalbum->photoalbum_id . "\n";
-                $slide_ini .= "photoalbum_name = \"" . $nc3_photoalbum->photoalbum_name . "\"\n";
-                $slide_ini .= "room_id = " . $nc3_photoalbum_block->room_id . "\n";
-                $slide_ini .= "plugin_key = \"photoalbum\"\n";
-                $slide_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_photoalbum_block->created) . "\"\n";
-                $slide_ini .= "created_name    = \"" . $nc3_photoalbum_block->insert_user_name . "\"\n";
-                $slide_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_block->created_user) . "\"\n";
-                $slide_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_photoalbum_block->modified) . "\"\n";
-                $slide_ini .= "updated_name    = \"" . $nc3_photoalbum_block->update_user_name . "\"\n";
-                $slide_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_block->modified_user) . "\"\n";
+                $slide_ini .= "slideshows_block_id = " . $nc3_photoalbum_frame_setting->frame_id . "\n";    // block_idは無いため、frame_idで代用
+                $slide_ini .= "photoalbum_id       = " . $nc3_photoalbum_alubum->id . "\n";
+                $slide_ini .= "photoalbum_name     = \"" . $nc3_photoalbum_alubum->name . "\"\n";
+                $slide_ini .= "room_id             = " . $nc3_photoalbum_alubum->room_id . "\n";
+                $slide_ini .= "plugin_key      = \"photoalbums\"\n";
+                $slide_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_photoalbum_frame_setting->created) . "\"\n";
+                $slide_ini .= "created_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_photoalbum_frame_setting->created_user) . "\"\n";
+                $slide_ini .= "insert_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_frame_setting->created_user) . "\"\n";
+                $slide_ini .= "updated_at      = \"" . $this->getCCDatetime($nc3_photoalbum_frame_setting->modified) . "\"\n";
+                $slide_ini .= "updated_name    = \"" . Nc3User::getNc3HandleFromNc3UserId($nc3_users, $nc3_photoalbum_frame_setting->modified_user) . "\"\n";
+                $slide_ini .= "update_login_id = \"" . Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $nc3_photoalbum_frame_setting->modified_user) . "\"\n";
 
-                // 写真
-                $nc3_photoalbum_photos = $nc3_photoalbum_photos_all->where('album_id', $nc3_photoalbum_block->display_album_id);
+                // 写真（並び順指定のため、DBから再取得）
+                // photos_sort=PhotoAlbumPhoto.modified
+                $photos_sorts = explode('.', $nc3_photoalbum_frame_setting->photos_sort);
+                $nc3_photoalbum_photos = Nc3PhotoAlbumPhoto::where('album_key', $nc3_photoalbum_alubum->key)
+                    ->where('is_latest', 1)
+                    ->orderBy($photos_sorts[1], $nc3_photoalbum_frame_setting->photos_direction)
+                    ->get();
 
                 // TSV でエクスポート
                 // image_path{\t}uploads_id{\t}link_url{\t}link_target{\t}caption{\t}display_flag{\t}display_sequence
@@ -4634,23 +4703,25 @@ trait MigrationNc3ExportTrait
 
                     $display_sequence = $i + 1;
 
+                    $photo_upload = $photoalbum_uploads_all->where('field_name', 'photo')->firstWhere('content_key', $nc3_photoalbum_photo->key) ?? new Nc3UploadFile();
+
                     // TSV 形式でエクスポート
                     if (!empty($slides_tsv)) {
                         $slides_tsv .= "\n";
                     }
                     $slides_tsv .= "\t";                                        // image_path
-                    $slides_tsv .= $nc3_photoalbum_photo->upload_id . "\t";     // uploads_id
+                    $slides_tsv .= $photo_upload->id . "\t";                    // uploads_id
                     $slides_tsv .= "\t";                                        // link_url
                     $slides_tsv .= "\t";                                        // link_target
-                    $slides_tsv .= "\t";                                        // caption
+                    $slides_tsv .= "{$nc3_photoalbum_photo->description}\t";    // caption
                     $slides_tsv .= "1\t";                                       // display_flag
                     $slides_tsv .= $display_sequence . "\t";                    // display_sequence
                 }
 
                 // スライダーの設定を出力
-                $this->storagePut($this->getImportPath('slideshows/slideshows_') . $this->zeroSuppress($nc3_photoalbum_block->block_id) . '.ini', $slide_ini);
+                $this->storagePut($this->getImportPath('slideshows/slideshows_') . $this->zeroSuppress($nc3_photoalbum_frame_setting->frame_id) . '.ini', $slide_ini);
                 // スライダーの付与情報を出力
-                $this->storagePut($this->getImportPath('slideshows/slideshows_') . $this->zeroSuppress($nc3_photoalbum_block->block_id) . '.tsv', $slides_tsv);
+                $this->storagePut($this->getImportPath('slideshows/slideshows_') . $this->zeroSuppress($nc3_photoalbum_frame_setting->frame_id) . '.tsv', $slides_tsv);
             }
         }
     }
@@ -5157,6 +5228,7 @@ trait MigrationNc3ExportTrait
                     ->where('display_type', Nc3PhotoAlbumFrameSetting::DISPLAY_SLIDESHOW)
                     ->first();
                 if ($nc3_photoalbum_frame_setting) {
+                    // NC3フォトアルバムにblock_idはないため、frame_idで代用
                     $ret = "slideshows_block_id = \"" . $this->zeroSuppress($nc3_frame->id) . "\"\n";
                 } else {
                     $ret = "photoalbum_id = \"" . $this->zeroSuppress($nc3_photoalbum->id) . "\"\n";
@@ -5196,6 +5268,9 @@ trait MigrationNc3ExportTrait
         } elseif ($plugin_name == 'counters') {
             // カウンター
             $this->nc3FrameExportCounters($nc3_frame, $new_page_index, $frame_index_str);
+        } elseif ($plugin_name == 'photoalbums') {
+            // フォトアルバム
+            $this->nc3FrameExportPhotoalbums($nc3_frame, $new_page_index, $frame_index_str);
         }
     }
 
@@ -5427,6 +5502,39 @@ trait MigrationNc3ExportTrait
 
         $frame_ini  = "[counter]\n";
         $frame_ini .= "design_type = {$design_type}\n";
+        $this->storageAppend($save_folder . "/"     . $ini_filename, $frame_ini);
+    }
+
+    /**
+     * NC3：フォトアルバムのフレーム特有部分のエクスポート
+     */
+    private function nc3FrameExportPhotoalbums(Nc3Frame $nc3_frame, int $new_page_index, string $frame_index_str): void
+    {
+        // NC3 フレーム設定の取得
+        $photo_album_frame_setting = Nc3PhotoAlbumFrameSetting::where('frame_key', $nc3_frame->key)->firstOrNew([]);
+
+        $ini_filename = "frame_" . $frame_index_str . '.ini';
+
+        $save_folder = $this->getImportPath('pages/') . $this->zeroSuppress($new_page_index);
+
+        // (NC3)albums_order -> (Connect)sort_album 変換
+        $convert_sort_albums = [
+            Nc3PhotoAlbumFrameSetting::albums_order_new    => PhotoalbumSort::created_desc,
+            Nc3PhotoAlbumFrameSetting::albums_order_create => PhotoalbumSort::created_asc,
+            Nc3PhotoAlbumFrameSetting::albums_order_title  => PhotoalbumSort::name_asc,
+        ];
+        $sort_album = $convert_sort_albums[$photo_album_frame_setting->albums_order] ?? PhotoalbumSort::name_asc;
+
+        // (NC3)photos_order -> (Connect)sort_photo 変換
+        $convert_sort_photos = [
+            Nc3PhotoAlbumFrameSetting::photos_order_new    => PhotoalbumSort::created_desc,
+            Nc3PhotoAlbumFrameSetting::photos_order_create => PhotoalbumSort::created_asc,
+        ];
+        $sort_photo = $convert_sort_photos[$photo_album_frame_setting->photos_order] ?? PhotoalbumSort::name_asc;
+
+        $frame_ini  = "[photoalbum]\n";
+        $frame_ini .= "sort_album = \"{$sort_album}\"\n";
+        $frame_ini .= "sort_photo = \"{$sort_photo}\"\n";
         $this->storageAppend($save_folder . "/"     . $ini_filename, $frame_ini);
     }
 

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -412,14 +412,6 @@ trait MigrationNc3ExportTrait
         // 移行の初期処理
         $this->migrationInit();
 
-        // uploads_path の取得
-        $uploads_path = config('migration.NC3_EXPORT_UPLOADS_PATH');
-
-        // uploads_path の最後に / がなければ追加
-        if (!empty($uploads_path) && mb_substr($uploads_path, -1) != '/') {
-            $uploads_path = $uploads_path . '/';
-        }
-
         // サイト基本設定のエクスポート
         if ($this->isTarget('nc3_export', 'basic')) {
             $this->nc3ExportBasic();
@@ -427,7 +419,7 @@ trait MigrationNc3ExportTrait
 
         // アップロード・データとファイルのエクスポート
         if ($this->isTarget('nc3_export', 'uploads')) {
-            $this->nc3ExportUploads($uploads_path, $redo);
+            $this->nc3ExportUploads($redo);
         }
 
         // ユーザデータのエクスポート
@@ -835,7 +827,7 @@ trait MigrationNc3ExportTrait
      * [2]
      * ・・・
      */
-    private function nc3ExportUploads($uploads_path, $redo)
+    private function nc3ExportUploads($redo)
     {
         $this->putMonitor(3, "Start nc3ExportUploads.");
 
@@ -861,6 +853,9 @@ trait MigrationNc3ExportTrait
         // uploads,ini ファイルの詳細（変数に保持、後でappend。[uploads] セクションが切れないため。）
         $uploads_ini = "";
         $uploads_ini_detail = "";
+
+        // nc3 uploads_path の取得
+        $uploads_path = $this->getExportUploadsPath();
 
         // アップロード・ファイルのループ
         foreach ($nc3_uploads as $nc3_upload) {
@@ -6616,5 +6611,20 @@ trait MigrationNc3ExportTrait
 
         // 移行対象外 (link_checkログには吐かない)
         $this->putMonitor(3, $nc3_plugin_key . '|内部リンク|移行対象外URL', $url, $nc3_frame);
+    }
+
+    /**
+     * nc3 uploads_path の取得
+     */
+    private function getExportUploadsPath(): string
+    {
+        // uploads_path の取得
+        $uploads_path = config('migration.NC3_EXPORT_UPLOADS_PATH');
+
+        // uploads_path の最後に / がなければ追加
+        if (!empty($uploads_path) && mb_substr($uploads_path, -1) != '/') {
+            $uploads_path = $uploads_path . '/';
+        }
+        return $uploads_path;
     }
 }

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -4467,11 +4467,11 @@ trait MigrationTrait
                     $children->save();
 
                     // カスタムジャケットのアップロードIDあり
-                    if ($photoalbums_ini[$album_id]['nc2_upload_id']) {
+                    if ($photoalbums_ini[$album_id]['upload_id']) {
                         // アルバムのジャケット登録
                         $contents = [
                             'photoalbum_id' => $photoalbum->id,
-                            'nc2_upload_id' => $photoalbums_ini[$album_id]['nc2_upload_id'],
+                            'upload_id'     => $photoalbums_ini[$album_id]['upload_id'],
                             'name'          => $album_name,
                             'width'         => $photoalbums_ini[$album_id]['width'],
                             'height'        => $photoalbums_ini[$album_id]['height'],
@@ -4489,7 +4489,7 @@ trait MigrationTrait
                         // マッピングテーブルの追加
                         $mapping_album_cover_tmp = MigrationMapping::create([
                             'target_source_table'  => 'photoalbums_album_cover',
-                            'source_key'           => $photoalbums_ini[$album_id]['nc2_upload_id'],
+                            'source_key'           => $photoalbums_ini[$album_id]['upload_id'],
                             'destination_key'      => $grandchild->id,
                         ]);
 
@@ -4508,7 +4508,7 @@ trait MigrationTrait
 
                     // マッピングテーブルの取得
                     $mapping_album_cover = MigrationMapping::where('target_source_table', 'photoalbums_album_cover')
-                        ->where('source_key', $photoalbums_ini[$album_id]['nc2_upload_id'])
+                        ->where('source_key', $photoalbums_ini[$album_id]['upload_id'])
                         ->first();
 
                     if ($mapping_album_cover) {
@@ -4530,7 +4530,7 @@ trait MigrationTrait
                     // 行ループで使用する各種変数
                     $header_skip = true;       // ヘッダースキップフラグ（1行目はカラム名の行）
                     $tsv_idxs['photo_id'] = 0;
-                    $tsv_idxs['nc2_upload_id'] = 0;
+                    $tsv_idxs['upload_id'] = 0;
                     $tsv_idxs['photo_name'] = 0;
                     $tsv_idxs['photo_description'] = 0;
                     $tsv_idxs['width'] = 0;
@@ -4577,7 +4577,7 @@ trait MigrationTrait
                             // 写真登録
                             $contents = [
                                 'photoalbum_id' => $photoalbum->id,
-                                'nc2_upload_id' => $photoalbum_tsv_cols[$tsv_idxs['nc2_upload_id']],
+                                'upload_id' => $photoalbum_tsv_cols[$tsv_idxs['upload_id']],
                                 'name' => $photoalbum_tsv_cols[$tsv_idxs['photo_name']],
                                 'width' => $photoalbum_tsv_cols[$tsv_idxs['width']],
                                 'height' => $photoalbum_tsv_cols[$tsv_idxs['height']],
@@ -4618,15 +4618,15 @@ trait MigrationTrait
      */
     private function createPhotoalbumContent(Collection $upload_mappings, Collection $uploads_all, PhotoalbumContent $children, array $contents): PhotoalbumContent
     {
-        $upload_mapping = $upload_mappings->firstWhere('source_key', $contents['nc2_upload_id']);
+        $upload_mapping = $upload_mappings->firstWhere('source_key', $contents['upload_id']);
         $upload = null;
         if ($upload_mapping) {
             $upload = $uploads_all->firstWhere('id', $upload_mapping->destination_key);
             if (!$upload) {
-                $this->putMonitor(3, "Connectの Uploads にアップロードIDなし。nc2_album_name={$contents['name']}, nc2_upload_id={$contents['nc2_upload_id']}, is_cover={$contents['is_cover']}");
+                $this->putMonitor(3, "Connectの Uploads にアップロードIDなし。nc2_album_name={$contents['name']}, upload_id={$contents['upload_id']}, is_cover={$contents['is_cover']}");
             }
         } else {
-            $this->putMonitor(3, "Connectの MigrationMapping にアップロードIDなし。nc2_album_name={$contents['name']}, nc2_upload_id={$contents['nc2_upload_id']}, is_cover={$contents['is_cover']}\n");
+            $this->putMonitor(3, "Connectの MigrationMapping にアップロードIDなし。nc2_album_name={$contents['name']}, upload_id={$contents['upload_id']}, is_cover={$contents['is_cover']}\n");
         }
 
         // 写真登録
@@ -11033,7 +11033,7 @@ trait MigrationTrait
                 $photoalbum_ini .= "album_name                 = \"" . $nc2_photoalbum_alubum->album_name . "\"\n";
                 $photoalbum_ini .= "album_description          = \"" . $nc2_photoalbum_alubum->album_description . "\"\n";
                 $photoalbum_ini .= "public_flag                = "   . $nc2_photoalbum_alubum->public_flag . "\n";
-                $photoalbum_ini .= "nc2_upload_id              = "   . $nc2_photoalbum_alubum->upload_id . "\n";
+                $photoalbum_ini .= "upload_id                  = "   . $nc2_photoalbum_alubum->upload_id . "\n";
                 $photoalbum_ini .= "width                      = "   . $nc2_photoalbum_alubum->width . "\n";
                 $photoalbum_ini .= "height                     = "   . $nc2_photoalbum_alubum->height . "\n";
                 $photoalbum_ini .= "created_at                 = \"" . $this->getCCDatetime($nc2_photoalbum_alubum->insert_time) . "\"\n";
@@ -11049,11 +11049,11 @@ trait MigrationTrait
             $this->storagePut($this->getImportPath('photoalbums/photoalbum_') . $this->zeroSuppress($nc2_photoalbum->photoalbum_id) . '.ini', $photoalbum_ini);
 
             // カラムのヘッダー及びTSV 行毎の枠準備
-            $tsv_header = "photo_id" . "\t" . "nc2_upload_id" . "\t" . "photo_name" . "\t" . "photo_description" . "\t" . "width" . "\t" ."height" . "\t" .
+            $tsv_header = "photo_id" . "\t" . "upload_id" . "\t" . "photo_name" . "\t" . "photo_description" . "\t" . "width" . "\t" ."height" . "\t" .
                 "created_at" . "\t" . "created_name" . "\t" . "insert_login_id" . "\t" . "updated_at" . "\t" . "updated_name" . "\t" . "update_login_id";
 
             $tsv_cols['photo_id'] = "";
-            $tsv_cols['nc2_upload_id'] = "";
+            $tsv_cols['upload_id'] = "";
             $tsv_cols['photo_name'] = "";
             $tsv_cols['photo_description'] = "";
             $tsv_cols['width'] = "";
@@ -11080,7 +11080,7 @@ trait MigrationTrait
                     $tsv_record = $tsv_cols;
 
                     $tsv_record['photo_id']          = $nc2_photoalbum_photo->photo_id;
-                    $tsv_record['nc2_upload_id']     = $nc2_photoalbum_photo->upload_id;
+                    $tsv_record['upload_id']         = $nc2_photoalbum_photo->upload_id;
                     $tsv_record['photo_name']        = $nc2_photoalbum_photo->photo_name;
                     $tsv_record['photo_description'] = $nc2_photoalbum_photo->photo_description;
                     $tsv_record['width']             = $nc2_photoalbum_photo->width;

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -5912,13 +5912,9 @@ trait MigrationTrait
 
         // counter_frames 登録
         if (!empty($counter)) {
-            // 表示形式
-            $design_type = Arr::get($counter_ini, 'counter_base.design_type', CounterDesignType::numeric);
-            $design_type = Arr::get($frame_ini, 'counter.design_type', $design_type);
-
             CounterFrame::create([
                 'frame_id' => $frame->id,
-                'design_type' => $design_type,
+                'design_type'     => Arr::get($frame_ini, 'counter.design_type', CounterDesignType::numeric),
                 'use_total_count' => 1,
                 'use_today_count' => 1,
                 'use_yesterday_count' => 1,
@@ -9948,51 +9944,16 @@ trait MigrationTrait
                 continue;
             }
 
-            // (NC2)show_type -> (Connect)design_type 変換
-            $convert_design_types = [
-                'black'       => CounterDesignType::badge_dark,
-                'black2'      => CounterDesignType::badge_dark,
-                'black3'      => CounterDesignType::badge_dark,
-                'color'       => CounterDesignType::badge_light,
-                'digit01'     => CounterDesignType::white_number_warning,
-                'digit02'     => CounterDesignType::white_number_warning,
-                'digit03'     => CounterDesignType::white_number_danger,
-                'digit04'     => CounterDesignType::white_number_danger,
-                'digit05'     => CounterDesignType::white_number_primary,
-                'digit06'     => CounterDesignType::white_number_info,
-                'digit07'     => CounterDesignType::white_number_dark,
-                'digit08'     => CounterDesignType::white_number_dark,
-                'digit09'     => CounterDesignType::white_number_dark,
-                'digit10'     => CounterDesignType::white_number_dark,
-                'digit11'     => CounterDesignType::white_number_success,
-                'digit12'     => CounterDesignType::white_number_success,
-                'gray'        => CounterDesignType::badge_light,
-                'gray2'       => CounterDesignType::badge_light,
-                'gray3'       => CounterDesignType::badge_light,
-                'gray_large'  => CounterDesignType::badge_light,
-                'green'       => CounterDesignType::badge_success,
-                'green_large' => CounterDesignType::badge_success,
-                'white'       => CounterDesignType::white_number,
-                'white_large' => CounterDesignType::circle_success,
-            ];
-            $design_type = $convert_design_types[$nc2_counter->show_type] ?? CounterDesignType::numeric;
-
             // カウンター設定
             $ini = "";
             $ini .= "[counter_base]\n";
             // カウント数
             $ini .= "counter_num = " . $nc2_counter->counter_num . "\n";
-            // 表示する桁数
-            // $ini .= "counter_digit = " .  $nc2_counter->counter_digit . "\n";
-
-            $ini .= "design_type = " . $design_type . "\n";
 
             // 文字(前)
             $ini .= "show_char_before = '" . $nc2_counter->show_char_before . "'\n";
             // 文字(後)
             $ini .= "show_char_after = '" . $nc2_counter->show_char_after . "'\n";
-            // 上記以外に表示したい文字
-            // $ini .= "comment = " . $nc2_counter->comment . "\n";
 
             // NC2 情報
             $ini .= "\n";
@@ -11828,6 +11789,9 @@ trait MigrationTrait
         } elseif ($plugin_name == 'linklists') {
             // リンクリスト
             $this->nc2BlockExportLinklists($nc2_page, $nc2_block, $new_page_index, $frame_index_str);
+        } elseif ($plugin_name == 'counters') {
+            // カウンター
+            $this->nc2BlockExportCounters($nc2_page, $nc2_block, $new_page_index, $frame_index_str);
         }
     }
 
@@ -12009,6 +11973,56 @@ trait MigrationTrait
         $frame_ini = "[linklist]\n";
         // $frame_ini .= "view_count = 10\n";
         $frame_ini .= "type = {$type}\n";
+        $this->storageAppend($save_folder . "/"     . $ini_filename, $frame_ini);
+    }
+
+    /**
+     * NC2：リンクリストのブロック特有部分のエクスポート
+     */
+    private function nc2BlockExportCounters($nc2_page, $nc2_block, $new_page_index, $frame_index_str)
+    {
+        // NC2 ブロック設定の取得
+        $nc2_counter = Nc2Counter::where('block_id', $nc2_block->block_id)->first();
+
+        if (empty($nc2_counter)) {
+            return;
+        }
+
+        $ini_filename = "frame_" . $frame_index_str . '.ini';
+
+        $save_folder = $this->getImportPath('pages/') . $this->zeroSuppress($new_page_index);
+
+        // (NC2)show_type -> (Connect)design_type 変換
+        $convert_design_types = [
+            'black'       => CounterDesignType::badge_dark,
+            'black2'      => CounterDesignType::badge_dark,
+            'black3'      => CounterDesignType::badge_dark,
+            'color'       => CounterDesignType::badge_light,
+            'digit01'     => CounterDesignType::white_number_warning,
+            'digit02'     => CounterDesignType::white_number_warning,
+            'digit03'     => CounterDesignType::white_number_danger,
+            'digit04'     => CounterDesignType::white_number_danger,
+            'digit05'     => CounterDesignType::white_number_primary,
+            'digit06'     => CounterDesignType::white_number_info,
+            'digit07'     => CounterDesignType::white_number_dark,
+            'digit08'     => CounterDesignType::white_number_dark,
+            'digit09'     => CounterDesignType::white_number_dark,
+            'digit10'     => CounterDesignType::white_number_dark,
+            'digit11'     => CounterDesignType::white_number_success,
+            'digit12'     => CounterDesignType::white_number_success,
+            'gray'        => CounterDesignType::badge_light,
+            'gray2'       => CounterDesignType::badge_light,
+            'gray3'       => CounterDesignType::badge_light,
+            'gray_large'  => CounterDesignType::badge_light,
+            'green'       => CounterDesignType::badge_success,
+            'green_large' => CounterDesignType::badge_success,
+            'white'       => CounterDesignType::white_number,
+            'white_large' => CounterDesignType::circle_success,
+        ];
+        $design_type = $convert_design_types[$nc2_counter->show_type] ?? CounterDesignType::numeric;
+
+        $frame_ini  = "[counter]\n";
+        $frame_ini .= "design_type = {$design_type}\n";
         $this->storageAppend($save_folder . "/"     . $ini_filename, $frame_ini);
     }
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -169,6 +169,8 @@ use App\Enums\LinklistType;
 use App\Enums\NoticeEmbeddedTag;
 use App\Enums\NotShowType;
 use App\Enums\PermissionType;
+use App\Enums\PhotoalbumFrameConfig;
+use App\Enums\PhotoalbumSort;
 use App\Enums\Required;
 use App\Enums\ReservationCalendarDisplayType;
 use App\Enums\ReservationColumnType;
@@ -6354,6 +6356,21 @@ trait MigrationTrait
 
         // Frames 登録
         $frame = $this->importPluginFrame($page, $frame_ini, $display_sequence, $bucket);
+
+        // frame_configs 登録
+        if (!empty($photoalbums)) {
+            // アルバム並び順
+            $frame_config = FrameConfig::updateOrCreate(
+                ['frame_id' => $frame->id, 'name' => PhotoalbumFrameConfig::sort_folder],
+                ['value' => Arr::get($frame_ini, 'photoalbum.sort_album', PhotoalbumSort::name_asc)]
+            );
+
+            // 写真並び順
+            $frame_config = FrameConfig::updateOrCreate(
+                ['frame_id' => $frame->id, 'name' => PhotoalbumFrameConfig::sort_file],
+                ['value' => Arr::get($frame_ini, 'photoalbum.sort_photo', PhotoalbumSort::name_asc)]
+            );
+        }
     }
 
     /**

--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -107,7 +107,7 @@ nc3_export_plugins[] = "linklists"
 nc3_export_plugins[] = "counters"
 nc3_export_plugins[] = "calendars"
 nc3_export_plugins[] = "reservations"
-; nc3_export_plugins[] = "photoalbums"
+nc3_export_plugins[] = "photoalbums"
 
 
 ; --- インポート（指定されたプラグインをインポート対象とする）
@@ -123,7 +123,7 @@ cc_import_plugins[] = "linklists"
 cc_import_plugins[] = "counters"
 cc_import_plugins[] = "calendars"
 cc_import_plugins[] = "reservations"
-; cc_import_plugins[] = "photoalbums"
+cc_import_plugins[] = "photoalbums"
 
 
 ;------------------------------------------------
@@ -190,7 +190,7 @@ import_frame_plugins[] = "linklists"
 import_frame_plugins[] = "counters"
 import_frame_plugins[] = "calendars"
 import_frame_plugins[] = "reservations"
-; import_frame_plugins[] = "photoalbums"
+import_frame_plugins[] = "photoalbums"
 
 
 ; 強制的にフレームデザインを適用する（none は対象外）
@@ -386,3 +386,24 @@ export_clear_style[] = "font-family"
 ; --- インポート
 ;インポート対象の表示施設カテゴリで、施設カテゴリ名とルーム名が同じものは表示する
 ; import_is_show_reservations_category_name_and_room_name_are_the_same = true
+
+;------------------------------------------------
+;- フォトアルバムプラグイン・オプション
+;------------------------------------------------
+[photoalbums]
+
+; --- エクスポート
+; エクスポート対象のNC2汎用フォトアルバムIDを絞る（指定がなければすべて対象）
+;nc3_export_where_photoalbum_ids[] = 11
+;nc3_export_where_photoalbum_ids[] = 22
+
+; 変換したい文字や、取り除きたい文字(キー部分 = 探したい値, 値部分 = 置き換える値)
+;nc3_export_str_replace[''] = ''
+
+; フォトアルバムがスライドショー表示で高さが自動(0)だった場合、指定の高さ(px)に変更する
+; nc3_export_slideshow_convert_auto_height_value = 250
+
+; --- インポート
+; インポートするフォトアルバムを絞る
+;cc_import_where_photoalbum_ids[] = 11
+;cc_import_where_photoalbum_ids[] = 22


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: [nc3移行エクスポート] フォトアルバムの移行対応](https://github.com/opensource-workshop/connect-cms/commit/75dd0ae8d7a594c0797f520e785353c80de41bdc)
    * [change: [nc3移行エクスポート] configのNC3_EXPORT_UPLOADS_PATH取得をメソッド化](https://github.com/opensource-workshop/connect-cms/commit/0340e0871aa67df7fd9c0226b6d6756dc83df889)
    * [add: [移行インポート] フォトアルバムのアルバム/写真の並び順移行に対応](https://github.com/opensource-workshop/connect-cms/commit/884accb23e7acf77e8bda3222845ad2fa8be9b5f)
* 関連対応
    * [change: [nc2移行] カウンターの表示形式の移行の汎用化対応](https://github.com/opensource-workshop/connect-cms/pull/1521/commits/f30955186655829d55b9250c84a7d45f4926c324)
    * [change: [nc2/nc3移行] フォトアルバムの移行カラムを nc2_upload_id → upload_id に変更](https://github.com/opensource-workshop/connect-cms/pull/1521/commits/0c2dfa737a4a03581bb00d2d709babf1d316dcc7)
    * [refactor: [nc3移行エクスポート] nc3ExportCalendar() カラムのテーブル名指定を追加](https://github.com/opensource-workshop/connect-cms/commit/7891e9f9961cc25e33e8e938ad70c37adfd291b1)
    * [delete: [nc3移行エクスポート] nc3にはないスライダーとシンプル動画の移行メソッド削除](https://github.com/opensource-workshop/connect-cms/pull/1521/commits/ef665d55875e06874e36d503a10d9c99eb1f8419)

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
