### PR TITLE
[移行ツール] nc3移行エクスポートでメニューのフレームタイトルを残す設定を追加

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -5151,6 +5151,9 @@ trait MigrationNc3ExportTrait
             }
         }
 
+        // メニューのフレームタイトルを消さずに残す
+        $export_frame_title = $this->getMigrationConfig('menus', 'export_frame_title');
+
         // ページ内のブロック
         foreach ($nc3_frames as $nc3_frame) {
             $this->putMonitor(1, "Frame", "frame_id = " . $nc3_frame->id);
@@ -5177,7 +5180,12 @@ trait MigrationNc3ExportTrait
 
             // フレームタイトル＆メニューの特別処理
             if ($nc3_frame->plugin_key == 'menus') {
-                $frame_ini .= "frame_title = \"\"\n";
+                if ($export_frame_title) {
+                    // メニューのフレームタイトルを残す
+                    $frame_ini .= "frame_title = \"" . $nc3_frame->frame_name . "\"\n";
+                } else {
+                    $frame_ini .= "frame_title = \"\"\n";
+                }
             } else {
                 $frame_ini .= "frame_title = \"" . $nc3_frame->frame_name . "\"\n";
             }

--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -240,6 +240,9 @@ export_clear_style[] = "font-family"
 ; メニューをエクスポート対象外にする場合 true を指定
 ;export_ommit_menu = true
 
+; メニューのフレームタイトルを消さずに残す場合 true を指定
+;export_frame_title = true
+
 ; --- インポート
 ; エリアごとのメニューのインポート
 import_menu_area[] = "header"


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

## 設定例
app\Traits\Migration\sample\migration_config\migration_config_nc3.sample.ini
```ini
[menus]

; --- エクスポート
; メニューのフレームタイトルを消さずに残す場合 true を指定
export_frame_title = true
```

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
