### PR TITLE
[データベース]ファイルのダウンロード件数で並べ替えをする機能を追加しました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -433,14 +433,17 @@ class DatabasesPlugin extends UserPluginBase
             // ソート(セッションがあれば優先。なければ初期値を使用)
             $sort_column_id = '';
             $sort_column_order = '';
+            $sort_column_option = '';
             if (session('sort_column_id.'.$frame_id) && session('sort_column_order.'.$frame_id)) {
                 $sort_column_id = session('sort_column_id.'.$frame_id);
                 $sort_column_order = session('sort_column_order.'.$frame_id);
+                $sort_column_option = session('sort_column_option.'.$frame_id);
             } elseif ($databases_frames && $databases_frames->default_sort_flag) {
                 $sort_flag = explode('_', $databases_frames->default_sort_flag);
-                if (count($sort_flag) == 2) {
+                if (count($sort_flag) >= 2) {
                     $sort_column_id = $sort_flag[0];
                     $sort_column_order = $sort_flag[1];
+                    $sort_column_option = $sort_flag[2] ?? '';
                 }
             }
 
@@ -458,6 +461,10 @@ class DatabasesPlugin extends UserPluginBase
                                                          ->where('databases_input_cols.databases_columns_id', '=', $sort_column_id);
                                                 })
                                                ->where('databases_id', $database->id);
+                // ダウンロード件数でのソート
+                if ($sort_column_option === 'downloadcount') {
+                    $inputs_query = $inputs_query->leftjoin('uploads', 'databases_input_cols.value', 'uploads.id');
+                }
             }
 
             // 権限によって表示する記事を絞る
@@ -725,9 +732,17 @@ class DatabasesPlugin extends UserPluginBase
             } elseif ($sort_column_id == DatabaseSortFlag::posted && $sort_column_order == DatabaseSortFlag::order_desc) {
                 $inputs_query->orderBy('databases_inputs.posted_at', 'desc');
             } elseif ($sort_column_id && ctype_digit($sort_column_id) && $sort_column_order == DatabaseSortFlag::order_asc) {
-                $inputs_query->orderBy('databases_input_cols.value', 'asc');
+                if ($sort_column_option === 'downloadcount') {
+                    $inputs_query->orderBy('uploads.download_count', 'asc');
+                } else {
+                    $inputs_query->orderBy('databases_input_cols.value', 'asc');
+                }
             } elseif ($sort_column_id && ctype_digit($sort_column_id) && $sort_column_order == DatabaseSortFlag::order_desc) {
-                $inputs_query->orderBy('databases_input_cols.value', 'desc');
+                if ($sort_column_option === 'downloadcount') {
+                    $inputs_query->orderBy('uploads.download_count', 'desc');
+                } else {
+                    $inputs_query->orderBy('databases_input_cols.value', 'desc');
+                }
             }
             $inputs_query->orderBy('databases_inputs.id', 'asc');
 
@@ -983,12 +998,15 @@ class DatabasesPlugin extends UserPluginBase
             if (count($sort_column_parts) == 1) {
                 session(['sort_column_id.'.$frame_id    => $sort_column_parts[0]]);
                 session(['sort_column_order.'.$frame_id => '']);
-            } elseif (count($sort_column_parts) == 2) {
+                session(['sort_column_option.'.$frame_id => '']);
+            } elseif (count($sort_column_parts) >= 2) {
                 session(['sort_column_id.'.$frame_id    => $sort_column_parts[0]]);
                 session(['sort_column_order.'.$frame_id => $sort_column_parts[1]]);
+                session(['sort_column_option.'.$frame_id => $sort_column_parts[2] ?? '']);
             } else {
                 session(['sort_column_id.'.$frame_id    => '']);
                 session(['sort_column_order.'.$frame_id => '']);
+                session(['sort_column_option.'.$frame_id => '']);
             }
             // var_dump($sort_column_parts);
 
