### PR TITLE
[フォーム] フォームを拡張してアンケート機能を追加 OW-1663

### DIFF
--- a/app/Enums/FormMode.php
+++ b/app/Enums/FormMode.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * フォームモード
+ */
+final class FormMode extends EnumsBase
+{
+    // 定数メンバ
+    const form = 'form';
+    const questionnaire = 'questionnaire';
+
+    // key/valueの連想配列
+    const enum = [
+        self::form => 'フォームとして使用する',
+        self::questionnaire => 'アンケートとして使用する',
+    ];
+
+    /**
+     * 初期値
+     */
+    public static function getDefault()
+    {
+        return self::form;
+    }
+}

--- a/app/Models/Migration/Nc2/Nc2QuestionnaireAnswer.php
+++ b/app/Models/Migration/Nc2/Nc2QuestionnaireAnswer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc2;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc2QuestionnaireAnswer extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc2';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'questionnaire_answer';
+}

--- a/app/Models/Migration/Nc2/Nc2QuestionnaireBlock.php
+++ b/app/Models/Migration/Nc2/Nc2QuestionnaireBlock.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc2;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc2QuestionnaireBlock extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc2';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'questionnaire_block';
+}

--- a/app/Models/Migration/Nc2/Nc2QuestionnaireChoice.php
+++ b/app/Models/Migration/Nc2/Nc2QuestionnaireChoice.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc2;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc2QuestionnaireChoice extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc2';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'questionnaire_choice';
+}

--- a/app/Models/Migration/Nc2/Nc2QuestionnaireQuestion.php
+++ b/app/Models/Migration/Nc2/Nc2QuestionnaireQuestion.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Migration\Nc2;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Nc2QuestionnaireQuestion extends Model
+{
+    /**
+     * 使用するDB Connection
+     */
+    protected $connection = 'nc2';
+
+    /**
+     * テーブル名の指定
+     */
+    protected $table = 'questionnaire_question';
+}

--- a/app/Models/User/Forms/Forms.php
+++ b/app/Models/User/Forms/Forms.php
@@ -23,6 +23,7 @@ class Forms extends Model
     protected $fillable = [
         'bucket_id',
         'forms_name',
+        'form_mode',
         'entry_limit',
         'entry_limit_over_message',
         'display_control_flag',
@@ -31,6 +32,7 @@ class Forms extends Model
         'regist_control_flag',
         'regist_from',
         'regist_to',
+        'can_view_inputs_moderator',
         'mail_send_flag',
         'mail_send_address',
         'user_mail_send_flag',

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -1959,7 +1959,7 @@ class FormsPlugin extends UserPluginBase
         }
 
         // 編集画面テンプレートを呼び出す。
