### PR TITLE
[移行ツール] NC3移行バグ修正

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -6116,6 +6116,12 @@ trait MigrationNc3ExportTrait
      */
     private function checkDeadLinkNc3(string $url, string $nc3_plugin_key, ?Nc3Frame $nc3_frame = null): void
     {
+        // リンクチェックしない場合は返却
+        $check_deadlink_nc3 = $this->getMigrationConfig('basic', 'check_deadlink_nc3', '');
+        if (empty($check_deadlink_nc3)) {
+            return;
+        }
+
         $scheme = parse_url($url, PHP_URL_SCHEME);
 
         if (in_array($scheme, ['http', 'https'])) {

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -2935,6 +2935,10 @@ trait MigrationNc3ExportTrait
                 $mail_body =        str_ireplace($convert_embedded_tag[0], $convert_embedded_tag[1], $mail_body);
             }
 
+            $after_message = $this->nc3Wysiwyg(null, null, null, null, $nc3_registration->thanks_content, 'registrations');
+            // ダブルクォーテーション対策
+            $after_message = str_replace('"', '\"', $after_message);
+
             // 登録フォーム設定
             $registration_ini = "";
             $registration_ini .= "[form_base]\n";
@@ -2946,7 +2950,7 @@ trait MigrationNc3ExportTrait
             $registration_ini .= "mail_subject = \""      . $mail_subject . "\"\n";
             $registration_ini .= "mail_format = \""       . $mail_body . "\"\n";
             $registration_ini .= "data_save_flag = 1\n";
-            $registration_ini .= "after_message = \""     . $nc3_registration->thanks_content . "\"\n";
+            $registration_ini .= "after_message = \""     . $after_message . "\"\n";
             $registration_ini .= "numbering_use_flag = 0\n";
             $registration_ini .= "numbering_prefix = null\n";
             $registration_ini .= "regist_control_flag = " . $regist_control_flag . "\n";

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -2284,11 +2284,12 @@ trait MigrationNc3ExportTrait
                 }
 
                 $linklist_category = $linklist_categories->firstWhere('id', $nc3_link->category_id) ?? new Nc3Category();
+                $open_new_tab = $nc3_link_frame_setting->open_new_tab ?? 1;
 
                 $linklists_tsv .= str_replace(array("\r", "\n", "\t"), "", $nc3_link->title)        . "\t";
                 $linklists_tsv .= str_replace(array("\r", "\n", "\t"), "", $nc3_link->url)          . "\t";
                 $linklists_tsv .= str_replace(array("\r", "\n", "\t"), " ", $nc3_link->description) . "\t";
-                $linklists_tsv .= $nc3_link_frame_setting->open_new_tab                             . "\t"; // [3] 新規ウィンドウで表示
+                $linklists_tsv .= $open_new_tab                                                     . "\t"; // [3] 新規ウィンドウで表示
                 $linklists_tsv .= $nc3_link->display_sequence                                       . "\t";
                 $linklists_tsv .= $linklist_category->name;
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -1006,6 +1006,9 @@ trait MigrationTrait
             // ルームの指定（あれば後で使う）
             //$cc_import_page_room_ids = $this->getMigrationConfig('pages', 'cc_import_page_room_ids');
 
