### PR TITLE
[フォーム]登録データを掲示板、FAQ、ブログへ連携する機能を追加しました

### DIFF
--- a/app/Enums/FormsRegisterTargetPlugin.php
+++ b/app/Enums/FormsRegisterTargetPlugin.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * 検索対象プラグイン
+ */
+final class FormsRegisterTargetPlugin extends EnumsBase
+{
+    // 定数メンバ
+    const blogs = 'blogs';
+    const bbses = 'bbses';
+    const faq = 'faqs';
+
+    // key/valueの連想配列
+    const enum = [
+        self::blogs => 'ブログ',
+        self::bbses => '掲示板',
+        self::faq => 'FAQ',
+    ];
+
+    /**
+     * フレーム指定できるプラグイン取得
+     */
+    public static function getPluginsCanSpecifiedFrames()
+    {
+        $enum = static::enum;
+
+        return $enum;
+    }
+
+    /**
+     * フレーム指定できるプラグインキー取得
+     */
+    public static function getKeysPluginsCanSpecifiedFrames()
+    {
+        return array_keys(self::getPluginsCanSpecifiedFrames());
+    }
+}

--- a/app/Models/User/Faqs/FaqsPosts.php
+++ b/app/Models/User/Faqs/FaqsPosts.php
@@ -19,7 +19,7 @@ class FaqsPosts extends Model
     protected $dates = ['posted_at'];
 
     // 更新する項目の定義
-    protected $fillable = ['contents_id', 'faqs_id', 'post_title', 'post_text', 'categories_id', 'posted_at', 'display_sequence'];
+    protected $fillable = ['contents_id', 'faqs_id', 'post_title', 'post_text', 'categories_id', 'posted_at', 'display_sequence', 'status'];
 
     /**
      *  リスト表示用タイトル

--- a/app/Models/User/Forms/Forms.php
+++ b/app/Models/User/Forms/Forms.php
@@ -43,4 +43,16 @@ class Forms extends Model
         'numbering_use_flag',
         'numbering_prefix'
     ];
+
+    /**
+     *  指定したFrame が表示対象か判定
+     *
+     */
+    public function isTargetFrame($frame_id)
+    {
+        if (in_array($frame_id, explode(',', $this->target_frame_ids))) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -2714,7 +2714,7 @@ ORDER BY forms_inputs_id, forms_columns_id
         }
 
         // 登録処理
