### PR TITLE
[ブログ] 観覧者に表示件数リストを表示する設定追加

### DIFF
--- a/app/Models/User/Blogs/Blogs.php
+++ b/app/Models/User/Blogs/Blogs.php
@@ -16,5 +16,6 @@ class Blogs extends Model
         'bucket_id',
         'blog_name',
         'use_like',
+        'use_view_count_spectator',
     ];
 }

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -65,7 +65,7 @@ class BlogsPlugin extends UserPluginBase
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
         $functions = array();
-        $functions['get']  = ['settingBlogFrame', 'saveLikeJson', 'copy', 'index', 'index_count'];
+        $functions['get']  = ['settingBlogFrame', 'saveLikeJson', 'copy', 'index', 'indexCount'];
         $functions['post'] = ['saveBlogFrame'];
         return $functions;
     }
@@ -660,7 +660,7 @@ WHERE status = 0
     /**
      * 件数指定
      */
-    public function index_count($request, $page_id, $frame_id)
+    public function indexCount($request, $page_id, $frame_id)
     {
         session(["view_count_spectator_{$frame_id}" => $request->input("view_count_spectator")]);
 

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -65,7 +65,7 @@ class BlogsPlugin extends UserPluginBase
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
         $functions = array();
-        $functions['get']  = ['settingBlogFrame', 'saveLikeJson', 'copy'];
+        $functions['get']  = ['settingBlogFrame', 'saveLikeJson', 'copy', 'index', 'index_count'];
         $functions['post'] = ['saveBlogFrame'];
         return $functions;
     }
@@ -211,6 +211,7 @@ class BlogsPlugin extends UserPluginBase
                 'blogs.rss_count',
                 'blogs.use_like',
                 'blogs.like_button_name',
+                'blogs.use_view_count_spectator',
                 'blogs_frames.scope',
                 'blogs_frames.scope_value',
                 'blogs_frames.important_view',
@@ -287,10 +288,11 @@ class BlogsPlugin extends UserPluginBase
         //$blogs_posts = null;
 
         // 件数
-        $count = FrameConfig::getConfigValue($this->frame_configs, BlogFrameConfig::blog_view_count);
-        if ($option_count != null) {
-            $count = $option_count;
-        }
+        // $count = FrameConfig::getConfigValue($this->frame_configs, BlogFrameConfig::blog_view_count);
+        // if ($option_count != null) {
+        //     $count = $option_count;
+        // }
+        $count = $option_count;
         if ($count < 0) {
             $count = 0;
         }
@@ -609,8 +611,20 @@ WHERE status = 0
             return;
         }
 
+        // 件数
+        $count = FrameConfig::getConfigValue($this->frame_configs, BlogFrameConfig::blog_view_count, 15);
+        if ($count < 0) {
+            $count = 0;
+        }
+        // 件数選ぶONならセッション、OFFなら初期の表示件数
+        if ($blog_frame->use_view_count_spectator == 1) {
+            $view_count = session("view_count_spectator_{$frame_id}", $count);
+        } else {
+            $view_count = $count;
+        }
+
         // ブログデータ一覧の取得
-        $blogs_posts = $this->getPosts($blog_frame);
+        $blogs_posts = $this->getPosts($blog_frame, $view_count);
 
         // タグ：画面表示するデータのblogs_posts_id を集める
         $posts_ids = array();
@@ -639,7 +653,18 @@ WHERE status = 0
             'blogs_posts' => $blogs_posts,
             'blog_frame'  => $blog_frame,
             'blog_frame_setting' => BlogsFrames::where('frames_id', $frame_id)->firstOrNew([]),
+            'count'       => $count,
         ]);
