### PR TITLE
[施設管理] 翌月表示後に施設の詳細ボタン押下で「施設の詳細データが取得できませんでした」エラー対応 OW-1861

### DIFF
--- a/app/Plugins/User/Reservations/ReservationsPlugin.php
+++ b/app/Plugins/User/Reservations/ReservationsPlugin.php
@@ -269,7 +269,7 @@ class ReservationsPlugin extends UserPluginBase
         $facility_display_type = FrameConfig::getConfigValue($this->frame_configs, ReservationFrameConfig::facility_display_type, FacilityDisplayType::all);
         $initial_facility = null;
         if ($facility_display_type == FacilityDisplayType::only) {
-            $initial_facility = (int) session('initial_facility'. $frame_id, FrameConfig::getConfigValue($this->frame_configs, ReservationFrameConfig::initial_facility));
+            $initial_facility = (int) session('initial_facility'. $frame_id) ?? FrameConfig::getConfigValue($this->frame_configs, ReservationFrameConfig::initial_facility);
         }
 
         // 予約データ
@@ -450,6 +450,9 @@ class ReservationsPlugin extends UserPluginBase
             $calendar['calendar_cells'] = $calendar_cells;
             $calendars[$facility->facility_name] = $calendar;
         }
+
+// \Log::error('[' . __METHOD__ . '] ' . __FILE__ . ' (line ' . __LINE__ . ')');
+// \Log::error(var_export($initial_facility, true));
 
         // 必要なデータ揃っているか確認
         // フレームに紐づいた施設予約親データが存在すること


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り

## エラー画面

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/74b0af57-80bc-4948-a6bc-745adbd3dd8c)
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/b6267b83-ed49-4063-8c6d-07432fbbf06f)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
