### PR TITLE
[施設予約] 終日毎日繰り返し＋終了日指定だと＋１日予約される不具合修正

### DIFF
--- a/app/Plugins/User/Reservations/ReservationsPlugin.php
+++ b/app/Plugins/User/Reservations/ReservationsPlugin.php
@@ -928,7 +928,7 @@ class ReservationsPlugin extends UserPluginBase
             // 繰り返し終了
             if ($request->rrule_repeat_end == 'UNTIL') {
                 // 指定日 UNTIL
-                $rrule_setting['UNTIL'] = $request->rrule_until . ' ' . $request->end_datetime . ':00';
+                $rrule_setting['UNTIL'] = $request->rrule_until . ' 00:00:00';
             } else {
                 // 指定の回数後 COUNT とみなす
                 $rrule_setting['COUNT'] = (int) $request->rrule_count;


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

### 不具合動作

* 00:00-24:00 毎日（終了）指定日で繰り返すと＋１日される。
* 00:00-23:55 毎日（終了）指定日で繰り返すと＋１日されない。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