-        return $this->view('forms_edit',[
+        return $this->view('forms_edit', [
             'forms_id'        => $forms_id,
             'form_mode'       => $form_mode,
             'columns'         => $columns,

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -956,7 +956,8 @@ class FormsPlugin extends UserPluginBase
                     $contents_text .= $forms_column->column_name . "：" . $upload->client_original_name . "\n";
                 } else {
                     // アンケート
-                    $contents_text .= "Q{$no} {$forms_column->column_name}：\n{$upload->client_original_name}\n\n";
+                    $column_name = strip_tags($forms_column->column_name);
+                    $contents_text .= "Q{$no} {$column_name}：\n{$upload->client_original_name}\n\n";
                 }
 
             } else {
@@ -966,7 +967,8 @@ class FormsPlugin extends UserPluginBase
                     $contents_text .= $forms_column->column_name . "：" . $value . "\n";
                 } else {
                     // アンケート
-                    $contents_text .= "Q{$no} {$forms_column->column_name}：\n$value\n\n";
+                    $column_name = strip_tags($forms_column->column_name);
+                    $contents_text .= "Q{$no} {$column_name}：\n$value\n\n";
                 }
             }
 
@@ -2453,7 +2455,7 @@ ORDER BY forms_inputs_id, forms_columns_id
         $copy_base['status'] = '';
         // 見出し行
         foreach ($columns as $column) {
-            $csv_array[0][$column->id] = $column->column_name;
+            $csv_array[0][$column->id] = strip_tags($column->column_name);
             $copy_base[$column->id] = '';
         }
         if ($form->numbering_use_flag) {

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -87,6 +87,7 @@ use App\Enums\DatabaseSortFlag;
 use App\Enums\DayOfWeek;
 use App\Enums\FaqSequenceConditionType;
 use App\Enums\FormColumnType;
+use App\Enums\FormMode;
 use App\Enums\LinklistType;
 use App\Enums\NoticeEmbeddedTag;
 use App\Enums\PhotoalbumSort;
@@ -2894,13 +2895,13 @@ trait MigrationNc3ExportTrait
             $convert_embedded_tags = [
                 // nc3埋込タグ, cc埋込タグ
                 ['{X-SITE_NAME}', '[[' . NoticeEmbeddedTag::site_name . ']]'],
-                ['{X-SUBJECT}',   '[[' . NoticeEmbeddedTag::title . ']]'],
-                ['{X-USER}',      '[[' . NoticeEmbeddedTag::created_name . ']]'],
-                ['{X-TO_DATE}',   '[[' . NoticeEmbeddedTag::created_at . ']]'],
+                ['{X-SUBJECT}',   '[[form_name]]'],
+                ['{X-TO_DATE}',   '[[to_datetime]]'],
                 ['{X-DATA}',      '[[' . NoticeEmbeddedTag::body . ']]'],
                 ['{X-PLUGIN_NAME}', '登録フォーム'],
                 // 除外
                 ['{X-ROOM}', ''],
+                ['{X-USER}', ''],
             ];
             foreach ($convert_embedded_tags as $convert_embedded_tag) {
                 $mail_subject =     str_ireplace($convert_embedded_tag[0], $convert_embedded_tag[1], $mail_subject);
@@ -2911,13 +2912,14 @@ trait MigrationNc3ExportTrait
             $registration_ini = "";
             $registration_ini .= "[form_base]\n";
             $registration_ini .= "forms_name = \""        . $nc3_registration->title . "\"\n";
+            $registration_ini .= "form_mode  = \""        . FormMode::form . "\"\n";
             $registration_ini .= "mail_send_flag = "      . $mail_send_flag . "\n";
             $registration_ini .= "mail_send_address = \"\"\n";
             $registration_ini .= "user_mail_send_flag = " . $user_mail_send_flag . "\n";
             $registration_ini .= "mail_subject = \""      . $mail_subject . "\"\n";
             $registration_ini .= "mail_format = \""       . $mail_body . "\"\n";
             $registration_ini .= "data_save_flag = 1\n";
-            $registration_ini .= "after_message = \""     . str_replace("\n", '\n', $nc3_registration->thanks_content) . "\"\n";
+            $registration_ini .= "after_message = \""     . $nc3_registration->thanks_content . "\"\n";
             $registration_ini .= "numbering_use_flag = 0\n";
             $registration_ini .= "numbering_prefix = null\n";
             $registration_ini .= "regist_control_flag = " . $regist_control_flag . "\n";
@@ -4793,7 +4795,10 @@ trait MigrationNc3ExportTrait
         // データクリア
         if ($redo === true) {
             // 移行用ファイルの削除
-            Storage::deleteDirectory($this->getImportPath('videos/'));
+            $import_file_paths = glob($this->getImportPath('photoalbums/photoalbum_video_*'));
+            foreach ($import_file_paths as $import_file_path) {
+                Storage::delete($import_file_path);
+            }
         }
 
         // NC3動画（videos）を移行する。
@@ -4852,7 +4857,7 @@ trait MigrationNc3ExportTrait
             // NC3 情報
             $photoalbum_ini .= "\n";
             $photoalbum_ini .= "[source_info]\n";
-            $photoalbum_ini .= "photoalbum_id   = " . $nc3_block->id . "\n";
+            $photoalbum_ini .= "photoalbum_id   = VIDEO_" . $nc3_block->id . "\n";
             $photoalbum_ini .= "room_id         = " . $nc3_block->room_id . "\n";
             $photoalbum_ini .= "module_name     = \"videos\"\n";
             $photoalbum_ini .= "created_at      = \"" . $this->getCCDatetime($nc3_block->created) . "\"\n";

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -130,6 +130,10 @@ use App\Models\Migration\Nc2\Nc2PhotoalbumAlbum;
 use App\Models\Migration\Nc2\Nc2PhotoalbumBlock;
 use App\Models\Migration\Nc2\Nc2PhotoalbumPhoto;
 use App\Models\Migration\Nc2\Nc2Questionnaire;
+use App\Models\Migration\Nc2\Nc2QuestionnaireAnswer;
+use App\Models\Migration\Nc2\Nc2QuestionnaireBlock;
+use App\Models\Migration\Nc2\Nc2QuestionnaireChoice;
+use App\Models\Migration\Nc2\Nc2QuestionnaireQuestion;
 use App\Models\Migration\Nc2\Nc2Quiz;
 use App\Models\Migration\Nc2\Nc2Registration;
 use App\Models\Migration\Nc2\Nc2RegistrationBlock;
@@ -166,6 +170,7 @@ use App\Enums\DayOfWeek;
 use App\Enums\FacilityDisplayType;
 use App\Enums\FaqSequenceConditionType;
 use App\Enums\FormColumnType;
+use App\Enums\FormMode;
 use App\Enums\LinklistType;
 use App\Enums\NoticeEmbeddedTag;
 use App\Enums\NotShowType;
@@ -256,7 +261,7 @@ trait MigrationTrait
         'online'        => 'Development',  // オンライン状況
         'photoalbum'    => 'photoalbums',  // フォトアルバム
         'pm'            => 'Abolition',    // プライベートメッセージ
-        'questionnaire' => 'Development',  // アンケート
+        'questionnaire' => 'forms',        // アンケート
         'quiz'          => 'Development',  // 小テスト
         'registration'  => 'forms',        // フォーム
         'reservation'   => 'reservations', // 施設予約
@@ -2973,10 +2978,10 @@ trait MigrationTrait
             $form_ini = parse_ini_file($form_ini_path, true);
 
             // ルーム指定を探しておく。
-            $room_id = null;
-            if (array_key_exists('source_info', $form_ini) && array_key_exists('room_id', $form_ini['source_info'])) {
-                $room_id = $form_ini['source_info']['room_id'];
-            }
+            // $room_id = null;
+            // if (array_key_exists('source_info', $form_ini) && array_key_exists('room_id', $form_ini['source_info'])) {
+            //     $room_id = $form_ini['source_info']['room_id'];
+            // }
 
             // nc2 の registration_id
             $nc2_registration_id = 0;
@@ -3050,28 +3055,21 @@ trait MigrationTrait
                 $regist_to = $regist_to ? $regist_to : null;
             }
 
-            // メールフォーマットの置換処理
-            $mail_format = str_replace('\n', "\n", $form_ini['form_base']['mail_format']);
-            // 登録日時、ルームの出力は未実装機能
-            $replace_tags = [
-                '{X-SITE_NAME}'=>'[[site_name]]',
-                '{X-ROOM}'=>'',
-                '{X-REGISTRATION_NAME}'=>'[[form_name]]',
-                '{X-TO_DATE}'=>'[[to_datetime]]',
-                '{X-DATA}'=>'[[body]]',
-            ];
-            $mail_subject = str_replace(array_keys($replace_tags), array_values($replace_tags), $form_ini['form_base']['mail_subject']);
-            $mail_format = str_replace(array_keys($replace_tags), array_values($replace_tags), $mail_format);
+            if ($form_ini['form_base']['mail_send_flag'] && empty($form_ini['form_base']['mail_send_address']) && empty($form_ini['form_base']['user_mail_send_flag'])) {
+                $this->putMonitor(3, 'メール送信=ONですが、送信メールアドレス=空＆登録者にメール送る=OFFのため、メール飛びません。設定画面から設定してください。', "バケツ名={$bucket->bucket_name}, bucket_id={$bucket->id}");
+            }
+
             $form = new Forms([
                 'bucket_id'           => $bucket->id,
                 'forms_name'          => $form_name,
+                'form_mode'           => Arr::get($form_ini, 'form_base.form_mode', FormMode::form),
                 'mail_send_flag'      => $form_ini['form_base']['mail_send_flag'],
                 'mail_send_address'   => $form_ini['form_base']['mail_send_address'],
                 'user_mail_send_flag' => $form_ini['form_base']['user_mail_send_flag'],
-                'mail_subject'        => $mail_subject,
-                'mail_format'         => $mail_format,
+                'mail_subject'        => $form_ini['form_base']['mail_subject'],
+                'mail_format'         => $form_ini['form_base']['mail_format'],
                 'data_save_flag'      => $form_ini['form_base']['data_save_flag'],
-                'after_message'       => str_replace('\n', "\n", $form_ini['form_base']['after_message']),
+                'after_message'       => $form_ini['form_base']['after_message'],
                 'numbering_use_flag'  => $form_ini['form_base']['numbering_use_flag'],
                 'numbering_prefix'    => $form_ini['form_base']['numbering_prefix'],
                 'regist_control_flag' => $regist_control_flag,
@@ -6272,10 +6270,22 @@ trait MigrationTrait
         if (array_key_exists('frame_base', $frame_ini) && array_key_exists('form_id', $frame_ini['frame_base'])) {
             $form_id = $frame_ini['frame_base']['form_id'];
         }
+
+        $target_source_table = Arr::get($frame_ini, 'source_info.target_source_table');
+
         // フォームの情報取得
-        if (!empty($form_id) && Storage::exists($this->getImportPath('forms/form_') . $form_id . '.ini')) {
-            $form_ini = parse_ini_file(storage_path() . '/app/' . $this->getImportPath('forms/form_') . $form_id . '.ini', true);
+        if ($target_source_table == 'questionnaire') {
+            // questionnaire -> forms
+            if (!empty($form_id) && Storage::exists($this->getImportPath('forms/form_questionnaire_') . $form_id . '.ini')) {
+                $form_ini = parse_ini_file(storage_path() . '/app/' . $this->getImportPath('forms/form_questionnaire_') . $form_id . '.ini', true);
+            }
+        } else {
+            // フォーム
+            if (!empty($form_id) && Storage::exists($this->getImportPath('forms/form_') . $form_id . '.ini')) {
+                $form_ini = parse_ini_file(storage_path() . '/app/' . $this->getImportPath('forms/form_') . $form_id . '.ini', true);
+            }
         }
+
         // NC2 の registration_id でマップ確認
         if (!empty($form_ini) && array_key_exists('source_info', $form_ini) && array_key_exists('registration_id', $form_ini['source_info'])) {
             $registration_id = $form_ini['source_info']['registration_id'];
@@ -7709,6 +7719,11 @@ trait MigrationTrait
         // NC2 検索（search）データのエクスポート
         if ($this->isTarget('nc2_export', 'plugins', 'searchs')) {
             $this->nc2ExportSearch($redo);
+        }
+
+        // NC2 アンケート（questionnaire）データのエクスポート
+        if ($this->isTarget('nc2_export', 'plugins', 'questionnaires')) {
+            $this->nc2ExportQuestionnaire($redo);
         }
 
         // NC2 固定リンク（abbreviate_url）データのエクスポート
@@ -10068,6 +10083,38 @@ trait MigrationTrait
                 $mail_send_flag = 0;
             }
 
+            $mail_subject = $nc2_registration->mail_subject;
+            $mail_body = $nc2_registration->mail_body;
+
+            // --- メール配信設定
+            // {X-REGISTRATION_NAME}の登録通知先メールアドレスとしてあなたのメールアドレスが使用されました。
+            // もし{X-REGISTRATION_NAME}への登録に覚えがない場合はこのメールを破棄してください。
+            //
+            // {X-REGISTRATION_NAME}を受け付けました。
+            //
+            // 登録日時:{X-TO_DATE}
+            //
+            //
+            // {X-DATA}
+            //
+            // メール内容を印刷の上、会場にご持参ください。
+
+            // 変換
+            $convert_embedded_tags = [
+                // nc2埋込タグ, cc埋込タグ
+                ['{X-SITE_NAME}', '[[' . NoticeEmbeddedTag::site_name . ']]'],
+                ['{X-REGISTRATION_NAME}', '[[form_name]]'],
+                ['{X-TO_DATE}', '[[to_datetime]]'],
+                ['{X-DATA}', '[[' . NoticeEmbeddedTag::body . ']]'],
+                // 除外
+                ['{X-ROOM} ', ''],
+                ['{X-ROOM}', ''],
+            ];
+            foreach ($convert_embedded_tags as $convert_embedded_tag) {
+                $mail_subject = str_ireplace($convert_embedded_tag[0], $convert_embedded_tag[1], $mail_subject);
+                $mail_body = str_ireplace($convert_embedded_tag[0], $convert_embedded_tag[1], $mail_body);
+            }
+
             $registration_id = $nc2_registration->registration_id;
             $regist_control_flag = $nc2_registration->period ? 1 : 0;
             $regist_to =  $nc2_registration->period ? $this->getCCDatetime($nc2_registration->period) : '';
@@ -10076,13 +10123,14 @@ trait MigrationTrait
             $registration_ini = "";
             $registration_ini .= "[form_base]\n";
             $registration_ini .= "forms_name = \""        . $nc2_registration->registration_name . "\"\n";
+            $registration_ini .= "form_mode  = \""        . FormMode::form . "\"\n";
             $registration_ini .= "mail_send_flag = "      . $mail_send_flag . "\n";
             $registration_ini .= "mail_send_address = \"" . $mail_send_address . "\"\n";
             $registration_ini .= "user_mail_send_flag = " . $user_mail_send_flag . "\n";
-            $registration_ini .= "mail_subject = \""      . $nc2_registration->mail_subject . "\"\n";
-            $registration_ini .= "mail_format = \""       . str_replace("\n", '\n', $nc2_registration->mail_body) . "\"\n";
+            $registration_ini .= "mail_subject = \""      . $mail_subject . "\"\n";
+            $registration_ini .= "mail_format = \""       . $mail_body . "\"\n";
             $registration_ini .= "data_save_flag = 1\n";
-            $registration_ini .= "after_message = \""     . str_replace("\n", '\n', $nc2_registration->accept_message) . "\"\n";
+            $registration_ini .= "after_message = \""     . $nc2_registration->accept_message . "\"\n";
             $registration_ini .= "numbering_use_flag = 0\n";
             $registration_ini .= "numbering_prefix = null\n";
             $registration_ini .= "regist_control_flag = " . $regist_control_flag. "\n";
@@ -11782,6 +11830,327 @@ trait MigrationTrait
     }
 
     /**
+     * NC2：アンケート（Questionnaire）の移行
+     */
+    private function nc2ExportQuestionnaire($redo)
+    {
+        $this->putMonitor(3, "Start nc2ExportQuestionnaire.");
+
+        // データクリア
+        if ($redo === true) {
+            // 移行用ファイルの削除
+            $import_file_paths = glob($this->getImportPath('forms/form_questionnaire_*'));
+            foreach ($import_file_paths as $import_file_path) {
+                Storage::delete($import_file_path);
+            }
+        }
+
+        // NC2アンケート（Questionnaire）を移行する。
+        $nc2_export_where_questionnaire_ids = $this->getMigrationConfig('questionnaires', 'nc2_export_where_questionnaire_ids');
+
+        if (empty($nc2_export_where_questionnaire_ids)) {
+            $nc2_questionnaires = Nc2Questionnaire::orderBy('questionnaire_id')->get();
+        } else {
+            $nc2_questionnaires = Nc2Questionnaire::whereIn('questionnaire_id', $nc2_export_where_questionnaire_ids)->orderBy('questionnaire_id')->get();
+        }
+
+        // 空なら戻る
+        if ($nc2_questionnaires->isEmpty()) {
+            return;
+        }
+
+        // nc2の全ユーザ取得
+        $nc2_users = Nc2User::get();
+
+        // NC2アンケート（Questionnaire）のループ
+        foreach ($nc2_questionnaires as $nc2_questionnaire) {
+            $room_ids = $this->getMigrationConfig('basic', 'nc2_export_room_ids');
+            // ルーム指定があれば、指定されたルームのみ処理する。
+            if (empty($room_ids)) {
+                // ルーム指定なし。全データの移行
+            } elseif (!empty($room_ids) && in_array($nc2_questionnaire->room_id, $room_ids)) {
+                // ルーム指定あり。指定ルームに合致する。
+            } else {
+                // ルーム指定あり。条件に合致せず。移行しない。
+                continue;
+            }
+
+            // 対象外指定があれば、読み飛ばす
+            if ($this->isOmmit('questionnaires', 'export_ommit_questionnaire_ids', $nc2_questionnaire->questionnaire_id)) {
+                continue;
+            }
+
+            // このアンケートが配置されている最初のページオブジェクトを取得しておく
+            // WYSIWYG で相対パスを絶対パスに変換する際に、ページの固定URL が必要になるため。
+            $nc2_page = null;
+            $nc2_questionnaire_block = Nc2QuestionnaireBlock::where('questionnaire_id', $nc2_questionnaire->questionnaire_id)->orderBy('block_id', 'asc')->first();
+            if (!empty($nc2_questionnaire_block)) {
+                $nc2_block = Nc2Block::where('block_id', $nc2_questionnaire_block->block_id)->first();
+            }
+            if (!empty($nc2_block)) {
+                $nc2_page = Nc2Page::where('page_id', $nc2_block->page_id)->first();
+            }
+
+            // (nc2) mail_send = 登録をメールで通知する
+            if ($nc2_questionnaire->mail_send) {
+                // メール通知ON
+                $mail_send_flag = 1;
+
+            } else {
+                // メール通知OFF
+                $mail_send_flag = 0;
+            }
+
+            $mail_subject = $nc2_questionnaire->mail_subject;
+            $mail_body = $nc2_questionnaire->mail_body;
+
+            // --- メール配信設定
+            // [{X-SITE_NAME}]アンケート回答
+            //
+            // アンケートが回答されたのでお知らせします。
+            // ルーム名称:{X-ROOM}
+            // アンケートタイトル:{X-QUESTIONNAIRE_NAME}
+            // 回答者:{X-USER}
+            // 回答日時:{X-TO_DATE}
+
+            // 回答結果を参照するには、下記アドレスへ
+            // {X-URL}
+
+            // 変換
+            $convert_embedded_tags = [
+                // nc2埋込タグ, cc埋込タグ
+                ['{X-SITE_NAME}', '[[' . NoticeEmbeddedTag::site_name . ']]'],
+                ['{X-QUESTIONNAIRE_NAME}', '[[form_name]]'],
+                ['{X-TO_DATE}', '[[to_datetime]]'],
+                // 除外
+                ['ルーム名称:{X-ROOM}', ''],
+                ['回答者:{X-USER}', ''],
+                ['{X-ROOM}', ''],
+                ['回答結果を参照するには、下記アドレスへ', ''],
+                ['{X-URL}', ''],
+            ];
+            foreach ($convert_embedded_tags as $convert_embedded_tag) {
+                $mail_subject = str_ireplace($convert_embedded_tag[0], $convert_embedded_tag[1], $mail_subject);
+                $mail_body = str_ireplace($convert_embedded_tag[0], $convert_embedded_tag[1], $mail_body);
+            }
+
+            $regist_control_flag = $nc2_questionnaire->period ? 1 : 0;
+            $regist_to =  $nc2_questionnaire->period ? $this->getCCDatetime($nc2_questionnaire->period) : '';
+
+            // 状態 変換
+            // (nc) 0:未実施, 1:公開, 2:終了
+            // (cc) 0:停止, 1:公開
+            // (key:nc2)status => (value:cc)active_flag
+            $convert_active_flags = [
+                0 => 0,
+                1 => 1,
+                2 => 0,
+            ];
+            if (isset($convert_active_flags[$nc2_questionnaire->status])) {
+                $active_flag = $convert_active_flags[$nc2_questionnaire->status];
+            } else {
+                $active_flag = 0;
+                $this->putError(3, '掲示板の表示形式が未対応の形式', "nc2_questionnaire->status = " . $nc2_questionnaire->status);
+            }
+
+            // アンケート設定
+            $questionnaire_ini = "";
+            $questionnaire_ini .= "[form_base]\n";
+            $questionnaire_ini .= "forms_name = \""        . $nc2_questionnaire->questionnaire_name . "\"\n";
+            $questionnaire_ini .= "form_mode  = \""        . FormMode::questionnaire . "\"\n";
+            $questionnaire_ini .= "mail_send_flag = "      . $mail_send_flag . "\n";
+            $questionnaire_ini .= "mail_send_address =\n";
+            $questionnaire_ini .= "user_mail_send_flag = 0\n";
+            $questionnaire_ini .= "mail_subject = \""      . $mail_subject . "\"\n";
+            $questionnaire_ini .= "mail_format = \""       . $mail_body . "\"\n";
+            $questionnaire_ini .= "data_save_flag = 1\n";
+            $questionnaire_ini .= "after_message =\n";
+            $questionnaire_ini .= "numbering_use_flag = 0\n";
+            $questionnaire_ini .= "numbering_prefix = null\n";
+            $questionnaire_ini .= "regist_control_flag = " . $regist_control_flag. "\n";
+            $questionnaire_ini .= "regist_to = \""         . $regist_to . "\"\n";
+
+            // NC2 情報
+            $questionnaire_ini .= "\n";
+            $questionnaire_ini .= "[source_info]\n";
+            $questionnaire_ini .= "registration_id  = QUESTIONNAIRE_" . $nc2_questionnaire->questionnaire_id . "\n";
+            $questionnaire_ini .= "active_flag      = " . $active_flag . "\n";
+            $questionnaire_ini .= "room_id          = " . $nc2_questionnaire->room_id . "\n";
+            $questionnaire_ini .= "module_name      = \"questionnaire\"\n";
+            $questionnaire_ini .= "created_at       = \"" . $this->getCCDatetime($nc2_questionnaire->insert_time) . "\"\n";
+            $questionnaire_ini .= "created_name     = \"" . $nc2_questionnaire->insert_user_name . "\"\n";
+            $questionnaire_ini .= "insert_login_id  = \"" . $this->getNc2LoginIdFromNc2UserId($nc2_users, $nc2_questionnaire->insert_user_id) . "\"\n";
+            $questionnaire_ini .= "updated_at       = \"" . $this->getCCDatetime($nc2_questionnaire->update_time) . "\"\n";
+            $questionnaire_ini .= "updated_name     = \"" . $nc2_questionnaire->update_user_name . "\"\n";
+            $questionnaire_ini .= "update_login_id  = \"" . $this->getNc2LoginIdFromNc2UserId($nc2_users, $nc2_questionnaire->update_user_id) . "\"\n";
+
+            // アンケートのカラム情報
+            $questionnaire_questions = Nc2QuestionnaireQuestion::where('questionnaire_id', $nc2_questionnaire->questionnaire_id)
+                ->orderBy('question_sequence', 'asc')
+                ->get();
+
+            if (empty($questionnaire_questions)) {
+                continue;
+            }
+
+            // カラム情報出力
+            $questionnaire_ini .= "\n";
+            $questionnaire_ini .= "[form_columns]\n";
+
+            // カラム情報
+            foreach ($questionnaire_questions as $questionnaire_question) {
+                $question_value = $this->nc2Wysiwyg(null, null, null, null, $questionnaire_question->question_value, 'questionnaire', $nc2_page);
+
+                $questionnaire_ini .= "form_column[" . $questionnaire_question->question_id . "] = \"" . $question_value . "\"\n";
+            }
+            $questionnaire_ini .= "\n";
+
+            $option_values = Nc2QuestionnaireChoice::where('questionnaire_id', $nc2_questionnaire->questionnaire_id)
+                ->orderBy('choice_sequence', 'asc')
+                ->get();
+
+            // カラム詳細情報
+            foreach ($questionnaire_questions as $questionnaire_question) {
+                $questionnaire_ini .= "[" . $questionnaire_question->question_id . "]" . "\n";
+
+                // type
+                if ($questionnaire_question->question_type == 0) {
+                    $column_type = "radio";
+                } elseif ($questionnaire_question->question_type == 1) {
+                    $column_type = "checkbox";
+                } elseif ($questionnaire_question->question_type == 2) {
+                    $column_type = "textarea";
+                }
+
+                // 選択肢
+                $option_value = $option_values->where('question_id', $questionnaire_question->question_id)
+                    ->pluck('choice_value')
+                    ->implode('|');
+
+                $questionnaire_ini .= "column_type                = \"" . $column_type                     . "\"\n";
+                $questionnaire_ini .= "column_name                = \"" . $questionnaire_question->question_value    . "\"\n";
+                $questionnaire_ini .= "option_value               = \"" . $option_value . "\"\n";
+                $questionnaire_ini .= "required                   = "   . $questionnaire_question->require_flag . "\n";
+                $questionnaire_ini .= "frame_col                  = "   . 0                                . "\n";
+                $questionnaire_ini .= "caption                    = \"" . $questionnaire_question->description  . "\"\n";
+                $questionnaire_ini .= "caption_color              = \"" . "text-dark"                      . "\"\n";
+                $questionnaire_ini .= "minutes_increments         = "   . 10                               . "\n";
+                $questionnaire_ini .= "minutes_increments_from    = "   . 10                               . "\n";
+                $questionnaire_ini .= "minutes_increments_to      = "   . 10                               . "\n";
+                $questionnaire_ini .= "rule_allowed_numeric       = null\n";
+                $questionnaire_ini .= "rule_allowed_alpha_numeric = null\n";
+                $questionnaire_ini .= "rule_digits_or_less        = null\n";
+                $questionnaire_ini .= "rule_max                   = null\n";
+                $questionnaire_ini .= "rule_min                   = null\n";
+                $questionnaire_ini .= "rule_word_count            = null\n";
+                $questionnaire_ini .= "rule_date_after_equal      = null\n";
+                $questionnaire_ini .= "\n";
+            }
+
+            // フォーム の設定
+            $this->storagePut($this->getImportPath('forms/form_questionnaire_') . $this->zeroSuppress($nc2_questionnaire->questionnaire_id) . '.ini', $questionnaire_ini);
+
+            // 登録データもエクスポートする場合
+            if ($this->hasMigrationConfig('questionnaires', 'nc2_export_questionnaire_data', true)) {
+                // 対象外指定があれば、読み飛ばす
+                if ($this->isOmmit('questionnaires', 'export_ommit_questionnaire_data_ids', $nc2_questionnaire->questionnaire_id)) {
+                    continue;
+                }
+
+                // データ部
+                $questionnaire_data_header = "[form_inputs]\n";
+                $questionnaire_data = "";
+                $questionnaire_answers = Nc2QuestionnaireAnswer::
+                    select(
+                        'questionnaire_answer.*',
+                        'questionnaire_question.question_type',
+                        'questionnaire_summary.insert_time AS summary_insert_time',
+                        'questionnaire_summary.insert_user_name AS summary_insert_user_name',
+                        'questionnaire_summary.insert_user_id AS summary_insert_user_id',
+                        'questionnaire_summary.update_time AS summary_update_time',
+                        'questionnaire_summary.update_user_name AS summary_update_user_name',
+                        'questionnaire_summary.update_user_id AS summary_update_user_id'
+                    )
+                    ->join('questionnaire_question', function ($join) {
+                        $join->on('questionnaire_question.questionnaire_id', '=', 'questionnaire_answer.questionnaire_id')
+                            ->on('questionnaire_question.question_id', '=', 'questionnaire_answer.question_id');
+                    })
+                    ->join('questionnaire_summary', function ($join) {
+                        $join->on('questionnaire_summary.questionnaire_id', '=', 'questionnaire_answer.questionnaire_id')
+                            ->on('questionnaire_summary.summary_id', '=', 'questionnaire_answer.summary_id');
+                    })
+                    ->where('questionnaire_answer.questionnaire_id', $nc2_questionnaire->questionnaire_id)
+                    ->orderBy('questionnaire_answer.summary_id', 'asc')
+                    ->orderBy('questionnaire_question.question_sequence', 'asc')
+                    ->get();
+
+                $summary_id = null;
+                foreach ($questionnaire_answers as $questionnaire_answer) {
+                    if ($questionnaire_answer->summary_id != $summary_id) {
+                        $questionnaire_data_header .= "input[" . $questionnaire_answer->summary_id . "] = \"\"\n";
+                        $questionnaire_data .= "\n[" . $questionnaire_answer->summary_id . "]\n";
+                        $questionnaire_data .= "created_at      = \"" . $this->getCCDatetime($questionnaire_answer->summary_insert_time) . "\"\n";
+                        $questionnaire_data .= "created_name    = \"" . $questionnaire_answer->summary_insert_user_name . "\"\n";
+                        $questionnaire_data .= "insert_login_id = \"" . $this->getNc2LoginIdFromNc2UserId($nc2_users, $questionnaire_answer->summary_insert_user_id) . "\"\n";
+                        $questionnaire_data .= "updated_at      = \"" . $this->getCCDatetime($questionnaire_answer->summary_update_time) . "\"\n";
+                        $questionnaire_data .= "updated_name    = \"" . $questionnaire_answer->summary_update_user_name . "\"\n";
+                        $questionnaire_data .= "update_login_id = \"" . $this->getNc2LoginIdFromNc2UserId($nc2_users, $questionnaire_answer->summary_update_user_id) . "\"\n";
+                        $summary_id = $questionnaire_answer->summary_id;
+                    }
+
+                    $value = str_replace('"', '\"', $questionnaire_answer->answer_value);
+                    $value = str_replace("\n", '\n', $value);
+
+                    // 選択肢
+                    $option_value = $option_values->where('question_id', $questionnaire_answer->question_id)->pluck('choice_value');
+
+                    // type
+                    if ($questionnaire_answer->question_type == 0) {
+                        // radio
+                        // (nc2)value = 0|1|0
+                        $value_arr = explode('|', $value);
+                        $value_return = '';
+                        foreach ($value_arr as $key => $val) {
+                            if ($val) {
+                                if (isset($option_value[$key])) {
+                                    // 選択肢を値に変換
+                                    $value_return = $option_value[$key];
+                                    break;
+                                }
+                            }
+                        }
+                        $value = $value_return;
+
+                    } elseif ($questionnaire_answer->question_type == 1) {
+                        // checkbox
+                        // (nc2)value = 0|1|1
+                        $value_arr = explode('|', $value);
+                        $value_returns = [];
+                        foreach ($value_arr as $key => $val) {
+                            if ($val) {
+                                if (isset($option_value[$key])) {
+                                    // 選択肢を値に変換
+                                    $value_returns[] = $option_value[$key];
+                                    break;
+                                }
+                            }
+                        }
+                        $value = implode('|', $value_returns);
+
+                    } elseif ($questionnaire_answer->question_type == 2) {
+                        // textarea
+                        // 何もしない
+                    }
+
+                    $questionnaire_data .=  "{$questionnaire_answer->question_id} = \"{$value}\"\n";
+                }
+                // フォーム の登録データ
+                $this->storagePut($this->getImportPath('forms/form_questionnaire_') . $this->zeroSuppress($nc2_questionnaire->questionnaire_id) . '.txt', $questionnaire_data_header . $questionnaire_data);
+            }
+        }
+    }
+
+    /**
      * NC2：固定リンク（abbreviate_url）の移行
      */
     private function nc2ExportAbbreviateUrl($redo)
@@ -12366,6 +12735,12 @@ trait MigrationTrait
         } elseif ($module_name == 'search') {
             $nc2_search_block = Nc2SearchBlock::where('block_id', $nc2_block->block_id)->first();
             $ret = "search_block_id = \"" . $this->zeroSuppress($nc2_search_block->block_id) . "\"\n";
+        } elseif ($module_name == 'questionnaire') {
+            $nc2_questionnaire_block = Nc2QuestionnaireBlock::where('block_id', $nc2_block->block_id)->first();
+            // ブロックがあり、アンケートがない場合は対象外
+            if (!empty($nc2_questionnaire_block)) {
+                $ret = "form_id = \"" . $this->zeroSuppress($nc2_questionnaire_block->questionnaire_id) . "\"\n";
+            }
         }
         return $ret;
     }

--- a/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
@@ -114,6 +114,7 @@ nc2_export_plugins[] = "calendars"
 nc2_export_plugins[] = "reservations"
 nc2_export_plugins[] = "photoalbums"
 nc2_export_plugins[] = "searchs"
+nc2_export_plugins[] = "questionnaires"
 
 
 ; --- インポート（指定されたプラグインをインポート対象とする）
@@ -429,3 +430,21 @@ img_fluid_min_width = 200
 ; インポートするフォトアルバムを絞る
 ;cc_import_where_photoalbum_ids[] = 11
 ;cc_import_where_photoalbum_ids[] = 22
+
+;------------------------------------------------
+;- アンケート・オプション
+;------------------------------------------------
+[questionnaires]
+
+; --- エクスポート
+; 登録データもエクスポートする場合に true を指定
+nc2_export_questionnaire_data = true;
+
+;エクスポート対象のフォームIDを絞る（指定がなければすべて対象）
+; nc2_export_where_questionnaire_ids[] = 1
+
+; 登録データを移行しない登録フォーム
+;export_ommit_questionnaire_data_ids[] = 3
+
+; エクスポートしない登録フォーム
+;export_ommit_registration_ids[] = 3

--- a/config/app.php
+++ b/config/app.php
@@ -318,6 +318,7 @@ $app_array = [
         'FaqNarrowingDownType' => \App\Enums\FaqNarrowingDownType::class,
         'ColorName' => \App\Enums\ColorName::class,
         'FaqSequenceConditionType' => \App\Enums\FaqSequenceConditionType::class,
+        'FormMode' => \App\Enums\FormMode::class,
 
         // utils
         'DateUtils' => \App\Utilities\Date\DateUtils::class,

--- a/database/migrations/2023_02_18_214425_add_form_mode_and_can_view_inputs_moderator_from_forms.php
+++ b/database/migrations/2023_02_18_214425_add_form_mode_and_can_view_inputs_moderator_from_forms.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Enums\FormMode;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFormModeAndCanViewInputsModeratorFromForms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->string('form_mode')->default(FormMode::form)->comment('フォームモード')->after('forms_name');
+            $table->integer('can_view_inputs_moderator')->nullable()->comment('モデレータは集計結果を表示できる')->after('regist_to');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('form_mode');
+            $table->dropColumn('can_view_inputs_moderator');
+        });
+    }
+}

