### PR TITLE
[ページ送り] ページ送り（paginate）が中央エリアでもフレーム幅以上になるとはみ出るため、flex-wrapで折り返しするよう対応

### DIFF
--- a/resources/views/vendor/pagination/bootstrap-4.blade.php
+++ b/resources/views/vendor/pagination/bootstrap-4.blade.php
@@ -1,5 +1,6 @@
 @if ($paginator->hasPages())
-    <ul class="pagination">
+    {{-- bugfix: ページ送り（paginate）が中央エリアでもフレーム幅以上になるとはみ出るため、flex-wrapで折り返しするよう対応 --}}
+    <ul class="pagination flex-wrap">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <li class="page-item disabled"><span class="page-link">&laquo;</span></li>

--- a/resources/views/vendor/pagination/bootstrap-4.blade.php
+++ b/resources/views/vendor/pagination/bootstrap-4.blade.php
@@ -38,7 +38,7 @@
 
                     {{-- 1ページ目と2ページ目以外は、カレントの前に「...」表示 --}}
                     @if ($page == $paginator->currentPage() && $page != 1 && $page != 2)
-                        <li class="page-item disabled d-block d-md-none"><span class="page-link">...</span></li>
+                        <li class="page-item disabled d-block d-sm-none"><span class="page-link">...</span></li>
                     @endif
 
                     @if ($page == $paginator->currentPage())
@@ -49,7 +49,7 @@
 
                     {{-- 最終ページと最終ページの1ページ前以外は、カレントの後に「...」表示 --}}
                     @if ($page == $paginator->currentPage() && $page != $paginator->lastPage() && $page != (intval($paginator->lastPage()) - 1))
-                        <li class="page-item disabled d-block d-md-none"><span class="page-link">...</span></li>
+                        <li class="page-item disabled d-block d-sm-none"><span class="page-link">...</span></li>
                     @endif
                 @endforeach
             @endif


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [bugfix: コア, ページ送り（paginate）が中央エリアでもフレーム幅以上になるとはみ出るため、flex-wrapで折り返しするよう対応](https://github.com/opensource-workshop/connect-cms/commit/e132fc6a205b5b6fa5b12c362865713a7f9dc419) 
* 関連修正
    * [bugfix: コア, ページネーションでmd表示の時に不要な...が表示されないように修正](https://github.com/opensource-workshop/connect-cms/commit/ea587230c64fe9375fcab3a4c801f359fac86678)

# 画面
## ページ送りを折り返しするよう対応

* 前提
  * 左右エリアを表示
  * ブログの表示件数１件
  * ブログ件数１５件程度

### 修正後
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/6afc21ec-8dd8-41c2-83c7-cf942756dc59)

### 修正前
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/773c8f0e-7893-4c00-8639-dd1905552c46)


## md表示の時に不要な...が表示されないように修正

* 前提
  * ブログの表示件数１件
  * ブログ件数１５件程度
  * ５ページ目を表示
  * md幅（≥768px）でサイト表示

### 修正後
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/90307f04-208c-4a60-9023-f8473e62b320)

### 修正前
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/6a64627d-0c29-432a-b963-4e8ecb1991d4)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* flex-wrap
https://getbootstrap.jp/docs/4.2/utilities/flex/#wrap
* Medium ≥768px
https://getbootstrap.jp/docs/4.2/layout/grid/#grid-options

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

