### PR TITLE
[フォーム] 登録時にファイル型データをアップロードした状態で入力チェックエラーになると500エラーになる不具合の修正

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -278,9 +278,6 @@ class FormsPlugin extends UserPluginBase
      */
     public function index($request, $page_id, $frame_id, $errors = null)
     {
-        // セッション初期化などのLaravel 処理。
-        $request->flash();
-
         // Forms、Frame データ
         $form = $this->getForms($frame_id);
 
@@ -703,6 +700,17 @@ class FormsPlugin extends UserPluginBase
         // エラーがあった場合は入力画面に戻る。
         // $message = null;
         if ($validator->fails()) {
+
+            // ファイル項目を探してセッション対象から除く
+            $flashExcepts = [];
+            foreach ($forms_columns as $forms_column) {
+                if (FormsColumns::isFileColumnType($forms_column->column_type)) {
+                    $flashExcepts[] = 'forms_columns_value.' . $forms_column->id;
+                }
+            }
+            // 入力をフラッシュデータとして保存
+            $request->flashExcept($flashExcepts);
+
             return $this->index($request, $page_id, $frame_id, $validator->errors());
         }
 

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -676,7 +676,6 @@ class FormsPlugin extends UserPluginBase
 
         // 入力値をトリム
         // bugfix: 【データベース】（Laravel6テスト）ファイル型項目にファイルをアップするとシステムエラーと同じ対応 https://github.com/opensource-workshop/connect-cms/issues/732
-        // $request->merge(StringUtils::trimInput($request->all()));
         foreach ($forms_columns as $forms_column) {
             // ファイルタイプ以外の入力値をトリム
             if (! FormsColumns::isFileColumnType($forms_column->column_type)) {
@@ -698,7 +697,6 @@ class FormsPlugin extends UserPluginBase
         $validator->setAttributeNames($validator_array['message']);
 
         // エラーがあった場合は入力画面に戻る。
-        // $message = null;
         if ($validator->fails()) {
 
             // ファイル項目を探してセッション対象から除く
@@ -749,8 +747,6 @@ class FormsPlugin extends UserPluginBase
                 }
             }
         }
-
-        // var_dump('publicConfirm', $request->forms_columns_value);
 
         // 表示テンプレートを呼び出す。
         return $this->view('forms_confirm', [


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1542 

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