--- a/database/migrations/2023_02_18_214941_change_column_name_from_forms_columns.php
+++ b/database/migrations/2023_02_18_214941_change_column_name_from_forms_columns.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeColumnNameFromFormsColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms_columns', function (Blueprint $table) {
+            $table->text('column_name')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms_columns', function (Blueprint $table) {
+            $table->string('column_name')->change();
+        });
+    }
+}

--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -257,6 +257,11 @@
             readonly : 1,
         @endif
 
+        @if(isset($use_br) && $use_br)
+            // 改行を p タグから br タグに変更
+            forced_root_block : false,
+        @endif
+
         {{-- plugins --}}
         {!!$plugins!!}
 

--- a/resources/views/plugins/user/forms/default/aggregate.blade.php
+++ b/resources/views/plugins/user/forms/default/aggregate.blade.php
@@ -1,0 +1,140 @@
+{{--
+ * 集計結果
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォーム・プラグイン
+--}}
+@extends('core.cms_frame_base')
+
+@section("plugin_contents_$frame->id")
+
+{{-- 登録後メッセージ表示 --}}
+@include('plugins.common.flash_message')
+
+{{-- ダウンロード用フォーム --}}
+<form action="" method="post" name="form_download" class="d-inline">
+    {{ csrf_field() }}
+    <input type="hidden" name="character_code" value="">
+</form>
+
+<script type="text/javascript">
+    {{-- ダウンロードのsubmit JavaScript --}}
+    function submit_download_shift_jis(id) {
+        if( !confirm('{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}で登録データをダウンロードします。\nよろしいですか？') ) {
+            return;
+        }
+        form_download.action = "{{url('/')}}/download/plugin/forms/downloadCsvAggregate/{{$page->id}}/{{$frame_id}}/" + id;
+        form_download.character_code.value = '{{CsvCharacterCode::sjis_win}}';
+        form_download.submit();
+    }
+    function submit_download_utf_8(id) {
+        if( !confirm('{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}で登録データをダウンロードします。\nよろしいですか？') ) {
+            return;
+        }
+        form_download.action = "{{url('/')}}/download/plugin/forms/downloadCsvAggregate/{{$page->id}}/{{$frame_id}}/" + id;
+        form_download.character_code.value = '{{CsvCharacterCode::utf_8}}';
+        form_download.submit();
+    }
+</script>
+
+<div class="row">
+    <div class="col-3 text-left d-flex align-items-end">
+        {{-- (左側)件数 --}}
+        <span class="badge badge-pill badge-light">{{ $inputs->total() }} 件</span>
+    </div>
+
+    <div class="col text-right">
+        {{-- (右側)ダウンロードボタン --}}
+        <div class="btn-group">
+            <button type="button" class="btn btn-primary btn-sm" onclick="submit_download_shift_jis({{$form->id}});">
+                <i class="fas fa-file-download"></i> ダウンロード
+            </button>
+            <button type="button" class="btn btn-primary btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="sr-only">ドロップダウンボタン</span>
+            </button>
+            <div class="dropdown-menu dropdown-menu-right">
+                <a class="dropdown-item" href="#" onclick="submit_download_shift_jis({{$form->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                <a class="dropdown-item" href="#" onclick="submit_download_utf_8({{$form->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- データのループ --}}
+<table class="table table-bordered table-responsive table-sm mt-2">
+    <thead class="thead-light">
+        <tr>
+            <th nowrap>状態</th>
+            @foreach($columns as $column)
+                <th>{{$column->column_name}}</th>
+            @endforeach
+            @if ($form->numbering_use_flag)
+                <th nowrap>採番</th>
+            @endif
+            <th nowrap>登録日時</th>
+        </tr>
+    </thead>
+
+    <tbody>
+    @foreach($inputs as $input)
+
+        @if ($input->status == FormStatusType::temporary)
+        {{-- 仮登録 --}}
+        <tr class="table-warning">
+        @elseif ($input->status == FormStatusType::delete)
+        {{-- 削除 --}}
+        <tr class="table-danger">
+        @else
+        {{-- 本登録 --}}
+        <tr>
+        @endif
+
+            <td nowrap>{{$input->status}}</td>
+
+            @foreach($columns as $column)
+                <td style="min-width: 100px;">
+                    @include('plugins.user.forms.default.forms_include_value')
+                </td>
+            @endforeach
+
+            @if ($form->numbering_use_flag)
+                <td>
+                    {{$input->number_with_prefix}}
+                </td>
+            @endif
+
+            <td nowrap>
+                {{$input->created_at}}
+            </td>
+
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+
+<table class="table-bordered table-sm">
+    <tbody>
+    <tr>
+        <td>状態:0 = 本登録</td>
+        <td class="table-warning">状態:1 = 仮登録</td>
+        <td class="table-danger">状態:9 = 削除</td>
+    </tr>
+    </tbody>
+</table>
+
+{{-- ページング処理 --}}
+@include('plugins.common.user_paginate', ['posts' => $inputs, 'frame' => $frame, 'aria_label_name' => $form->forms_name, 'class' => 'form-group mt-3'])
+
+{{-- ボタン --}}
+<div class="text-center pt-2">
+    <div class="row">
+        <div class="col">
+            <a href="{{url($page->permanent_link)}}#frame-{{$frame->id}}" class="btn btn-secondary">
+                <i class="fas fa-chevron-left"></i> フォームへ
+            </a>
+        </div>
+    </div>
+</div>
+
+@endsection

