### PR TITLE
[データベース]詳細画面の一覧へボタンで戻ると検索結果が表示されない事象を修正しました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -352,7 +352,7 @@ class DatabasesPlugin extends UserPluginBase
         // $request->flash();
 
         // リクエストにページが渡ってきたら、セッションに保持しておく。（詳細や更新後に元のページに戻るため）
-        $frame_page = "frame_{$frame_id}_page";
+        $frame_page = $this->pageName($frame_id);
         if ($request->has($frame_page)) {
                 $request->session()->put('page_no.'.$frame_id, $request->$frame_page);
         } else {
@@ -1900,7 +1900,7 @@ class DatabasesPlugin extends UserPluginBase
             )
             ->orderBy($plugin_name . '.bucket_id', 'desc')
             ->orderBy($plugin_name . '.created_at', 'desc')
-            ->paginate(10, ["*"], "frame_{$frame_id}_page");
+            ->paginate(10, ["*"], $this->pageName($frame_id));
 
         // 表示テンプレートを呼び出す。
         return $this->view('databases_list_buckets', [

--- a/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
@@ -93,7 +93,7 @@
         @if(Session::has('page_no.'.$frame_id))
         <a href="{{url('/')}}{{$page->getLinkUrl()}}?frame_{{$frame_id}}_page={{Session::get('page_no.'.$frame_id)}}#frame-{{$frame_id}}">
         @else
-        <a href="{{url('/')}}{{$page->getLinkUrl()}}#frame-{{$frame_id}}">
+        <a href="{{url('/')}}{{$page->getLinkUrl()}}?frame_{{$frame_id}}_page=1#frame-{{$frame_id}}">
         @endif
             <span class="btn btn-info"><i class="fas fa-list"></i> <span class="d-none d-sm-inline">{{__('messages.to_list')}}</span></span>
         </a>

--- a/resources/views/plugins/user/databases/default/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_detail.blade.php
@@ -87,7 +87,7 @@
         @if(Session::has('page_no.'.$frame_id))
         <a href="{{url('/')}}{{$page->getLinkUrl()}}?frame_{{$frame_id}}_page={{Session::get('page_no.'.$frame_id)}}#frame-{{$frame_id}}">
         @else
-        <a href="{{url('/')}}{{$page->getLinkUrl()}}#frame-{{$frame_id}}">
+        <a href="{{url('/')}}{{$page->getLinkUrl()}}?frame_{{$frame_id}}_page=1#frame-{{$frame_id}}">
         @endif
             <span class="btn btn-info"><i class="fas fa-list"></i> <span class="d-none d-sm-inline">{{__('messages.to_list')}}</span></span>
         </a>

--- a/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
@@ -90,7 +90,7 @@
         @if(Session::has('page_no.'.$frame_id))
         <a href="{{url('/')}}{{$page->getLinkUrl()}}?frame_{{$frame_id}}_page={{Session::get('page_no.'.$frame_id)}}#frame-{{$frame_id}}">
         @else
-        <a href="{{url('/')}}{{$page->getLinkUrl()}}#frame-{{$frame_id}}">
+        <a href="{{url('/')}}{{$page->getLinkUrl()}}?frame_{{$frame_id}}_page=1#frame-{{$frame_id}}">
         @endif
             <span class="btn btn-info"><i class="fas fa-list"></i> <span class="d-none d-sm-inline">{{__('messages.to_list')}}</span></span>
         </a>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

検索結果1ページ目の詳細で一覧へボタンを押すと、初期表示を隠す判定に引っかかり検索結果が表示されていませんでした。
一覧へボタン押下時のパラメータにページ数=1を渡すように修正しました。
これにより、初期表示を隠す判定にかからなくなります。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
#1632 

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
