### PR TITLE
[サイト内検索]検索結果に本文を表示するようにしました

### DIFF
--- a/app/Plugins/User/Bbses/BbsesPlugin.php
+++ b/app/Plugins/User/Bbses/BbsesPlugin.php
@@ -298,7 +298,8 @@ class BbsesPlugin extends UserPluginBase
                 DB::raw("null             as classname"),
                 DB::raw("null             as category_id"),
                 DB::raw("null             as category"),
-                DB::raw('"bbses"          as plugin_name')
+                DB::raw('"bbses"          as plugin_name'),
+                'bbs_posts.body as body',
             )
             ->join('bbses', function ($join) {
                 // 論理削除対応

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -533,7 +533,8 @@ WHERE status = 0
                           'categories.classname        as classname',
                           'blogs_posts.categories_id   as categories_id',
                           'categories.category         as category',
-                          DB::raw('"blogs" as plugin_name')
+                          DB::raw('"blogs" as plugin_name'),
+                          DB::raw('CONCAT(IFNULL(blogs_posts.post_text, ""), IFNULL(blogs_posts.post_text2, "")) as body'),
                       )
                       ->join('blogs', 'blogs.id', '=', 'blogs_posts.blogs_id')
                       ->join('frames', 'frames.bucket_id', '=', 'blogs.bucket_id')

--- a/app/Plugins/User/Contents/ContentsPlugin.php
+++ b/app/Plugins/User/Contents/ContentsPlugin.php
@@ -258,7 +258,8 @@ class ContentsPlugin extends UserPluginBase
                        DB::raw('null as classname'),
                        DB::raw('null as categories_id'),
                        DB::raw('null as category'),
-                       DB::raw('"contents" as plugin_name')
+                       DB::raw('"contents" as plugin_name'),
+                       'contents.content_text as body'
                    )
                    ->join('frames', 'frames.bucket_id', '=', 'contents.bucket_id')
                    ->join('pages', 'pages.id', '=', 'frames.page_id')

--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -388,7 +388,8 @@ class FaqsPlugin extends UserPluginBase
                           'categories.classname        as classname',
                           'faqs_posts.categories_id   as categories_id',
                           'categories.category         as category',
-                          DB::raw('"faqs" as plugin_name')
+                          DB::raw('"faqs" as plugin_name'),
+                          'faqs_posts.post_text as body'
                       )
                       ->join('faqs', 'faqs.id', '=', 'faqs_posts.faqs_id')
                       ->join('frames', 'frames.bucket_id', '=', 'faqs.bucket_id')

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -166,7 +166,8 @@ class SearchsPlugin extends UserPluginBase
                      DB::raw("null as classname"),
                      DB::raw("null as categories_id"),
                      DB::raw("null as category"),
-                     DB::raw("null as plugin_name")
+                     DB::raw("null as plugin_name"),
+                     DB::raw("null as body")
                  )
                  ->leftJoin('categories', 'categories.id', '=', 'searchs_dual.categories_id');
 

--- a/resources/views/plugins/user/searchs/default/searchs_result.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_result.blade.php
@@ -46,7 +46,7 @@
             @endif
         </dd>
         {{-- 本文 半角160文字（全角80文字）まで 世の検索エンジンがだいたいこれくらい --}}
-        <dd class="text-secondary">
+        <dd class="text-secondary search-result-body">
             {!! mb_strimwidth(strip_tags($searchs_result->body), 0, 160, '…') !!}
         </dd>
     @endforeach

--- a/resources/views/plugins/user/searchs/default/searchs_result.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_result.blade.php
@@ -45,6 +45,10 @@
                 - {{$searchs_result->posted_name}}
             @endif
         </dd>
+        {{-- 本文 半角160文字（全角80文字）まで 世の検索エンジンがだいたいこれくらい --}}
+        <dd class="text-secondary">
+            {!! mb_strimwidth(strip_tags($searchs_result->body), 0, 160, '…') !!}
+        </dd>
     @endforeach
     </dl>
 @php


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
検索結果に本文を表示するようにしました。
いままでの検索結果にはタイトルしか出ておらず、目的のページまで辿り着きにくくなっていました。
本文を併せて表示することで、ページ遷移せずとも内容がわかるように改善しました。

<img width="685" alt="image" src="https://github.com/opensource-workshop/connect-cms/assets/32890286/ca208b3d-d5c2-452d-8b21-ae74c55cfac5">

## 特記事項

データベースプラグインの検索では、本文として出したい項目に本文指定の設定が必要です。
設定は以下から行えます。
**項目設定> 項目詳細設定 > 新着情報等の設定 > 本文指定にチェックをする**


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
