### PR TITLE
[データベース] 複数単語で検索した場合の結果表示が遅い問題に対応

### DIFF
--- a/app/Plugins/User/Databases/DatabasesTool.php
+++ b/app/Plugins/User/Databases/DatabasesTool.php
@@ -268,20 +268,22 @@ class DatabasesTool
          */
         $search_keywords = explode(' ', mb_convert_kana($search_keyword, 's'));
 
-        // キーワードAND検索
-        foreach ($search_keywords as $search_keyword) {
-            $inputs_query->whereIn($where_in_colum_name, function ($query) use ($search_keyword, $databases_columns_ids, $hide_columns_ids) {
-                // 縦持ちのvalue を検索して、行の id を取得。search_flag で対象のカラムを絞る。
-                $query->select('databases_inputs_id')
-                        ->from('databases_input_cols')
-                        ->join('databases_columns', 'databases_columns.id', '=', 'databases_input_cols.databases_columns_id')
-                        ->where('databases_columns.search_flag', 1)
-                        ->whereIn('databases_columns.id', $databases_columns_ids)
-                        ->whereNotIn('databases_columns.id', $hide_columns_ids)
-                        ->where('value', 'like', '%' . $search_keyword . '%')
-                        ->groupBy('databases_inputs_id');
-            });
-        }
+        $inputs_query->whereIn($where_in_colum_name, function ($query) use ($search_keywords, $databases_columns_ids, $hide_columns_ids) {
+            // 縦持ちのvalue を検索して、行の id を取得。search_flag で対象のカラムを絞る。
+            $query->select('databases_inputs_id')
+                    ->from('databases_input_cols')
+                    ->join('databases_columns', 'databases_columns.id', '=', 'databases_input_cols.databases_columns_id')
+                    ->where('databases_columns.search_flag', 1)
+                    ->whereIn('databases_columns.id', $databases_columns_ids)
+                    ->whereNotIn('databases_columns.id', $hide_columns_ids);
+
+            // キーワードAND検索
+            foreach ($search_keywords as $search_keyword) {
+                $query->where('value', 'like', '%' . $search_keyword . '%');
+            }
+
+            $query->groupBy('databases_inputs_id');
+        });
         return $inputs_query;
     }
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

複数単語のAND検索の仕方を見直しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
