### PR TITLE
[連番管理] 連番クリア機能の無効化設定追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,8 +88,11 @@ VERIFY_CSRF_TOKEN_EXCEPT=""
 # Use the container (beta)
 USE_CONTAINER_BETA=false
 
-# PHP BIN path used when QUEUE_CONNECTION=database. Automatic judgment when null e.g.) QUEUE_PHP_BIN=/usr/local/php/7.4/bin/php
+# PHP BIN path used when QUEUE_CONNECTION=database. Automatic judgment when null. e.g.) QUEUE_PHP_BIN=/usr/local/php/7.4/bin/php
 QUEUE_PHP_BIN=
+
+# Specify the plug-in name that disables the serial number clear function of serial number management. e.g.) PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR="forms"
+PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR=""
 
 # --- Connect-CMS Migration option
 

--- a/app/Models/Common/Numbers.php
+++ b/app/Models/Common/Numbers.php
@@ -3,9 +3,18 @@
 namespace App\Models\Common;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+use App\UserableNohistory;
 
 class Numbers extends Model
 {
+    // 論理削除
+    use SoftDeletes;
+
+    // 保存時のユーザー関連データの保持（履歴なしUserable）
+    use UserableNohistory;
+
     /**
      * create()やupdate()で入力を受け付ける ホワイトリスト
      */

--- a/app/Plugins/Manage/NumberManage/NumberManage.php
+++ b/app/Plugins/Manage/NumberManage/NumberManage.php
@@ -2,13 +2,6 @@
 
 namespace App\Plugins\Manage\NumberManage;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Validator;
-
-use File;
-use DB;
-
 use App\Models\Common\Numbers;
 
 use App\Plugins\Manage\ManagePluginBase;
@@ -19,7 +12,7 @@ use App\Plugins\Manage\ManagePluginBase;
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 連番管理
- * @package Contoroller
+ * @package Controller
  * @plugin_title 連番管理
  * @plugin_desc 連番管理に関する機能が集まった管理機能です。
  */
@@ -33,7 +26,6 @@ class NumberManage extends ManagePluginBase
         // 権限チェックテーブル
         $role_ckeck_table = array();
         $role_ckeck_table["index"]             = array('admin_site');
-        $role_ckeck_table["update"]            = array('admin_site');
         $role_ckeck_table["clearSerialNumber"] = array('admin_site');
         return $role_ckeck_table;
     }
@@ -49,17 +41,21 @@ class NumberManage extends ManagePluginBase
     public function index($request, $page_id = null, $errors = array())
     {
         // 現在の連番管理データの取得
-        $numbers = Numbers::select(
-            'numbers.*',
-            'buckets.bucket_name',
-            'plugins.plugin_name_full'
-        )
-                          ->leftJoin('buckets', 'buckets.id', '=', 'numbers.buckets_id')
-                          ->leftJoin('plugins', 'plugins.plugin_name', '=', 'numbers.plugin_name')
-                          ->orderBy('plugin_name')
-                          ->orderBy('buckets_id')
-                          ->orderBy('prefix')
-                          ->get();
+        $numbers = Numbers::
+            select(
+                'numbers.*',
+                'buckets.bucket_name',
+                'plugins.plugin_name_full'
+            )
+            ->leftJoin('buckets', 'buckets.id', '=', 'numbers.buckets_id')
+            ->leftJoin('plugins', 'plugins.plugin_name', '=', 'numbers.plugin_name')
+            ->orderBy('plugin_name')
+            ->orderBy('buckets_id')
+            ->orderBy('prefix')
+            ->get();
+
+        // 連番管理の連番クリア機能を無効化するプラグイン名
+        $cc_disable_plugin = config('connect.PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR');
 
         // 管理画面プラグインの戻り値の返し方
         // view 関数の第一引数に画面ファイルのパス、第二引数に画面に渡したいデータを名前付き配列で渡し、その結果のHTML。
@@ -67,6 +63,7 @@ class NumberManage extends ManagePluginBase
             "function"    => __FUNCTION__,
             "plugin_name" => "number",
             "numbers"     => $numbers,
+            "cc_disable_plugin" => $cc_disable_plugin,
         ]);
     }
 
