### PR TITLE
[nc3移行エクスポート] バグ修正-汎用DBのアップロードデータが無かった場合に対応,  施設予約で必須のブロックデータがない場合、施設予約は移行しない対応, [nc2/nc3移行エクスポート] ウィジウィグのタブコード混入を除去対応（nc3-migrateブランチにマージ）

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -2698,7 +2698,7 @@ trait MigrationNc3ExportTrait
                         // (nc3) 画像、ファイル型は、ファイルあってもvalue空。毎回UploadFile見る必要あり。
 
                         // NC3 のアップロードID 抜き出し
-                        $multidatabase_upload = $multidatabase_uploads->firstWhere('field_name', $value_no . '_attach');
+                        $multidatabase_upload = $multidatabase_uploads->firstWhere('field_name', $value_no . '_attach') ?? new Nc3UploadFile();
                         $nc3_uploads_id = $multidatabase_upload->id;
                         if ($nc3_uploads_id) {
                             // uploads.ini からファイルを探す

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -3798,7 +3798,13 @@ trait MigrationNc3ExportTrait
 
         // 施設カテゴリ
         // ----------------------------------------------------
-        $block = Nc3Block::where('plugin_key', 'reservations')->first() ?? new Nc3Block();
+        $block = Nc3Block::where('plugin_key', 'reservations')->first();
+
+        // 空なら戻る
+        if (empty($block)) {
+            return;
+        }
+
         // カテゴリ
         $nc3_reservation_categories = Nc3Category::getCategoriesByBlockIds([$block->id]);
         foreach ($nc3_reservation_categories as $nc3_reservation_category) {

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -5513,8 +5513,8 @@ trait MigrationNc3ExportTrait
      */
     private function cleaningContent($content, $nc3_plugin_key)
     {
-        // 改行コードが含まれる場合があるので置換
-        $content = str_replace(array("\r", "\n"), '', $content);
+        // 改行コード・タブコードが含まれる場合があるので置換
+        $content = str_replace(array("\r", "\n", "\t"), '', $content);
 
         $plugin_name = $this->nc3GetPluginName($nc3_plugin_key);
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -12292,8 +12292,8 @@ trait MigrationTrait
      */
     private function cleaningContent($content, $nc2_module_name)
     {
-        // 改行コードが含まれる場合があるので置換
-        $content = str_replace(array("\r", "\n"), '', $content);
+        // 改行コード・タブコードが含まれる場合があるので置換
+        $content = str_replace(array("\r", "\n", "\t"), '', $content);
 
         $plugin_name = $this->nc2GetPluginName($nc2_module_name);
 


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし
## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
