### PR TITLE
[サイト管理]サイト設計書のリンクチェック出力でシステムエラーとなる事象を修正しました

### DIFF
--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -1642,6 +1642,13 @@ class SiteManage extends ManagePluginBase
     private function checkLink(?string $html, string $page_name, ?string $frame_title, ?string $attr = 'href') : array
     {
         $ret = [];
+
+        // チェック対象が空ならチェックしない
+        // preg_match_all()の第2引数がnullだとこける（PHP8.1～
+        if (empty($html)) {
+            return $ret;
+        }
+
         if (preg_match_all('/'. $attr.'="(.*?)"/', $html, $m)) {
             foreach ($m[1] as $url) {
                 $url_display_pdf = $url;


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
PHP8.1からpreg_match_all()の第2引数がnullだとERRORとなっていたため、システムエラーが発生していました。
固定記事の続きを読むの内容が空（ contents.content2_text = null）だと当事象が発生します。

preg_match_all()を実行する前に、対象の変数がNULLだとアーリーリターンするように修正しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
#1603

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
