### PR TITLE
[サイト全体]ナビバーのサイト名が長い場合にウィンドウ幅に合わせて省略するようにしました

### DIFF
--- a/public/css/connect.css
+++ b/public/css/connect.css
@@ -178,14 +178,12 @@ a.cc-icon-external:after {
 }
 
 /* サイト名が長い場合に途切れないようにする */
-@media (max-width: 767px){
-    .cc-custom-brand{
-        overflow: hidden;
-        text-align: left;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        width: 240px;
-    }
+.cc-custom-brand{
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: calc(100% - 4em);
 }
 
 /*  Active


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
長いサイト名の場合、ナビバー右にあるログインリンク等が表示されなくなっていました。
<img width="960" alt="image" src="https://user-images.githubusercontent.com/32890286/214468266-98e0ccd8-181f-4e0f-bc26-eb377b25620c.png">
この場合にサイト名が省略されるようにしました。
<img width="959" alt="image" src="https://user-images.githubusercontent.com/32890286/214468394-a2311636-c15a-441b-963c-3ba085986865.png">

スマホ表示ではすでに省略する対応が入っていましたが、このPRで改善されます。
v1.4.1以前は、ウィンドウ幅に関係なく幅固定で省略していました。
そのため、余白があるにもかかわらず、省略されてしまっていました。
このPRにより余白部分が少なくなります。

修正前
<img width="375" alt="image" src="https://user-images.githubusercontent.com/32890286/214468766-b1a1352e-d261-4fca-a17d-a4599bfba95c.png">

修正後
<img width="377" alt="image" src="https://user-images.githubusercontent.com/32890286/214468725-69ebb120-eb6a-4056-8dba-7a8be5f70856.png">



## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
