### PR TITLE
[データベース]項目名非表示フラグが効かないテンプレートに対して、フラグが利用できるように修正しました。

### DIFF
--- a/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
@@ -2,6 +2,7 @@
  * 一覧画面テンプレート（tableテンプレートをベース）
  *
  * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @author 牧野 可也子 <makino@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
 --}}
@@ -23,7 +24,11 @@
                 <tr>
                 @foreach($columns as $column)
                     @if($column->list_hide_flag == 0)
-                    <th>{{$column->column_name}}</th>
+                    <th>
+                        @if($column->label_hide_flag == 0)
+                        {{$column->column_name}}
+                        @endif
+                    </th>
                     @endif
                 @endforeach
                 </tr>

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -1,8 +1,9 @@
 {{--
- * 登録画面テンプレート。
+ * 一覧画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @author 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @author 牧野 可也子 <makino@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category データベース・プラグイン
 --}}
@@ -25,7 +26,11 @@
                 <tr>
                 @foreach($columns as $column)
                     @if($column->list_hide_flag == 0)
-                    <th class="text-nowrap">{{$column->column_name}}</th>
+                    <th class="text-nowrap">
+                        @if($column->label_hide_flag == 0)
+                        {{$column->column_name}}
+                        @endif
+                    </th>
                     @endif
                 @endforeach
                 </tr>


### PR DESCRIPTION
# 概要
【対象テンプレート】
 - table
 - design-table-dl

項目名を非表示設定にしても、一覧上に項目名が表示されっぱなしになってしまう問題を修正しました。

# スクリーンショット

【table】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/d5d4d915-baa5-4cad-afd2-f110760f8dc0)

【design-table-dl】
![image](https://github.com/opensource-workshop/connect-cms/assets/34463938/331787a4-99a6-48d6-abdb-12013db9f963)

# レビュー完了希望日
いつでも

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