+    }
+
+    /**
+     * 件数指定
+     */
+    public function index_count($request, $page_id, $frame_id)
+    {
+        session(["view_count_spectator_{$frame_id}" => $request->input("view_count_spectator")]);
+
+        // リダイレクト先を指定しないため、画面から渡されたredirect_pathに飛ぶ
     }
 
     /**
@@ -1246,6 +1271,7 @@ WHERE status = 0
         $blogs->rss_count     = $request->rss_count;
         $blogs->use_like      = $request->use_like;
         $blogs->like_button_name = $request->like_button_name;
+        $blogs->use_view_count_spectator = $request->use_view_count_spectator;
         //$blogs->approval_flag = $request->approval_flag;
 
         // データ保存

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -65,7 +65,7 @@ class BlogsPlugin extends UserPluginBase
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
         $functions = array();
-        $functions['get']  = ['settingBlogFrame', 'saveLikeJson', 'copy', 'index', 'indexCount'];
+        $functions['get']  = ['settingBlogFrame', 'saveLikeJson', 'copy', 'indexCount'];
         $functions['post'] = ['saveBlogFrame'];
         return $functions;
     }

--- a/database/migrations/2023_06_12_102116_add_use_view_count_spectator_from_blogs.php
+++ b/database/migrations/2023_06_12_102116_add_use_view_count_spectator_from_blogs.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUseViewCountSpectatorFromBlogs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('blogs', function (Blueprint $table) {
+            $table->integer('use_view_count_spectator')->default(0)->comment('表示件数リストを表示')->after('like_button_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('blogs', function (Blueprint $table) {
+            $table->dropColumn('use_view_count_spectator');
+        });
+    }
+}

--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -44,6 +44,8 @@
 
 {{-- ブログ表示 --}}
 @if (isset($blogs_posts))
+    {{-- 表示件数リスト --}}
+    @include('plugins.user.blogs.default.include_view_count_spectator')
 
     @if (isset($is_template_titleindex))
     {{-- titleindexテンプレート --}}

--- a/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
@@ -66,20 +66,20 @@
         <label class="{{$frame->getSettingLabelClass(true)}}">RSSの表示</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-radio custom-control-inline">
-                @if (old('rss', $blog->rss) == 1)
-                    <input type="radio" value="1" id="rss_on" name="rss" class="custom-control-input" checked="checked">
-                @else
-                    <input type="radio" value="1" id="rss_on" name="rss" class="custom-control-input">
-                @endif
-                <label class="custom-control-label" for="rss_on" id="label_rss_on">表示する</label>
-            </div>
-            <div class="custom-control custom-radio custom-control-inline">
                 @if (old('rss', $blog->rss) == 0)
                     <input type="radio" value="0" id="rss_off" name="rss" class="custom-control-input" checked="checked">
                 @else
                     <input type="radio" value="0" id="rss_off" name="rss" class="custom-control-input">
                 @endif
                 <label class="custom-control-label" for="rss_off" id="label_rss_off">表示しない</label>
+            </div>
+            <div class="custom-control custom-radio custom-control-inline">
+                @if (old('rss', $blog->rss) == 1)
+                    <input type="radio" value="1" id="rss_on" name="rss" class="custom-control-input" checked="checked">
+                @else
+                    <input type="radio" value="1" id="rss_on" name="rss" class="custom-control-input">
+                @endif
+                <label class="custom-control-label" for="rss_on" id="label_rss_on">表示する</label>
             </div>
         </div>
     </div>
@@ -96,12 +96,12 @@
         <label class="{{$frame->getSettingLabelClass(true)}}">いいねボタンの表示</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-radio custom-control-inline">
-                <input type="radio" value="1" id="use_like_on" name="use_like" class="custom-control-input" data-toggle="collapse" data-target="#collapse_like_button_name:not(.show)" aria-expanded="false" aria-controls="collapse_like_button_name" @if (old('use_like', $blog->use_like) == 1) checked="checked" @endif>
-                <label class="custom-control-label" for="use_like_on" id="label_use_like_on">表示する</label>
-            </div>
-            <div class="custom-control custom-radio custom-control-inline">
                 <input type="radio" value="0" id="use_like_off" name="use_like" class="custom-control-input" data-toggle="collapse" data-target="#collapse_like_button_name.show" aria-expanded="false" aria-controls="collapse_like_button_name"  @if (old('use_like', $blog->use_like) == 0) checked="checked" @endif>
                 <label class="custom-control-label" for="use_like_off" id="label_use_like_off">表示しない</label>
+            </div>
+            <div class="custom-control custom-radio custom-control-inline">
+                <input type="radio" value="1" id="use_like_on" name="use_like" class="custom-control-input" data-toggle="collapse" data-target="#collapse_like_button_name:not(.show)" aria-expanded="false" aria-controls="collapse_like_button_name" @if (old('use_like', $blog->use_like) == 1) checked="checked" @endif>
+                <label class="custom-control-label" for="use_like_on" id="label_use_like_on">表示する</label>
             </div>
         </div>
     </div>

--- a/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
@@ -115,6 +115,29 @@
         </div>
     </div>
 
+    <div class="row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">表示件数リストを表示</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="custom-control custom-radio custom-control-inline">
+                <input type="radio" value="0" id="use_view_count_spectator_off" name="use_view_count_spectator" class="custom-control-input"  @if (old('use_view_count_spectator', $blog->use_view_count_spectator) == 0) checked="checked" @endif>
+                <label class="custom-control-label" for="use_view_count_spectator_off" id="label_use_view_count_spectator_off">表示しない</label>
+            </div>
+            <div class="custom-control custom-radio custom-control-inline">
+                <input type="radio" value="1" id="use_view_count_spectator_on" name="use_view_count_spectator" class="custom-control-input" @if (old('use_view_count_spectator', $blog->use_view_count_spectator) == 1) checked="checked" @endif>
+                <label class="custom-control-label" for="use_view_count_spectator_on" id="label_use_view_count_spectator_on">表示する</label>
+            </div>
+        </div>
+    </div>
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}"></label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <small class="form-text text-muted">
+                「表示する」場合、観覧者が表示件数を変更できます。<br />
+                表示件数の初期値は「 <a href="{{url('/')}}/plugin/blogs/settingBlogFrame/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}">表示条件</a> 」から設定できます。<br />
+            </small>
+        </div>
+    </div>
+
     {{-- Submitボタン --}}
     <div class="form-group text-center">
         <div class="row">

--- a/resources/views/plugins/user/blogs/default/include_view_count_spectator.blade.php
+++ b/resources/views/plugins/user/blogs/default/include_view_count_spectator.blade.php
@@ -7,7 +7,7 @@
 --}}
 @if (isset($blog_frame->use_view_count_spectator) && $blog_frame->use_view_count_spectator == 1)
     <form action="{{url('/')}}/redirect/plugin/blogs/indexCount/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="get" name="view_count_spectator_down{{$frame_id}}">
-        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/blogs/index/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
+        <input type="hidden" name="redirect_path" value="{{url($page->permanent_link)}}#frame-{{$frame_id}}">
         <div class="float-right">
             {{-- 表示件数リスト --}}
             <select class="form-control form-control-sm" name="view_count_spectator" onchange="document.forms.view_count_spectator_down{{$frame_id}}.submit();">

--- a/resources/views/plugins/user/blogs/default/include_view_count_spectator.blade.php
+++ b/resources/views/plugins/user/blogs/default/include_view_count_spectator.blade.php
@@ -1,0 +1,30 @@
+{{--
+ * 表示件数リスト テンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ブログプラグイン
+--}}
+@if (isset($blog_frame->use_view_count_spectator) && $blog_frame->use_view_count_spectator == 1)
+    <form action="{{url('/')}}/redirect/plugin/blogs/index_count/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="get" name="view_count_spectator_down{{$frame_id}}">
+        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/blogs/index/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
+        <div class="float-right">
+            {{-- 表示件数リスト --}}
+            <select class="form-control form-control-sm" name="view_count_spectator" onchange="document.forms.view_count_spectator_down{{$frame_id}}.submit();">
+                @php
+                    $view_count_spectator = session('view_count_spectator_'. $frame_id, $count);
+                @endphp
+                <option value="1"  @if($view_count_spectator == 1)    selected @endif>1件</option>
+                <option value="5"  @if($view_count_spectator == 5)    selected @endif>5件</option>
+                <option value="10" @if($view_count_spectator == 10)   selected @endif>10件</option>
+                <option value="20" @if($view_count_spectator == 20)   selected @endif>20件</option>
+                {{-- 表示条件の表示件数がリストに含まれて無かったら選択肢追加 --}}
+                @if(!in_array($count, [1,5,10,20]))
+                <option value="{{$count}}"  @if($view_count_spectator == $count)    selected @endif>{{$count}}件</option>
+                @endif
+            </select>
+        </div>
+        {{-- floatの回り込み解除 --}}
+        <div class="clearfix"></div>
+    </form>
+@endif

--- a/resources/views/plugins/user/blogs/default/include_view_count_spectator.blade.php
+++ b/resources/views/plugins/user/blogs/default/include_view_count_spectator.blade.php
@@ -6,7 +6,7 @@
  * @category ブログプラグイン
 --}}
 @if (isset($blog_frame->use_view_count_spectator) && $blog_frame->use_view_count_spectator == 1)
-    <form action="{{url('/')}}/redirect/plugin/blogs/index_count/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="get" name="view_count_spectator_down{{$frame_id}}">
+    <form action="{{url('/')}}/redirect/plugin/blogs/indexCount/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="get" name="view_count_spectator_down{{$frame_id}}">
         <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/blogs/index/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
         <div class="float-right">
             {{-- 表示件数リスト --}}

--- a/resources/views/plugins/user/blogs/designbase/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs.blade.php
@@ -42,6 +42,8 @@
 
 {{-- ブログ表示 --}}
 @if (isset($blogs_posts))
+{{-- 表示件数リスト --}}
+@include('plugins.user.blogs.default.include_view_count_spectator')
 <div>
     <dl>
     @foreach($blogs_posts as $post)


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 表示件数リストを表示する設定を追加して、設定ON時に観覧者が表示件数を変更できるように対応しました。
* 関連対応
    * [change: ブログの設定画面, ラジオでON・OFF時、左側はOFFで統一する](https://github.com/opensource-workshop/connect-cms/commit/5f89b65e3c02cc290a90945cd6e43e0747e28d18) https://github.com/opensource-workshop/connect-cms/issues/737

# 修正後画面
## 設定変更画面（表示件数リストを表示 設定追加）
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/307a36ae-bf1b-4b20-af31-5517d8c5be82)

## 一覧表示（表示件数リストを表示ON）
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/7518bd6c-c952-4a3b-832a-e8f5cfcfd3cf)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
