### PR TITLE
[コア] ログインのリンク名を.envで変更可能にする OW-1598

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ CACHE_CONTROL="max-age=604800"
 
 # Login link path
 LOGIN_PATH="login"
+# Login link string
+LOGIN_STR="ログイン"
 
 # Self register base role.(comma separator. Not set is guest)
 #SELF_REGISTER_BASE_ROLES="role_reporter"

--- a/config/connect.php
+++ b/config/connect.php
@@ -73,6 +73,8 @@ return [
 
     // Login link path
     'LOGIN_PATH' => env('LOGIN_PATH', 'login'),
+    // Login link string
+    'LOGIN_STR' => env('LOGIN_STR', 'ログイン'),
 
     // Self register base role.(comma separator. Not set is guest)
     'SELF_REGISTER_BASE_ROLES' => env('SELF_REGISTER_BASE_ROLES', null),

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -301,9 +301,9 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                     @endphp
 
                     @if ($auth_method_event->value == AuthMethodType::shibboleth)
-                        <li><a class="nav-link" href="{{ route('shibboleth.login') }}">ログイン</a></li>
+                        <li><a class="nav-link" href="{{ route('shibboleth.login') }}">{{config('connect.LOGIN_STR')}}</a></li>
                     @else
-                        <li><a class="nav-link" href="{{ route('show_login_form') }}">ログイン</a></li>
+                        <li><a class="nav-link" href="{{ route('show_login_form') }}">{{config('connect.LOGIN_STR')}}</a></li>
                     @endif
                 @endif
                 {{-- @if (isset($configs['user_register_enable']) && ($configs['user_register_enable'] == '1')) --}}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

.envでログインのリンク名を変更できます。

## .env 
```.env
# Login link string
LOGIN_STR="ログイン"
```

## 設定例
### .env 

```.env
# Login link string
LOGIN_STR="管理者ログイン"
```

### ログインリンク
![image](https://user-images.githubusercontent.com/2756509/206884861-a1ce61e6-a73d-4630-acc9-b09a9d435164.png)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
