### PR TITLE
[ユーザ管理] システム管理者権限付与は、システム管理者のみ可に修正

### DIFF
--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -236,15 +236,18 @@ use App\Models\Core\UsersColumns;
         <div class="form-group row">
             <label for="password-confirm" class="col-md-4 text-md-right">管理権限</label>
             <div class="col-md-8">
-                <div class="custom-control custom-checkbox">
-                    @if ((isset($users_roles["manage"]) && isset($users_roles["manage"]["admin_system"]) && $users_roles["manage"]["admin_system"] == 1) ||
-                          old('manage.admin_system') == 1)
-                        <input name="manage[admin_system]" value="1" type="checkbox" class="custom-control-input" id="admin_system" checked="checked">
-                    @else
-                        <input name="manage[admin_system]" value="1" type="checkbox" class="custom-control-input" id="admin_system">
-                    @endif
-                    <label class="custom-control-label" for="admin_system" id="label_admin_system">システム管理者</label>
-                </div>
+                {{-- システム管理者権限付与は、システム管理者のみ可 --}}
+                @if (Auth::user()->can('admin_system'))
+                    <div class="custom-control custom-checkbox">
+                        @if ((isset($users_roles["manage"]) && isset($users_roles["manage"]["admin_system"]) && $users_roles["manage"]["admin_system"] == 1) ||
+                            old('manage.admin_system') == 1)
+                            <input name="manage[admin_system]" value="1" type="checkbox" class="custom-control-input" id="admin_system" checked="checked">
+                        @else
+                            <input name="manage[admin_system]" value="1" type="checkbox" class="custom-control-input" id="admin_system">
+                        @endif
+                        <label class="custom-control-label" for="admin_system" id="label_admin_system">システム管理者</label>
+                    </div>
+                @endif
                 <div class="custom-control custom-checkbox">
                     @if ((isset($users_roles["manage"]) && isset($users_roles["manage"]["admin_site"]) && $users_roles["manage"]["admin_site"] == 1) ||
                           old('manage.admin_site') == 1)


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/pull/1681
* 上記の関連修正です。
    * システム管理者以外は、自身でシステム管理者に昇格できないように対応しました。
    * システム管理者権限付与は、システム管理者のみ行えます。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
