### PR TITLE
[フォーム] php80＋任意の単一選択１つのみのフォーム＋未選択で確認画面にいくと500エラーになるバグ修正

### DIFF
--- a/resources/views/plugins/user/forms/default/forms_confirm_column_checkbox.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm_column_checkbox.blade.php
@@ -1,7 +1,7 @@
 {{--
  * 確認画面(confirm checkbox)テンプレート。
 --}}
-@if (array_key_exists($form_obj->id, $request->forms_columns_value))
+@if (array_key_exists($form_obj->id, (array)$request->forms_columns_value))
     @foreach($request->forms_columns_value[$form_obj->id] as $checkbox_item)
         <input name="forms_columns_value[{{$form_obj->id}}][]" type="hidden" value="{{$checkbox_item}}">{{$checkbox_item}}@if (!$loop->last), @endif
     @endforeach

--- a/resources/views/plugins/user/forms/default/forms_confirm_column_radio.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm_column_radio.blade.php
@@ -1,7 +1,7 @@
 {{--
  * 確認画面(confirm radio)テンプレート。
 --}}
-@if (array_key_exists($form_obj->id, $request->forms_columns_value))
+@if (array_key_exists($form_obj->id, (array)$request->forms_columns_value))
     <input name="forms_columns_value[{{$form_obj->id}}]" type="hidden" value="{{$request->forms_columns_value[$form_obj->id]}}">{{$request->forms_columns_value[$form_obj->id]}}
 @else
     <input name="forms_columns_value[{{$form_obj->id}}]" type="hidden">

--- a/resources/views/plugins/user/forms/default/forms_confirm_column_select.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm_column_select.blade.php
@@ -1,7 +1,7 @@
 {{--
  * 確認画面(confirm select)テンプレート。
 --}}
-@if (array_key_exists($form_obj->id, $request->forms_columns_value))
+@if (array_key_exists($form_obj->id, (array)$request->forms_columns_value))
     <input name="forms_columns_value[{{$form_obj->id}}]" type="hidden" value="{{$request->forms_columns_value[$form_obj->id]}}">{{$request->forms_columns_value[$form_obj->id]}}
 @else
     <input name="forms_columns_value[{{$form_obj->id}}]" type="hidden">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

任意の選択肢１個だけのフォームを作り、未選択で確認画面にいくと500エラーになる不具合の修正
通常のフォームの使い方であれば、複数の項目設定と必須項目があると思います（＋php8のサーバ環境）ので、まず遭遇しない不具合かと思います。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1200

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* PHP8.0がリリースされたので新機能全部やる - Qiita
https://qiita.com/rana_kualu/items/c110cb244c3ee38c6859#removed-ability-to-use-array_key_exists-with-objects

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
