### PR TITLE
[データベース]カテゴリ未選択時に確認画面でエラーになる問題を修正しました

### DIFF
--- a/resources/views/plugins/user/databases/default/databases_confirm.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_confirm.blade.php
@@ -202,7 +202,8 @@
         <label class="col-sm-3 control-label text-nowrap">カテゴリ</label>
         <div class="col-sm-9">
             @php
-                $category_name = $databases_categories->where('id', $request->categories_id)->first()->category;
+                $category = $databases_categories->where('id', $request->categories_id)->first();
+                $category_name = $category ? $category->category : null;
             @endphp
             {{$category_name}}
             <input name="categories_id" class="form-control" type="hidden" value="{{$request->categories_id}}">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
#1639 の修正です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
