### PR TITLE
[データベース]初期表示オフの時に検索結果のページ番号を押すと検索結果が表示されない事象を修正しました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -734,7 +734,7 @@ class DatabasesPlugin extends UserPluginBase
             if ($databases_frames) {
                 $get_count = $databases_frames->view_count;
             }
-            $inputs = $inputs_query->paginate($get_count, ["*"], "frame_{$frame_id}_page");
+            $inputs = $inputs_query->paginate($get_count, ["*"], $this->pageName($frame_id));
 
             // 登録データ行のタイトル取得
             $inputs_titles = DatabasesInputs::
@@ -798,7 +798,7 @@ class DatabasesPlugin extends UserPluginBase
 
         // 初期表示を隠す判定
         $default_hide_list = false;
-        if (($database_frame && $database_frame->default_hide == 1 && $request->isMethod('get') && !$request->page)) {
+        if (($database_frame && $database_frame->default_hide == 1 && $request->isMethod('get') && !$request->{$this->pageName($frame_id)})) {
             $default_hide_list = true;
         }
 
@@ -826,6 +826,17 @@ class DatabasesPlugin extends UserPluginBase
         // change: 同ページに(a)データベースプラグイン,(b)フォームを配置して(b)フォームで入力エラーが起きても、入力値が復元しないバグ対応。
         // ])->withInput($request->all);
         ]);
+    }
+
+    /**
+     * ぺジネーション用のページ名を取得する
+     *
+     * @param int $frame_id
+     * @return string ページ名
+     */
+    private function pageName(int $frame_id): string
+    {
+        return "frame_{$frame_id}_page";
     }
 
     /**


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

初期表示を隠す判定でページ名の変数名が間違ってました。
フレームごとにページ名を独自に採番してたので、独自採番のページ名を用いて判定するように修正しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

#1614

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