--- a/resources/views/plugins/user/forms/default/aggregate.blade.php
+++ b/resources/views/plugins/user/forms/default/aggregate.blade.php
@@ -1,5 +1,6 @@
 {{--
  * 集計結果
+ * forms_list_inputs.blade.phpよりコピー
  *
  * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
@@ -36,6 +37,11 @@
         form_download.character_code.value = '{{CsvCharacterCode::utf_8}}';
         form_download.submit();
     }
+
+    $(function () {
+        // ツールチップ有効化
+        $('[data-toggle="tooltip"]').tooltip()
+    })
 </script>
 
 <div class="row">
@@ -67,7 +73,9 @@
         <tr>
             <th nowrap>状態</th>
             @foreach($columns as $column)
-                <th>{{$column->column_name}}</th>
+                <th>
+                    {{mb_substr(strip_tags($column->column_name), 0, 20)}}@if (mb_strlen(strip_tags($column->column_name)) > 20)<a href="#frame-{{$frame_id}}" data-toggle="tooltip" data-placement="right" title="{{strip_tags($column->column_name)}}">...</a> @endif
+                </th>
             @endforeach
             @if ($form->numbering_use_flag)
                 <th nowrap>採番</th>

--- a/resources/views/plugins/user/forms/default/forms_confirm_tandem.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm_tandem.blade.php
@@ -41,7 +41,7 @@
 
         @case(FormColumnType::group)
             {{-- defaultテンプレート --}}
-            <label class="col-12 control-label">{!!nl2br(e($form_column->column_name))!!}</label>
+            <label class="col-12 control-label">{!! $form_column->column_name !!}</label>
 
             @php
             // グループカラムの幅の計算
@@ -56,7 +56,7 @@
                 <div class="row p-0">
                     @foreach($form_column->group as $group_row)
                         <div class="col-sm-{{$col_count}} pr-0">
-                            <label class="control-label">Q{{$no}} {!!nl2br(e($group_row->column_name))!!}</label><br />
+                            <label class="control-label">Q{{$no}} {!! $group_row->column_name !!}</label><br />
                             @include('plugins.user.forms.default.forms_confirm_column_' . $group_row->column_type, ['form_obj' => $group_row])
                             @php $no++; @endphp
                         </div>
@@ -66,7 +66,7 @@
             @break
 
         @default
-            <label class="col-12 control-label">Q{{$no}}  {!!nl2br(e($form_column->column_name))!!}</label>
+            <label class="col-12 control-label">Q{{$no}}  {!! $form_column->column_name !!}</label>
 
             {{-- 項目 --}}
             <div class="col-12">

--- a/resources/views/plugins/user/forms/default/forms_confirm_tandem.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm_tandem.blade.php
@@ -1,0 +1,89 @@
+{{--
+ * 縦並び 確認画面テンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォーム・プラグイン
+--}}
+@extends('core.cms_frame_base')
+
+@section("plugin_contents_$frame->id")
+<script type="text/javascript">
+    {{-- 保存のsubmit JavaScript --}}
+    function submit_forms_store() {
+        forms_store{{$frame_id}}.action = "{{URL::to('/')}}/plugin/forms/publicStore/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+        forms_store{{$frame_id}}.submit();
+    }
+    {{-- 保存のキャンセル JavaScript --}}
+    function submit_forms_cancel() {
+        forms_store{{$frame_id}}.action = "{{URL::to('/')}}/plugin/forms/index/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+        forms_store{{$frame_id}}.submit();
+    }
+    {{-- 二重クリック防止 JavaScript --}}
+    $(function () {
+        $('form').submit(function () {
+            $(this).find(':submit').prop('disabled', true);
+        });
+    });
+</script>
+
+<div class="alert alert-secondary" role="alert">
+    <i class="fas fa-exclamation-circle"></i> 以下の内容でよろしいですか？
+</div>
+
+<form action="" name="forms_store{{$frame_id}}" method="POST">
+    {{ csrf_field() }}
+    @php $no = 1; @endphp
+    @foreach($forms_columns as $form_column)
+    <div class="form-group container-fluid row">
+
+        @switch($form_column->column_type)
+
+        @case(FormColumnType::group)
+            {{-- defaultテンプレート --}}
+            <label class="col-12 control-label">{!!nl2br(e($form_column->column_name))!!}</label>
+
+            @php
+            // グループカラムの幅の計算
+            $col_count = floor(12/count($form_column->group));
+            if ($col_count < 3) {
+                $col_count = 3;
+            }
+            @endphp
+
+            {{-- 項目 --}}
+            <div class="col-sm pr-0">
+                <div class="row p-0">
+                    @foreach($form_column->group as $group_row)
+                        <div class="col-sm-{{$col_count}} pr-0">
+                            <label class="control-label">Q{{$no}} {!!nl2br(e($group_row->column_name))!!}</label><br />
+                            @include('plugins.user.forms.default.forms_confirm_column_' . $group_row->column_type, ['form_obj' => $group_row])
+                            @php $no++; @endphp
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+            @break
+
+        @default
+            <label class="col-12 control-label">Q{{$no}}  {!!nl2br(e($form_column->column_name))!!}</label>
+
+            {{-- 項目 --}}
+            <div class="col-12">
+                @include('plugins.user.forms.default.forms_confirm_column_' . $form_column->column_type, ['form_obj' => $form_column])
+            </div>
+            @php $no++; @endphp
+        @endswitch
+    </div>
+    @endforeach
+    {{-- ボタンエリア --}}
+    <div class="form-group text-center">
+        <button type="button" class="btn btn-secondary mr-2" onclick="submit_forms_cancel();"><i class="fas fa-times"></i> {{__('messages.cancel')}}</button>
+        @if ($form->use_temporary_regist_mail_flag)
+            <button type="submit" class="btn btn-info" onclick="submit_forms_store();"><i class="fas fa-check"></i> {{__('messages.temporary_regist')}}</button>
+        @else
+            <button type="submit" class="btn btn-primary" onclick="submit_forms_store();"><i class="fas fa-check"></i> {{__('messages.submit')}}</button>
+        @endif
+    </div>
+</form>
+@endsection

--- a/resources/views/plugins/user/forms/default/forms_edit.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit.blade.php
@@ -22,9 +22,6 @@
             </div>
         @else
 
-        {{-- WYSIWYG 呼び出し --}}
-        @include('plugins.common.wysiwyg', ['target_class' => 'wysiwyg' . $frame->id])
-
 <script type="text/javascript">
 
     /**

--- a/resources/views/plugins/user/forms/default/forms_edit.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit.blade.php
@@ -2,6 +2,7 @@
  * 項目の設定画面
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>, 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
 --}}
@@ -116,35 +117,71 @@
                     </div>
                 @endif
 
-                <div class="table-responsive">
+                @if ($form_mode == FormMode::form)
+                    {{-- フォームの場合 --}}
+                    <div class="table-responsive">
+                        {{-- 項目の一覧 --}}
+                        <table class="table table-hover table-sm">
+                            <thead>
+                                <tr>
+                                    <th class="text-center" nowrap>表示順</th>
+                                    <th class="text-center" style="min-width: 165px;" nowrap>項目名</th>
+                                    <th class="text-center" style="min-width: 165px;" nowrap>型</th>
+                                    <th class="text-center" nowrap>必須</th>
+                                    <th class="text-center" nowrap>詳細 <a href="https://manual.connect-cms.jp/user/forms/editColumnDetail/index.html" target="_brank"><span class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></a></th>
+                                    <th class="text-center" nowrap>コピー</th>
+                                    <th class="text-center" nowrap>更新</th>
+                                    <th class="text-center" nowrap>削除</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {{-- 更新用の行 --}}
+                                @foreach($columns as $column)
+                                    @include('plugins.user.forms.default.forms_edit_row')
+                                @endforeach
+                                {{-- 新規登録用の行 --}}
+                                <tr>
+                                    <th colspan="8">【項目の追加行】</th>
+                                </tr>
+                                @include('plugins.user.forms.default.forms_edit_row_add')
+                            </tbody>
+                        </table>
+                    </div>
+                @else
+                    {{-- アンケートの場合 --}}
+                    <div class="table-responsive">
+                        {{-- 項目の一覧 --}}
+                        <table class="table table-hover table-sm">
+                            <thead>
+                                <tr>
+                                    <th class="text-center align-middle" rowspan="2" nowrap>表示順</th>
+                                    <th class="text-center" colspan="6" nowrap>項目名</th>
+                                </tr>
+                                <tr>
+                                    {{-- <th class="text-center" style="min-width: 165px;" nowrap>型</th> --}}
+                                    <th class="text-center" style="min-width: 165px;" nowrap>型</th>
+                                    <th class="text-center" nowrap>必須</th>
+                                    <th class="text-center" nowrap>詳細 <a href="https://manual.connect-cms.jp/user/forms/editColumnDetail/index.html" target="_brank"><span class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></a></th>
+                                    <th class="text-center" nowrap>コピー</th>
+                                    <th class="text-center" nowrap>更新</th>
+                                    <th class="text-center" nowrap>削除</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {{-- 更新用の行 --}}
+                                @foreach($columns as $column)
+                                    @include('plugins.user.forms.default.forms_edit_row2')
+                                @endforeach
+                                {{-- 新規登録用の行 --}}
+                                <tr>
+                                    <th colspan="8">【項目の追加行】</th>
+                                </tr>
+                                @include('plugins.user.forms.default.forms_edit_row2_add')
+                            </tbody>
+                        </table>
+                    </div>
+                @endif
 
-                    {{-- 項目の一覧 --}}
-                    <table class="table table-hover table-sm">
-                        <thead>
-                            <tr>
-                                <th class="text-center" nowrap>表示順</th>
-                                <th class="text-center" style="min-width: 165px;" nowrap>項目名</th>
-                                <th class="text-center" style="min-width: 165px;" nowrap>型</th>
-                                <th class="text-center" nowrap>必須</th>
-                                <th class="text-center" nowrap>詳細 <a href="https://manual.connect-cms.jp/user/forms/editColumnDetail/index.html" target="_brank"><span class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></a></th>
-                                <th class="text-center" nowrap>コピー</th>
-                                <th class="text-center" nowrap>更新</th>
-                                <th class="text-center" nowrap>削除</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {{-- 更新用の行 --}}
-                            @foreach($columns as $column)
-                                @include('plugins.user.forms.default.forms_edit_row')
-                            @endforeach
-                            {{-- 新規登録用の行 --}}
-                            <tr>
-                                <th colspan="8">【項目の追加行】</th>
-                            </tr>
-                            @include('plugins.user.forms.default.forms_edit_row_add')
-                        </tbody>
-                    </table>
-                </div>
                 {{-- ボタンエリア --}}
                 <div class="text-center mt-3 mt-md-0">
                     {{-- キャンセルボタン --}}

--- a/resources/views/plugins/user/forms/default/forms_edit.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit.blade.php
@@ -22,6 +22,9 @@
             </div>
         @else
 
+        {{-- WYSIWYG 呼び出し --}}
+        @include('plugins.common.wysiwyg', ['target_class' => 'wysiwyg' . $frame->id])
+
 <script type="text/javascript">
 
     /**
@@ -111,8 +114,13 @@
                 @if ($errors && $errors->any())
                     <div class="alert alert-danger mt-2">
                         @foreach ($errors->all() as $error)
-                        <i class="fas fa-exclamation-circle"></i>
-                            {{ $error }}<br>
+                            <i class="fas fa-exclamation-triangle"></i> {{ $error }}<br />
+                            @if (stripos($error, 'バイト以下の文字列'))
+                                <small>
+                                    <i class="fas fa-exclamation-triangle"></i> WYSIWYG のバイト数エラーの詳細については、Connect-CMS公式サイトを参照してください。<br />
+                                    <a href="https://manual.connect-cms.jp/common/wysiwyg/error/index.html" target="_blank">https://manual.connect-cms.jp/common/wysiwyg/error/index.html</a>
+                                </small>
+                            @endif
                         @endforeach
                     </div>
                 @endif

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -359,7 +359,8 @@
             <input type="text" name="temporary_regist_mail_subject" value="{{old('temporary_regist_mail_subject', $form->temporary_regist_mail_subject)}}" class="form-control" placeholder="（例）仮登録のお知らせと本登録のお願い">
             <small class="text-muted">
                 ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
-                ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。
+                ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
+                ※ [[to_datetime]] を記述すると該当部分に登録日時が入ります。<br>
             </small>
         </div>
     </div>
@@ -373,6 +374,7 @@
                 ※ [[entry_url]] を記述すると本登録URLが入ります。本登録URLの有効期限は仮登録後60分です。<br>
                 ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
                 ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
+                ※ [[to_datetime]] を記述すると該当部分に登録日時が入ります。<br>
                 ※ [[body]] を記述すると該当部分に登録内容が入ります。
             </small>
             @if ($errors && $errors->has('temporary_regist_mail_format')) <div class="text-danger">{{$errors->first('temporary_regist_mail_format')}}</div> @endif
@@ -401,6 +403,7 @@
             <small class="text-muted">
                 ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
                 ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
+                ※ [[to_datetime]] を記述すると該当部分に登録日時が入ります。<br>
                 ※ [[number]] を記述すると該当部分に採番した番号が入ります。（採番機能の使用時）
             </small>
         </div>
@@ -414,6 +417,7 @@
             <small class="text-muted">
                 ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
                 ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
+                ※ [[to_datetime]] を記述すると該当部分に登録日時が入ります。<br>
                 ※ [[body]] を記述すると該当部分に登録内容が入ります。<br>
                 ※ [[number]] を記述すると該当部分に採番した番号が入ります。（採番機能の使用時）
             </small>

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -2,6 +2,7 @@
  * フォーム編集画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォームプラグイン
 --}}
@@ -82,6 +83,25 @@
     </div>
 
     <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}} pt-0">フォームモード</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="col pl-0">
+                @foreach (FormMode::getMembers() as $enum_value => $enum_label)
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @php $form_mode = $form->form_mode ?? FormMode::getDefault(); @endphp
+                        @if (old('form_mode', $form_mode) == $enum_value)
+                            <input type="radio" value="{{$enum_value}}" id="form_mode_{{$enum_value}}" name="form_mode" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="{{$enum_value}}" id="form_mode_{{$enum_value}}" name="form_mode" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="form_mode_{{$enum_value}}">{{$enum_label}}</label>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}} pt-0">データ保存</label>
         <div class="{{$frame->getSettingInputClass()}}">
             <div class="custom-control custom-checkbox">
@@ -104,6 +124,22 @@
         <label class="{{$frame->getSettingLabelClass()}} pt-0">本登録数</label>
         <div class="{{$frame->getSettingInputClass()}}">
             {{$form->active_entry_count}}
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}} pt-0">集計結果</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <label>以下の権限は集計結果を表示できる</label>
+            <div class="custom-control custom-checkbox">
+                <input type="hidden" name="can_view_inputs_moderator" value="0">
+                <input type="checkbox" name="can_view_inputs_moderator" value="1" class="custom-control-input" id="can_view_inputs_moderator" @if(old('can_view_inputs_moderator', $form->can_view_inputs_moderator)) checked=checked @endif>
+                <label class="custom-control-label" for="can_view_inputs_moderator">モデレータ</label>
+            </div>
+            <small class="text-muted">
+                ※ 集計結果は、登録一覧と同じの登録データが確認できます。<br />
+                ※ チェックONにすると、表側に集計結果ボタンを表示します。
+            </small>
         </div>
     </div>
 

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -137,7 +137,7 @@
                 <label class="custom-control-label" for="can_view_inputs_moderator">モデレータ</label>
             </div>
             <small class="text-muted">
-                ※ 集計結果は、登録一覧と同じの登録データが確認できます。<br />
+                ※ 集計結果は、登録一覧と同じ内容を確認できます。<br />
                 ※ チェックONにすると、表側に集計結果ボタンを表示します。
             </small>
         </div>

--- a/resources/views/plugins/user/forms/default/forms_edit_row2.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row2.blade.php
@@ -20,7 +20,7 @@
     </td>
     {{-- 項目名 --}}
     <td colspan="6">
-        <small>{{ $column->column_name }}</small>
+        <small>{{ strip_tags($column->column_name) }}</small>
     </td>
 </tr>
 <tr>

--- a/resources/views/plugins/user/forms/default/forms_edit_row2.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row2.blade.php
@@ -20,7 +20,7 @@
     </td>
     {{-- 項目名 --}}
     <td colspan="6">
-        <textarea rows="2" name="column_name_{{ $column->id }}" class="form-control @if ($errors && $errors->has('column_name_'.$column->id)) border-danger @endif" >{{ old('column_name_'.$column->id, $column->column_name)}}</textarea>
+        <small>{{ $column->column_name }}</small>
     </td>
 </tr>
 <tr>

--- a/resources/views/plugins/user/forms/default/forms_edit_row2.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row2.blade.php
@@ -1,0 +1,124 @@
+{{--
+ * 項目の設定行テンプレート（２行）
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォーム・プラグイン
+--}}
+<tr>
+    {{-- 表示順 --}}
+    <td class="align-middle" rowspan="2" nowrap>
+        {{-- 上移動 --}}
+        <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->first) disabled @endif onclick="javascript:submit_display_sequence({{ $column->id }}, {{ $column->display_sequence }}, 'up')">
+            <i class="fas fa-arrow-up"></i>
+        </button>
+
+        {{-- 下移動 --}}
+        <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->last) disabled @endif onclick="javascript:submit_display_sequence({{ $column->id }}, {{ $column->display_sequence }}, 'down')">
+            <i class="fas fa-arrow-down"></i>
+        </button>
+    </td>
+    {{-- 項目名 --}}
+    <td colspan="6">
+        <textarea rows="2" name="column_name_{{ $column->id }}" class="form-control @if ($errors && $errors->has('column_name_'.$column->id)) border-danger @endif" >{{ old('column_name_'.$column->id, $column->column_name)}}</textarea>
+    </td>
+</tr>
+<tr>
+    {{-- 型 --}}
+    <td>
+        <select class="form-control" name="column_type_{{ $column->id }}">
+            <option value="" disabled>型を指定</option>
+            @foreach (FormColumnType::getMembers() as $key=>$value)
+                <option value="{{$key}}" @if(old("column_type_{$column->id}", $column->column_type) == $key) selected="selected" @endif>
+                    {{ $value }}
+                </option>
+            @endforeach
+        </select>
+    </td>
+    {{-- 必須 --}}
+    <td class="align-middle text-center">
+        <input type="checkbox" name="required_{{ $column->id }}" value="1" data-toggle="tooltip" title="必須項目として指定します。" @if (old("required_{$column->id}", $column->required) == Required::on) checked="checked" @endif>
+    </td>
+    {{-- 詳細設定 --}}
+    <td class="text-center px-2">
+        {{-- 詳細ボタン --}}
+        <button
+            type="button"
+            class="btn btn-success btn-xs cc-font-90 text-nowrap"
+            {{-- 選択肢を保持する項目、且つ、選択肢の設定がない場合のみツールチップを表示 --}}
+            @if (
+                ($column->column_type == FormColumnType::radio ||
+                $column->column_type == FormColumnType::checkbox ||
+                $column->column_type == FormColumnType::select) &&
+                $column->select_count == 0
+                )
+                id="detail-button-tip" data-toggle="tooltip" title="選択肢がありません。設定してください。" data-trigger="manual" data-placement="bottom"
+            @endif
+            {{-- まとめ数を保持する項目、且つ、まとめ数の設定がない場合、ツールチップで設定を促すメッセージを表示 --}}
+            @if ($column->column_type == FormColumnType::group && !$column->frame_col)
+                id="frame-col-tip" data-toggle="tooltip" title="まとめ数の設定がありません。設定してください。" data-trigger="manual" data-placement="bottom"
+            @endif
+            onclick="location.href='{{url('/')}}/plugin/forms/editColumnDetail/{{$page->id}}/{{$frame_id}}/{{ $column->id }}#frame-{{$frame->id}}'"
+        >
+            <i class="far fa-window-restore"></i> <span class="d-sm-none">詳細</span>
+        </button>
+    </td>
+    {{-- コピーボタン --}}
+    <td class="text-center px-2">
+        <button
+            type="button"
+            class="btn btn-outline-primary text-nowrap"
+            onclick="javascript:submit_copy_column({{ $column->id }});"
+        >
+            <i class="far fa-copy"></i> <span class="d-sm-none">コピー</span>
+        </button>
+    </td>
+    {{-- 更新ボタン --}}
+    <td class="text-center px-2">
+        <button
+            class="btn btn-primary cc-font-90 text-nowrap"
+            onclick="javascript:submit_update_column({{ $column->id }});"
+        >
+            <i class="fas fa-check"></i> <span class="d-sm-none">更新</span>
+        </button>
+    </td>
+    {{-- 削除ボタン --}}
+    <td class="text-center px-2">
+        <button class="btn btn-danger cc-font-90 text-nowrap" onclick="javascript:return submit_delete_column({{ $column->id }});"><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+    </td>
+</tr>
+{{-- 選択肢の設定内容の表示行 --}}
+@if (
+    $column->column_type == FormColumnType::radio ||
+    $column->column_type == FormColumnType::checkbox ||
+    $column->column_type == FormColumnType::select ||
+    $column->column_type == FormColumnType::group ||
+    $column->caption ||
+    $column->place_holder
+    )
+    <tr>
+        <td class="pt-0 border border-0"></td>
+        <td class="pt-0 border border-0" colspan="7">
+
+        @if ($column->column_type != FormColumnType::group && $column->select_count > 0)
+            {{-- 選択肢データがある場合、カンマ付で一覧表示する --}}
+            <div class="small"><i class="far fa-list-alt"></i> {{ $column->select_names }}</div>
+        @elseif($column->column_type != FormColumnType::group && !$column->caption && !$column->place_holder && $column->select_count == 0)
+            {{-- 選択肢データがなく、キャプション／プレースホルダーの設定もない場合はツールチップ分、余白として改行する --}}
+            <br>
+        @endif
+        @if ($column->caption)
+            {{-- キャプションが設定されている場合、キャプションを表示する --}}
+            <div class="small {{ $column->caption_color }}"><i class="fas fa-pen"></i> {{ mb_strimwidth($column->caption, 0, 60, '...', 'UTF-8') }}</div>
+        @endif
+        @if ($column->place_holder)
+            {{-- プレースホルダーが設定されている場合、プレースホルダーを表示する --}}
+            <div class="small"><i class="fas fa-pen-fancy"></i> {{ mb_strimwidth($column->place_holder, 0, 60, '...', 'UTF-8') }}</div>
+        @endif
+        @if ($column->column_type == FormColumnType::group && !isset($column->frame_col))
+            {{-- まとめ行でまとめ数の設定がない場合はツールチップ分、余白として改行する --}}
+            <br>
+        @endif
+        </td>
+    </tr>
+@endif

--- a/resources/views/plugins/user/forms/default/forms_edit_row2_add.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row2_add.blade.php
@@ -10,6 +10,8 @@
     <td></td>
     {{-- 項目名 --}}
     <td colspan="6">
+        {{-- WYSIWYG 呼び出し --}}
+        @include('plugins.common.wysiwyg', ['target_class' => 'wysiwyg' . $frame->id, 'use_br' => true])
         <textarea name="column_name" class="wysiwyg{{$frame->id}} @if ($errors && $errors->has('column_name')) border-danger @endif" >{{ old('column_name')}}</textarea>
     </td>
 </tr>

--- a/resources/views/plugins/user/forms/default/forms_edit_row2_add.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row2_add.blade.php
@@ -10,7 +10,7 @@
     <td></td>
     {{-- 項目名 --}}
     <td colspan="6">
-        <textarea rows="2" name="column_name" class="form-control @if ($errors && $errors->has('column_name')) border-danger @endif" >{{ old('column_name')}}</textarea>
+        <textarea name="column_name" class="wysiwyg{{$frame->id}} @if ($errors && $errors->has('column_name')) border-danger @endif" >{{ old('column_name')}}</textarea>
     </td>
 </tr>
 <tr>

--- a/resources/views/plugins/user/forms/default/forms_edit_row2_add.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row2_add.blade.php
@@ -1,0 +1,47 @@
+{{--
+ * 項目の追加行テンプレート（２行）
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォーム・プラグイン
+--}}
+<tr>
+    {{-- 余白 --}}
+    <td></td>
+    {{-- 項目名 --}}
+    <td colspan="6">
+        <textarea rows="2" name="column_name" class="form-control @if ($errors && $errors->has('column_name')) border-danger @endif" >{{ old('column_name')}}</textarea>
+    </td>
+</tr>
+<tr>
+    {{-- 余白 --}}
+    <td></td>
+    {{-- 型 --}}
+    <td>
+        <select class="form-control" name="column_type">
+            <option value="" disabled>型を指定</option>
+            @foreach (FormColumnType::getMembers() as $key=>$value)
+                <option value="{{$key}}"
+                    {{-- validation用 --}}
+                    @if($key == old('column_type'))
+                        selected="selected"
+                    @endif
+                >{{ $value }}</option>
+            @endforeach
+        </select>
+    </td>
+    {{-- 必須 --}}
+    <td class="align-middle text-center">
+        <input type="checkbox" name="required" value="1" data-toggle="tooltip" title="必須項目として指定します。" @if (old("required") == Required::on) checked="checked" @endif>
+    </td>
+    {{-- 余白 --}}
+    <td></td>
+    {{-- 余白 --}}
+    <td></td>
+    {{-- ＋ボタン --}}
+    <td class="text-center">
+        <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_add_column();" id="button_submit_add_column"><i class="fas fa-plus"></i> <span class="d-sm-none">追加</span></button>
+    </td>
+    {{-- 余白 --}}
+    <td></td>
+</tr>

--- a/resources/views/plugins/user/forms/default/forms_edit_row_add.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row_add.blade.php
@@ -5,7 +5,7 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
 --}}
-    <tr id="column_add_tr">
+<tr id="column_add_tr">
     {{-- 余白 --}}
     <td>
     </td>

--- a/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
@@ -18,7 +18,7 @@
 @include('plugins.common.errors_form_line')
 
 {{-- WYSIWYG 呼び出し --}}
-@include('plugins.common.wysiwyg', ['target_class' => 'wysiwyg' . $frame->id])
+@include('plugins.common.wysiwyg', ['target_class' => 'wysiwyg' . $frame->id, 'use_br' => true])
 
 <script type="text/javascript">
 
@@ -101,6 +101,7 @@
                     <textarea name="column_name" class="wysiwyg{{$frame->id}}">{!!old('column_name', $column->column_name)!!}</textarea>
                 </div>
                 @include('plugins.common.errors_inline_wysiwyg', ['name' => 'column_name'])
+                <small class="text-muted">※ 項目名の改行はbrタグになります。</small>
             </div>
 
             {{-- ボタンエリア --}}

--- a/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_row_detail.blade.php
@@ -17,6 +17,9 @@
 
 @include('plugins.common.errors_form_line')
 
+{{-- WYSIWYG 呼び出し --}}
+@include('plugins.common.wysiwyg', ['target_class' => 'wysiwyg' . $frame->id])
+
 <script type="text/javascript">
 
     /**
@@ -80,9 +83,32 @@
 
     {{-- メッセージエリア --}}
     <div class="alert alert-info mt-2">
-        <i class="fas fa-exclamation-circle"></i> {{ $message ? $message : '項目【' . $column->column_name . ' 】の詳細設定を行います。' }}
+        @if ($form_mode == FormMode::form)
+            {{-- フォーム --}}
+            <i class="fas fa-exclamation-circle"></i> {{ $message ? $message : '項目【' . $column->column_name . ' 】の詳細設定を行います。' }}
+        @else
+            {{-- アンケート --}}
+            <i class="fas fa-exclamation-circle"></i> {{ $message ? $message : '項目の詳細設定を行います。' }}
+        @endif
     </div>
 
+    @if ($form_mode == FormMode::questionnaire)
+        {{-- アンケートの場合のみ、詳細で項目名をwysiwyg入力させる --}}
+        <div class="card mb-4">
+            <h5 class="card-header">項目名 <span class="badge badge-danger">必須</span></h5>
+            <div class="card-body">
+                <div @if ($errors && $errors->has('column_name')) class="border border-danger" @endif>
+                    <textarea name="column_name" class="wysiwyg{{$frame->id}}">{!!old('column_name', $column->column_name)!!}</textarea>
+                </div>
+                @include('plugins.common.errors_inline_wysiwyg', ['name' => 'column_name'])
+            </div>
+
+            {{-- ボタンエリア --}}
+            <div class="form-group text-center">
+                <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary form-horizontal" id="button_col_original"><i class="fas fa-check"></i> 更新</button>
+            </div>
+        </div>
+    @endif
 
     @if ($column->column_type == FormColumnType::radio || $column->column_type == FormColumnType::checkbox || $column->column_type == FormColumnType::select)
     {{-- 選択肢の設定 --}}

--- a/resources/views/plugins/user/forms/default/forms_list_buckets.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_buckets.blade.php
@@ -79,8 +79,6 @@
         $(function () {
             // 有効化
             $('[data-toggle="tooltip"]').tooltip()
-            // 常時表示 ※表示の判定は項目側で実施
-            $('[id^=detail-button-tip]').tooltip('show');
         })
     </script>
 

--- a/resources/views/plugins/user/forms/default/forms_list_buckets.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_buckets.blade.php
@@ -81,7 +81,6 @@
             $('[data-toggle="tooltip"]').tooltip()
             // 常時表示 ※表示の判定は項目側で実施
             $('[id^=detail-button-tip]').tooltip('show');
-            $('#frame-col-tip').tooltip('show');
         })
     </script>
 

--- a/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
@@ -39,18 +39,25 @@
     }
 </script>
 
-<div class="text-right">
-    {{-- (右側)ダウンロードボタン --}}
-    <div class="btn-group">
-        <button type="button" class="btn btn-primary btn-sm" onclick="submit_download_shift_jis({{$form->id}});">
-            <i class="fas fa-file-download"></i> ダウンロード
-        </button>
-        <button type="button" class="btn btn-primary btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span class="sr-only">ドロップダウンボタン</span>
-        </button>
-        <div class="dropdown-menu dropdown-menu-right">
-            <a class="dropdown-item" href="#" onclick="submit_download_shift_jis({{$form->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
-            <a class="dropdown-item" href="#" onclick="submit_download_utf_8({{$form->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+<div class="row">
+    <div class="col-3 text-left d-flex align-items-end">
+        {{-- (左側)件数 --}}
+        <span class="badge badge-pill badge-light">{{ $inputs->total() }} 件</span>
+    </div>
+
+    <div class="col text-right">
+        {{-- (右側)ダウンロードボタン --}}
+        <div class="btn-group">
+            <button type="button" class="btn btn-primary btn-sm" onclick="submit_download_shift_jis({{$form->id}});">
+                <i class="fas fa-file-download"></i> ダウンロード
+            </button>
+            <button type="button" class="btn btn-primary btn-sm dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="sr-only">ドロップダウンボタン</span>
+            </button>
+            <div class="dropdown-menu dropdown-menu-right">
+                <a class="dropdown-item" href="#" onclick="submit_download_shift_jis({{$form->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                <a class="dropdown-item" href="#" onclick="submit_download_utf_8({{$form->id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+            </div>
         </div>
     </div>
 </div>

--- a/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
@@ -125,7 +125,7 @@
 @include('plugins.common.user_paginate', ['posts' => $inputs, 'frame' => $frame, 'aria_label_name' => $form->forms_name, 'class' => 'form-group mt-3'])
 
 {{-- ボタン --}}
-<div class="text-center">
+<div class="text-center pt-2">
     <div class="row">
         <div class="col">
             <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/listBuckets/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}">

--- a/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
@@ -37,6 +37,11 @@
         form_download.character_code.value = '{{CsvCharacterCode::utf_8}}';
         form_download.submit();
     }
+
+    $(function () {
+        // ツールチップ有効化
+        $('[data-toggle="tooltip"]').tooltip()
+    })
 </script>
 
 <div class="row">
@@ -68,7 +73,9 @@
         <tr>
             <th nowrap>状態</th>
             @foreach($columns as $column)
-                <th>{{$column->column_name}}</th>
+                <th>
+                    {{mb_substr(strip_tags($column->column_name), 0, 20)}}@if (mb_strlen(strip_tags($column->column_name)) > 20)<a href="#frame-{{$frame_id}}" data-toggle="tooltip" data-placement="right" title="{{strip_tags($column->column_name)}}">...</a> @endif
+                </th>
             @endforeach
             @if ($form->numbering_use_flag)
                 <th nowrap>採番</th>

--- a/resources/views/plugins/user/forms/default/index_tandem.blade.php
+++ b/resources/views/plugins/user/forms/default/index_tandem.blade.php
@@ -1,7 +1,6 @@
 {{--
- * 登録画面テンプレート。
+ * 縦並び 登録画面テンプレート
  *
- * @author 永原　篤 <nagahara@opensource-workshop.jp>, 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
  * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
@@ -28,21 +27,14 @@
         <legend class="sr-only">{{$form->forms_name}}</legend>
         {{ csrf_field() }}
 
+        @php $no = 1; @endphp
         @foreach($forms_columns as $form_column)
             <div class="form-group row">
 
                 @switch($form_column->column_type)
                     @case("group")
-                        @if (isset($is_template_label_sm_4))
-                            {{-- label-sm-4テンプレート --}}
-                            <label class="col-sm-4 control-label">{{$form_column->column_name}} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger lead' }}">{{__('messages.required')}}</strong> @endif</label>
-                        @elseif (isset($is_template_label_sm_6))
-                            {{-- label-sm-6テンプレート --}}
-                            <label class="col-sm-6 control-label">{{$form_column->column_name}} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
-                        @else
-                            {{-- defaultテンプレート --}}
-                            <label class="col-sm-2 control-label">{{$form_column->column_name}} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
-                        @endif
+                        {{-- defaultテンプレート --}}
+                        <label class="col-12 control-label">{!!nl2br(e($form_column->column_name))!!} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
 
                         @php
                             // グループカラムの幅の計算
@@ -59,13 +51,13 @@
                                         時間FromToは入力項目のtitleで項目説明しているため、項目名のラベルにforを付けない。--}}
                                     @if ($group_row->column_type == 'radio' || $group_row->column_type == 'checkbox')
                                         <div class="col-sm-{{$col_count}} pl-0">
-                                        <label class="control-label" style="vertical-align: top; padding-left: 16px; padding-top: 8px;">{{$group_row->column_name}}</label>
+                                        <label class="control-label" style="vertical-align: top; padding-left: 16px; padding-top: 8px;">Q{{$no}} {!!nl2br(e($group_row->column_name))!!}</label>
                                     @elseif ($group_row->column_type == 'time_from_to')
                                         <div class="col-sm-{{$col_count}} pr-0">
-                                        <label class="control-label">{{$group_row->column_name}}</label>
+                                        <label class="control-label">Q{{$no}} {!!nl2br(e($group_row->column_name))!!}</label>
                                     @else
                                         <div class="col-sm-{{$col_count}} pr-0">
-                                        <label class="control-label" for="column-{{$group_row->id}}-{{$frame_id}}">{{$group_row->column_name}}</label>
+                                        <label class="control-label" for="column-{{$group_row->id}}-{{$frame_id}}">Q{{$no}} {!!nl2br(e($group_row->column_name))!!}</label>
                                     @endif
 
                                     {{-- 必須 --}}
@@ -88,6 +80,7 @@
                                     @endphp
                                     <div class="small {{ $group_row->caption_color }}">{!! $caption !!}</div>
                                         </div>
+                                    @php $no++; @endphp
                                 @endforeach
                             </div>
                             @php
@@ -110,18 +103,10 @@
                             }
                         @endphp
 
-                        @if (isset($is_template_label_sm_4))
-                            {{-- label-sm-4テンプレート --}}
-                            <label class="col-sm-4 control-label" {{$label_for}}>{{$form_column->column_name}} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger lead' }}">{{__('messages.required')}}</strong> @endif</label>
-                        @elseif (isset($is_template_label_sm_6))
-                            {{-- label-sm-6テンプレート --}}
-                            <label class="col-sm-6 control-label" {{$label_for}}>{{$form_column->column_name}} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
-                        @else
-                            {{-- defaultテンプレート --}}
-                            <label class="col-sm-2 control-label" {{$label_for}}>{{$form_column->column_name}} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
-                        @endif
+                        {{-- defaultテンプレート --}}
+                        <label class="col-12 control-label" {{$label_for}}>Q{{$no}} {!!nl2br(e($form_column->column_name))!!} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
 
-                        <div class="col-sm">
+                        <div class="col-12">
                             @include('plugins.user.forms.default.forms_input_' . $form_column->column_type, ['form_obj' => $form_column, 'label_id' => 'column-'.$form_column->id.'-'.$frame_id])
                             @php
                                 $caption = nl2br($form_column->caption);
@@ -129,6 +114,7 @@
                             @endphp
                             <div class="small {{ $form_column->caption_color }}">{!! $caption !!}</div>
                         </div>
+                        @php $no++; @endphp
                 @endswitch
             </div>
         @endforeach

--- a/resources/views/plugins/user/forms/default/index_tandem.blade.php
+++ b/resources/views/plugins/user/forms/default/index_tandem.blade.php
@@ -34,7 +34,7 @@
                 @switch($form_column->column_type)
                     @case("group")
                         {{-- defaultテンプレート --}}
-                        <label class="col-12 control-label">{!!nl2br(e($form_column->column_name))!!} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
+                        <label class="col-12 control-label">{!! $form_column->column_name !!} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
 
                         @php
                             // グループカラムの幅の計算
@@ -51,13 +51,13 @@
                                         時間FromToは入力項目のtitleで項目説明しているため、項目名のラベルにforを付けない。--}}
                                     @if ($group_row->column_type == 'radio' || $group_row->column_type == 'checkbox')
                                         <div class="col-sm-{{$col_count}} pl-0">
-                                        <label class="control-label" style="vertical-align: top; padding-left: 16px; padding-top: 8px;">Q{{$no}} {!!nl2br(e($group_row->column_name))!!}</label>
+                                        <label class="control-label" style="vertical-align: top; padding-left: 16px; padding-top: 8px;">Q{{$no}} {!! $group_row->column_name !!}</label>
                                     @elseif ($group_row->column_type == 'time_from_to')
                                         <div class="col-sm-{{$col_count}} pr-0">
-                                        <label class="control-label">Q{{$no}} {!!nl2br(e($group_row->column_name))!!}</label>
+                                        <label class="control-label">Q{{$no}} {!! $group_row->column_name !!}</label>
                                     @else
                                         <div class="col-sm-{{$col_count}} pr-0">
-                                        <label class="control-label" for="column-{{$group_row->id}}-{{$frame_id}}">Q{{$no}} {!!nl2br(e($group_row->column_name))!!}</label>
+                                        <label class="control-label" for="column-{{$group_row->id}}-{{$frame_id}}">Q{{$no}} {!! $group_row->column_name !!}</label>
                                     @endif
 
                                     {{-- 必須 --}}
@@ -104,7 +104,7 @@
                         @endphp
 
                         {{-- defaultテンプレート --}}
-                        <label class="col-12 control-label" {{$label_for}}>Q{{$no}} {!!nl2br(e($form_column->column_name))!!} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
+                        <label class="col-12 control-label" {{$label_for}}>Q{{$no}} {!! $form_column->column_name !!} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong> @endif</label>
 
                         <div class="col-12">
                             @include('plugins.user.forms.default.forms_input_' . $form_column->column_type, ['form_obj' => $form_column, 'label_id' => 'column-'.$form_column->id.'-'.$frame_id])


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* フォームを拡張してアンケート機能を追加
* 関連修正
    * [add: フォーム, 登録一覧画面のフォーム選択へボタンの余白間隔調整](https://github.com/opensource-workshop/connect-cms/pull/1586/commits/f78f667a9061b69e3917fcdf266f35727f0bc0f4)
    * [add: フォーム, 登録一覧に総件数の表示追加](https://github.com/opensource-workshop/connect-cms/pull/1586/commits/f644e9d9436ed05213a8f98fc499c4d4996170a8)
    * [add: wysiwyg, 改行を p タグから br タグに変更するオプション設定 use_br を追加](https://github.com/opensource-workshop/connect-cms/pull/1586/commits/e0917bc04f8da7b721ed3f01a671e2b78d07a97b)
    * https://github.com/opensource-workshop/connect-cms/pull/1587

# 修正画面
## フォーム設定
・フォームモード（フォームorアンケートの切替）と、モデレータの集計結果のON・OFF設定を追加しました。
（フォームの場合でも、モデレータの集計結果のONにすれば、集計結果（登録一覧）を確認・ダウンロードできます）
![image](https://user-images.githubusercontent.com/2756509/219909623-a7bb3707-65a7-4679-be2a-fabc50cefd92.png)

## 項目設定
・アンケートモードの場合
　・項目名の登録は、当画面（項目設定）で出来ます。
　・項目名の更新は、項目詳細画面で出来ます。項目設定では表示のみです。
　・項目名のwisywig対応しました。
　・編集エリアを２行で表示するようにしました。
![image](https://user-images.githubusercontent.com/2756509/220769530-e1c6e30e-5e76-40da-865a-7d1530fd2073.png)
![image](https://user-images.githubusercontent.com/2756509/220769645-c8cad6f1-ddff-4996-83ea-d792043ff0e1.png)

## 項目詳細設定
・アンケートモードの場合、項目名を更新できます。
![image](https://user-images.githubusercontent.com/2756509/220770027-302b345c-86ff-4151-9f0d-a233e7bf274c.png)


## アンケート回答
・モデレータの集計結果のONの場合、集計結果ボタンを表示します。
・アンケートモードの場合、項目は縦並び表示します。まとめ行は横並びに表示します。
・アンケートモードの場合、項目名の頭に「Q1」などをつけます。
![image](https://user-images.githubusercontent.com/2756509/219909261-19780d7c-ec88-468b-8804-ae67181d702a.png)

・まとめ行
![image](https://user-images.githubusercontent.com/2756509/219909351-3716784a-3603-4f04-9fb9-96c4be7412a4.png)

## アンケート回答確認
・確認画面も同様です。
![image](https://user-images.githubusercontent.com/2756509/219909382-d0560704-2db6-4bef-9ff7-7eb810a1cfa4.png)

## アンケート回答メール
・メールも同様です。
　（参考：メール文の内容は任意で変更できます。）
・アンケートの場合、[[body]]の埋め込みコードは、項目名＜改行＞値＜改行＞＜改行＞として表示します。
　（参考：フォームの場合は項目：値は１行横並び）
```
新規登録フォーム1の登録通知先メールアドレスとしてあなたのメールアドレスが使用されました。
もし新規登録フォーム1への登録に覚えがない場合はこのメールを破棄してください。

新規登録フォーム1を受け付けました。

登録日時:2023/02/19 11:23:40


Q1 お名前（漢字）
aaaa
bbb
cccc：
３２３３３３

Q2 ふりがな：


Q3 メールアドレス：


（省略）
```
## 集計結果
・登録一覧と同じ内容です。
・表示のみで編集できません。
・項目名が２０文字より大きい場合、（...）で省略します。全文は(...)から確認できます。
![image](https://user-images.githubusercontent.com/2756509/220770284-0ca86321-6f9d-45c2-b6bb-714e69b05652.png)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
