### PR TITLE
[タブ]共通エリアに配置された時、タブが表示されなくなるバグを修正しました。

### DIFF
--- a/app/Plugins/User/Tabs/TabsPlugin.php
+++ b/app/Plugins/User/Tabs/TabsPlugin.php
@@ -95,8 +95,7 @@ class TabsPlugin extends UserPluginBase
         if ($this->frame->area_id == AreaType::main) {
             // タブ自身が配置されているエリアが中央エリアの場合、現在表示されているpage_idを使用する
             $target_page_id = $page_id;
-        }
-        else {
+        } else {
             // タブ自身が配置されているエリアが共通エリアの場合、$page_idのIDは中央エリアのpage_idなので、タブ自身のpage_idを使用する
             $target_page_id =  $this->frame->page_id;
         }

--- a/app/Plugins/User/Tabs/TabsPlugin.php
+++ b/app/Plugins/User/Tabs/TabsPlugin.php
@@ -8,6 +8,7 @@ use App\Models\Common\Frame;
 use App\Models\User\Tabs\Tabs;
 
 use App\Plugins\User\UserPluginBase;
+use App\Enums\AreaType;
 
 /**
  * タブ・プラグイン
@@ -89,9 +90,21 @@ class TabsPlugin extends UserPluginBase
         if (!empty($tabs)) {
             $frame_ids = explode(',', $tabs->frame_ids);
         }
-
+        
+        $target_page_id = null;
+        if( $this->frame->area_id == AreaType::main )
+        {
+            // タブ自身が配置されているエリアが中央エリアの場合、現在表示されているpage_idを使用する
+            $target_page_id = $page_id;
+        }
+        else
+        {
+            // タブ自身が配置されているエリアが共通エリアの場合、$page_idのIDは中央エリアのpage_idなので、タブ自身のpage_idを使用する
+            $target_page_id =  $this->frame->page_id;
+        }
+        
         // タブでくくるために、同じページの自分以外のフレーム取得
-        $frames = Frame::where('page_id', $page_id)
+        $frames = Frame::where('page_id', $target_page_id)
                        ->where('area_id', $this->frame->area_id)
                        ->where('id', '!=', $frame_id)
                        ->whereIn('id', $frame_ids)

--- a/app/Plugins/User/Tabs/TabsPlugin.php
+++ b/app/Plugins/User/Tabs/TabsPlugin.php
@@ -92,13 +92,11 @@ class TabsPlugin extends UserPluginBase
         }
         
         $target_page_id = null;
-        if( $this->frame->area_id == AreaType::main )
-        {
+        if ($this->frame->area_id == AreaType::main) {
             // タブ自身が配置されているエリアが中央エリアの場合、現在表示されているpage_idを使用する
             $target_page_id = $page_id;
         }
-        else
-        {
+        else {
             // タブ自身が配置されているエリアが共通エリアの場合、$page_idのIDは中央エリアのpage_idなので、タブ自身のpage_idを使用する
             $target_page_id =  $this->frame->page_id;
         }


### PR DESCRIPTION
タブプラグインが共通エリア（ヘッダー・フッター・左・右）に配置された時、タブを配置したページ以外へと遷移すると、タブが表示されなくなる。

【タブを配置したページ：左エリア】
![image](https://user-images.githubusercontent.com/34463938/224214856-1c5cc050-dc77-4d64-b579-0b154353ec57.png)

【ページ遷移した後：左エリア】
![image](https://user-images.githubusercontent.com/34463938/224214948-50b20e4b-a461-4e1a-81d4-abcb5e180639.png)

 共通エリア（ヘッダー・フッター・左・右）に配置された時には、現表示page_idではなく、tab自身に設定されたpage_idを参照するように修正した。

# 概要
タブプラグインを共通エリアに以外に配置された事が考慮されていなかった為、共通エリアにタブプラグインを配置すると、配置したページ以外へ遷移すると、タブが消える。

# レビュー完了希望日
不具合対応なので急ぎたいです

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
