### PR TITLE
[サイト管理]サイト設計書のリンク切れチェック出力で見出し名の平伏を合わせました

### DIFF
--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Lang;
 
 use setasign\Fpdi\Tcpdf\Fpdi;
 
@@ -1584,13 +1585,13 @@ class SiteManage extends ManagePluginBase
 
             // リンク切れチェック
             $pdf->addPage();
-            $pdf->Bookmark('リンク切れチェック', 0, 0, '', '', array(0, 0, 0));
+            $pdf->Bookmark(Lang::get('messages.content_url_broken_link_check'), 0, 0, '', '', array(0, 0, 0));
             // リンク切れチェック
             $sections = [
                 ['check_link', compact(
                     'link_error_list_src',
                     'link_error_list_href',
-                ), 'リンク切れチェック一覧'],
+                ), Lang::get('messages.content_url_broken_link_check') . '一覧'],
             ];
             $this->outputSection($pdf, $sections);
         }

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -6,6 +6,7 @@
  |-----------------------------------------------------------------
  */
 return [
+    'content_url_broken_link_check' => 'Content URL Broken Link Check',
     'enter_keyword' => 'Enter Keyword',
     'select_achievement_type' => 'Select holding achievement type',
     'confirm' => 'Confirm',

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -6,6 +6,7 @@
  |-----------------------------------------------------------------
  */
 $messages = [
+    'content_url_broken_link_check' => '固定記事内のURLリンク切れチェック',
     'enter_keyword' => 'キーワードを入力',
     'select_achievement_type' => '保有業績タイプを選択',
     'confirm' => '確定',

--- a/resources/views/plugins/manage/site/document.blade.php
+++ b/resources/views/plugins/manage/site/document.blade.php
@@ -65,7 +65,7 @@
                         </div>
                         <div class="custom-control custom-checkbox custom-control-inline">
                             <input name="document_link_check" value="1" type="checkbox" class="custom-control-input" id="document_link_check" @if(Configs::getConfigsValueAndOld($configs, "document_link_check") == "1") checked="checked" @endif>
-                            <label class="custom-control-label" for="document_link_check">リンクチェック</label>
+                            <label class="custom-control-label" for="document_link_check">{{ __('messages.content_url_broken_link_check') }}</label>
                         </div>
                     </div>
                 </div>

--- a/resources/views/plugins/manage/site/pdf/check_link.blade.php
+++ b/resources/views/plugins/manage/site/pdf/check_link.blade.php
@@ -9,9 +9,9 @@
 @include('plugins/manage/site/pdf/css')
 
 <br />
-<h2 style="text-align: center; font-size: 28px;">リンクチェック</h2>
+<h2 style="text-align: center; font-size: 28px;">{{ __('messages.content_url_broken_link_check') }}</h2>
 <br />
-<h4>リンクチェックデータ一覧</h4>
+<h4>{{ __('messages.content_url_broken_link_check') }}一覧</h4>
 <h5>
     - 固定記事プラグインで設定されているすべてのリンクに対してHTTPレスポンスチェックを行い、HTTPステータスがNGのものを一覧で出力しています。<br>
     - 代表的なNGのHTTPステータスの凡例：


### PR DESCRIPTION
# 概要
 - 先のPR対応の追加修正です。https://github.com/opensource-workshop/connect-cms/pull/1594
 - 動作に影響はなく見出し名の統一のみです。
     - 統一対象
         - 目次
         - 該当ページの見出し名
         - 画面上（追加出力の選択部）の見出し名
 - また「リンクチェック」のみだと内容の詳細がイメージしづらい指摘があったので、見出し名を「固定記事内のURLリンク切れチェック」に統一しています。

# レビュー完了希望日
なし

# 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/pull/1594

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
