### PR TITLE
[データベース]詳細画面でブラウザバックするとフォーム再送信の確認が表示される事象を修正しました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -1001,7 +1001,13 @@ class DatabasesPlugin extends UserPluginBase
                 session(['search_term.'.$frame_id => '']);
             }
         }
-        return $this->index($request, $page_id, $frame_id);
+
+        // 詳細画面のブラウザバックでフォーム再送信の確認を表示させないようにするため、リダイレクトする
+        // リダイレクト後にindex処理を行うようにviewでredirect_pathを指定する
+        if (!$request->has('redirect_path')) {
+            // リダイレクト指定がなければ、当アクションで検索処理を実行する
+            return $this->index($request, $page_id, $frame_id);
+        }
     }
 
     /**

--- a/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
@@ -23,8 +23,10 @@
 {{-- アクセシビリティ対応。検索OFF & 絞り込み項目なし & ソートOFFの時、検索の空フォームを作らないようにする。 --}}
 @if(($database_frame && $database_frame->use_search_flag == 1) || (($select_columns && count($select_columns) >= 1) || $databases_frames->isBasicUseSortFlag()))
 
-<form action="{{url('/')}}/plugin/databases/search/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" role="search" aria-label="{{$database_frame->databases_name}}">
+<form action="{{url('/')}}/redirect/plugin/databases/search/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" role="search" aria-label="{{$database_frame->databases_name}}">
     {{ csrf_field() }}
+    {{-- 詳細画面でブラウザバックをしたときに、フォーム再送信の確認が表示されないようにリダイレクトする --}}
+    <input type="hidden" name="redirect_path" value="{{$page->getLinkUrl()}}?frame_{{$frame_id}}_page=1#frame-{{$frame_id}}">
 
     {{-- 検索 --}}
     @if($database_frame && $database_frame->use_search_flag == 1)


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
検索処理がPOSTでリクエストされるため、ブラウザバックするとフォーム再送信の確認が表示されます。
そこで、GETにリダイレクトすることで、フォーム再送信の確認が表示されないように修正しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
#1634

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
