### PR TITLE
[ユーザ管理]ユーザー項目「所属型」を追加しました

### DIFF
--- a/app/Enums/UserColumnType.php
+++ b/app/Enums/UserColumnType.php
@@ -17,6 +17,7 @@ final class UserColumnType extends EnumsBase
     const select = 'select';
     const mail = 'mail';
     const agree = 'agree';
+    const affiliation = 'affiliation';
 
     // key/valueの連想配列
     const enum = [
@@ -27,5 +28,6 @@ final class UserColumnType extends EnumsBase
         self::select => 'リストボックス型',
         self::mail => 'メールアドレス型',
         self::agree => '同意型',
+        self::affiliation => '所属型',
     ];
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Validator;
 
 use Illuminate\Support\Facades\Auth;
 use App\Models\Core\Configs;
+use App\Models\Core\Section;
 use App\Models\Core\UserSection;
 use App\Models\Core\UsersInputCols;
 use App\Plugins\Manage\UserManage\UsersTool;
@@ -180,7 +181,9 @@ class RegisterController extends Controller
                     ['user_id' => $user->id],
                     ['section_id' => $value]
                 );
-                continue;
+
+                // users_input_cols には　名称を設定する
+                $value = Section::find($value)->name;
             }
 
             // データ登録フラグを見て登録

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Enums\UserColumnType;
 use App\Enums\UserStatus;
 use App\Http\Controllers\Controller;
 //use App\Providers\RouteServiceProvider;
@@ -13,6 +14,7 @@ use Illuminate\Support\Facades\Validator;
 
 use Illuminate\Support\Facades\Auth;
 use App\Models\Core\Configs;
+use App\Models\Core\UserSection;
 use App\Models\Core\UsersInputCols;
 use App\Plugins\Manage\UserManage\UsersTool;
 use App\Rules\CustomValiUserEmailUnique;
@@ -170,6 +172,15 @@ class RegisterController extends Controller
                 $value = implode(UsersTool::CHECKBOX_SEPARATOR, $data['users_columns_value'][$users_column->id]);
             } else {
                 $value = $data['users_columns_value'][$users_column->id];
+            }
+
+            // 所属型は個別のテーブルに書き込む
+            if (!empty($value) && $users_column->column_type === UserColumnType::affiliation) {
+                UserSection::updateOrCreate(
+                    ['user_id' => $user->id],
+                    ['section_id' => $value]
+                );
+                continue;
             }
 
             // データ登録フラグを見て登録

--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -25,6 +25,8 @@ use App\Providers\RouteServiceProvider;
 
 use App\Enums\UserRegisterNoticeEmbeddedTag;
 use App\Enums\UserStatus;
+use App\Models\Core\Section;
+use App\Models\Core\UserSection;
 
 trait RegistersUsers
 {
@@ -87,6 +89,8 @@ trait RegistersUsers
             'users_columns_id_select' => $users_columns_id_select,
             'input_cols' => $input_cols,
             'themes' => $themes,
+            'sections' => Section::orderBy('display_sequence')->get(),
+            'user_section' => new UserSection(),
         ]);
     }
 

--- a/app/Models/Core/Section.php
+++ b/app/Models/Core/Section.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models\Core;
+
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+
+class Section extends Model
+{
+    // 更新する項目の定義
+    protected $fillable = [
+        'code',
+        'name',
+        'display_sequence',
+    ];
+
+    /**
+     * 利用者所属
+     */
+    public function users() // phpcs:ignore
+    {
+        return $this->belongsToMany(User::class, 'user_sections', 'section_id', 'user_id');
+    }
+}

--- a/app/Models/Core/UserSection.php
+++ b/app/Models/Core/UserSection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models\Core;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserSection extends Model
+{
+    // 更新する項目の定義
+    protected $fillable = [
+        'user_id',
+        'section_id',
+    ];
+
+    /**
+     * 組織
+     */
+    public function section()
+    {
+        return $this->belongsTo(Section::class);
+    }
+}

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1740,6 +1740,19 @@ class UserManage extends ManagePluginBase
                 $users_input_cols->users_columns_id = $users_column->id;
                 $users_input_cols->value = $value;
                 $users_input_cols->save();
