### PR TITLE
[データベース]絞り込み項目の登録済み件数を表示する機能を追加しました(beta)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,10 @@ QUEUE_PHP_BIN=
 # Specify the plug-in name that disables the serial number clear function of serial number management. e.g.) PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR="forms"
 PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR=""
 
+# --- Databases Plugin option
+# (BETA) If you want to show registered count about column on search conditions, set it true.
+DATABASES_SHOW_SEARCH_COLUMN_COUNT=false
+
 # --- Connect-CMS Migration option
 
 # migration option (Common)

--- a/app/Models/User/Databases/DatabasesColumnsSelects.php
+++ b/app/Models/User/Databases/DatabasesColumnsSelects.php
@@ -13,4 +13,12 @@ class DatabasesColumnsSelects extends Model
 
     // 更新する項目の定義
     protected $fillable = ['databases_columns_id', 'value', 'display_sequence', 'created_at', 'updated_at'];
+
+    /**
+     * この項目の登録済み件数を設定する
+     */
+    public function setRegisteredCount(int $count)
+    {
+        $this->attributes['registered_count'] = $count;
+    }
 }

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -2,6 +2,7 @@
 
 namespace App\Plugins\User\Databases;
 
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -774,6 +775,12 @@ class DatabasesPlugin extends UserPluginBase
 
             // カラム選択肢の取得
             $columns_selects = DatabasesColumnsSelects::whereIn('databases_columns_id', $columns->pluck('id'))->orderBy('display_sequence', 'asc')->get();
+
+            //  絞り込み項目の登録済み件数を表示する(beta)
+            if (config('connect.DATABASES_SHOW_SEARCH_COLUMN_COUNT')) {
+                $all_databases_inputs = $this->appendAuthWhereBase(DatabasesInputs::where('databases_id', $database->id), 'databases_inputs')->get();
+                $columns_selects = $this->setColumnsSelectsRegisteredCount($columns_selects, $all_databases_inputs);
+            }
 
             // 絞り込み対象カラム
             $select_columns = $columns->where('select_flag', 1)
@@ -4201,5 +4208,36 @@ AND databases_inputs.posted_at <= NOW()
         View::share('columns', $columns);
 
         return $view;
+    }
+
+    /**
+     * DatabasesColumnsSelectsのregistered_countを設定する
+     *
+     * @param Illuminate\Database\Eloquent\Collection $columns_selects 設定対象
+     * @param Illuminate\Database\Eloquent\Collection $all_databases_inputs 対象データベースの全登録データ
+     * @return lluminate\Database\Eloquent\Collection 設定済みのデータ
+     */
+    private function setColumnsSelectsRegisteredCount(EloquentCollection $columns_selects, EloquentCollection $all_databases_inputs): EloquentCollection
+    {
+        $databases_inputs_ids = $all_databases_inputs->pluck('id');
+        $databases_input_cols = DatabasesInputCols::whereIn('databases_inputs_id', $databases_inputs_ids)->get();
+
+        foreach ($columns_selects as $select) {
+            $databases_column = DatabasesColumns::find($select->databases_columns_id);
+            $hit = $databases_input_cols->where('databases_columns_id', $select->databases_columns_id);
+            if ($databases_column->column_type === DatabaseColumnType::checkbox) {
+                // チェックボックスの場合、パイプ区切りで登録されているので部分一致検索
+                $hit = $hit->filter(function ($record) use ($select) {
+                    return strpos($record->value, $select->value) !== false;
+                });
+            } else {
+                $hit = $hit->where('value', $select->value);
+            }
+
+            $hit = $hit->pluck('id')->unique();
+            $select->setRegisteredCount($hit->count());
+        }
+
+        return $columns_selects;
     }
 }

--- a/config/connect.php
+++ b/config/connect.php
@@ -161,4 +161,8 @@ return [
 
     // 連番管理の連番クリア機能を無効化するプラグイン名
     'PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR' => env('PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR', null),
+
+    // データベースプラグイン
+    // 絞り込み項目の登録済み件数を表示する(beta)
+    'DATABASES_SHOW_SEARCH_COLUMN_COUNT' => env('DATABASES_SHOW_SEARCH_COLUMN_COUNT', false),
 ];


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
betaのうちは独自にテンプレートを作成して利用する想定です。

## 機能説明

絞り込み項目に該当する件数を表示する機能です。

## 利用方法

### .envに設定値を追加する

.env.sampleを参考に以下の項目を.envに追加してください。
`DATABASES_SHOW_SEARCH_COLUMN_COUNT=true`

### 独自テンプレートを作成する

default から databases.blade.php と databases_include_ctrl_head.blade.php をコピーして独自テンプレートを作成します。

#### databases.blade.php

databases_include_ctrl_headをincludeする部分をテンプレート名に修正します。

```
    {{-- ヘッダー部分 --}}
    @include('plugins.user.databases.{template-name}.databases_include_ctrl_head')
```

#### databases_include_ctrl_head.blade.php

`$columns_select->registered_count`に件数が設定されています。
任意の形式で出力することが可能です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
