### PR TITLE
[データベース] DB選択でmysql5.6でエラーに対応（SQLSTATE[42000]: Syntax error or access violation: 1055 'cc_db.frames.bucket_id' isn't in GROUP BY）

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -1872,7 +1872,7 @@ class DatabasesPlugin extends UserPluginBase
                 $plugin_name . '.' . $plugin_name . '_name',
                 'databases_inputs.databases_id'
             )
-            ->orderBy('frames.bucket_id', 'desc')
+            ->orderBy($plugin_name . '.bucket_id', 'desc')
             ->orderBy($plugin_name . '.created_at', 'desc')
             ->paginate(10, ["*"], "frame_{$frame_id}_page");
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り。
mysql5.6はサポート対象外ですが、気になったため修正しました。
mysql5.7では影響ない修正かと思います。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
