### PR TITLE
[コア] sessionのexpire_on_closeを.envで設定できるように対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,10 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 # --- Connect-CMS Common option
 
+# Session Options
+# If you want them to immediately expire on the browser closing, set that option. (SESSION_LIFETIME is disabled when set to true)
+SESSION_EXPIRE_ON_CLOSE=false
+
 # cURL Options
 HTTPPROXYTUNNEL=false
 PROXYPORT=

--- a/config/session.php
+++ b/config/session.php
@@ -33,7 +33,7 @@ return [
 
     'lifetime' => env('SESSION_LIFETIME', 120),
 
-    'expire_on_close' => false,
+    'expire_on_close' => env('SESSION_EXPIRE_ON_CLOSE', false),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

ブラウザを閉じたら、自動ログアウトさせる機能を.envで設定できるように対応しました。
expire_on_close=trueにすると、SESSION_LIFETIMEは無制限になります。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://laracasts.com/discuss/channels/laravel/expire-on-close-not-working

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