@@ -78,6 +75,19 @@ class NumberManage extends ManagePluginBase
         // httpメソッド確認
         if (!$request->isMethod('post')) {
             abort(403, '権限がありません。');
+        }
+
+        $number = Numbers::find($id);
+        if (is_null($number)) {
+            // データなし
+            abort(404, 'データがありません。');
+        }
+
+        $cc_disable_plugin = config('connect.PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR');
+        if ($cc_disable_plugin) {
+            if ($number->plugin_name == $cc_disable_plugin) {
+                abort(403, $cc_disable_plugin . 'プラグインの連番クリア機能は無効化されています。');
+            }
         }
 
         // 連番クリア

--- a/app/Plugins/Manage/NumberManage/NumberManage.php
+++ b/app/Plugins/Manage/NumberManage/NumberManage.php
@@ -10,6 +10,7 @@ use App\Plugins\Manage\ManagePluginBase;
  * 連番管理クラス
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 連番管理
  * @package Controller
@@ -91,7 +92,11 @@ class NumberManage extends ManagePluginBase
         }
 
         // 連番クリア
-        Numbers::where('id', $id)->update(['serial_number' => 0]);
+        // bugfix: updated_id,updated_nameが自動セットされるアップデート方法に見直し
+        // Numbers::where('id', $id)->update(['serial_number' => 0]);
+        $number = Numbers::find($id);
+        $number->serial_number = 0;
+        $number->save();
 
         return redirect("/manage/number");
     }

--- a/app/Plugins/PluginBase.php
+++ b/app/Plugins/PluginBase.php
@@ -91,6 +91,8 @@ class PluginBase
 
         // インクリメント
         $numbers->increment('serial_number', 1);
+        // インクリメントでupdating()イベントが走らないため、saveを実行してupdated_id,updated_nameを自動セット
+        $numbers->save();
 
         return $numbers->serial_number;
     }

--- a/config/connect.php
+++ b/config/connect.php
@@ -155,4 +155,7 @@ return [
 
     // QUEUE_CONNECTION=database 時に使われるPHP BINのパス. null時は自動判定
     'QUEUE_PHP_BIN' => env('QUEUE_PHP_BIN', null),
+
+    // 連番管理の連番クリア機能を無効化するプラグイン名
+    'PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR' => env('PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR', null),
 ];

--- a/resources/views/plugins/manage/number/number.blade.php
+++ b/resources/views/plugins/manage/number/number.blade.php
@@ -27,7 +27,7 @@
     }
 </script>
 
-<form action="" method="POST" name="form_clear_no" class="">
+<form action="" method="POST" name="form_clear_no">
     {{ csrf_field() }}
 </form>
 
@@ -73,33 +73,13 @@
         <td class="d-block d-sm-table-cell"><span class="d-sm-none">連番：</span>{{$number->serial_number}}</td>
 
         <td class="d-block d-sm-table-cell pb-sm-0"><span class="d-sm-none">連番クリア：</span>
-            <a href="javascript:form_clear('{{$number->id}}');"><span class="btn btn-danger btn-sm"><i class="fas fa-eraser"></i></span></a>
+            <button onclick="javascript:form_clear('{{$number->id}}');" class="btn btn-danger btn-sm" @if ($number->plugin_name == $cc_disable_plugin) disabled @endif><i class="fas fa-eraser"></i></button>
         </td>
     </tr>
     @endforeach
 </tbody>
 </table>
 
-
-    <form action="{{url('/')}}/manage/number/update" method="POST">
-        {{csrf_field()}}
-
-        {{-- サイト名 --}}
-{{--
-        <div class="form-group">
-            <label class="col-form-label">サイト名</label>
-            <input type="text" name="base_site_name" value="{{$configs["base_site_name"]}}" class="form-control">
-            <small class="form-text text-muted">サイト名（各ページで上書き可能 ※予定）</small>
-        </div>
---}}
-
-        {{-- Submitボタン --}}
-{{--
-        <div class="form-group text-center">
-            <button type="submit" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
-        </div>
---}}
-    </form>
 </div>
 </div>
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

[連番管理] 連場クリア機能の無効化設定を、`.env`に追加しました。
.envに無効化プラグイン名を設定する事で、対象プラグインの連番クリア機能を無効化できます。

## 設定例

.env
```env
PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR="forms"
```

### 設定後画面

formsプラグインの連番クリアボタン（赤いボタン）は押せなくなります。
![image](https://user-images.githubusercontent.com/2756509/223078331-dc4a9aeb-5513-4912-8168-1b5f2af81c14.png)

## 関連修正

* [bugfix: 連番, updated_id,updated_nameの自動セット対応](https://github.com/opensource-workshop/connect-cms/pull/1597/commits/e270dba16db4cc0f2e3c51e76fb91c27131602a3)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
