### PR TITLE
[移行ツール] nc3の移行設定サンプルからslideshowsの移行設定に抜けがあったため追記

### DIFF
--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -134,6 +134,7 @@ cc_import_plugins[] = "calendars"
 cc_import_plugins[] = "reservations"
 cc_import_plugins[] = "photoalbums"
 cc_import_plugins[] = "searchs"
+cc_import_plugins[] = "slideshows"
 
 
 ;------------------------------------------------
@@ -203,6 +204,7 @@ import_frame_plugins[] = "calendars"
 import_frame_plugins[] = "reservations"
 import_frame_plugins[] = "photoalbums"
 import_frame_plugins[] = "searchs"
+import_frame_plugins[] = "slideshows"
 
 
 ; 強制的にフレームデザインを適用する（none は対象外）


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通り
下記設定漏れがあった。

## 設定サンプル

app\Traits\Migration\sample\migration_config\migration_config_nc3.sample.ini
```ini
[plugins]
cc_import_plugins[] = "slideshows"

[frames]
import_frame_plugins[] = "slideshows"
```

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
