### PR TITLE
[データベース]詳細内容が表示されない問題を修正しました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -450,7 +450,7 @@ class DatabasesPlugin extends UserPluginBase
 
             // ソートなし or ソートするカラムIDが数値じゃない（=入力なしと同じ扱いにする）
             if (empty($sort_column_id) || !ctype_digit($sort_column_id)) {
-                $inputs_query = DatabasesInputs::where('databases_id', $database->id);
+                $inputs_query = DatabasesInputs::select('databases_inputs.*')->where('databases_id', $database->id);
             } else {
                 // ソートあり
                 $inputs_query = DatabasesInputs::select('databases_inputs.*', 'databases_input_cols.value')


### PR DESCRIPTION

# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
#1639 の修正です。
categoriesを結合した結果、databases_inputsが取得されていなくなっていました。
並べ替えを設定していると問題なく表示されていました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
