### PR TITLE
[コア]FrameConfigの登録処理について、複数選択（チェックボックス）の設定値に対応しました

### DIFF
--- a/app/Models/Core/FrameConfig.php
+++ b/app/Models/Core/FrameConfig.php
@@ -15,6 +15,11 @@ class FrameConfig extends Model
     use SoftDeletes, UserableNohistory;
 
     /**
+     * @var string
+     */
+    const CHECKBOX_SEPARATOR = '|';
+
+    /**
      * create()やupdate()で入力を受け付ける ホワイトリスト
      */
     protected $fillable = [
@@ -69,13 +74,18 @@ class FrameConfig extends Model
     {
         foreach ($frame_config_names as $key => $name) {
 
-            if ($request->$name != '0' && empty($request->$name)) {
+            // 必須入力チェック
+            // チェックボックスの場合、すべて選択しない場合があるので除外する
+            if (!is_array($request->$name) && $request->$name != '0' && empty($request->$name)) {
                 continue;
             }
 
+            // 配列の設定値はパイプ区切りにする
+            $value = is_array($request->$name) ? implode(self::CHECKBOX_SEPARATOR, $request->$name) : $request->$name;
+
             self::updateOrCreate(
                 ['frame_id' => $frame_id, 'name' => $name],
-                ['value' => $request->$name]
+                ['value' => $value]
             );
         }
     }


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
App\Models\Core\FrameConfig::saveFrameConfigs()
チェックボックスを複数選択して入力するUIの場合、リクエストパラメータは配列となります。
この場合、パイプ区切りの値で登録するようにしました。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
