### PR TITLE
[ユーザ管理] システム管理者権限持ちユーザはシステム管理者のみ編集可

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -484,6 +484,11 @@ class UserManage extends ManagePluginBase
         $groups_select = Group::get();
         // dd($groups);
 
+        // ユーザ権限取得
+        $auth_users_roles = $this->getRoles(Auth::user()->id);
+        // 自身のシステム管理者権限持ち
+        $has_auth_role_admin_system = Arr::get($auth_users_roles, 'manage.admin_system') == 1 ? true : false;
+
         return view('plugins.manage.user.list', [
             "function" => __FUNCTION__,
             "plugin_name" => "user",
@@ -493,6 +498,7 @@ class UserManage extends ManagePluginBase
             "input_cols" => $input_cols,
             "groups_select" => $groups_select,
             "sections" => Section::orderBy('display_sequence')->get(),
+            "has_auth_role_admin_system" => $has_auth_role_admin_system,
         ]);
     }
 
@@ -656,6 +662,17 @@ class UserManage extends ManagePluginBase
             }
         }
 
+        // 対象がシステム管理者ありユーザー
+        if (Arr::get($users_roles, 'manage.admin_system') == 1) {
+            // 自身のユーザ権限取得
+            $auth_users_roles = $this->getRoles(Auth::user()->id);
+
+            // 自身がシステム管理者でない場合はエラー
+            if (empty(Arr::get($auth_users_roles, 'manage.admin_system'))) {
+                abort(403, '権限がありません。');
+            }
+        }
+
         // 画面呼び出し
         return view('plugins.manage.user.regist', [
             "function" => __FUNCTION__,
@@ -678,6 +695,20 @@ class UserManage extends ManagePluginBase
      */
     public function update($request, $id = null)
     {
+        // ユーザ権限取得
+        $users_roles = $this->getRoles($id);
+
+        // 対象がシステム管理者ありユーザー
+        if (Arr::get($users_roles, 'manage.admin_system') == 1) {
+            // 自身のユーザ権限取得
+            $auth_users_roles = $this->getRoles(Auth::user()->id);
+
+            // 自身がシステム管理者でない場合はエラー
+            if (empty(Arr::get($auth_users_roles, 'manage.admin_system'))) {
+                abort(403, '権限がありません。');
+            }
+        }
+
         // 項目のエラーチェック
         // change: ユーザーの追加項目に対応
         // $validator = Validator::make($request->all(), [
@@ -729,11 +760,8 @@ class UserManage extends ManagePluginBase
         // Log::debug(var_export($validator_array, true));
 
         // 任意のバリデーションを追加
-        $validator->after(function ($validator) use ($id, $request) {
+        $validator->after(function ($validator) use ($users_roles, $request) {
             // システム管理者持ちユーザーで && システム管理者権限持ちが１人 && システム管理者権限が外れてたら入力エラー
-
-            // ユーザ権限取得
-            $users_roles = $this->getRoles($id);
 
             // システム管理者持ちユーザー
             if (Arr::get($users_roles, 'manage.admin_system') == 1) {
@@ -875,7 +903,6 @@ class UserManage extends ManagePluginBase
      */
     public function destroy($request, $id = null)
     {
-
         // セッション初期化などのLaravel 処理。
         $request->flash();
 
@@ -902,6 +929,19 @@ class UserManage extends ManagePluginBase
             if ($admin_system_user_count <= 1) {
                 $validator = Validator::make($request->all(), []);
                 $validator->errors()->add('undelete', '最後のシステム管理者保持者は削除できません。');
+                return $this->edit($request, $id)->withErrors($validator);
+            }
+        }
+
+        // 対象がシステム管理者ありユーザー
+        if (Arr::get($users_roles, 'manage.admin_system') == 1) {
+            // 自身のユーザ権限取得
+            $auth_users_roles = $this->getRoles($user_id);
+
+            // 自身がシステム管理者でない場合はエラー
+            if (empty(Arr::get($auth_users_roles, 'manage.admin_system'))) {
+                $validator = Validator::make($request->all(), []);
+                $validator->errors()->add('undelete', '権限がありません。');
                 return $this->edit($request, $id)->withErrors($validator);
             }
         }

--- a/app/User.php
+++ b/app/User.php
@@ -140,6 +140,26 @@ class User extends Authenticatable
     }
 
     /**
+     * システム管理者権限持ちか（一覧用）
+     */
+    public function hasRoleAdminSystem() : bool
+    {
+        // 権限データがあるか確認
+        if (empty($this->view_user_roles)) {
+            return false;
+        }
+
+        foreach ($this->view_user_roles as $view_user_role) {
+            if ($view_user_role->role_name == 'admin_system') {
+                // システム権限あり
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * 仮登録のinput disable 属性の要否を判断して返す。
      */
     public function getStstusTemporaryDisabled($enum_value)

--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -317,7 +317,17 @@ use App\Models\Core\UsersColumns;
             @foreach($users as $user)
                 <tr class="{{$user->getStstusBackgroundClass()}}">
                     <td nowrap>
-                        <a href="{{url('/')}}/manage/user/edit/{{$user->id}}" title="ユーザ変更"><i class="far fa-edit"></i></a>
+                        @if ($user->hasRoleAdminSystem())
+                            @if ($has_auth_role_admin_system)
+                                {{-- システム管理者権限持ちユーザの編集は、システム管理者のみ可 --}}
+                                <a href="{{url('/')}}/manage/user/edit/{{$user->id}}" title="ユーザ変更"><i class="far fa-edit"></i></a>
+                            @else
+                                {{-- 編集させない --}}
+                            @endif
+                        @else
+                            {{-- 通常 --}}
+                            <a href="{{url('/')}}/manage/user/edit/{{$user->id}}" title="ユーザ変更"><i class="far fa-edit"></i></a>
+                        @endif
                         {{$user->userid}}
                     </td>
                     <td>{{$user->name}}</td>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* うっかりシステム管理者の編集・削除をさせないために、システム管理者権限持ちユーザはシステム管理者のみ編集可に見直しました。
  * システム管理者権限ありユーザは、システム管理者権限ありユーザの編集・削除できます。
  * ユーザ管理権限あり（システム管理者権限なし）ユーザは、システム管理者権限ありユーザー以外を編集・削除できます。

## 背景

NetCommons3移行の関連対応で、NetCommons3には下位権限のユーザ（サイト管理者）は、上位権限のユーザー（システム管理者）をユーザ編集できない機能があり、その移植になります。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
