### PR TITLE
[移行ツール] NC3移行エクスポートでNC3.2.0より古いバージョンで移行するONの時、ページ順番を移行後に再現するよう対応

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -556,7 +556,9 @@ trait MigrationNc3ExportTrait
 
             $older_than_nc3_2_0 = $this->getMigrationConfig('basic', 'older_than_nc3_2_0');
             if ($older_than_nc3_2_0) {
-                // nc3.2.0より古い場合は、sort_key が無いため sort_key でソートしない
+                // nc3.2.0より古い場合は、sort_key が無いため parent_id, lft でソートすると、ページの並び順を再現できた。
+                $nc3_top_page_query->orderBy('pages.parent_id')
+                                    ->orderBy('pages.lft');
             } else {
                 // 通常
                 $nc3_top_page_query->orderBy('pages.sort_key');

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -595,13 +595,14 @@ trait MigrationNc3ExportTrait
                 // ->get();
 
             if ($older_than_nc3_2_0) {
-                // nc3.2.0より古い場合は、sort_key が無いため sort_key でソートしない
+                // nc3.2.0より古い場合は、sort_key が無いため parent_id, lft でソートすると、ページの並び順を再現できた。
                 // @see https://github.com/NetCommons3/Pages/commit/77840e492352a21f7300ab1fa877f47f94f0bd1c
                 // @see https://github.com/NetCommons3/Rooms/commit/8edfd1ea18f4b45f5aee7f961d0480048e2d6fc9
-
-                // 若い親IDのページを先に移行しないと、MigrationMappingに親ページID達がなくマッチングできず、移行後にページ階層を再現できないため、parent_idのソート追加。
+                //
+                // ※ 若い親IDのページを先に移行しないと、MigrationMappingに親ページID達がなくマッチングできず、移行後にページ階層を再現できないため、parent_idのソート必要。
                 // nc3.2.0より新しければ、sort_keyで対応され、親ページID達が先に登録されるため、parent_idのソートは不要と思う。
-                $nc3_pages_query->orderBy('pages.parent_id');
+                $nc3_pages_query->orderBy('pages.parent_id')
+                                ->orderBy('pages.lft');
             } else {
                 // 通常
                 $nc3_pages_query->orderBy('pages.sort_key')


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: [移行ツール] NC3移行エクスポートでNC3.2.0より古いバージョンで移行するONの時、ページ順番を移行後に再現するよう対応](https://github.com/opensource-workshop/connect-cms/commit/26f726c502439b061ceb10511361728fef4e7bcd)
* [bugfix: [移行ツール] NC3移行エクスポートでNC3.2.0より古いバージョンで移行するONの時、違うページがトップページとして移行されるバグ修正](https://github.com/opensource-workshop/connect-cms/commit/b6f46190c9d1122b642840961b5de1726f441f90) 

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
