### PR TITLE
[システム管理] エラーログ設定画面を廃止して、出力ログを１本化する OW-1684

### DIFF
--- a/app/Plugins/Manage/SystemManage/SystemManage.php
+++ b/app/Plugins/Manage/SystemManage/SystemManage.php
@@ -33,7 +33,7 @@ class SystemManage extends ManagePluginBase
         $role_ckeck_table = array();
         $role_ckeck_table["index"]           = array('admin_system');
         $role_ckeck_table["updateDebugmode"] = array('admin_system');
-        $role_ckeck_table["log"]             = array('admin_system');
+        // $role_ckeck_table["log"]             = array('admin_system');
         $role_ckeck_table["updateLog"]       = array('admin_system');
         $role_ckeck_table["server"]          = array('admin_system');
         $role_ckeck_table["updateServer"]    = array('admin_system');
@@ -110,54 +110,54 @@ class SystemManage extends ManagePluginBase
      * @method_desc エラーログファイルの出力方法を変更できます。
      * @method_detail エラーログの形式は必要に応じて変更してください。
      */
-    public function log($request, $page_id = null)
-    {
-        // Config データの取得
-        $categories_configs = Configs::where('category', 'log')->get();
+    // public function log($request, $page_id = null)
+    // {
+    //     // Config データの取得
+    //     $categories_configs = Configs::where('category', 'log')->get();
 
-        // 管理画面プラグインの戻り値の返し方
-        // view 関数の第一引数に画面ファイルのパス、第二引数に画面に渡したいデータを名前付き配列で渡し、その結果のHTML。
-        return view('plugins.manage.system.log', [
-            "function"           => __FUNCTION__,
-            "plugin_name"        => "system",
-            "categories_configs" => $categories_configs,
-        ]);
-    }
+    //     // 管理画面プラグインの戻り値の返し方
+    //     // view 関数の第一引数に画面ファイルのパス、第二引数に画面に渡したいデータを名前付き配列で渡し、その結果のHTML。
+    //     return view('plugins.manage.system.log', [
+    //         "function"           => __FUNCTION__,
+    //         "plugin_name"        => "system",
+    //         "categories_configs" => $categories_configs,
+    //     ]);
+    // }
 
     /**
      *  ログ設定更新
      */
