### PR TITLE
[サイト内検索]「登録日・登録者後ろ」テンプレート追加しました。

### DIFF
--- a/resources/views/plugins/user/searchs/posted_bottom/searchs_result.blade.php
+++ b/resources/views/plugins/user/searchs/posted_bottom/searchs_result.blade.php
@@ -20,7 +20,7 @@
 @if ($searchs_results)
 <div class="container pt-3">
     @foreach($searchs_results as $searchs_result)
-        <div class="row mb-3 search-result-row">
+        <div class="row search-result-row pb-3 pt-3 border-bottom">
             {{-- カテゴリ --}}
             @if(!empty($searchs_result->category))
             <div class="search-result-category text-nowrap col-md-auto col-auto order-md-1 order-1">

--- a/resources/views/plugins/user/searchs/posted_bottom/searchs_result.blade.php
+++ b/resources/views/plugins/user/searchs/posted_bottom/searchs_result.blade.php
@@ -1,0 +1,82 @@
+{{--
+ * 検索画面：登録者・登録日時後ろテンプレート
+ *
+ * @author 牧野　可也子 <makino@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category 検索プラグイン
+--}}
+@extends('core.cms_frame_base')
+
+@section("plugin_contents_$frame->id")
+@if(isset($searchs_frame))
+    @include('plugins.user.searchs.default.searchs_form')
+@else
+    <div class="alert alert-danger">
+        <i class="fas fa-exclamation-circle"></i>
+        検索設定を作成してください。
+    </div>
+@endif
+
+@if ($searchs_results)
+<div class="container pt-3">
+    @foreach($searchs_results as $searchs_result)
+        <div class="row mb-3 search-result-row">
+            {{-- カテゴリ --}}
+            @if(!empty($searchs_result->category))
+            <div class="search-result-category text-nowrap col-md-auto col-auto order-md-1 order-1">
+                <span class="badge cc_category_{{$searchs_result->classname}}">{{$searchs_result->category}}</span>
+            </div>
+            @endif
+
+            {{-- タイトル --}}
+            <div class="search-result-title text-truncate col-md col order-md-2 order-2">
+            @if($link_pattern[$searchs_result->plugin_name] == 'show_page_frame_post')
+                <a href="{{url('/')}}{{$link_base[$searchs_result->plugin_name]}}/{{$searchs_result->page_id}}/{{$searchs_result->frame_id}}/{{$searchs_result->post_id}}#frame-{{$searchs_result->frame_id}}">
+            @elseif($link_pattern[$searchs_result->plugin_name] == 'show_page')
+                <a href="{{url('/')}}{{$searchs_result->permanent_link}}">
+            @else
+                {{-- 上記以外は想定していない為、取り敢えず permanent_link をリンク先とする --}}
+                <a href="{{url('/')}}{{$searchs_result->permanent_link}}">
+            @endif
+                @if(!empty(strip_tags($searchs_result->post_title)))
+                    {{ strip_tags($searchs_result->post_title) }}
+                @else
+                    (無題)
+                @endif
+                </a>
+            </div>
+
+            {{-- 登録日 --}}
+            @if($searchs_frame->view_posted_at && !empty($searchs_result->posted_at))
+            <div class="search-result-postedat text-nowrap col-md-auto col-auto order-md-3 order-4 ml-auto">
+                {{(new Carbon($searchs_result->posted_at))->format('Y/m/d')}}
+            </div>
+            @endif
+
+            {{-- 登録者 --}}
+            @if($searchs_frame->view_posted_name && !empty($searchs_result->posted_name))
+            <div class="search-result-postedname text-truncate col-md-auto col-auto order-md-3 order-5 @if(!($searchs_frame->view_posted_at && !empty($searchs_result->posted_at))) ml-auto @endif)">
+                {{$searchs_result->posted_name}}
+            </div>
+            @endif
+
+            {{-- 本文 --}}
+            @if(!empty(strip_tags($searchs_result->body)))
+            <div class="search-result-body text-secondary col-12 order-md-5 order-3">
+                {!! mb_strimwidth(strip_tags($searchs_result->body), 0, 160, '…') !!}
+            </div>
+            @endif
+
+        </div>
+    @endforeach
+    
+    {{-- ページング処理 --}}
+    <div class="row">
+        <div class="col">
+            @include('plugins.common.user_paginate', ['posts' => $searchs_results, 'frame' => $frame, 'appends' => ['search_keyword' => old('search_keyword')], 'aria_label_name' => $searchs_frame->search_name])
+        </div>
+    </div>
+</div>
+@endif
+
+@endsection


### PR DESCRIPTION
# 概要
サイト内検索プラグインの検索結果の表示内容について、
登録日・登録者名が後ろに来るようなテンプレートを追加しました。

# スクリーンショット
【パソコン】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/61491908-5806-4a69-887b-c3cbd3ec7893)
【スマホ】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/08b6f032-9c71-4be7-89b4-97b429af71f8)

※登録日・登録者　非表示
【パソコン】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/2c38797c-849c-4739-a83f-8080952c1da5)
【スマホ】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/443dc0dd-9db2-4dd1-a7b5-f3880353ae96)

※登録者　非表示
【パソコン】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/fb85dae3-9b86-4d65-ab56-22de0fa386aa)
【スマホ】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/041b988d-2615-4e8e-94f2-c699e324980e)

※登録日　非表示
【パソコン】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/d74f1f41-3af3-4590-8a1b-0005c50f2254)
【スマホ】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/7d7b0fe2-4e20-443b-b40a-5d2fafae1331)

# defaultテンプレートとの違い

- パソコン表示の場合、登録日と登録者が、タイトルの後ろに来るようになります。
- 登録日、登録者は右寄せされます。
- タイトル行が長い場合、途中で「…」で途切れます。
- スマホ表示させた時、登録日・登録日時が、本文よりも後ろになるようになります。
- タイトル項目がない場合「（無題）」と表示されます。
- 登録日を表示させなくても、カテゴリが表示されるようになります。
- 各項目にclass名を追加し、CSSを当てやすくしました。

# このテンプレートを用意した理由
defaultテンプレートは、登録日が先頭にきていました。
サイト内検索の場合、登録日・登録者は重要ではない場合もある為、登録日・更新者をタイトルより後ろにもってくるようにしました。
また、カテゴリが、登録日を表示しないと表示されなかった為、カテゴリが登録されていれば表示されるようにしたかった為です。

# レビュー完了希望日
お時間のある時に

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