+            // 強制的にレイアウト上書き
+            $cc_import_force_layouts = $this->getMigrationConfig('pages', 'cc_import_force_layouts', null);
+
             // 新ページのループ
             foreach ($paths as $path) {
                 // ページ指定の有無
@@ -1074,6 +1077,17 @@ trait MigrationTrait
                 $page = Page::where('permanent_link', $page_ini['page_base']['permanent_link'])->first();
                 // var_dump($page);
 
+                $layout = Arr::get($page_ini, 'page_base.layout');
+
+                // インポートページのディレクトリNo
+                $import_page_dir_no = ltrim(basename($path), '_');
+
+                // 強制的にレイアウトを適用する指定があれば上書きする。
+                $cc_import_force_layout = Arr::get($cc_import_force_layouts, $import_page_dir_no);
+                if ($cc_import_force_layout) {
+                    $layout = $cc_import_force_layout;
+                }
+
                 // 対象のURL がなかった場合はページの作成
                 if (empty($page)) {
                     $this->putMonitor(1, "Page create.");
@@ -1081,7 +1095,7 @@ trait MigrationTrait
                     // ページの作成
                     $page = Page::create(['page_name'         => $page_ini['page_base']['page_name'],
                                           'permanent_link'    => $page_ini['page_base']['permanent_link'],
-                                          'layout'            => array_key_exists('layout', $page_ini['page_base']) ? $page_ini['page_base']['layout'] : null,
+                                          'layout'            => $layout,
                                           'base_display_flag' => $page_ini['page_base']['base_display_flag'],
                                           'membership_flag'   => empty($page_ini['page_base']['membership_flag']) ? 0 : $page_ini['page_base']['membership_flag'],
                                         ]);
@@ -1100,7 +1114,7 @@ trait MigrationTrait
                 } else {
                     // 対象のURL があった場合はページの更新
                     $page->page_name         = $page_ini['page_base']['page_name'];
-                    $page->layout            = array_key_exists('layout', $page_ini['page_base']) ? $page_ini['page_base']['layout'] : null;
+                    $page->layout            = $layout;
                     $page->base_display_flag = $page_ini['page_base']['base_display_flag'];
                     $page->membership_flag   = empty($page_ini['page_base']['membership_flag']) ? 0 : $page_ini['page_base']['membership_flag'];
                     $page->save();
@@ -1111,9 +1125,9 @@ trait MigrationTrait
                 // マッピングテーブルの追加
                 $mapping = MigrationMapping::updateOrCreate(
                     ['target_source_table' => 'connect_page',
-                    'source_key' => ltrim(basename($path), '_')],
+                    'source_key' => $import_page_dir_no],
                     ['target_source_table'  => 'connect_page',
-                    'source_key'           => ltrim(basename($path), '_'),
+                    'source_key'           => $import_page_dir_no,
                     'destination_key'      => $page->id]
                 );
 

--- a/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
@@ -174,7 +174,8 @@ cc_import_pages = true
 ;cc_import_add_src_dir = "/sample"
 
 ; 強制的にレイアウトを変更するページ
-;cc_import_force_layouts["0099"] = "1|1|0|1"
+; cc_import_force_layouts["インポートページのディレクトリNo"] = "ヘッダー|左|右|フッター"、 1:表示,0:非表示
+;cc_import_force_layouts["0001"] = "1|1|0|1"
 
 ;------------------------------------------------
 ;- フレーム関係

--- a/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
@@ -23,6 +23,9 @@ nc2_export_str_replace['http://localhost'] = 'http://kuina-el.localhost'
 ; --- NC2のディスプレイシーケンスが異なる場合の調整/NC2の際にトップページを消しちゃった場合に発生する
 nc2_toppage_display_sequence = '1'
 
+; --- リンク切れチェックを使う
+;check_deadlink_nc2 = true
+
 ; --- NC2ベースURL. リンク切れチェックの内部URL判定で利用
 check_deadlink_nc2_base_url = 'http://localhost'
 

--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -26,6 +26,10 @@ nc3_export_str_replace['http://localhost'] = 'http://kuina-el.localhost'
 ; --- NC3ベースURL. リンク切れチェックの内部URL判定で利用
 check_deadlink_nc3_base_url = 'http://localhost'
 
+; --- NC3.2.0より古いバージョンで移行する (beta)
+; ※ NC3バージョンが古いため、ページやルームの並び順が再現されない等の制限がある移行モードです。
+;older_than_nc3_2_0 = true
+
 ; --- インポート
 cc_import_basic = true
 

--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -168,7 +168,8 @@ cc_import_pages = true
 ;cc_import_add_src_dir = "/sample"
 
 ; 強制的にレイアウトを変更するページ
-;cc_import_force_layouts["0099"] = "1|1|0|1"
+; cc_import_force_layouts["インポートページのディレクトリNo"] = "ヘッダー|左|右|フッター"、 1:表示,0:非表示
+;cc_import_force_layouts["0001"] = "1|1|0|1"
 
 ;------------------------------------------------
 ;- フレーム関係

--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -20,6 +20,9 @@ nc3_export_basic = true
 ; --- 文字列変換(キー部分 = 探したい値, 値部分 = 置き換える値)
 nc3_export_str_replace['http://localhost'] = 'http://kuina-el.localhost'
 
+; --- リンク切れチェックを使う
+;check_deadlink_nc3 = true
+
 ; --- NC3ベースURL. リンク切れチェックの内部URL判定で利用
 check_deadlink_nc3_base_url = 'http://localhost'
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: NC3移行, リンク切れチェックOFFできるよう設定追加](https://github.com/opensource-workshop/connect-cms/commit/5924bce7e1a92206fbff11022d635b97e7e522d3)
  * 初期値：なし（コメントアウト）＝リンク切れチェックしない
  * 設定例： `check_deadlink_nc3 = true`
* [add: nc3移行, NC3.2.0より古いバージョンで移行する (beta)オプション設定追加](https://github.com/opensource-workshop/connect-cms/pull/1676/commits/8e809aa8e361b7073dd4749b92c09144f7dfb5b6)
  * 初期値：なし（コメントアウト）＝ nc3.2.0より新しい
  * 設定例： `older_than_nc3_2_0 = true`
* [add: nc移行インポート, 強制的にレイアウト上書きオプションに対応](https://github.com/opensource-workshop/connect-cms/pull/1676/commits/82d6d4b681b65cd66d63e2d4b93c95194bf95fca)
  * 初期値：なし（コメントアウト）
  * 設定例： `cc_import_force_layouts["0001"] = "1|1|0|1`
    * ※ cc_import_force_layouts["インポートページのディレクトリNo"] = "ヘッダー|左|右|フッター"、 1:表示,0:非表示
* [bugfix: nc3移行エクスポート, 登録フォームのサンクスページメッセージ設定値のwysiwyg値対応とダブルクォーテーション対策](https://github.com/opensource-workshop/connect-cms/pull/1676/commits/9d07a1941935bba0bfd9f2b8fdbac88792d388ad)
* [bugfix: nc3移行エクスポート, リンクリストの新規ウィンドウで開く値、フレーム設定データなし時にインポート時にnullをセットしてDBエラーになるため修正](https://github.com/opensource-workshop/connect-cms/pull/1676/commits/21b1975f3101e1af229605dadae30cd48ee19a94) 
* 関連修正
  * [add: NC2移行, リンク切れチェックOFF設定値を設定サンプルに追加](https://github.com/opensource-workshop/connect-cms/pull/1676/commits/b73a113ed41186a6dec5a1fc5f96b3c60f656e05)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
