### PR TITLE
[フレーム]ログインしていると、権限に関係なくフレームステータスラベルが見えてしまう不具合を修正しました。

### DIFF
--- a/resources/views/core/cms_frame_header.blade.php
+++ b/resources/views/core/cms_frame_header.blade.php
@@ -59,25 +59,25 @@ if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null
 
     {{-- フレームタイトル --}}
     {{$frame->frame_title}}
-    
+
     {{-- 各ステータスラベルは、ログインしている＆プラグイン管理者＆プレビューモードではない状態の時のみ表示 --}}
     @if (Auth::check() &&
-        (Auth::user()->can('role_arrangement')) &&
-         app('request')->input('mode') != 'preview')
-    
-        @if (Auth::check() && $frame->default_hidden)
+        Auth::user()->can('role_arrangement') &&
+        app('request')->input('mode') != 'preview')
+
+        @if ($frame->default_hidden)
             <small><span class="badge badge-warning">初期非表示</span></small>
         @endif
 
-        @if (Auth::check() && $frame->none_hidden)
+        @if ($frame->none_hidden)
             <small><span class="badge badge-warning">データがない場合は非表示</span></small>
         @endif
 
-        @if (Auth::check() && $frame->page_only == 1 && $page->id == $frame->page_id)
+        @if ($frame->page_only == 1 && $page->id == $frame->page_id)
             <small><span class="badge badge-warning">このページのみ表示する。</span></small>
         @endif
 
-        @if (Auth::check() && $frame->page_only == 2 && $page->id == $frame->page_id)
+        @if ($frame->page_only == 2 && $page->id == $frame->page_id)
             <small><span class="badge badge-warning">このページのみ表示しない。</span></small>
         @endif
     @endif

--- a/resources/views/core/cms_frame_header.blade.php
+++ b/resources/views/core/cms_frame_header.blade.php
@@ -59,20 +59,27 @@ if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null
 
     {{-- フレームタイトル --}}
     {{$frame->frame_title}}
-    @if (Auth::check() && $frame->default_hidden)
-        <small><span class="badge badge-warning">初期非表示</span></small>
-    @endif
+    
+    {{-- 各ステータスラベルは、ログインしている＆プラグイン管理者＆プレビューモードではない状態の時のみ表示 --}}
+    @if (Auth::check() &&
+        (Auth::user()->can('role_arrangement')) &&
+         app('request')->input('mode') != 'preview')
+    
+        @if (Auth::check() && $frame->default_hidden)
+            <small><span class="badge badge-warning">初期非表示</span></small>
+        @endif
 
-    @if (Auth::check() && $frame->none_hidden)
-        <small><span class="badge badge-warning">データがない場合は非表示</span></small>
-    @endif
+        @if (Auth::check() && $frame->none_hidden)
+            <small><span class="badge badge-warning">データがない場合は非表示</span></small>
+        @endif
 
-    @if (Auth::check() && $frame->page_only == 1 && $page->id == $frame->page_id)
-        <small><span class="badge badge-warning">このページのみ表示する。</span></small>
-    @endif
+        @if (Auth::check() && $frame->page_only == 1 && $page->id == $frame->page_id)
+            <small><span class="badge badge-warning">このページのみ表示する。</span></small>
+        @endif
 
-    @if (Auth::check() && $frame->page_only == 2 && $page->id == $frame->page_id)
-        <small><span class="badge badge-warning">このページのみ表示しない。</span></small>
+        @if (Auth::check() && $frame->page_only == 2 && $page->id == $frame->page_id)
+            <small><span class="badge badge-warning">このページのみ表示しない。</span></small>
+        @endif
     @endif
 
     {{-- 公開以外の場合にステータス表示 ※デフォルト状態の公開もステータス表示すると画面表示が煩雑になる為、意識的な設定（非公開、又は、限定公開）のみステータス表示を行う --}}


### PR DESCRIPTION
# 概要
フレームに対して
- 初期状態を非表示にする。
- このページのみ表示する。
- このページのみ表示しない。
- データがない場合にフレームも非表示にする。

上記ステータスを付与していた時、プラグイン管理の権限がないユーザにも、フレームのステータスラベルが見えてしまっていた。
![image](https://user-images.githubusercontent.com/34463938/224610835-b9f6f0be-df6a-4351-a6a7-f55ca80dbf64.png)

なので、フレームのステータスラベルは

- ログインしている
- プラグイン管理者権限を持っている
- プレビュー画面ではない

の時のみ表示するように修正した。


# レビュー完了希望日
不具合対応なので急ぎたいです

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