@@ -2714,6 +2732,8 @@ class DatabasesPlugin extends UserPluginBase
         $column->show_download_count = (empty($request->show_download_count)) ? 0 : $request->show_download_count;
         // ダウンロードボタンを表示する
         $column->show_download_button = (empty($request->show_download_button)) ? 0 : $request->show_download_button;
+        // ダウンロード件数で並び替え
+        $column->sort_download_count = (empty($request->sort_download_count)) ? 0 : $request->sort_download_count;
         // 行グループ
         $column->row_group = $request->row_group;
         // 列グループ

--- a/database/migrations/2023_04_17_154545_add_sort_download_count_to_databases_columns_table.php
+++ b/database/migrations/2023_04_17_154545_add_sort_download_count_to_databases_columns_table.php
@@ -14,7 +14,7 @@ class AddSortDownloadCountToDatabasesColumnsTable extends Migration
     public function up()
     {
         Schema::table('databases_columns', function (Blueprint $table) {
-            $table->integer('sort_download_count')->default(0)->comment('ダウンロード件数で並び替え')->after('show_download_count');
+            $table->integer('sort_download_count')->default(0)->comment('ダウンロード件数で並び替え')->after('show_download_button');
         });
     }
 

--- a/database/migrations/2023_04_17_154545_add_sort_download_count_to_databases_columns_table.php
+++ b/database/migrations/2023_04_17_154545_add_sort_download_count_to_databases_columns_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSortDownloadCountToDatabasesColumnsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->integer('sort_download_count')->default(0)->comment('ダウンロード件数で並び替え')->after('show_download_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->dropColumn('sort_download_count');
+        });
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -664,6 +664,23 @@
                     </div>
                 </div>
 
+                {{-- ダウンロード件数でのソートを行う --}}
+                @if ($column->column_type == DatabaseColumnType::file)
+                <div class="form-group row">
+                    <label class="{{$frame->getSettingLabelClass(true)}}">ダウンロード件数で並べ替え</label>
+                    <div class="{{$frame->getSettingInputClass(true)}}">
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="0" id="sort_download_count_0" name="sort_download_count" class="custom-control-input" @if(old('sort_download_count', $column->sort_download_count) == 0) checked="checked" @endif>
+                            <label class="custom-control-label" for="sort_download_count_0">使用しない</label>
+                        </div>
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="1" id="sort_download_count_1" name="sort_download_count" class="custom-control-input" @if(old('sort_download_count', $column->sort_download_count) == 1) checked="checked" @endif>
+                            <label class="custom-control-label" for="sort_download_count_1">使用する</label>
+                        </div>
+                    </div>
+                </div>
+                @endif
+
                 {{-- 検索対象指定 --}}
                 <div class="form-group row">
                     <label class="{{$frame->getSettingLabelClass(true)}}">検索対象指定</label>

--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -154,12 +154,17 @@
                 {{-- 1:昇順＆降順、2:昇順のみ、3:降順のみ --}}
                 @foreach($columns->whereIn('sort_flag', [1, 2, 3]) as $sort_column)
 
+                    @php
+                        $sort_option = $sort_column->sort_download_count ? '_downloadcount' : null;
+                        $sort_option_name = $sort_column->sort_download_count ? 'ダウンロード数' : null;
+                    @endphp
+
                     @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 2)
-                        <option value="{{$sort_column->id}}_asc" @if(($sort_column->id . '_asc') == $default_sort_flag) selected @endif>{{$sort_column->column_name}}(昇順)</option>
+                        <option value="{{$sort_column->id}}_asc{{$sort_option}}" @if(($sort_column->id . '_asc' . $sort_option) == $default_sort_flag) selected @endif>{{$sort_column->column_name}}{{$sort_option_name}}(昇順)</option>
                     @endif
 
                     @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 3)
