### PR TITLE
[役割設定] 定義名にダッシュ(-)、下線(_)も入力可能にする

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -874,7 +874,7 @@ class UserManage extends ManagePluginBase
         if (!empty($request->add_additional1) || !empty($request->add_name) || !empty($request->add_value)) {
             // 項目のエラーチェック
             $rules['add_additional1'] = ['required', 'numeric'];
-            $rules['add_name'] = ['required', 'alpha_num'];
+            $rules['add_name'] = ['required', 'alpha_dash'];
             $rules['add_value'] = ['required'];
 
             $setAttributeNames['add_additional1'] = '追加行の表示順';
@@ -887,7 +887,7 @@ class UserManage extends ManagePluginBase
             foreach ($request->configs_id as $config_id) {
                 // 項目のエラーチェック
                 $rules['additional1.'.$config_id] = ['required', 'numeric'];
-                $rules['name.'.$config_id] = ['required', 'alpha_num'];
+                $rules['name.'.$config_id] = ['required', 'alpha_dash'];
                 $rules['value.'.$config_id] = ['required'];
 
                 $setAttributeNames['additional1.'.$config_id] = '表示順';
@@ -911,7 +911,7 @@ class UserManage extends ManagePluginBase
                 // 項目のエラーチェック
                 $validator = Validator::make($request->all(), [
                     'additional1.'.$config_id => ['required', 'numeric'],
-                    'name.'.$config_id        => ['required', 'alpha_num'],
+                    'name.'.$config_id        => ['required', 'alpha_dash'],
                     'value.'.$config_id       => ['required'],
                 ]);
                 $validator->setAttributeNames([

--- a/resources/views/plugins/manage/user/original_role.blade.php
+++ b/resources/views/plugins/manage/user/original_role.blade.php
@@ -43,7 +43,7 @@
                     <thead>
                         <tr>
                             <th nowrap>表示順</th>
-                            <th nowrap>定義名（半角英数字）</th>
+                            <th nowrap>定義名</th>
                             <th nowrap>表示名</th>
                             <th nowrap><i class="fas fa-trash-alt"></i></th>
                         </tr>
@@ -97,6 +97,7 @@
                         @endforeach
                         です。
                     </li>
+                    <li>定義名は、半角英数字、ダッシュ(-)、下線(_)で入力できます。</li>
                 </ul>
             </div>
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

役割設定画面の定義名は、半角英数字のみでした。
定義名という事で、ダッシュ(-)、下線(_)も使いたくなったため、対応しました。

# 修正後画面
## 役割設定画面
![image](https://user-images.githubusercontent.com/2756509/225254978-d1c113f9-12c7-4240-ac65-c82f0d1446b0.png)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
