### PR TITLE
[robots.txt] 同一ドメイン＋nc2の短縮URLでnc2->cc移行時のgoogle image bot等へのインデックス除外対応

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Disallow: /plugin/*?frame_*_page=
 Disallow: /json/
 Disallow: /redirect/
+Disallow: *?action=common_download_main


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

同一ドメインでnetcommons2からConnect-CMSに移行時、nc2の短縮URL＋画像（?action=common_download_main&upload_id=9999）の場合、google image bot等の画像botがクロールし続ける問題に対応。
robots.txtに除外対象を追記して対応しました。

### 症状詳細
nc2の画像URL例
http://example.com/230lkhjfakl-19?action=common_download_main&upload_id=9999
↓
ConnectのURL例
http://example.com/230lkhjfakl-19?action=common_download_main&upload_id=9999
※ Connectは移行しても短縮URLを開けるため、302を返す。しかしnc2画像（?action=common_download_main&upload_id=9999）はないけど302が返されるため、google image bot等は何度もアクセスしてくる。

## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
