### PR TITLE
[データベース]ファイル項目のダウンロード件数、ダウンロードボタンを表示できるようにしました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -2706,6 +2706,8 @@ class DatabasesPlugin extends UserPluginBase
         $column->use_select_and_or_flag = (empty($request->use_select_and_or_flag)) ? 0 : $request->use_select_and_or_flag;
         // ダウンロード件数を表示する
         $column->show_download_count = (empty($request->show_download_count)) ? 0 : $request->show_download_count;
+        // ダウンロードボタンを表示する
+        $column->show_download_button = (empty($request->show_download_button)) ? 0 : $request->show_download_button;
         // 行グループ
         $column->row_group = $request->row_group;
         // 列グループ

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -299,7 +299,8 @@ class DatabasesPlugin extends UserPluginBase
                 'databases_columns.databases_id',
                 'databases_columns.title_flag',
                 'databases_columns.body_flag',
-                'uploads.client_original_name'
+                'uploads.client_original_name',
+                'uploads.download_count',
             )
             ->leftJoin('databases_columns', 'databases_columns.id', '=', 'databases_input_cols.databases_columns_id')
             ->leftJoin('uploads', 'uploads.id', '=', 'databases_input_cols.value')
@@ -767,7 +768,7 @@ class DatabasesPlugin extends UserPluginBase
             // Log::debug(var_export(DB::getQueryLog(), true));
 
             // 登録データ詳細の取得
-            $input_cols = DatabasesInputCols::select('databases_input_cols.*', 'uploads.client_original_name')
+            $input_cols = DatabasesInputCols::select('databases_input_cols.*', 'uploads.client_original_name', 'uploads.download_count')
                                             ->leftJoin('uploads', 'uploads.id', '=', 'databases_input_cols.value')
                                             ->whereIn('databases_inputs_id', $inputs->pluck('id'))
                                             ->orderBy('databases_inputs_id', 'asc')->orderBy('databases_columns_id', 'asc')
@@ -2703,6 +2704,8 @@ class DatabasesPlugin extends UserPluginBase
         $column->select_flag = (empty($request->select_flag)) ? 0 : $request->select_flag;
         // 複数選択の絞り込みでAND/ORを表示する
         $column->use_select_and_or_flag = (empty($request->use_select_and_or_flag)) ? 0 : $request->use_select_and_or_flag;
+        // ダウンロード件数を表示する
+        $column->show_download_count = (empty($request->show_download_count)) ? 0 : $request->show_download_count;
         // 行グループ
         $column->row_group = $request->row_group;
         // 列グループ

--- a/database/migrations/2023_04_05_175111_add_show_download_count_to_databases_columns_table.php
+++ b/database/migrations/2023_04_05_175111_add_show_download_count_to_databases_columns_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddShowDownloadCountToDatabasesColumnsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->integer('show_download_count')->default(0)->comment('ダウンロード件数を表示する')->after('use_select_and_or_flag');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->dropColumn('show_download_count');
+        });
+    }
+}

--- a/database/migrations/2023_04_05_175112_add_show_download_button_to_databases_columns_table.php
+++ b/database/migrations/2023_04_05_175112_add_show_download_button_to_databases_columns_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddShowDownloadButtonToDatabasesColumnsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->integer('show_download_button')->default(0)->comment('ダウンロードボタンを表示する')->after('show_download_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->dropColumn('show_download_button');
+        });
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -730,6 +730,23 @@
                 </div>
                 @endif
 
+                {{-- ダウンロードボタンを表示する --}}
+                @if ($column->column_type == DatabaseColumnType::file)
+                <div class="form-group row">
+                    <label class="{{$frame->getSettingLabelClass(true)}}">ダウンロードボタンを表示する</label>
+                    <div class="{{$frame->getSettingInputClass(true)}}">
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="0" id="show_download_button_0" name="show_download_button" class="custom-control-input" @if(old('show_download_button', $column->show_download_button) == 0) checked="checked" @endif>
+                            <label class="custom-control-label" for="show_download_button_0" id="label_show_download_button_0">表示しない</label>
+                        </div>
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="1" id="show_download_button_1" name="show_download_button" class="custom-control-input" @if(old('show_download_button', $column->show_download_button) == 1) checked="checked" @endif>
+                            <label class="custom-control-label" for="show_download_button_1" id="label_show_download_button_1">表示する</label>
+                        </div>
+                    </div>
+                </div>
+                @endif
+
                 {{-- グループ --}}
                 <div class="form-group row" id="div_group">
                     <label class="{{$frame->getSettingLabelClass(true)}} pt-0">グループ</label>

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -713,6 +713,23 @@
                 </div>
                 @endif
 