+
+                // 所属型
+                if ($users_column->column_type === UserColumnType::affiliation) {
+                    // 値無しは所属情報を削除
+                    if (empty($value)) {
+                        UserSection::where('user_id', $user->id)->delete();
+                    } else {
+                        UserSection::updateOrCreate(
+                            ['user_id' => $user->id],
+                            ['section_id' => Section::where('name', $value)->first()->id]
+                        );
+                    }
+                }
             }
 
             // --- 権限(コンテンツ権限 & 管理権限)
@@ -1919,6 +1932,13 @@ class UserManage extends ManagePluginBase
                             // 配列値の入力値をトリム (preg_replace(/u)で置換. /u = UTF-8 として処理)
                             $csv_column = StringUtils::trimInput($csv_column);
                             // Log::debug(var_export($csv_column, true));
+                        }
+
+                        // 所属型
+                        if ($users_column->column_type == UserColumnType::affiliation) {
+                            $section = Section::where('name', $csv_column)->first();
+                            // マスタにない組織名が設定されたら、後続のバリデーションでエラーになるようにIDとしてありえない文字列を設定する
+                            $csv_column = $section ? $section->id : '-';
                         }
                     }
                 }

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2565,7 +2565,7 @@ class UserManage extends ManagePluginBase
     {
         // エラーチェック
         $validator = Validator::make($request->all(), [
-            'section_name'  => ['required', 'max:191'],
+            'section_name'  => ['required', 'max:191', Rule::unique('sections', 'name')],
             'section_code'  => ['max:191'],
         ]);
         $validator->setAttributeNames([
@@ -2604,7 +2604,7 @@ class UserManage extends ManagePluginBase
 
         // エラーチェック
         $validator = Validator::make($request->all(), [
-            $str_section_name => ['required', 'max:191'],
+            $str_section_name => ['required', 'max:191', Rule::unique('sections', 'name')->ignore($request->section_id)],
             $str_section_code => ['max:191'],
         ]);
         $validator->setAttributeNames([

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2172,6 +2172,7 @@ class UserManage extends ManagePluginBase
             "function"       => __FUNCTION__,
             "plugin_name"    => "user",
             'columns'        => $columns,
+            'exists_user_sections' => UserSection::exists(),
         ]);
     }
 

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2581,7 +2581,7 @@ class UserManage extends ManagePluginBase
         $max_display_sequence = Section::max('display_sequence');
         $max_display_sequence = $max_display_sequence ? $max_display_sequence + 1 : 1;
 
-        // 施設の登録処理
+        // 組織の登録処理
         $section = new Section();
         $section->name = $request->section_name;
         $section->code = $request->section_code;

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -760,10 +760,10 @@ class UserManage extends ManagePluginBase
                 if (empty($value)) {
                     UserSection::where('user_id', $user->id)->delete();
                 } else {
-                UserSection::updateOrCreate(
-                    ['user_id' => $user->id],
-                    ['section_id' => $value]
-                );
+                    UserSection::updateOrCreate(
+                        ['user_id' => $user->id],
+                        ['section_id' => $value]
+                    );
                     // users_input_cols には　名称を設定する
                     $value = Section::find($value)->name;
                 }
@@ -1697,7 +1697,7 @@ class UserManage extends ManagePluginBase
             // --- グループ
             $group_col_no = array_search('group', $import_column_col_no);
             // 配列に変換する。
-            $csv_groups = explode(UsersTool::CHECKBOX_SEPARATOR, $csv_columns[$group_col_no]);
+            $csv_groups = explode(UsersTool::CHECKBOX_SEPARATOR, $csv_columns[$group_col_no] ?? '');
             // 配列値の入力値をトリム (preg_replace(/u)で置換. /u = UTF-8 として処理)
             $csv_groups = StringUtils::trimInput($csv_groups);
 
@@ -1782,7 +1782,7 @@ class UserManage extends ManagePluginBase
             // --- 役割設定
             $user_original_roles_col_no = array_search('user_original_roles', $import_column_col_no);
             // 配列に変換する。
-            $csv_user_original_roles_names = explode(UsersTool::CHECKBOX_SEPARATOR, $csv_columns[$user_original_roles_col_no]);
+            $csv_user_original_roles_names = explode(UsersTool::CHECKBOX_SEPARATOR, $csv_columns[$user_original_roles_col_no] ?? '');
             // 配列値の入力値をトリム (preg_replace(/u)で置換. /u = UTF-8 として処理)
             $csv_user_original_roles_names = StringUtils::trimInput($csv_user_original_roles_names);
             // dd($csv_user_original_roles_names);

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2682,5 +2682,4 @@ class UserManage extends ManagePluginBase
         // 編集画面を呼び出す
         return redirect("/manage/user/editColumnDetail/" . $request->column_id)->with('flash_message', $message);
     }
-
 }