-        foreach ($this->fetchTargetFrames(explode(',' , $form->target_frame_ids)) as $frame) {
+        foreach ($this->fetchTargetFrames(explode(',', $form->target_frame_ids)) as $frame) {
             // バケツ未指定は連携できない
             if (!$frame->bucket_id) {
                 Log::debug('bucket_id is null.');
@@ -2735,7 +2735,6 @@ ORDER BY forms_inputs_id, forms_columns_id
                     break;
             }
         }
-
     }
 
     /**

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -2764,6 +2764,7 @@ ORDER BY forms_inputs_id, forms_columns_id
             ->leftJoin('forms_input_cols', 'forms_inputs.id', '=', 'forms_input_cols.forms_inputs_id')
             ->leftJoin('forms_columns', 'forms_input_cols.forms_columns_id', '=', 'forms_columns.id')
             ->where('forms_inputs.id', $form_inputs_id)
+            ->orderBy('display_sequence')
             ->get();
 
 

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -2735,6 +2735,8 @@ ORDER BY forms_inputs_id, forms_columns_id
                     break;
             }
         }
+
+        $request->flash_message = '登録内容を他プラグインへ連携しました。連携した情報は連携先で一時保存状態になっています。登録内容を確認して公開してください。';
     }
 
     /**

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -39,9 +39,17 @@ use App\Enums\Bs4TextColor;
 use App\Enums\CsvCharacterCode;
 use App\Enums\FormColumnType;
 use App\Enums\FormMode;
+use App\Enums\FormsRegisterTargetPlugin;
 use App\Enums\FormStatusType;
 use App\Enums\PluginName;
 use App\Enums\Required;
+use App\Enums\StatusType;
+use App\Models\User\Bbses\Bbs;
+use App\Models\User\Bbses\BbsPost;
+use App\Models\User\Blogs\Blogs;
+use App\Models\User\Blogs\BlogsPosts;
+use App\Models\User\Faqs\Faqs;
+use App\Models\User\Faqs\FaqsPosts;
 
 /**
  * フォーム・プラグイン
@@ -99,6 +107,7 @@ class FormsPlugin extends UserPluginBase
             'storeInput',
             'copyForm',
             'downloadCsvAggregate',
+            'registerOtherPlugins',
         ];
         return $functions;
     }
@@ -121,6 +130,7 @@ class FormsPlugin extends UserPluginBase
         $role_check_table["copyForm"]             = ['buckets.create'];
         $role_check_table["aggregate"]            = ['role_article'];
         $role_check_table["downloadCsvAggregate"] = ['role_article'];
+        $role_check_table["registerOtherPlugins"] = ['role_article'];
         return $role_check_table;
     }
 
@@ -1529,11 +1539,15 @@ class FormsPlugin extends UserPluginBase
         $form->tmp_entry_count = $tmp_entry_count;
         $form->active_entry_count = $active_entry_count;
 
+        // 選択できるフレームの一覧
+        $target_plugins_frames = $this->getTargetPluginsFrames();
+
         // 表示テンプレートを呼び出す。
         return $this->view('forms_edit_form', [
             'form_frame'  => $form_frame,
             'form'        => $form,
             'create_flag' => $create_flag,
+            'target_plugins_frames' => $target_plugins_frames,
             'message'     => $message,
             'errors'      => $errors,
         ])->withInput($request->all);
@@ -1691,6 +1705,8 @@ class FormsPlugin extends UserPluginBase
         $forms->after_message       = $this->clean($request->after_message);
         $forms->numbering_use_flag  = empty($request->numbering_use_flag) ? 0 : $request->numbering_use_flag;
         $forms->numbering_prefix    = $request->numbering_prefix;
+        $forms->other_plugins_register_use_flag  = empty($request->other_plugins_register_use_flag) ? 0 : $request->other_plugins_register_use_flag;
+        $forms->target_frame_ids = empty($request->target_frame_ids) ? "": implode(',', $request->target_frame_ids);
 
         // データ保存
         $forms->save();
@@ -2674,6 +2690,212 @@ ORDER BY forms_inputs_id, forms_columns_id
                 $copy_form_column_select->save();
             }
         }
+    }
+
+    /**
+     * 他プラグイン連携機能
+     */
+    public function registerOtherPlugins($request, $page_id, $frame_id, $form_inputs_id)
+    {
+        // 有効のステータスのみ連携可能
+        $form_input = FormsInputs::where('id', $form_inputs_id)->where('status', FormStatusType::active)->first();
+
+        // パラメータ不正
+        if (!isset($form_input)) {
+            Log::debug('form_inputs_id is not found or not active.');
+            return;
+        }
+
+        $form = Forms::find($form_input->forms_id);
+        // 他プラグイン連携未設定はどうしようもない
+        if ($form->other_plugins_register_use_flag == 0 || empty($form->target_frame_ids)) {
+            Log::debug($form->target_frame_ids);
+            return;
+        }
+
+        // 登録処理
+        foreach ($this->fetchTargetFrames(explode(',' , $form->target_frame_ids)) as $frame) {
+            // バケツ未指定は連携できない
+            if (!$frame->bucket_id) {
+                Log::debug('bucket_id is null.');
+                continue;
+            }
+
+            switch ($frame->plugin_name) {
+                case PluginName::getPluginName(PluginName::bbses):
+                    $this->toBbs($frame->bucket_id, $this->fetchFormInputValues($form_inputs_id), $form);
+                    break;
+                case PluginName::getPluginName(PluginName::blogs):
+                    $this->toBlog($frame->bucket_id, $this->fetchFormInputValues($form_inputs_id), $form);
+                    break;
+                case PluginName::getPluginName(PluginName::faqs):
+                    $this->toFaq($frame->bucket_id, $this->fetchFormInputValues($form_inputs_id), $form);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+    }
+
+    /**
+     * 他プラグイン連携対象のフレームを取得する
+     *
+     * @param array $target_frame_ids
+     * @return Collection
+     */
+    private function fetchTargetFrames(array $target_frame_ids): Collection
+    {
+        return Frame::select('plugin_name', 'bucket_id')
+            ->whereIn('id', $target_frame_ids)
+            ->whereIn('plugin_name', FormsRegisterTargetPlugin::getKeysPluginsCanSpecifiedFrames())
+            ->groupBy('plugin_name', 'bucket_id')
+            ->get();
+    }
+
+    /**
+     * 本文用にフォーム登録データを取得する
+     *
+     * @param array $target_frame_ids
+     * @return Collection
+     */
+    private function fetchFormInputValues(int $form_inputs_id): Collection
+    {
+        $input_values = FormsInputs::select('forms_columns.column_name', 'forms_input_cols.value')
+            ->leftJoin('forms_input_cols', 'forms_inputs.id', '=', 'forms_input_cols.forms_inputs_id')
+            ->leftJoin('forms_columns', 'forms_input_cols.forms_columns_id', '=', 'forms_columns.id')
+            ->where('forms_inputs.id', $form_inputs_id)
+            ->get();
+
+
+        return $input_values;
+    }
+
+    /**
+     * フォーム登録データを掲示板に登録する
+     *
+     * @param int $bucket_id 登録先のバケツID
+     * @param Collection $input_values フォーム登録データ
+     * @param Forms $form
+     */
+    private function toBbs(int $bucket_id, Collection $input_values, Forms $form)
+    {
+        $bbs_id = Bbs::where('bucket_id', $bucket_id)->first()->id;
+
+        $post = BbsPost::create([
+            'bbs_id' => $bbs_id,
+            'title' => $this->getTitle($form->forms_name),
+            'body' => $this->getBody($input_values),
+            'status' => StatusType::temporary,
+            'thread_updated_at' => date('Y-m-d H:i:s'),
+            'created_id' => Auth::user()->id,
+        ]);
+        $post->thread_root_id = $post->id;
+        $post->save();
+    }
+
+    /**
+     * フォーム登録データをブログに登録する
+     *
+     * @param int $bucket_id 登録先のバケツID
+     * @param Collection $input_values フォーム登録データ
+     * @param Forms $form
+     */
+    private function toBlog(int $bucket_id, Collection $input_values, Forms $form)
+    {
+        $blogs_id = Blogs::where('bucket_id', $bucket_id)->first()->id;
+
+        $post = BlogsPosts::create([
+            'blogs_id' => $blogs_id,
+            'post_title' => $this->getTitle($form->forms_name),
+            'posted_at' => date('Y-m-d H:i:s'),
+            'post_text' => $this->getBody($input_values),
+            'read_more_flag' => 0,
+            'status' => StatusType::temporary,
+            'created_id' => Auth::user()->id,
+        ]);
+
+        $post->contents_id = $post->id;
+        $post->save();
+    }
+
+    /**
+     * フォーム登録データをFAQに登録する
+     *
+     * @param int $bucket_id 登録先のバケツID
+     * @param Collection $input_values フォーム登録データ
+     * @param Forms $form
+     */
+    private function toFaq(int $bucket_id, Collection $input_values, Forms $form)
+    {
+        $faqs_id = Faqs::where('bucket_id', $bucket_id)->first()->id;
+
+        $max_display_sequence = FaqsPosts::where('faqs_id', $faqs_id)->max('display_sequence');
+        $display_sequence = empty($max_display_sequence) ? 1 : $max_display_sequence + 1;
+
+        $post = FaqsPosts::create([
+            'faqs_id' => $faqs_id,
+            'post_title' => $this->getTitle($form->forms_name),
+            'posted_at' => date('Y-m-d H:i:s'),
+            'post_text' => $this->getBody($input_values),
+            'display_sequence' => $display_sequence,
+            'status' => StatusType::temporary,
+            'created_id' => Auth::user()->id,
+        ]);
+
+        $post->contents_id = $post->id;
+        $post->save();
+    }
+
+    /**
+     * 他プラグイン連携時の件名を取得する
+     *
+     * @param string $form_name
+     * @return string
+     */
+    private function getTitle(string $form_name): string
+    {
+        return "フォーム「{$form_name}」から連携";
+    }
+
+    /**
+     * 他プラグイン連携時の本文を取得する
+     *
+     * @param Collection $input_values フォーム登録データ
+     * @return string
+     */
+    private function getBody(Collection $input_values)
+    {
+        $body = '';
+
+        foreach ($input_values as $value) {
+            $body .= '<h1>';
+            $body .= htmlspecialchars($value->column_name);
+            $body .= '</h1>';
+            $body .= '<p>';
+            $body .= htmlspecialchars($value->value);
+            $body .= '</p>';
+        }
+
+        return $body;
+    }
+
+    /**
+     * 他プラグイン連携対象のプラグインがあるフレームデータの取得
+     */
+    private function getTargetPluginsFrames()
+    {
+        // Frame データ
+        $frames = Frame::select('frames.*', 'pages._lft', 'pages.page_name', 'buckets.bucket_name')
+            // ->whereIn('frames.plugin_name', array('blogs'))
+            ->whereIn('frames.plugin_name', FormsRegisterTargetPlugin::getKeysPluginsCanSpecifiedFrames())
+            ->leftJoin('buckets', 'frames.bucket_id', '=', 'buckets.id')
+            ->leftJoin('pages', 'frames.page_id', '=', 'pages.id')
+            // ->where('disable_searchs', 0)
+            ->orderBy('pages._lft', 'asc')
+            ->get();
+
+        return $frames;
     }
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -320,6 +320,7 @@ $app_array = [
         'FaqSequenceConditionType' => \App\Enums\FaqSequenceConditionType::class,
         'DatabaseFrameConfig' => \App\Enums\DatabaseFrameConfig::class,
         'FormMode' => \App\Enums\FormMode::class,
+        'FormsRegisterTargetPlugin' => \App\Enums\FormsRegisterTargetPlugin::class,
 
         // utils
         'DateUtils' => \App\Utilities\Date\DateUtils::class,

--- a/database/migrations/2023_04_20_140941_add_target_frame_ids_to_forms_table.php
+++ b/database/migrations/2023_04_20_140941_add_target_frame_ids_to_forms_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTargetFrameIdsToFormsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->integer('other_plugins_register_use_flag')->default(0)->comment('他プラグイン連携を使用する')->after('numbering_prefix');
+            $table->text('target_frame_ids')->nullable()->comment('他プラグイン連携対象フレーム')->after('other_plugins_register_use_flag');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('other_plugins_register_use_flag');
+            $table->dropColumn('target_frame_ids');
+        });
+    }
+}

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -466,6 +466,50 @@
         </div>
     </div>
 