-    public function updateLog($request, $page_id = null, $errors = array())
-    {
-        // httpメソッド確認
-        if (!$request->isMethod('post')) {
-            abort(403, '権限がありません。');
-        }
+    // public function updateLog($request, $page_id = null, $errors = array())
+    // {
+    //     // httpメソッド確認
+    //     if (!$request->isMethod('post')) {
+    //         abort(403, '権限がありません。');
+    //     }
 
-        // ログファイルの形式
-        $configs = Configs::updateOrCreate(
-            ['name'     => 'log_handler'],
-            ['category' => 'log',
-             'value'    => $request->log_handler]
-        );
+    //     // ログファイルの形式
+    //     $configs = Configs::updateOrCreate(
+    //         ['name'     => 'log_handler'],
+    //         ['category' => 'log',
+    //          'value'    => $request->log_handler]
+    //     );
 
-        // ログファイル名の指定の有無
-        $configs = Configs::updateOrCreate(
-            ['name'     => 'log_filename_choice'],
-            ['category' => 'log',
-             'value'    => $request->log_filename_choice]
-        );
+    //     // ログファイル名の指定の有無
+    //     $configs = Configs::updateOrCreate(
+    //         ['name'     => 'log_filename_choice'],
+    //         ['category' => 'log',
+    //          'value'    => $request->log_filename_choice]
+    //     );
 
-        // ログファイル名
-        $configs = Configs::updateOrCreate(
-            ['name'     => 'log_filename'],
-            ['category' => 'log',
-             'value'    => $request->log_filename]
-        );
+    //     // ログファイル名
+    //     $configs = Configs::updateOrCreate(
+    //         ['name'     => 'log_filename'],
+    //         ['category' => 'log',
+    //          'value'    => $request->log_filename]
+    //     );
 
-        // ログ設定画面に戻る
-        return redirect("/manage/system/log")->with('flash_message', '更新しました。');
-    }
+    //     // ログ設定画面に戻る
+    //     return redirect("/manage/system/log")->with('flash_message', '更新しました。');
+    // }
 
     /**
      * サーバ設定画面表示

--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -1254,50 +1254,51 @@ class UserPluginBase extends PluginBase
      */
     public function putLog($e)
     {
-        // Config データの取得
-        $configs = Configs::where('category', 'log')->get();
+        // // Config データの取得
+        // $configs = Configs::where('category', 'log')->get();
 
-        // ログファイル名
-        $log_filename = 'laravel';
+        // // ログファイル名
+        // $log_filename = 'laravel';
 
-        $config_log_filename_choice_obj = $configs->where('name', 'log_filename_choice')->first();
+        // $config_log_filename_choice_obj = $configs->where('name', 'log_filename_choice')->first();
 
-        $config_log_filename_obj = $configs->where('name', 'log_filename')->first();
-        if (empty($config_log_filename_obj)) {
-            $config_log_filename = "";
-        } else {
-            $config_log_filename = $config_log_filename_obj->value;
-        }
+        // $config_log_filename_obj = $configs->where('name', 'log_filename')->first();
+        // if (empty($config_log_filename_obj)) {
+        //     $config_log_filename = "";
+        // } else {
+        //     $config_log_filename = $config_log_filename_obj->value;
+        // }
 
-        if (!empty($config_log_filename_choice_obj) && $config_log_filename_choice_obj->value == '1' && isset($config_log_filename)) {
-            $log_filename = $config_log_filename;
-        }
-        $log_path =  storage_path() .'/logs/' . $log_filename . '.log';
+        // if (!empty($config_log_filename_choice_obj) && $config_log_filename_choice_obj->value == '1' && isset($config_log_filename)) {
+        //     $log_filename = $config_log_filename;
+        // }
+        // $log_path =  storage_path() .'/logs/' . $log_filename . '.log';
 
-        // ログレベル（Laravel6 でログのレベル指定が変わったため修正）
-        $log_level =  config('logging.channels.errorlog.level');
+        // // ログレベル（Laravel6 でログのレベル指定が変わったため修正）
+        // $log_level =  config('logging.channels.errorlog.level');
 
-        // 以降のハンドラに処理を続行させるかどうかのフラグ、デフォルトは、true
-        $bubble = true;
+        // // 以降のハンドラに処理を続行させるかどうかのフラグ、デフォルトは、true
+        // $bubble = true;
 
-        // ログを生成
-        $log = new Logger('connect_error_log');
+        // // ログを生成
+        // $log = new Logger('connect_error_log');
 
-        // ハンドラー（単一 or 日付毎）
-        $log_handler_obj = $configs->where('name', 'log_handler')->first();
-        if (!empty($log_handler_obj) && $log_handler_obj->value == '1') {
-            $handler = new RotatingFileHandler($log_path, $maxFiles = 0, $log_level, $bubble);
-        } else {
-            $handler = new StreamHandler($log_path, $log_level, $bubble);
-        }
+        // // ハンドラー（単一 or 日付毎）
+        // $log_handler_obj = $configs->where('name', 'log_handler')->first();
+        // if (!empty($log_handler_obj) && $log_handler_obj->value == '1') {
+        //     $handler = new RotatingFileHandler($log_path, $maxFiles = 0, $log_level, $bubble);
+        // } else {
+        //     $handler = new StreamHandler($log_path, $log_level, $bubble);
+        // }
 
-        // StackTrace用フォーマッタで整形
-        $formatter = new LineFormatter();
-        $formatter->includeStacktraces(true);
+        // // StackTrace用フォーマッタで整形
+        // $formatter = new LineFormatter();
+        // $formatter->includeStacktraces(true);
 
-        // ログ出力
-        $log->pushHandler($handler->setFormatter($formatter));
-        $log->error($e);
+        // // ログ出力
+        // $log->pushHandler($handler->setFormatter($formatter));
+        // $log->error($e);
+        Log::error($e);
     }
 
     /**

--- a/resources/views/plugins/manage/system/system_tab.blade.php
+++ b/resources/views/plugins/manage/system/system_tab.blade.php
@@ -45,13 +45,13 @@
                 @endif
                 </li>
 
-                <li role="presentation" class="nav-item">
+                {{-- <li role="presentation" class="nav-item">
                 @if ($function == "log")
                     <span class="nav-link"><span class="active">エラーログ設定</span></span>
                 @else
                     <a href="{{url('/manage/system/log')}}" class="nav-link">エラーログ設定</a></li>
                 @endif
-                </li>
+                </li> --}}
             </ul>
         </div>
     </nav>

--- a/tests/Browser/Manage/SystemManageTest.php
+++ b/tests/Browser/Manage/SystemManageTest.php
@@ -25,7 +25,7 @@ class SystemManageTest extends DuskTestCase
         $this->updateDebugmodeOff();
         $this->mail();
         $this->mailTest();
-        $this->log();
+        // $this->log();
         $this->server();
         $this->updateLog();
     }
@@ -132,6 +132,7 @@ class SystemManageTest extends DuskTestCase
     /**
      * エラーログ設定の表示
      */
+    /*
     private function log()
     {
         $this->browse(function (Browser $browser) {
@@ -149,6 +150,7 @@ class SystemManageTest extends DuskTestCase
             }
         ]', null, 3);
     }
+    */
 
     /**
      * エラーログ設定の更新


### PR DESCRIPTION
## 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1563

上記の対応しました。

### 詳細

システム管理＞エラーログ設定画面は、 .envで「APP_DEBUG=false」 時に、一般プラグインで500エラーが起こった際のエラーログを記録できるようにする設定です。

しかし、Laravel自体のログ機能と被っているため、①エラーログ設定画面と②Laravel自体のログ設定が異なると、２つのログができ、あれ？っとなります。

そのためログを「②Laravel自体のログ設定」に１本化しました。

（補足：システム管理＞エラーログ設定画面は、デイリーでログをローテーションする機能がなかった昔に作られて、今はLaravel自体にログのローテーション機能があるため、エラーログ設定画面が既に不要かと思われます。）


## レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

要相談
* Q. ログ出力を１本化するため、エラーログ設定画面は廃止。と思ったけど、どうか。
* Q. エラーログ設定画面のメソッド, log()のphpdocに、マニュアル生成の`@method_title` `@method_desc` `@method_detail` を残したが、メソッドをコメントアウトしてもマニュアルに生成されちゃうか？
    * https://github.com/opensource-workshop/connect-cms/pull/1564/files#diff-c8da8f9f17f26ef65e465d84837b4cdd90ba298b5d516d5a619e24f60c231bdaR109-R111
    * マニュアル生成されちゃうならマニュアル生成のphpdocのタグ削除する方向。
        * （追記）マニュアル生成の該当メソッドをコメントアウトで対応 https://github.com/opensource-workshop/connect-cms/pull/1564/commits/0f83eb484048adcd9ab01254917eada50ccaa490

## 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

## 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

## DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

## チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