--- a/app/Plugins/Manage/UserManage/UsersTool.php
+++ b/app/Plugins/Manage/UserManage/UsersTool.php
@@ -177,6 +177,11 @@ class UsersTool
                 $validator_rule[] = Rule::in($selects);
             }
         }
+        // 所属型マスタ存在チェック
+        if ($users_column->column_type == UserColumnType::affiliation) {
+            $validator_rule[] = 'nullable';
+            $validator_rule[] = 'exists:sections,id';
+        }
 
         // バリデータールールをセット
         if ($validator_rule) {
@@ -217,7 +222,9 @@ class UsersTool
 
         foreach ($users_columns as $users_column) {
             $value = "";
-            if (is_array($users_input_cols[$users_column->id])) {
+            if ($users_column->column_type === UserColumnType::affiliation) {
+                $value = $user->section->name;
+            } elseif (is_array($users_input_cols[$users_column->id])) {
                 $value = implode(self::CHECKBOX_SEPARATOR, $users_input_cols[$users_column->id]->value);
             } else {
                 $value = $users_input_cols[$users_column->id]->value;
@@ -253,7 +260,9 @@ class UsersTool
 
         foreach ($users_columns as $users_column) {
             $value = "";
-            if (is_array($users_input_cols[$users_column->id])) {
+            if ($users_column->column_type === UserColumnType::affiliation) {
+                $value = $user->section->name;
+            } elseif (is_array($users_input_cols[$users_column->id])) {
                 $value = implode(self::CHECKBOX_SEPARATOR, $users_input_cols[$users_column->id]->value);
             } else {
                 $value = $users_input_cols[$users_column->id]->value;

--- a/app/Plugins/Manage/UserManage/UsersTool.php
+++ b/app/Plugins/Manage/UserManage/UsersTool.php
@@ -222,9 +222,7 @@ class UsersTool
 
         foreach ($users_columns as $users_column) {
             $value = "";
-            if ($users_column->column_type === UserColumnType::affiliation) {
-                $value = $user->section->name;
-            } elseif (is_array($users_input_cols[$users_column->id])) {
+            if (is_array($users_input_cols[$users_column->id])) {
                 $value = implode(self::CHECKBOX_SEPARATOR, $users_input_cols[$users_column->id]->value);
             } else {
                 $value = $users_input_cols[$users_column->id]->value;
@@ -260,9 +258,7 @@ class UsersTool
 
         foreach ($users_columns as $users_column) {
             $value = "";
-            if ($users_column->column_type === UserColumnType::affiliation) {
-                $value = $user->section->name;
-            } elseif (is_array($users_input_cols[$users_column->id])) {
+            if (is_array($users_input_cols[$users_column->id])) {
                 $value = implode(self::CHECKBOX_SEPARATOR, $users_input_cols[$users_column->id]->value);
             } else {
                 $value = $users_input_cols[$users_column->id]->value;

--- a/app/User.php
+++ b/app/User.php
@@ -11,6 +11,8 @@ use App\Notifications\PasswordResetNotification;
 use App\Enums\UserStatus;
 
 use App\Models\Common\GroupUser;
+use App\Models\Core\UserSection;
+use App\Models\Core\Section;
 
 class User extends Authenticatable
 {
@@ -209,5 +211,21 @@ class User extends Authenticatable
     public function group_users()    // phpcs:ignore
     {
         return $this->hasMany(GroupUser::class);
+    }
+
+    /**
+     * 所属情報
+     */
+    public function user_section()  // phpcs:ignore
+    {
+        return $this->hasOne(UserSection::class);
+    }
+
+    /**
+     * 所属の組織
+     */
+    public function section()
+    {
+        return $this->hasOneThrough(Section::class, UserSection::class, 'user_id', 'id', 'id', 'section_id');
     }
 }

--- a/database/migrations/2023_03_13_004114_create_sections_table.php
+++ b/database/migrations/2023_03_13_004114_create_sections_table.php
@@ -15,7 +15,7 @@ class CreateSectionsTable extends Migration
     {
         Schema::create('sections', function (Blueprint $table) {
             $table->id();
-            $table->string('code', 191)->comment('組織コード');
+            $table->string('code', 191)->nullable()->comment('組織コード');
             $table->string('name', 191)->comment('組織名');
             $table->integer('display_sequence')->comment('並び順');
 
@@ -25,6 +25,9 @@ class CreateSectionsTable extends Migration
             $table->integer('updated_id')->nullable();
             $table->string('updated_name', 255)->nullable();
             $table->timestamp('updated_at')->nullable();
+
+            // 一意制約
+            $table->unique('name');
         });
     }
 

--- a/database/migrations/2023_03_13_004114_create_sections_table.php
+++ b/database/migrations/2023_03_13_004114_create_sections_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSectionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sections', function (Blueprint $table) {
+            $table->id();
+            $table->string('code', 191)->comment('組織コード');
+            $table->string('name', 191)->comment('組織名');
+            $table->integer('display_sequence')->comment('並び順');
+
+            $table->integer('created_id')->nullable();
+            $table->string('created_name', 255)->nullable();
+            $table->timestamp('created_at')->nullable();
+            $table->integer('updated_id')->nullable();
+            $table->string('updated_name', 255)->nullable();
+            $table->timestamp('updated_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sections');
+    }
+}

--- a/database/migrations/2023_03_13_004114_create_sections_table.php
+++ b/database/migrations/2023_03_13_004114_create_sections_table.php
@@ -15,15 +15,15 @@ class CreateSectionsTable extends Migration
     {
         Schema::create('sections', function (Blueprint $table) {
             $table->id();
-            $table->string('code', 191)->nullable()->comment('組織コード');
-            $table->string('name', 191)->comment('組織名');
+            $table->string('code')->nullable()->comment('組織コード');
+            $table->string('name')->comment('組織名');
             $table->integer('display_sequence')->comment('並び順');
 
             $table->integer('created_id')->nullable();
-            $table->string('created_name', 255)->nullable();
+            $table->string('created_name')->nullable();
             $table->timestamp('created_at')->nullable();
             $table->integer('updated_id')->nullable();
-            $table->string('updated_name', 255)->nullable();
+            $table->string('updated_name')->nullable();
             $table->timestamp('updated_at')->nullable();
 
             // 一意制約

--- a/database/migrations/2023_03_13_004115_create_user_sections_table.php
+++ b/database/migrations/2023_03_13_004115_create_user_sections_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserSectionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_sections', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id')->comment('利用者ID');
+            $table->unsignedBigInteger('section_id')->comment('組織ID');
+
+            $table->integer('created_id')->nullable();
+            $table->string('created_name', 255)->nullable();
+            $table->timestamp('created_at')->nullable();
+            $table->integer('updated_id')->nullable();
+            $table->string('updated_name', 255)->nullable();
+            $table->timestamp('updated_at')->nullable();
+
+            // 外部キー
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('section_id')->references('id')->on('sections')->restrictOnDelete();
+            // 一意制約
+            $table->unique('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_sections');
+    }
+}

--- a/database/migrations/2023_03_13_004115_create_user_sections_table.php
+++ b/database/migrations/2023_03_13_004115_create_user_sections_table.php
@@ -19,10 +19,10 @@ class CreateUserSectionsTable extends Migration
             $table->unsignedBigInteger('section_id')->comment('組織ID');
 
             $table->integer('created_id')->nullable();
-            $table->string('created_name', 255)->nullable();
+            $table->string('created_name')->nullable();
             $table->timestamp('created_at')->nullable();
             $table->integer('updated_id')->nullable();
-            $table->string('updated_name', 255)->nullable();
+            $table->string('updated_name')->nullable();
             $table->timestamp('updated_at')->nullable();
 
             // 外部キー

--- a/resources/views/auth/registe_form_input_affiliation.blade.php
+++ b/resources/views/auth/registe_form_input_affiliation.blade.php
@@ -1,0 +1,23 @@
+{{--
+ * 登録画面(所属型)テンプレート。
+--}}
+{{-- @dd($user_section) --}}
+
+@if ($sections)
+    <select id="{{$label_id}}" name="users_columns_value[{{$user_obj->id}}]" class="custom-select @if ($errors->has("users_columns_value.$user_obj->id")) border-danger @endif" @if($user_obj->required) required @endif>
+        <option value=""></option>
+        @foreach ($sections as $section)
+            @if (old('users_columns_value.'.$user_obj->id) == $section['id'] ||
+                $section['id'] == $user_section->section_id)
+                <option value="{{$section['id']}}" selected>{{$section['name']}}</option>
+            @else
+                <option value="{{$section['id']}}">{{$section['name']}}</option>
+            @endif
+        @endforeach
+    </select>
+    @if ($errors && $errors->has("users_columns_value.$user_obj->id"))
+        <div class="d-block text-danger">
+            <i class="fas fa-exclamation-triangle"></i> {{$errors->first("users_columns_value.$user_obj->id")}}
+        </div>
+    @endif
+@endif

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -70,6 +70,48 @@
         return false;
     }
 
+
+    /**
+     * 組織追加ボタン押下
+     */
+     function submit_add_section(btn) {
+        form_selects.action = "{{url('/')}}/manage/user/addSection";
+        btn.disabled = true;
+        form_selects.submit();
+    }
+
+    /**
+     * 表示順操作ボタン押下
+     */
+    function submit_section_display_sequence(section_id, display_sequence, display_sequence_operation) {
+        form_selects.action = "{{url('/')}}/manage/user/updateSectionSequence";
+        form_selects.section_id.value = section_id;
+        form_selects.display_sequence.value = display_sequence;
+        form_selects.display_sequence_operation.value = display_sequence_operation;
+        form_selects.submit();
+    }
+
+    /**
+     * 組織の更新ボタン押下
+     */
+    function submit_update_section(section_id) {
+        form_selects.action = "{{url('/')}}/manage/user/updateSection";
+        form_selects.section_id.value = section_id;
+        form_selects.submit();
+    }
+
+    /**
+     * 組織の削除ボタン押下
+     */
+     function submit_delete_section(section_id) {
+        if (confirm('組織を削除します。\nよろしいですか？')){
+            form_selects.action = "{{url('/')}}/manage/user/deleteSection";
+            form_selects.section_id.value = section_id;
+            form_selects.submit();
+        }
+        return false;
+    }
+
     // ツールチップ
     $(function () {
         // 有効化
@@ -88,6 +130,7 @@
             {{ csrf_field() }}
             <input type="hidden" name="column_id" value="{{ $column->id }}">
             <input type="hidden" name="select_id" value="">
+            <input type="hidden" name="section_id" value="">
             <input type="hidden" name="display_sequence" value="">
             <input type="hidden" name="display_sequence_operation" value="">
 
@@ -349,6 +392,107 @@
                 </div>
             @endif
 
+            {{-- 所属型 --}}
+            @if ($column->column_type == UserColumnType::affiliation)
+                {{-- 選択肢の設定 --}}
+                <div class="card mb-4">
+                    <h5 class="card-header">選択肢の設定</h5>
+                    <div class="card-body">
+
+                        <div class="table-responsive">
+
+                            {{-- 選択項目の一覧 --}}
+                            <table class="table table-hover table-sm">
+                                <thead class="thead-light">
+                                    <tr>
+                                        @if (count($sections) > 0)
+                                            <th class="text-center" nowrap>表示順</th>
+                                            <th class="text-center" nowrap>組織名</th>
+                                            <th class="text-center" nowrap>コード</th>
+                                            <th class="text-center" nowrap>更新</th>
+                                            <th class="text-center" nowrap>削除</th>
+                                        @endif
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {{-- 更新用の行 --}}
+                                    @foreach ($sections as $section)
+                                        <tr>
+                                            {{-- 表示順操作 --}}
+                                            <td class="text-center" nowrap>
+                                                {{-- 上移動 --}}
+                                                <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->first) disabled @endif onclick="javascript:submit_section_display_sequence({{ $section->id }}, {{ $section->display_sequence }}, 'up')">
+                                                    <i class="fas fa-arrow-up"></i>
+                                                </button>
+
+                                                {{-- 下移動 --}}
+                                                <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->last) disabled @endif onclick="javascript:submit_section_display_sequence({{ $section->id }}, {{ $section->display_sequence }}, 'down')">
+                                                    <i class="fas fa-arrow-down"></i>
+                                                </button>
+                                            </td>
+
+                                            {{-- 組織名 --}}
+                                            <td>
+                                                <input class="form-control @if ($errors && $errors->has('section_name_'.$section->id)) border-danger @endif" type="text" name="section_name_{{ $section->id }}" value="{{ old('section_name_'.$section->id, $section->name)}}">
+                                            </td>
+
+                                            {{-- コード --}}
+                                            <td>
+                                                <input class="form-control @if ($errors && $errors->has('section_code_'.$section->id)) border-danger @endif" type="text" name="section_code_{{ $section->id }}" value="{{ old('section_code_'.$section->id, $section->code)}}">
+                                            </td>
+
+                                            {{-- 更新ボタン --}}
+                                            <td class="align-middle text-center">
+                                                <button
+                                                    class="btn btn-primary cc-font-90 text-nowrap"
+                                                    onclick="javascript:submit_update_section({{ $section->id }});"
+                                                >
+                                                    <i class="fas fa-check"></i> <span class="d-sm-none">更新</span>
+                                                </button>
+                                            </td>
+
+                                            {{-- 削除ボタン --}}
+                                            <td class="text-center">
+                                                <div class="button-wrapper" @if ($section->users->count()) data-toggle="tooltip" title="所属しているユーザがいるため削除できません。" @endif>
+                                                <button
+                                                    class="btn btn-danger cc-font-90 text-nowrap"
+                                                    onclick="javascript:return submit_delete_section({{ $section->id }});"
+                                                    @if ($section->users->count()) disabled @endif
+                                                >
+                                                    <i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span>
+                                                </button>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                    <tr class="thead-light">
+                                        <th colspan="7">【組織の追加行】</th>
+                                    </tr>
+
+                                    {{-- 新規登録用の行 --}}
+                                    <tr>
+                                        <td></td>
+                                        <td>
+                                            {{-- 組織名 --}}
+                                            <input class="form-control @if ($errors && $errors->has('section_name')) border-danger @endif" type="text" name="section_name" value="{{ old('section_name') }}" placeholder="組織名">
+                                        </td>
+                                        <td>
+                                            {{-- コード --}}
+                                            <input class="form-control @if ($errors && $errors->has('section_code')) border-danger @endif" type="text" name="section_code" value="{{ old('section_code') }}" placeholder="コード">
+                                        </td>
+                                        <td class="text-center">
+                                            {{-- ＋ボタン --}}
+                                            <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_add_section(this);"><i class="fas fa-plus"></i> <span class="d-sm-none">追加</span></button>
+                                        </td>
+                                        <td></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+                    </div>
+                </div>
+            @endif
 
             {{-- キャプション設定 --}}
             <div class="card mb-4" id="div_caption">
@@ -423,5 +567,16 @@
 
     </div>
 </div>
+
+{{-- disableのボタンにツールチップを置くための対応 --}}
+<style>
+.button-wrapper {
+  display: inline-block;
+}
+
+.button-wrapper .btn:disabled {
+  pointer-events: none;
+}
+</style>
 
 @endsection

--- a/resources/views/plugins/manage/user/edit_columns.blade.php
+++ b/resources/views/plugins/manage/user/edit_columns.blade.php
@@ -135,4 +135,15 @@
     </div>
 </div>
 
+{{-- disableのボタンにツールチップを置くための対応 --}}
+<style>
+    .button-wrapper {
+      display: inline-block;
+    }
+
+    .button-wrapper .btn:disabled {
+      pointer-events: none;
+    }
+    </style>
+
 @endsection

--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -65,7 +65,14 @@
 
     {{-- 削除ボタン --}}
     <td class="text-center px-2">
-        <button class="btn btn-danger cc-font-90 text-nowrap" onclick="javascript:return submit_delete_column({{ $column->id }});"><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+        {{-- 所属が登録されてたら項目の削除はさせない --}}
+        @if ($column->column_type == UserColumnType::affiliation && $exists_user_sections)
+            <div class="button-wrapper" data-toggle="tooltip" title="{{$column->column_name}}登録済みのユーザがいるため項目を削除できません。">
+                <button class="btn btn-danger cc-font-90 text-nowrap" disabled><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+            </div>
+        @else
+            <button class="btn btn-danger cc-font-90 text-nowrap" onclick="javascript:return submit_delete_column({{ $column->id }});"><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+        @endif
     </td>
 </tr>
 {{-- 選択肢の設定内容の表示行 --}}

--- a/resources/views/plugins/manage/user/list_include_value.blade.php
+++ b/resources/views/plugins/manage/user/list_include_value.blade.php
@@ -24,6 +24,11 @@
         // $value = "&nbsp;";
         $value = "\n";
     }
+
+    // 所属型
+    if ($users_column->column_type == UserColumnType::affiliation) {
+        $value = $user->section->name;
+    }
 @endphp
 
 {!!nl2br(e($value))!!}

--- a/resources/views/plugins/manage/user/list_search_affiliation.blade.php
+++ b/resources/views/plugins/manage/user/list_search_affiliation.blade.php
@@ -1,0 +1,18 @@
+{{--
+検索画面(search 所属型)テンプレート。
+--}}
+@php
+    $value = Session::get('user_search_condition.users_columns_value.' . $user_obj->id);
+@endphp
+@if ($sections)
+    <select id="{{$label_id}}" name="users_columns_value[{{$user_obj->id}}]" class="custom-select">
+        <option value=""></option>
+        @foreach($sections as $section)
+            @if ($section['id'] == $value)
+                <option value="{{$section['id']}}" selected>{{$section['name']}}</option>
+            @else
+                <option value="{{$section['id']}}">{{$section['name']}}</option>
+            @endif
+        @endforeach
+    </select>
+@endif

--- a/resources/views/plugins/manage/user/list_search_affiliation.blade.php
+++ b/resources/views/plugins/manage/user/list_search_affiliation.blade.php
@@ -8,10 +8,10 @@
     <select id="{{$label_id}}" name="users_columns_value[{{$user_obj->id}}]" class="custom-select">
         <option value=""></option>
         @foreach($sections as $section)
-            @if ($section['id'] == $value)
-                <option value="{{$section['id']}}" selected>{{$section['name']}}</option>
+            @if ($section['name'] == $value)
+                <option value="{{$section['name']}}" selected>{{$section['name']}}</option>
             @else
-                <option value="{{$section['id']}}">{{$section['name']}}</option>
+                <option value="{{$section['name']}}">{{$section['name']}}</option>
             @endif
         @endforeach
     </select>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

ユーザーの任意項目に所属型を追加しました。

## 内容

- ユーザ項目に所属型の選択肢を追加
- 所属は1ユーザー1つまで
- ユーザ項目に所属型は1つのみ設定可能
- 所属する組織には名称とコードを設定できる

## 単一選択型との違い

- 所属に関する物理テーブルが作られる（sections, user_sections）
- より強い制約を持つ 
  - 所属情報を設定しているユーザーがいると、所属型のユーザ項目を削除できない
  - 組織に所属するユーザがいると当該組織を削除できない

## 機能追加の背景

オプション機能で業務的な機能で利用する想定です。

## 特記事項

- 他のユーザ項目と同様にusers_input_colsのデータを登録するようにしました。
  - 他機能と同様のデータ登録とすることで、既存処理への影響を減らしました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
