### PR TITLE
[データベース] 検索結果０件時にメッセージ出ない不具合修正（table, design-table-dlテンプレート）

### DIFF
--- a/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
@@ -15,49 +15,60 @@
 
     @if ($default_hide_list)
     @else
-        {{-- データのループ --}}
-        <table class="table table-bordered">
-            <caption class="sr-only">{{$database_frame->databases_name}}</caption>
-            <thead class="thead-light">
-            <tr>
-            @foreach($columns as $column)
-                @if($column->list_hide_flag == 0)
-                <th>{{$column->column_name}}</th>
-                @endif
-            @endforeach
-            </tr>
-            </thead>
-
-            <tbody>
-            @foreach($inputs as $input)
-            <tr>
-                @php
-                // bugfix: $loop->firstだと1つ目の項目が、一覧非表示の場合、詳細画面に飛べなくなるため、フラグで対応する
-                $is_first = true;
-                @endphp
-
+        @if($inputs->isNotEmpty())
+            {{-- データのループ --}}
+            <table class="table table-bordered">
+                <caption class="sr-only">{{$database_frame->databases_name}}</caption>
+                <thead class="thead-light">
+                <tr>
                 @foreach($columns as $column)
                     @if($column->list_hide_flag == 0)
-                        @if($is_first)
-                            <td class="{{$column->classname}}">
-                                <a href="{{url('/')}}/plugin/databases/detail/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}">
-                                    @include('plugins.user.databases.default.databases_include_value')
-                                </a>
-                            </td>
-                            @php
-                            $is_first = false;
-                            @endphp
-                        @else
-                            <td class="{{$column->classname}}">
-                                @include('plugins.user.databases.default.databases_include_value')
-                            </td>
-                        @endif
+                    <th>{{$column->column_name}}</th>
                     @endif
                 @endforeach
-            </tr>
-            @endforeach
-            </tbody>
-        </table>
+                </tr>
+                </thead>
+
+                <tbody>
+                @foreach($inputs as $input)
+                <tr>
+                    @php
+                    // bugfix: $loop->firstだと1つ目の項目が、一覧非表示の場合、詳細画面に飛べなくなるため、フラグで対応する
+                    $is_first = true;
+                    @endphp
+
+                    @foreach($columns as $column)
+                        @if($column->list_hide_flag == 0)
+                            @if($is_first)
+                                <td class="{{$column->classname}}">
+                                    <a href="{{url('/')}}/plugin/databases/detail/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}">
+                                        @include('plugins.user.databases.default.databases_include_value')
+                                    </a>
+                                </td>
+                                @php
+                                $is_first = false;
+                                @endphp
+                            @else
+                                <td class="{{$column->classname}}">
+                                    @include('plugins.user.databases.default.databases_include_value')
+                                </td>
+                            @endif
+                        @endif
+                    @endforeach
+                </tr>
+                @endforeach
+                </tbody>
+            </table>
+        @else
+            {{-- 検索結果0件 --}}
+            @if (session('is_search.'.$frame_id))
+                @if ($database_frame->search_results_empty_message)
+                    {{$database_frame->search_results_empty_message}}
+                @else
+                    {{ __('messages.search_results_empty') }}
+                @endif
+            @endif
+        @endif
 
         {{-- ページング処理 --}}
         @include('plugins.common.user_paginate', ['posts' => $inputs, 'frame' => $frame, 'aria_label_name' => $database_frame->databases_name])

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -16,51 +16,62 @@
 
     @if ($default_hide_list)
     @else
-        {{-- データのループ --}}
-        <div class="table-responsive">
-        <table class="table table-bordered">
-            <caption class="sr-only">{{$database_frame->databases_name}}</caption>
-            <thead class="thead-light">
-            <tr>
-            @foreach($columns as $column)
-                @if($column->list_hide_flag == 0)
-                <th class="text-nowrap">{{$column->column_name}}</th>
-                @endif
-            @endforeach
-            </tr>
-            </thead>
-
-            <tbody>
-            @foreach($inputs as $input)
-            <tr>
-                @php
-                // bugfix: $loop->firstだと1つ目の項目が、一覧非表示の場合、詳細画面に飛べなくなるため、フラグで対応する
-                $is_first = true;
-                @endphp
-
+        @if($inputs->isNotEmpty())
+            {{-- データのループ --}}
+            <div class="table-responsive">
+            <table class="table table-bordered">
+                <caption class="sr-only">{{$database_frame->databases_name}}</caption>
+                <thead class="thead-light">
+                <tr>
                 @foreach($columns as $column)
                     @if($column->list_hide_flag == 0)
-                        @if($is_first)
-                            <td class="{{$column->classname}}">
-                                <a href="{{url('/')}}/plugin/databases/detail/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}">
-                                    @include('plugins.user.databases.default.databases_include_value')
-                                </a>
-                            </td>
-                            @php
-                            $is_first = false;
-                            @endphp
-                        @else
-                            <td class="{{$column->classname}}">
-                                @include('plugins.user.databases.default.databases_include_value')
-                            </td>
-                        @endif
+                    <th class="text-nowrap">{{$column->column_name}}</th>
                     @endif
                 @endforeach
-            </tr>
-            @endforeach
-            </tbody>
-        </table>
-        </div>
+                </tr>
+                </thead>
+
+                <tbody>
+                @foreach($inputs as $input)
+                <tr>
+                    @php
+                    // bugfix: $loop->firstだと1つ目の項目が、一覧非表示の場合、詳細画面に飛べなくなるため、フラグで対応する
+                    $is_first = true;
+                    @endphp
+
+                    @foreach($columns as $column)
+                        @if($column->list_hide_flag == 0)
+                            @if($is_first)
+                                <td class="{{$column->classname}}">
+                                    <a href="{{url('/')}}/plugin/databases/detail/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}">
+                                        @include('plugins.user.databases.default.databases_include_value')
+                                    </a>
+                                </td>
+                                @php
+                                $is_first = false;
+                                @endphp
+                            @else
+                                <td class="{{$column->classname}}">
+                                    @include('plugins.user.databases.default.databases_include_value')
+                                </td>
+                            @endif
+                        @endif
+                    @endforeach
+                </tr>
+                @endforeach
+                </tbody>
+            </table>
+            </div>
+        @else
+            {{-- 検索結果0件 --}}
+            @if (session('is_search.'.$frame_id))
+                @if ($database_frame->search_results_empty_message)
+                    {{$database_frame->search_results_empty_message}}
+                @else
+                    {{ __('messages.search_results_empty') }}
+                @endif
+            @endif
+        @endif
 
         {{-- ページング処理 --}}
         @include('plugins.common.user_paginate', ['posts' => $inputs, 'frame' => $frame, 'aria_label_name' => $database_frame->databases_name])


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## （参考）検索結果０件時のメッセージ

![image](https://user-images.githubusercontent.com/2756509/223305774-bb29d036-26a9-4e25-b1ba-1b59017d7ca9.png)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
