### PR TITLE
[コア] バケツ編集画面でプレビューモードにすると権限なしエラーが出るバグ修正

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -266,9 +266,17 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                                 @if (Auth::user()->can('role_arrangement'))
                                     @if (isset($page_list))
                                         @if (app('request')->input('mode') == 'preview')
-                                            <a href="{{ url()->current() }}" class="dropdown-item">プレビュー終了</a>
+                                            @isset ($page)
+                                                <a href="{{ url($page->permanent_link) }}" class="dropdown-item">プレビュー終了</a>
+                                            @else
+                                                <a href="{{ url()->current() }}" class="dropdown-item">プレビュー終了</a>
+                                            @endisset
                                         @else
-                                            <a href="{{ url()->current() }}/?mode=preview" class="dropdown-item">プレビューモード</a>
+                                            @isset ($page)
+                                                <a href="{{ url($page->permanent_link) }}?mode=preview" class="dropdown-item">プレビューモード</a>
+                                            @else
+                                                <a href="{{ url()->current() }}/?mode=preview" class="dropdown-item">プレビューモード</a>
+                                            @endisset
                                         @endif
                                         @if (Auth::user()->can('role_manage_on') && isset($page_list))
                                             <div class="dropdown-divider"></div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

下記エラー画面が出ないように修正しました。

## エラー画面

例）スライドショーの編集画面を開いた後に、プレビューモードを選択
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/8d7a4bd9-77d8-42d8-bba0-57db4d0e5ff7)

プレビューモードになるが、スライドショーの編集画面部分に403（権限がありません）エラーが表示される。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/24ad82d2-9514-466d-984a-ee2c24c63a50)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし


# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
