### PR TITLE
[フレーム] 左エリアにフレームタイトル空で「このページのみ表示する」を設定すると、歯車ボタンが押せなくなる不具合修正 OW-1656

### DIFF
--- a/resources/views/core/cms_frame_header.blade.php
+++ b/resources/views/core/cms_frame_header.blade.php
@@ -51,7 +51,7 @@ if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null
         <h1 class="card-header {{$class_header_bg}} border-0" style="padding-top: 0px;padding-bottom: 0px;">
     @elseif (Auth::check() && empty($frame->frame_title))
         @php $class_header_bg = "bg-transparent"; @endphp
-        <h1 class="card-header {{$class_header_bg}} border-0" style="padding-top: 0px;padding-bottom: 0px;height: 24px;">
+        <h1 class="card-header {{$class_header_bg}} border-0" style="padding-top: 0px;padding-bottom: 0px;">
     @else
         @php $class_header_bg = "bg-{$frame->frame_design}"; @endphp
         <h1 class="card-header {{$class_header_bg}} cc-{{$frame->frame_design}}-font-color">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## 修正前：フレームタイトルにheight: 24px;あり

コンテンツの後ろに歯車ボタンが回り込んでしまって押せない
![image](https://user-images.githubusercontent.com/2756509/210911168-71814968-b4b5-4e42-94d7-f3a7b4d36d51.png)

## 修正後：フレームタイトルのheight: 24px;削除

歯車ボタン押せる
![image](https://user-images.githubusercontent.com/2756509/210911029-5579722e-6c38-4e29-bed5-b9ebac6e3763.png)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
