### PR TITLE
[データベース]データにカテゴリを設定する機能を追加しました

### DIFF
--- a/app/Models/User/Databases/DatabasesInputs.php
+++ b/app/Models/User/Databases/DatabasesInputs.php
@@ -22,6 +22,7 @@ class DatabasesInputs extends Model
         'posted_at',
         'expires_at',
         'first_committed_at',
+        'categories_id',
         'created_at',
         'updated_at'
     ];

--- a/database/migrations/2023_04_13_115632_add_categories_id_to_databases_inputs_table.php
+++ b/database/migrations/2023_04_13_115632_add_categories_id_to_databases_inputs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCategoriesIdToDatabasesInputsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->integer('categories_id')->nullable()->comment('カテゴリID')->after('first_committed_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->dropColumn('categories_id');
+        });
+    }
+}

--- a/resources/views/plugins/user/databases/databases_frame_edit_tab.blade.php
+++ b/resources/views/plugins/user/databases/databases_frame_edit_tab.blade.php
@@ -79,3 +79,12 @@
         <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/editBucketsMails/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">メール設定</a>
     </li>
 @endif
+@if ($action == 'listCategories')
+    <li role="presentation" class="nav-item">
+        <span class="nav-link"><span class="active">カテゴリ</span></span>
+    </li>
+@else
+    <li role="presentation" class="nav-item">
+        <a href="{{url('/')}}/plugin/{{$frame->plugin_name}}/listCategories/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">カテゴリ</a>
+    </li>
+@endif

--- a/resources/views/plugins/user/databases/default/databases_confirm.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_confirm.blade.php
@@ -198,6 +198,17 @@
         </div>
     @endif
 
+    <div class="form-group row">
+        <label class="col-sm-3 control-label text-nowrap">カテゴリ</label>
+        <div class="col-sm-9">
+            @php
+                $category_name = $databases_categories->where('id', $request->categories_id)->first()->category;
+            @endphp
+            {{$category_name}}
+            <input name="categories_id" class="form-control" type="hidden" value="{{$request->categories_id}}">
+        </div>
+    </div>
+
     {{-- ボタンエリア --}}
     <div class="form-group text-center">
         <button type="button" class="btn btn-secondary mr-2" onclick="submit_databases_cancel();"><i class="fas fa-chevron-left"></i> 前へ</button>

--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -114,6 +114,7 @@
                     @endforeach
                 </select>
                 @include('plugins.common.errors_inline', ['name' => 'categories_id'])
+                <small class="text-muted">※ カテゴリは新着情報に表示されます。</small>
             </div>
         </div>
 

--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -104,6 +104,19 @@
             </div>
         @endif
 
+        <div class="form-group row">
+            <label class="col-sm-3 control-label">カテゴリ</label>
+            <div class="col-sm-9">
+                <select class="form-control" name="categories_id" class="form-control @if ($errors && $errors->has('category')) border-danger @endif">
+                    <option value=""></option>
+                    @foreach($databases_categories as $category)
+                    <option value="{{$category->id}}" @if(old('category', $inputs->categories_id)==$category->id) selected="selected" @endif>{{$category->category}}</option>
+                    @endforeach
+                </select>
+                @include('plugins.common.errors_inline', ['name' => 'categories_id'])
+            </div>
+        </div>
+
         {{-- ボタンエリア --}}
         <div class="form-group text-center">
             <div class="row">

--- a/resources/views/plugins/user/databases/default/databases_list_categories.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_list_categories.blade.php
@@ -1,0 +1,28 @@
+{{--
+ * カテゴリテンプレート
+ *
+ * @author 石垣　佑樹 <ishigaki@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category データベースプラグイン
+--}}
+@extends('core.cms_frame_base_setting')
+
+@section("core.cms_frame_edit_tab_$frame->id")
+    {{-- プラグイン側のフレームメニュー --}}
+    @include('plugins.user.databases.databases_frame_edit_tab')
+@endsection
+
+@section("plugin_setting_$frame->id")
+
+{{-- ワーニングメッセージ --}}
+@if (empty($database_frame) || empty($database_frame->databases_id))
+    <div class="alert alert-warning">
+        <i class="fas fa-exclamation-circle"></i> 設定画面から、使用するデータベースを選択するか、作成してください。
+    </div>
+@else
+
+    {{-- カテゴリ設定画面 --}}
+    @include('plugins.common.user_list_category')
+
+@endif
+@endsection


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
データベースの1データにカテゴリを設定できるようにしました。

## 用途

データベースプラグインのテンプレートでカテゴリを表示するところはありません。
用途として以下を想定しています。

- 新着情報プラグインでカテゴリを表示する
- サイト内検索でカテゴリ名を入力したときにヒットする（今後対応予定）

## 設定方法

1.  データベースメニューのカテゴリからカテゴリを追加する
2. データの登録画面、編集画面からカテゴリを選択し、登録する


カテゴリ設定画面
<img width="688" alt="image" src="https://user-images.githubusercontent.com/32890286/231915590-4c530635-671b-4816-a978-718033d74f1f.png">

編集画面
<img width="695" alt="image" src="https://user-images.githubusercontent.com/32890286/231915378-53e3069f-b88b-4385-9a0c-df192aeb5aa1.png">

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
ASAP

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
