### PR TITLE
[サイト内検索]defaultテンプレート、タイトル表示バグ、カテゴリ表示バグ、クラス名付与の修正を行いました。

### DIFF
--- a/resources/views/plugins/user/searchs/default/searchs_result.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_result.blade.php
@@ -1,7 +1,7 @@
 {{--
  * 検索画面
  *
- * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 永原　篤 <nagahara@opensource-workshop.jp> / 牧野　可也子 <makino@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 検索プラグイン
 --}}
@@ -17,40 +17,50 @@
     </div>
 @endif
 
-@if ($searchs_results)
-<div class="mt-3">
-    <dl>
+@if($searchs_results)
+<div class="searchs-result-body mt-3">
     @foreach($searchs_results as $searchs_result)
-        @if ($searchs_frame->view_posted_at)
+    <dl class="searchs-result-row border-bottom">
         <dt>
-            @if ($searchs_frame->view_posted_at)
+            {{-- 登録日 --}}
+            @if($searchs_frame->view_posted_at)
                 {{(new Carbon($searchs_result->posted_at))->format('Y/m/d')}}
-                @if($searchs_result->category)
-                    <span class="badge cc_category_{{$searchs_result->classname}}">{{$searchs_result->category}}</span>
-                @endif
+            @endif
+            {{-- カテゴリ --}}
+            @if($searchs_result->category)
+                <span class="badge cc_category_{{$searchs_result->classname}}">{{$searchs_result->category}}</span>
             @endif
         </dt>
-        @endif
-        <dd>
-            @if ($link_pattern[$searchs_result->plugin_name] == 'show_page_frame_post')
+        <dd class="searchs-result-posttitle">
+            {{-- タイトル --}}
+            @if($link_pattern[$searchs_result->plugin_name] == 'show_page_frame_post')
             <a href="{{url('/')}}{{$link_base[$searchs_result->plugin_name]}}/{{$searchs_result->page_id}}/{{$searchs_result->frame_id}}/{{$searchs_result->post_id}}#frame-{{$searchs_result->frame_id}}">
-                {{$searchs_result->post_title}}
-            </a>
-            @elseif ($link_pattern[$searchs_result->plugin_name] == 'show_page')
+            @elseif($link_pattern[$searchs_result->plugin_name] == 'show_page')
             <a href="{{url('/')}}{{$searchs_result->permanent_link}}">
-                {{$searchs_result->post_title}}
-            </a>
+            @else
+            {{-- 上記以外は想定していない為、取り敢えず permanent_link をリンク先とする --}}
+            <a href="{{url('/')}}{{$searchs_result->permanent_link}}">
             @endif
-            @if ($searchs_frame->view_posted_name)
+            @if(!empty(strip_tags($searchs_result->post_title)))
+                {{-- タイトル  本文と同じぐらいで取り敢えずカット。 --}}
+                {!! mb_strimwidth(strip_tags($searchs_result->post_title), 0, 160, '…') !!}
+            @else
+                (無題)
+            @endif
+            </a>
+            {{-- 登録者 --}}
+            @if($searchs_frame->view_posted_name)
                 - {{$searchs_result->posted_name}}
             @endif
         </dd>
         {{-- 本文 半角160文字（全角80文字）まで 世の検索エンジンがだいたいこれくらい --}}
-        <dd class="text-secondary search-result-body">
+        @if(!empty(strip_tags($searchs_result->body)))
+        <dd class="search-result-postbody text-secondary">
             {!! mb_strimwidth(strip_tags($searchs_result->body), 0, 160, '…') !!}
         </dd>
-    @endforeach
+        @endif
     </dl>
+    @endforeach
 @php
     $appends['search_keyword'] = old('search_keyword');
     // ページ配下の絞込み

--- a/resources/views/plugins/user/searchs/default/searchs_result.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_result.blade.php
@@ -18,9 +18,9 @@
 @endif
 
 @if($searchs_results)
-<div class="searchs-result-body mt-3">
+<div class="mt-3">
+    <dl>
     @foreach($searchs_results as $searchs_result)
-    <dl class="searchs-result-row border-bottom">
         <dt>
             {{-- 登録日 --}}
             @if($searchs_frame->view_posted_at)
@@ -31,7 +31,7 @@
                 <span class="badge cc_category_{{$searchs_result->classname}}">{{$searchs_result->category}}</span>
             @endif
         </dt>
-        <dd class="searchs-result-posttitle">
+        <dd>
             {{-- タイトル --}}
             @if($link_pattern[$searchs_result->plugin_name] == 'show_page_frame_post')
             <a href="{{url('/')}}{{$link_base[$searchs_result->plugin_name]}}/{{$searchs_result->page_id}}/{{$searchs_result->frame_id}}/{{$searchs_result->post_id}}#frame-{{$searchs_result->frame_id}}">
@@ -54,13 +54,11 @@
             @endif
         </dd>
         {{-- 本文 半角160文字（全角80文字）まで 世の検索エンジンがだいたいこれくらい --}}
-        @if(!empty(strip_tags($searchs_result->body)))
-        <dd class="search-result-postbody text-secondary">
+        <dd class="text-secondary search-result-body border-bottom">
             {!! mb_strimwidth(strip_tags($searchs_result->body), 0, 160, '…') !!}
         </dd>
-        @endif
-    </dl>
     @endforeach
+    </dl>
 @php
     $appends['search_keyword'] = old('search_keyword');
     // ページ配下の絞込み


### PR DESCRIPTION
# 概要
サイト内検索プラグイン、defaultテンプレートについて、以下のバグを修正しました。
 - タイトルが空の場合、何も表示されなかった為、「(無題)」と表示されるようにしました。
 - タイトルがウィジウィグ項目の場合（※データベース等）、タグが出力されてしまっていたのを、stripするようにしました。
 - タイトルがウィジウィグ項目だった場合、入力された情報が全て出てしまう為、本文と同じく160byteで途切れるようにしました。
 - 登録日を非表示にした場合、カテゴリも非表示になってしまっていたので、表示されるようにしました。

使いにくかった以下の部分を修正しました。
 - dlタグが、検索結果全てに対して１つしかつかなかったが、1検索結果につき1つ付くようにしました。
 - 上記修正したdlタグに、searchs-result-rowクラス名を付与しました。
 - 本文項目のddタグのクラス名がsearchs-result-bodyだったので、項目名と同じsearchs-result-postbodyに変更しました。
 - タイトルと登録名が表示されるddタグに、searchs-result-posttitleクラス名を付与しました。
 - 罫線が表示されるようにしました。
 - 各プラグインからの検索結果に付与されている「plugin_name」の値について、「show_page_frame_post」と「show_page」以外が来た時のelseがなかった為、付与しました。
 - 検索結果全体を囲むdivタグに、searchs-result-bodyクラス名を付与しました。

# スクリーンショット
【PC】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/1d746660-ea2b-4983-a32d-9cb4e59c0521)

【スマホ】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/e26ab194-a246-42b6-b13c-374304601d7b)

# レビュー完了希望日
お時間のある時に

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