-                        <option value="{{$sort_column->id}}_desc" @if(($sort_column->id . '_desc') == $default_sort_flag) selected @endif>{{$sort_column->column_name}}(降順)</option>
+                        <option value="{{$sort_column->id}}_desc{{$sort_option}}" @if(($sort_column->id . '_desc' . $sort_option) == $default_sort_flag) selected @endif>{{$sort_column->column_name}}{{$sort_option_name}}(降順)</option>
                     @endif
                 @endforeach
             </optgroup>

--- a/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
@@ -131,17 +131,20 @@
             @php
                 $sort_column_id = '';
                 $sort_column_order = '';
+                $sort_column_option = '';
 
                 // 並べ替え項目をセッション優先、次に初期値で変数に整理（選択肢のselected のため）
                 if (Session::get('sort_column_id.'.$frame_id) && Session::get('sort_column_order.'.$frame_id)) {
                     $sort_column_id = Session::get('sort_column_id.'.$frame_id);
                     $sort_column_order = Session::get('sort_column_order.'.$frame_id);
+                    $sort_column_option = Session::get('sort_column_option.'.$frame_id);
                 }
                 else if ($databases_frames && $databases_frames->default_sort_flag) {
                     $default_sort_flag_part = explode('_', $databases_frames->default_sort_flag);
-                    if (count($default_sort_flag_part) == 2) {
+                    if (count($default_sort_flag_part) >= 2) {
                         $sort_column_id = $default_sort_flag_part[0];
                         $sort_column_order = $default_sort_flag_part[1];
+                        $sort_column_option = $default_sort_flag_part[2] ?? '';
                     }
                 }
             @endphp
@@ -163,12 +166,17 @@
                         {{-- 1:昇順＆降順、2:昇順のみ、3:降順のみ --}}
                         @foreach($sort_columns as $sort_column)
 
+                            @php
+                                $sort_option = $sort_column->sort_download_count ? '_downloadcount' : null;
+                                $sort_option_name = $sort_column->sort_download_count ? 'ダウンロード数' : null;
+                            @endphp
+
                             @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 2)
-                                <option value="{{$sort_column->id}}_asc" @if($sort_column->id == $sort_column_id && $sort_column_order == 'asc') selected @endif>{{  $sort_column->column_name  }}(昇順)</option>
+                                <option value="{{$sort_column->id}}_asc{{$sort_option}}" @if($sort_column->id == $sort_column_id && $sort_column_order == 'asc') selected @endif>{{  $sort_column->column_name  }}{{ $sort_option_name }}(昇順)</option>
                             @endif
 
                             @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 3)
-                                <option value="{{$sort_column->id}}_desc" @if($sort_column->id == $sort_column_id && $sort_column_order == 'desc') selected @endif>{{  $sort_column->column_name  }}(降順)</option>
+                                <option value="{{$sort_column->id}}_desc{{$sort_option}}" @if($sort_column->id == $sort_column_id && $sort_column_order == 'desc') selected @endif>{{  $sort_column->column_name  }}{{ $sort_option_name }}(降順)</option>
                             @endif
 
                         @endforeach


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
データベースでファイル型の項目に関して、ファイルのダウンロード件数で並べ替えをする機能です。

## 設定方法

### ユーザーが選択して並べ替えをする

- [項目設定] 並べ替え指定 > 昇順＆降順、昇順のみ、降順のみ のいずれかにチェック
- [項目設定] ダウンロード件数で並べ替え > 使用するにチェック
- [表示設定] 並べ替え項目の表示 > 各カラム設定にチェック

### 初期表示での並び順を指定する

- [項目設定] 並べ替え指定 > 昇順＆降順、昇順のみ、降順のみ のいずれかにチェック
- [項目設定] ダウンロード件数で並べ替え > 使用するにチェック
- [表示設定] 初期表示での並び順 > ｛項目名｝ダウンロード数（昇順）、｛項目名｝ダウンロード数（降順）を選択する


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
