### PR TITLE
[サイト管理] 言語設定の削除処理が漏れていたので追加しました。

### DIFF
--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -131,6 +131,7 @@ class SiteManage extends ManagePluginBase
         $role_ckeck_table["saveLoginPermit"]  = array('admin_site');
         $role_ckeck_table["languages"]        = array('admin_site');
         $role_ckeck_table["saveLanguages"]    = array('admin_site');
+        $role_ckeck_table["deleteLanguages"]  = array('admin_site');
         $role_ckeck_table["meta"]             = array('admin_site');
         $role_ckeck_table["saveMeta"]         = array('admin_site');
         $role_ckeck_table["pageError"]        = array('admin_site');
@@ -624,6 +625,17 @@ class SiteManage extends ManagePluginBase
             }
         }
 
+        return $this->languages($request, $id, null);
+    }
+
+
+    /**
+     *  言語設定の削除処理
+     */
+    public function deleteLanguages($request, $id)
+    {
+        // 指定された言語設定を削除する。
+        Configs::where('name', 'language_' . $id)->delete();
         return $this->languages($request, $id, null);
     }
 

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -634,6 +634,11 @@ class SiteManage extends ManagePluginBase
      */
     public function deleteLanguages($request, $id)
     {
+        // httpメソッド確認
+        if (!$request->isMethod('post')) {
+            abort(403, '権限がありません。');
+        }
+
         // 指定された言語設定を削除する。
         Configs::where('name', 'language_' . $id)->delete();
         return $this->languages($request, $id, null);

--- a/tests/Browser/Manage/SiteManageTest.php
+++ b/tests/Browser/Manage/SiteManageTest.php
@@ -70,7 +70,24 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/index/images/index,manage/site/index/images/index2,manage/site/index/images/index3,manage/site/index/images/index4', null, 3, 'basic');
+        $this->putManualData('[
+            {"path": "manage/site/index/images/index",
+             "name": "画面1",
+             "comment": "<ul class=\"mb-0\"><li>サイト名や適用するテーマなど、サイトに関する基本的なことを設定します。</li><li>追加テーマを指定した際は基本テーマの後で追加テーマのCSSが反映されます。</li></ul>"
+            },
+            {"path": "manage/site/index/images/index2",
+             "name": "画面1",
+             "comment": "<ul class=\"mb-0\"><li>ヘッダーバーの文字色や各エリアに付加するクラス名を指定できます。</li><li>クラス名はテーマでオリジナルのCSSを作成する場合に参照するセレクタとなります。</li></ul>"
+            },
+            {"path": "manage/site/index/images/index3",
+             "name": "画面1",
+             "comment": "<ul class=\"mb-0\"><li>ヘッダーバーの表示、固定、ログインリンクの表示などが設定できます。</li></ul>"
+            },
+            {"path": "manage/site/index/images/index4",
+             "name": "画面1",
+             "comment": "<ul class=\"mb-0\"><li>パスワードリセットの使用可否、ログイン後に移動するページ、マイページの使用可否が設定できます。</li><li>画像の保存機能を無効化する設定もできます。</li><li>スマートフォン表示の際のハンバーガーメニューの表示は、全ページを表示するデフォルトか今いるフォルダの仮想のみ展開するオープンカレントツリーを選ぶことができます。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 
     /**
@@ -114,7 +131,12 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/meta/images/meta', null, 3);
+        $this->putManualData('[
+            {"path": "manage/site/meta/images/meta",
+             "name": "meta情報",
+             "comment": "<ul class=\"mb-0\"><li>HEADのdescriptionに出力される値を設定できます。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 
     /**
@@ -138,11 +160,17 @@ class SiteManageTest extends DuskTestCase
             $browser->visit('/manage/site/layout')
                     ->click('#label_browser_width_footer')
                     ->assertTitleContains('Connect-CMS')
+                    ->pause(500)
                     ->screenshot('manage/site/layout/images/layout');
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/layout/images/layout', null, 3);
+        $this->putManualData('[
+            {"path": "manage/site/layout/images/layout",
+             "name": "レイアウト設定",
+             "comment": "<ul class=\"mb-0\"><li>ブラウザ幅100％で表示するエリアをヘッダー、センター、フッターからそれぞれ選ぶことができます。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 
     /**
@@ -174,7 +202,12 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/categories/images/categories', null, 3, 'basic');
+        $this->putManualData('[
+            {"path": "manage/site/categories/images/categories",
+             "name": "カテゴリ設定",
+             "comment": "<ul class=\"mb-0\"><li>ここでは、対象がALLの共通カテゴリ―を設定できます。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 
     /**
@@ -204,7 +237,12 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/languages/images/languages', null, 3);
+        $this->putManualData('[
+            {"path": "manage/site/languages/images/languages",
+             "name": "他言語設定",
+             "comment": "<ul class=\"mb-0\"><li>URLは各言語のページの最初に付く値を設定します。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 
     /**
@@ -220,7 +258,7 @@ class SiteManageTest extends DuskTestCase
     }
 
     /**
-     * エラー画面設定
+     * エラーページ設定
      */
     private function pageError()
     {
@@ -233,7 +271,12 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/pageError/images/pageError', null, 3);
+        $this->putManualData('[
+            {"path": "manage/site/pageError/images/pageError",
+             "name": "エラーページ設定",
+             "comment": "<ul class=\"mb-0\"><li>ここで指定した表示ページはこの指定内容の固定リンクをページ管理で作成しておく必要があります。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 
     /**
@@ -261,7 +304,12 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/analytics/images/analytics', null, 3);
+        $this->putManualData('[
+            {"path": "manage/site/analytics/images/analytics",
+             "name": "アクセス解析設定",
+             "comment": "<ul class=\"mb-0\"><li>複数のトラッキングコードの指定なども可能です。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 
     /**
@@ -289,7 +337,12 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/favicon/images/favicon', null, 3);
+        $this->putManualData('[
+            {"path": "manage/site/favicon/images/favicon",
+             "name": "ファビコン設定",
+             "comment": "<ul class=\"mb-0\"><li>.ico形式のファイルをアップロードしてください。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 
     /**
@@ -317,7 +370,12 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/wysiwyg/images/wysiwyg', null, 3, 'basic');
+        $this->putManualData('[
+            {"path": "manage/site/wysiwyg/images/wysiwyg",
+             "name": "WYSIWYG設定",
+             "comment": "<ul class=\"mb-0\"><li>初期に選択させる画像サイズは1200px、800px、400px、200pxから選ぶことができます。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 
     /**
@@ -332,6 +390,11 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('manage/site/document/images/document', null, 3);
+        $this->putManualData('[
+            {"path": "manage/site/document/images/document",
+             "name": "サイト設計書",
+             "comment": "<ul class=\"mb-0\"><li>追加の出力内容で、サイト設計書に反映させる項目を増やせます。</li><li>最終ページには問合せ先や連絡先を提示するページがあり、最終ページの内容の各項目に登録してあるものが反映されます。</li></ul>"
+            }
+        ]', null, 3, 'basic');
     }
 }

--- a/tests/Browser/Manage/SiteManageTest.php
+++ b/tests/Browser/Manage/SiteManageTest.php
@@ -70,24 +70,7 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/index/images/index",
-             "name": "画面1",
-             "comment": "<ul class=\"mb-0\"><li>サイト名や適用するテーマなど、サイトに関する基本的なことを設定します。</li><li>追加テーマを指定した際は基本テーマの後で追加テーマのCSSが反映されます。</li></ul>"
-            },
-            {"path": "manage/site/index/images/index2",
-             "name": "画面1",
-             "comment": "<ul class=\"mb-0\"><li>ヘッダーバーの文字色や各エリアに付加するクラス名を指定できます。</li><li>クラス名はテーマでオリジナルのCSSを作成する場合に参照するセレクタとなります。</li></ul>"
-            },
-            {"path": "manage/site/index/images/index3",
-             "name": "画面1",
-             "comment": "<ul class=\"mb-0\"><li>ヘッダーバーの表示、固定、ログインリンクの表示などが設定できます。</li></ul>"
-            },
-            {"path": "manage/site/index/images/index4",
-             "name": "画面1",
-             "comment": "<ul class=\"mb-0\"><li>パスワードリセットの使用可否、ログイン後に移動するページ、マイページの使用可否が設定できます。</li><li>画像の保存機能を無効化する設定もできます。</li><li>スマートフォン表示の際のハンバーガーメニューの表示は、全ページを表示するデフォルトか今いるフォルダの仮想のみ展開するオープンカレントツリーを選ぶことができます。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/index/images/index,manage/site/index/images/index2,manage/site/index/images/index3,manage/site/index/images/index4', null, 3, 'basic');
     }
 
     /**
@@ -131,12 +114,7 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/meta/images/meta",
-             "name": "meta情報",
-             "comment": "<ul class=\"mb-0\"><li>HEADのdescriptionに出力される値を設定できます。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/meta/images/meta', null, 3);
     }
 
     /**
@@ -160,17 +138,11 @@ class SiteManageTest extends DuskTestCase
             $browser->visit('/manage/site/layout')
                     ->click('#label_browser_width_footer')
                     ->assertTitleContains('Connect-CMS')
-                    ->pause(500)
                     ->screenshot('manage/site/layout/images/layout');
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/layout/images/layout",
-             "name": "レイアウト設定",
-             "comment": "<ul class=\"mb-0\"><li>ブラウザ幅100％で表示するエリアをヘッダー、センター、フッターからそれぞれ選ぶことができます。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/layout/images/layout', null, 3);
     }
 
     /**
@@ -202,12 +174,7 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/categories/images/categories",
-             "name": "カテゴリ設定",
-             "comment": "<ul class=\"mb-0\"><li>ここでは、対象がALLの共通カテゴリ―を設定できます。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/categories/images/categories', null, 3, 'basic');
     }
 
     /**
@@ -237,12 +204,7 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/languages/images/languages",
-             "name": "他言語設定",
-             "comment": "<ul class=\"mb-0\"><li>URLは各言語のページの最初に付く値を設定します。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/languages/images/languages', null, 3);
     }
 
     /**
@@ -258,7 +220,7 @@ class SiteManageTest extends DuskTestCase
     }
 
     /**
-     * エラーページ設定
+     * エラー画面設定
      */
     private function pageError()
     {
@@ -271,12 +233,7 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/pageError/images/pageError",
-             "name": "エラーページ設定",
-             "comment": "<ul class=\"mb-0\"><li>ここで指定した表示ページはこの指定内容の固定リンクをページ管理で作成しておく必要があります。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/pageError/images/pageError', null, 3);
     }
 
     /**
@@ -304,12 +261,7 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/analytics/images/analytics",
-             "name": "アクセス解析設定",
-             "comment": "<ul class=\"mb-0\"><li>複数のトラッキングコードの指定なども可能です。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/analytics/images/analytics', null, 3);
     }
 
     /**
@@ -337,12 +289,7 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/favicon/images/favicon",
-             "name": "ファビコン設定",
-             "comment": "<ul class=\"mb-0\"><li>.ico形式のファイルをアップロードしてください。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/favicon/images/favicon', null, 3);
     }
 
     /**
@@ -370,12 +317,7 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/wysiwyg/images/wysiwyg",
-             "name": "WYSIWYG設定",
-             "comment": "<ul class=\"mb-0\"><li>初期に選択させる画像サイズは1200px、800px、400px、200pxから選ぶことができます。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/wysiwyg/images/wysiwyg', null, 3, 'basic');
     }
 
     /**
@@ -390,11 +332,6 @@ class SiteManageTest extends DuskTestCase
         });
 
         // マニュアル用データ出力
-        $this->putManualData('[
-            {"path": "manage/site/document/images/document",
-             "name": "サイト設計書",
-             "comment": "<ul class=\"mb-0\"><li>追加の出力内容で、サイト設計書に反映させる項目を増やせます。</li><li>最終ページには問合せ先や連絡先を提示するページがあり、最終ページの内容の各項目に登録してあるものが反映されます。</li></ul>"
-            }
-        ]', null, 3, 'basic');
+        $this->putManualData('manage/site/document/images/document', null, 3);
     }
 }


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
サイト管理の言語設定の削除処理が漏れていたので追加しました。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
要望が上がってきているわけではないので、急ぎません。
マニュアル作成時に気付きました。

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
https://github.com/opensource-workshop/connect-cms/issues/1059

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
無し

## チェックリスト
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