+    <hr>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">他プラグイン連携</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="custom-control custom-checkbox">
+                <input type="hidden" name="other_plugins_register_use_flag" value="0">
+                <input type="checkbox" name="other_plugins_register_use_flag" value="1" class="custom-control-input" id="other_plugins_register_use_flag" @if(old('other_plugins_register_use_flag', $form->other_plugins_register_use_flag)) checked=checked @endif>
+                <label class="custom-control-label" for="other_plugins_register_use_flag">他プラグイン連携機能を使用する</label>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">対象ページ - フレーム</label>
+        <div class="{{$frame->getSettingInputClass(false, true)}}">
+            <ul class="nav nav-pills" role="tablist">
+                @foreach(FormsRegisterTargetPlugin::getPluginsCanSpecifiedFrames() as $target_plugin => $target_plugin_full)
+                    <li class="nav-item">
+                        <a href="#{{$target_plugin}}{{$frame->id}}" class="nav-link @if($loop->first) active @endif" data-toggle="tab" role="tab">{{$target_plugin_full}}</a>
+                    </li>
+                @endforeach
+            </ul>
+
+            <div class="tab-content">
+                @foreach(FormsRegisterTargetPlugin::getPluginsCanSpecifiedFrames() as $target_plugin => $target_plugin_full)
+                    <div id="{{$target_plugin}}{{$frame->id}}" class="tab-pane card @if($loop->first) active @endif" role="tabpanel">
+                        <div class="card-body py-2 pl-3">
+                            @foreach($target_plugins_frames as $target_plugins_frame)
+                                @if ($target_plugins_frame->plugin_name == $target_plugin)
+                                    <div class="custom-control custom-checkbox">
+                                        <input type="checkbox" name="target_frame_ids[{{$target_plugins_frame->id}}]" value="{{$target_plugins_frame->id}}" class="custom-control-input" id="target_plugins_frame_{{$target_plugins_frame->id}}" @if(old("target_frame_ids.$target_plugins_frame->id", $form->isTargetFrame($target_plugins_frame->id))) checked=checked @endif>
+                                        <label class="custom-control-label" for="target_plugins_frame_{{$target_plugins_frame->id}}">{{$target_plugins_frame->page_name}} - {{$target_plugins_frame->frame_title}}</label>
+                                    </div>
+                                @endif
+                            @endforeach
+                        </div>
+                    </div>
+                @endforeach
+                @if ($errors && $errors->has('target_plugins_frames')) <div class="text-danger">{{$errors->first('target_plugins_frames')}}</div> @endif
+            </div>
+        </div>
+    </div>
+
     {{-- Submitボタン --}}
     <div class="form-group text-center">
         <div class="row">

