### PR TITLE
[ユーザ管理] 最後のシステム管理者保持者は削除させない・システム管理者権限を外させない対応

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -643,11 +643,13 @@ class UserManage extends ManagePluginBase
 
         // システム管理者ありユーザー
         if (Arr::get($users_roles, 'manage.admin_system') == 1) {
-            // システム管理者の人数
+            // システム管理者権限の人数
             $in_users = UsersRoles::select('users_roles.users_id')
                 ->where('role_name', 'admin_system')
                 ->get();
             $admin_system_user_count = User::whereIn('users.id', $in_users->pluck('users_id'))->count();
+
+            // システム管理者権限持ちが１人
             if ($admin_system_user_count <= 1) {
                 // 削除させない
                 $can_deleted = false;

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -319,8 +319,8 @@ use App\Models\Core\UsersColumns;
                 @endif
             @endif
         </div>
-        {{-- 既存ユーザの場合は削除処理のボタンも表示(自分自身の場合は表示しない) --}}
-        @if (isset($id) && $id && $id != Auth::user()->id)
+        {{-- 既存ユーザの場合は削除処理のボタンも表示(自分自身の場合は表示しない, 最後のシステム管理者保持者は削除させない) --}}
+        @if (isset($id) && $id && $id != Auth::user()->id && $can_deleted)
             <div class="col-sm-3 pull-right text-right">
                 <a data-toggle="collapse" href="#collapse{{$id}}">
                     <span class="btn btn-danger"><i class="fas fa-trash-alt"></i> <span class="d-none d-sm-inline">削除</span></span>
@@ -330,7 +330,7 @@ use App\Models\Core\UsersColumns;
     </div>
 </form>
 
-@if (isset($id) && $id && $id != Auth::user()->id)
+@if (isset($id) && $id && $id != Auth::user()->id && $can_deleted)
 <div id="collapse{{$id}}" class="collapse" style="margin-top: 8px;">
     <div class="card border-danger">
         <div class="card-body">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: ユーザ管理, 最後のシステム管理者保持者は削除させない](https://github.com/opensource-workshop/connect-cms/commit/80ebd00dd5fe5d357fe4eb7e7a7453c9c4b67ed3)
* [add: ユーザ管理, 最後のシステム管理者保持者から編集でシステム管理者権限を外せない様に入力チェック追加](https://github.com/opensource-workshop/connect-cms/commit/0e5af63a66bc66909e061f116fae6bc1cd8ef86c)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
