### PR TITLE
[エラーメッセージ] 入力チェックのinのエラーメッセージ内の選択肢を強調するように見直し

### DIFF
--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -62,7 +62,7 @@ return [
         'array' => ':attributeは:value以上選択してください。',
     ],
     'image'                => ':attributeには画像ファイルを指定してください。',
-    'in'                   => ':attributeには:valuesのうちいずれかの値を指定してください。',
+    'in'                   => ':attributeには「:values」のうちいずれかの値を指定してください。',
     'in_array'             => ':attributeが:otherに含まれていません。',
     'integer'              => ':attributeには整数を指定してください。',
     'ip'                   => ':attributeには正しい形式のIPアドレスを指定してください。',


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

入力チェック（validate）で`Rule::in(['はい']);`としたときの、エラーメッセージ内の選択肢がまぎれてしまって判りずらいと感じたので、見直しました。

## 修正前

![image](https://user-images.githubusercontent.com/2756509/222990014-e9a5dd42-a175-405c-b42c-28f3446131f5.png)

## 修正後

![image](https://user-images.githubusercontent.com/2756509/222989973-dbb93ab5-cb88-484c-8263-f44a8ffd728b.png)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
