### PR TITLE
[データベース] 項目設定で複数年月型に更新する時、キャプションが空だったらキャプションを自動設定する機能が動いていない不具合修正

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -2218,6 +2218,8 @@ class DatabasesPlugin extends UserPluginBase
             return $this->editColumn($request, $page_id, $frame_id, $request->databases_id, null, $errors);
         }
 
+        $message = '項目【 '. $request->column_name .' 】を追加しました。';
+
         // 新規登録時の表示順を設定
         $max_display_sequence = DatabasesColumns::query()->where('databases_id', $request->databases_id)->max('display_sequence');
         $max_display_sequence = $max_display_sequence ? $max_display_sequence + 1 : 1;
@@ -2232,12 +2234,12 @@ class DatabasesPlugin extends UserPluginBase
         $column->caption_color = Bs4TextColor::dark;
 
         // 複数年月型（テキスト入力）は、デフォルトでキャプションをセットする
-        if (DatabaseColumnType::dates_ym == $request->column_type) {
+        if ($column->column_type == DatabaseColumnType::dates_ym) {
             $column->caption = DatabaseColumnType::dates_ym_caption;
+            $message = '項目【 '.$column->column_name.' 】を追加し、キャプションに【 '.$column->caption.' 】を設定しました。';
         }
 
         $column->save();
-        $message = '項目【 '. $request->column_name .' 】を追加しました。';
 
         // 編集画面へ戻る。
         return $this->editColumn($request, $page_id, $frame_id, $request->databases_id, $message, $errors);
@@ -2443,6 +2445,8 @@ class DatabasesPlugin extends UserPluginBase
             return $this->editColumn($request, $page_id, $frame_id, $request->databases_id, null, $errors);
         }
 
+        $message = '項目【 '. $request->$str_column_name .' 】を更新しました。';
+
         // 項目の更新処理
         $column = DatabasesColumns::query()->where('id', $request->column_id)->first();
         $column->column_name = $request->$str_column_name;
@@ -2450,13 +2454,12 @@ class DatabasesPlugin extends UserPluginBase
         $column->required = $request->$str_required ? Required::on : Required::off;
 
         // 複数年月型（テキスト入力）は、キャプションが空なら定型文をセットする
-        if (DatabaseColumnType::dates_ym == $request->column_type &&
-                !$column->caption) {
+        if ($column->column_type == DatabaseColumnType::dates_ym && !$column->caption) {
             $column->caption = DatabaseColumnType::dates_ym_caption;
+            $message = '項目【 '.$column->column_name.' 】を更新し、キャプションが空のため【 '.$column->caption.' 】を設定しました。';
         }
 
         $column->save();
-        $message = '項目【 '. $request->$str_column_name .' 】を更新しました。';
 
         // 編集画面を呼び出す
         return $this->editColumn($request, $page_id, $frame_id, $request->databases_id, $message, $errors);


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 項目設定で複数年月型に更新する時、キャプションが空だったらキャプションを自動設定する機能が動いていない不具合修正
* 関連修正
    * 上記設定時にキャプションを自動設定したメッセージを表示。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし
# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
