### PR TITLE
[アップロードファイル管理] アップロードファイル一覧にサムネイル画像を追加しました

### DIFF
--- a/app/Enums/ImageMimetype.php
+++ b/app/Enums/ImageMimetype.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * MIMEタイプ（画像）
+ */
+final class ImageMimetype extends EnumsBase
+{
+    // 定数メンバ
+    const png = 'image/png';
+    const jpeg = 'image/jpeg';
+    const gif = 'image/gif';
+
+    // key/valueの連想配列
+    const enum = [
+        self::png => 'image/png',
+        self::jpeg => 'image/jpeg',
+        self::gif => 'image/gif',
+    ];
+}

--- a/app/Models/Common/Uploads.php
+++ b/app/Models/Common/Uploads.php
@@ -3,6 +3,7 @@
 namespace App\Models\Common;
 
 use App\Models\Core\Configs;
+use App\Enums\ImageMimetype;
 use Illuminate\Database\Eloquent\Model;
 use Intervention\Image\Facades\Image;
 
@@ -112,16 +113,13 @@ class Uploads extends Model
     }
 
     /**
-     *  画像ファイルか判定
+     * 画像ファイルならtrueを返す
+     *
+     * @return boolean
      */
-    public static function isImage($mimetype)
+    public function getIsImageAttribute() : bool
     {
-        if ($mimetype == 'image/png'  ||
-            $mimetype == 'image/jpeg' ||
-            $mimetype == 'image/gif') {
-            return true;
-        }
-        return false;
+        return in_array($this->mimetype, ImageMimetype::getMemberKeys()) ? true : false;
     }
 
     /**

--- a/app/Models/User/Photoalbums/PhotoalbumContent.php
+++ b/app/Models/User/Photoalbums/PhotoalbumContent.php
@@ -50,11 +50,6 @@ class PhotoalbumContent extends Model
         return $this->hasOne(Uploads::class, 'id', 'poster_upload_id')->withDefault();
     }
 
-    public function isImage($mimetype)
-    {
-        return Uploads::isImage($mimetype);
-    }
-
     public function isVideo($mimetype)
     {
         return Uploads::isVideo($mimetype);
@@ -135,7 +130,7 @@ class PhotoalbumContent extends Model
      */
     public function getCoverFileId()
     {
-        if (Uploads::isImage($this->mimetype)) {
+        if ($this->upload->is_image) {
             return $this->upload_id;
         } else {
             return $this->poster_upload_id;

--- a/resources/views/plugins/manage/uploadfile/index.blade.php
+++ b/resources/views/plugins/manage/uploadfile/index.blade.php
@@ -102,7 +102,15 @@
                 <tr>
                     <td><a href="{{url('/')}}/manage/uploadfile/edit/{{$upload->id}}" id="edit_{{$loop->iteration}}"><i class="far fa-edit"></i></a></td>
                     <td>{{$upload->id}}</td>
-                    <td><a href="{{url('/')}}/file/{{$upload->id}}" target="_blank">{{$upload->client_original_name}}</a></td>
+                    <td>
+                        <a href="{{url('/')}}/file/{{$upload->id}}" target="_blank">
+                            {{$upload->client_original_name}}
+                            @if ($upload->is_image)
+                                {{-- 画像ファイルの場合、サムネイル画像を表示 --}}
+                                <img src="{{url('/')}}/file/{{ $upload->id }}" class="w-10" loading="lazy">
+                            @endif
+                        </a>
+                    </td>
                     <td>{{$upload->getFormatSize()}}</td>
                     <td>{{$upload->created_at}}</td>
                     <td>{{$upload->getPluginNameFull()}}</td>

--- a/resources/views/plugins/user/photoalbums/default/index_image.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_image.blade.php
@@ -11,7 +11,7 @@
     @foreach($photoalbum_contents->where('is_folder', 0) as $photoalbum_content)
     <div class="col-md-4">
         <div class="card mt-3 shadow-sm">
-        @if ($photoalbum_content->isImage($photoalbum_content->mimetype))
+        @if ($photoalbum_content->upload->is_image)
             <img src="{{url('/')}}/file/{{$photoalbum_content->upload_id}}?size=small"
                  id="photo_{{$loop->iteration}}"
                  style="max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"


### PR DESCRIPTION
# 概要
 - ~欲しかったから~ 自web運営でアップロードファイルの削除を行う時にクリックしないと中身がわからず、開く->確認->削除（所望と違ってたら残念な気持ちになる）が煩雑だった為、補助機能としてアップロードファイル一覧にサムネイル画像を追加しました。
![image](https://user-images.githubusercontent.com/13323806/227415200-e2bc3998-bb1b-4e9d-bb11-35aca7793067.png)

 - pdf.jsを使えばフロント側でpdfのサムネイルも表示できそうでしたが、~そっ閉じ~ アセット系ファイルのコンパイル整備が未完の為、別の機会で検討します。
 - 併せて、リファクタリング（メソッドのアクセサ化）を行っています。

# レビュー完了希望日
3/31（金）

# 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms-ideas/issues/143

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