+                {{-- ダウンロード件数を表示する --}}
+                @if ($column->column_type == DatabaseColumnType::file)
+                <div class="form-group row">
+                    <label class="{{$frame->getSettingLabelClass(true)}}">ダウンロード件数を表示する</label>
+                    <div class="{{$frame->getSettingInputClass(true)}}">
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="0" id="show_download_count_0" name="show_download_count" class="custom-control-input" @if(old('show_download_count', $column->show_download_count) == 0) checked="checked" @endif>
+                            <label class="custom-control-label" for="show_download_count_0" id="label_show_download_count_0">表示しない</label>
+                        </div>
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="1" id="show_download_count_1" name="show_download_count" class="custom-control-input" @if(old('show_download_count', $column->show_download_count) == 1) checked="checked" @endif>
+                            <label class="custom-control-label" for="show_download_count_1" id="label_show_download_count_1">表示する</label>
+                        </div>
+                    </div>
+                </div>
+                @endif
+
                 {{-- グループ --}}
                 <div class="form-group row" id="div_group">
                     <label class="{{$frame->getSettingLabelClass(true)}} pt-0">グループ</label>

--- a/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
@@ -16,6 +16,14 @@
         }
         else {
             $value = '<a href="' . url('/') . '/file/' . $obj->value . '" target="_blank">' . $obj->client_original_name . '</a>';
+
+            // ダウンロード件数
+            if ($column->show_download_button) {
+                $value .= '<button class="ml-4 btn btn-sm btn-primary databases-file-download-button" onclick="window.open(\''. url('/') . '/file/' . $obj->value . '\', \'_blank\')">';
+                $value .= '<i class="fas fa-download"></i><span class="d-none d-sm-inline"> ダウンロード</span>';
+                $value .= '</button>';
+            }
+
         }
     }
     // 画像型

--- a/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
@@ -24,6 +24,11 @@
                 $value .= '</button>';
             }
 
+            // ダウンロード件数
+            if ($column->show_download_count) {
+                $value .= '<span class="ml-4 databases-file-download-count-label">ダウンロード数：</span>';
+                $value .= '<span class="databases-file-download-count">'. $obj->download_count . '</span>';
+            }
         }
     }
     // 画像型

--- a/resources/views/plugins/user/databases/default/databases_include_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_value.blade.php
@@ -26,6 +26,11 @@
                 $value .= '</button>';
             }
 
+            // ダウンロード件数
+            if ($column->show_download_count) {
+                $value .= '<span class="ml-4 databases-file-download-count-label">ダウンロード数：</span>';
+                $value .= '<span class="databases-file-download-count">'. $obj->download_count . '</span>';
+            }
         }
     }
     // 画像型

--- a/resources/views/plugins/user/databases/default/databases_include_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_value.blade.php
@@ -18,6 +18,14 @@
         }
         else {
             $value = '<a href="' . url('/') . '/file/' . $obj->value . '" target="_blank">' . $obj->client_original_name . '</a>';
+
+            // ダウンロード件数
+            if ($column->show_download_button) {
+                $value .= '<button class="ml-4 btn btn-sm btn-primary databases-file-download-button" onclick="window.open(\''. url('/') . '/file/' . $obj->value . '\', \'_blank\')">';
+                $value .= '<i class="fas fa-download"></i><span class="d-none d-sm-inline"> ダウンロード</span>';
+                $value .= '</button>';
+            }
+
         }
     }
     // 画像型


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
ファイル項目にダウンロードボタンとダウンロード件数を表示できるようにしました。
項目設定より表示要否を選択できます。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
