### PR TITLE
[データベース]絞り込みOFF＋並べ替えONで絞込みプルダウンが表示される不具合を修正しました

### DIFF
--- a/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
@@ -103,27 +103,29 @@
     @if(($databases_frames->use_select_flag && $select_columns && count($select_columns) >= 1) || $databases_frames->isBasicUseSortFlag())
         <div class="form-group form-row mb-3">
         {{-- 絞り込み --}}
-        @foreach($select_columns as $select_column)
-            @php
-                $session_column_name = "search_column." . $frame->id . '.' . $loop->index . ".value";
-            @endphp
-            <div class="col-sm">
-                <input name="search_column[{{$loop->index}}][name]" type="hidden" value="{{$select_column->column_name}}">
-                <input name="search_column[{{$loop->index}}][columns_id]" type="hidden" value="{{$select_column->id}}">
-                @if($select_column->column_type == DatabaseColumnType::checkbox)
-                <input name="search_column[{{$loop->index}}][where]" type="hidden" value="PART">
-                @else
-                <input name="search_column[{{$loop->index}}][where]" type="hidden" value="ALL">
-                @endif
-                <select class="form-control" name="search_column[{{$loop->index}}][value]" title="{{$select_column->column_name}}" onChange="javascript:submit(this.form);" aria-describedby="search_column{{$loop->index}}_{{$frame_id}}" id="select_search_column{{$loop->index}}_{{$frame_id}}">
-                    <option value="">{{$select_column->column_name}}</option>
-                    @foreach($columns_selects->where('databases_columns_id', $select_column->id) as $columns_select)
-                        <option value="{{$columns_select->value}}" @if($columns_select->value == Session::get($session_column_name)) selected @endif>{{  $columns_select->value  }}</option>
-                    @endforeach
-                </select>
-                <small class="form-text text-muted" id="search_column{{$loop->index}}_{{$frame_id}}">選択すると自動的に絞り込みします。</small>
-            </div>
-        @endforeach
+        @if ($databases_frames->use_select_flag && $select_columns && count($select_columns) >= 1)
+            @foreach($select_columns as $select_column)
+                @php
+                    $session_column_name = "search_column." . $frame->id . '.' . $loop->index . ".value";
+                @endphp
+                <div class="col-sm">
+                    <input name="search_column[{{$loop->index}}][name]" type="hidden" value="{{$select_column->column_name}}">
+                    <input name="search_column[{{$loop->index}}][columns_id]" type="hidden" value="{{$select_column->id}}">
+                    @if($select_column->column_type == DatabaseColumnType::checkbox)
+                    <input name="search_column[{{$loop->index}}][where]" type="hidden" value="PART">
+                    @else
+                    <input name="search_column[{{$loop->index}}][where]" type="hidden" value="ALL">
+                    @endif
+                    <select class="form-control" name="search_column[{{$loop->index}}][value]" title="{{$select_column->column_name}}" onChange="javascript:submit(this.form);" aria-describedby="search_column{{$loop->index}}_{{$frame_id}}" id="select_search_column{{$loop->index}}_{{$frame_id}}">
+                        <option value="">{{$select_column->column_name}}</option>
+                        @foreach($columns_selects->where('databases_columns_id', $select_column->id) as $columns_select)
+                            <option value="{{$columns_select->value}}" @if($columns_select->value == Session::get($session_column_name)) selected @endif>{{  $columns_select->value  }}</option>
+                        @endforeach
+                    </select>
+                    <small class="form-text text-muted" id="search_column{{$loop->index}}_{{$frame_id}}">選択すると自動的に絞り込みします。</small>
+                </div>
+            @endforeach
+        @endif
 
         {{-- 並び順 --}}
         @if($sort_count > 0 || $databases_frames->isBasicUseSortFlag())


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

絞り込み機能を表示しない設定になっていても、並べ替えが有効になっていると、絞り込みプルダウンが表示される不具合を修正しました。
修正後は表示設定に従って、表示されます。

### 不具合が発生する表示設定

- 絞り込み機能の表示 = 表示しない
- 並べ替え項目の表示 = チェックあり

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り / 無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