--- a/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
@@ -19,6 +19,13 @@
     <input type="hidden" name="character_code" value="">
 </form>
 
+{{-- 他プラグイン連携フォーム --}}
+<form action="" method="post" name="form_register_other_plugins" class="d-inline">
+    {{ csrf_field() }}
+    <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/forms/listInputs/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
+</form>
+
+
 <script type="text/javascript">
     {{-- ダウンロードのsubmit JavaScript --}}
     function submit_download_shift_jis(id) {
@@ -36,6 +43,14 @@
         form_download.action = "{{url('/')}}/download/plugin/forms/downloadCsv/{{$page->id}}/{{$frame_id}}/" + id;
         form_download.character_code.value = '{{CsvCharacterCode::utf_8}}';
         form_download.submit();
+    }
+
+    function submit_register_other_plugins(id) {
+        if( !confirm('登録データを設定した対象に連携します。\nよろしいですか？') ) {
+            return;
+        }
+        form_register_other_plugins.action = "{{url('/')}}/redirect/plugin/forms/registerOtherPlugins/{{$page->id}}/{{$frame_id}}/" + id;
+        form_register_other_plugins.submit();
     }
 
     $(function () {
@@ -71,6 +86,9 @@
 <table class="table table-bordered table-responsive table-sm mt-2">
     <thead class="thead-light">
         <tr>
+            @if ($form->other_plugins_register_use_flag)
+                <th nowrap>連携</th>
+            @endif
             <th nowrap>状態</th>
             @foreach($columns as $column)
                 <th>
@@ -97,6 +115,14 @@
         {{-- 本登録 --}}
         <tr>
         @endif
+
+            @if ($form->other_plugins_register_use_flag)
+                <td>
+                    @if ($input->status == FormStatusType::active)
+                        <button type="button" class="btn btn-sm btn-primary" onclick="submit_register_other_plugins({{$input->id}});"><i class="fas fa-check"></i></button>
+                    @endif
+                </td>
+            @endif
 
             <td nowrap>
                 <a href="{{url('/')}}/plugin/forms/editInput/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}" title="編集">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
フォームの登録データを掲示板、FAQ、ブログへ連携する機能を追加しました。
登録一覧から選択して、他プラグインへ登録することができます。
登録後は一時保存状態になります。自由に編集した後、投稿を公開できます。

## 想定する利用方法

問合せフォームに登録された内容を、回答内容とともにブログなどで公開します。
情報を公開することで、広く知識を共有することができます。
他プラグインへの転記を自動化することで、作業効率を向上することができます。

## 設定方法

- [フォーム設定] 他プラグイン連携 > チェックON
- [フォーム設定] 対象ページ - フレーム > 連携先のフレームをチェックする

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
