### PR TITLE
[ブログ] 一時保存のredirect_pathは保存時と同一のredirect_pathでよいため、セットできてないredirect_pathのJSセット指定行を削除

### DIFF
--- a/resources/views/plugins/user/blogs/default/blogs_input.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_input.blade.php
@@ -24,11 +24,9 @@ use App\Models\User\Blogs\BlogsPosts;
 <script type="text/javascript">
     function save_action() {
         @if (empty($blogs_posts->id))
-            form_blogs_posts{{$frame_id}}.action = "{{url('/')}}/redirect/plugin/blogs/temporarysave/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}";
-            form_blogs_posts{{$frame_id}}.redirect_path = "{{url('/')}}/plugin/blogs/edit/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}";
+            form_blogs_posts{{$frame_id}}.action = "{{url('/')}}/redirect/plugin/blogs/temporarysave/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
         @else
-            form_blogs_posts{{$frame_id}}.action = "{{url('/')}}/redirect/plugin/blogs/temporarysave/{{$page->id}}/{{$frame_id}}/{{$blogs_posts->id}}#frame-{{$frame->id}}";
-            form_blogs_posts{{$frame_id}}.redirect_path = "{{url('/')}}/plugin/blogs/edit/{{$page->id}}/{{$frame_id}}/{{$blogs_posts->id}}#frame-{{$frame->id}}";
+            form_blogs_posts{{$frame_id}}.action = "{{url('/')}}/redirect/plugin/blogs/temporarysave/{{$page->id}}/{{$frame_id}}/{{$blogs_posts->id}}#frame-{{$frame_id}}";
         @endif
         form_blogs_posts{{$frame_id}}.submit();
     }


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 動作に変更ない修正です。
* 詳細
  * ブログ記事の一時保存のredirect_pathと、登録時のredirect_pathは同じ指定が正解です。
  * しかし、一時保存のJSでセットしてる redirect_path は、登録も更新もeditに飛ぶ指定でしたが、JSでミスっていて redirect_path がセットされず、結果として正しい動きになっていました。
    * （誤）`form_blogs_posts{{$frame_id}}.redirect_path = "{{url('/')}}/plugin/blogs/edit/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}";`
    * （正）`form_blogs_posts{{$frame_id}}.redirect_path.value = "{{url('/')}}/plugin/blogs/create/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";`
      *  `.value` が抜けてた。
  * 紛らわしいため、一時保存でredirect_pathをセットしている個所を削除しました。


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる
内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
