### PR TITLE
[テンプレート] 任意のエラーメッセージテンプレートをcommonに移動

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -330,7 +330,7 @@ class FormsPlugin extends UserPluginBase
             // 登録期間外か
             if ($this->isOutOfTermRegist($form)) {
                 // エラー画面へ
-                return $this->view('forms_error_messages', [
+                return $this->commonView('error_messages', [
                     'error_messages' => ['登録期間外のため、登録出来ません。'],
                 ]);
             }
@@ -339,7 +339,7 @@ class FormsPlugin extends UserPluginBase
             if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
                 // $setting_error_messages[] = '制限数に達したため登録を終了しました。';
                 // エラー画面へ
-                return $this->view('forms_error_messages', [
+                return $this->commonView('error_messages', [
                     'error_messages' => [$form->entry_limit_over_message],
                 ]);
             }
@@ -445,7 +445,7 @@ class FormsPlugin extends UserPluginBase
             }
         } else {
             // エラーあり
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'setting_error_messages' => $setting_error_messages,
             ]);
         }
@@ -711,7 +711,7 @@ class FormsPlugin extends UserPluginBase
         // 登録期間外か
         if ($this->isOutOfTermRegist($form)) {
             // エラー画面へ
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => ['登録期間外のため、登録出来ません。'],
             ]);
         }
@@ -719,7 +719,7 @@ class FormsPlugin extends UserPluginBase
         // 登録制限数オーバーか
         if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
             // エラー画面へ
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => [$form->entry_limit_over_message],
             ]);
         }
@@ -861,7 +861,7 @@ class FormsPlugin extends UserPluginBase
         // 登録期間外か
         if ($this->isOutOfTermRegist($form)) {
             // エラー画面へ
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => ['登録期間外のため、登録出来ません。'],
             ]);
         }
@@ -869,7 +869,7 @@ class FormsPlugin extends UserPluginBase
         // 登録制限数オーバーか
         if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
             // エラー画面へ
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => [$form->entry_limit_over_message],
             ]);
         }
@@ -1162,7 +1162,7 @@ class FormsPlugin extends UserPluginBase
         // 登録期間外か
         if ($this->isOutOfTermRegist($form)) {
             // エラー画面へ
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => ['登録期間外のため、登録出来ません。'],
             ]);
         }
@@ -1170,7 +1170,7 @@ class FormsPlugin extends UserPluginBase
         // 登録制限数オーバーか
         if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
             // エラー画面へ
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => [$form->entry_limit_over_message],
             ]);
         }
@@ -1179,7 +1179,7 @@ class FormsPlugin extends UserPluginBase
         // $forms_inputs がなかったら、エラー画面へ
         $forms_inputs = FormsInputs::find($id);
         if (empty($forms_inputs)) {
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => ['有効期限切れのため、そのURLはご利用できません。'],
             ]);
         }
@@ -1191,7 +1191,7 @@ class FormsPlugin extends UserPluginBase
 
         // getで日付形式エラーは表示しない（通常URLをコピペミス等でいじらなければエラーにならない想定）
         if ($validator->fails()) {
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => $validator->errors()->all(),
             ]);
         }
@@ -1220,7 +1220,7 @@ class FormsPlugin extends UserPluginBase
         // 登録期間外か
         if ($this->isOutOfTermRegist($form)) {
             // エラー画面へ
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => ['登録期間外のため、登録出来ません。'],
             ]);
         }
@@ -1228,7 +1228,7 @@ class FormsPlugin extends UserPluginBase
         // 登録制限数オーバーか
         if ($this->isOverEntryLimit($form->id, $form->entry_limit)) {
             // エラー画面へ
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => [$form->entry_limit_over_message],
             ]);
         }
@@ -1237,7 +1237,7 @@ class FormsPlugin extends UserPluginBase
         // $forms_inputs がなかったら、エラー画面へ
         $forms_inputs = FormsInputs::find($id);
         if (empty($forms_inputs)) {
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => ['有効期限切れのため、そのURLはご利用できません。'],
             ]);
         }
@@ -1249,7 +1249,7 @@ class FormsPlugin extends UserPluginBase
 
         // getで日付形式エラーは表示しない（通常URLをコピペミス等でいじらなければエラーにならない想定）
         if ($validator->fails()) {
-            return $this->view('forms_error_messages', [
+            return $this->commonView('error_messages', [
                 'error_messages' => $validator->errors()->all(),
             ]);
         }

--- a/resources/views/plugins/common/error_messages.blade.php
+++ b/resources/views/plugins/common/error_messages.blade.php
@@ -1,10 +1,14 @@
 {{--
- * エラーメッセージのテンプレート。
+ * 任意のエラーメッセージのテンプレート。
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category プラグイン共通
 --}}
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
-{{-- フォーム利用者向けの業務メッセージ　表示期間外など --}}
+{{-- 利用者向けの業務メッセージ　表示期間外など --}}
 @isset($error_messages)
 <div class="card border-danger">
     <div class="card-body">
@@ -15,7 +19,7 @@
 </div>
 @endisset
 
-{{-- フォーム設定者向けのシステムメッセージ バケツ未設定など --}}
+{{-- 設定者向けのシステムメッセージ バケツ未設定など --}}
 @isset($setting_error_messages)
 @can('frames.edit',[[null, null, null, $frame]])
 <div class="card border-danger">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 他プラグインでも、フォームで使用していた任意のエラーメッセージテンプレートを使用したいため、commonに移動します。
    * フォームコピーであるデータベースプラグインでも利用見込みありです。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
