### PR TITLE
[フォーム]新規登録の場合は「データ保存」はonにしておく対応を入れました。

### DIFF
--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -106,7 +106,12 @@
         <div class="{{$frame->getSettingInputClass()}}">
             <div class="custom-control custom-checkbox">
                 <input type="hidden" name="data_save_flag" value="0">
-                <input type="checkbox" name="data_save_flag" value="1" class="custom-control-input" id="data_save_flag" @if(old('data_save_flag', $form->data_save_flag)) checked=checked @endif>
+                @if ($create_flag)
+                    {{-- 新規登録の場合は「データ保存」はonにしておく（データ保存設定の忘れ防止。基本は保存する。外したい時は外せるように。） --}}
+                    <input type="checkbox" name="data_save_flag" value="1" class="custom-control-input" id="data_save_flag" @if(old('data_save_flag', '1')) checked=checked @endif>
+                @else
+                    <input type="checkbox" name="data_save_flag" value="1" class="custom-control-input" id="data_save_flag" @if(old('data_save_flag', $form->data_save_flag)) checked=checked @endif>
+                @endif
                 <label class="custom-control-label" for="data_save_flag">データを保存する（チェックを外すと、サイト上にデータを保持しません）</label>
             </div>
             @if ($errors && $errors->has('data_save_flag')) <div class="text-danger">{{$errors->first('data_save_flag')}}</div> @endif


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
フォームの新規作成時に「データ保存」を忘れるケースの防止のため。
基本的には保存することが多いと思います。
そのため、基本は保存する。外したい時は外せるように。という方針にしたいための修正です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
トラブルが増える前にマージしたいです。

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
無し

# チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
