### PR TITLE
[移行ツール] NC3のFAQを移行した時、カテゴリの絞り込み機能を常時ONで移行する

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -86,6 +86,7 @@ use App\Enums\ContentOpenType;
 use App\Enums\DatabaseNoticeEmbeddedTag;
 use App\Enums\DatabaseSortFlag;
 use App\Enums\DayOfWeek;
+use App\Enums\FaqNarrowingDownType;
 use App\Enums\FaqSequenceConditionType;
 use App\Enums\FormColumnType;
 use App\Enums\FormMode;
@@ -5681,6 +5682,9 @@ trait MigrationNc3ExportTrait
         } elseif ($plugin_name == 'blogs') {
             // ブログ
             $this->nc3FrameExportBlogs($nc3_frame, $new_page_index, $frame_index_str);
+        } elseif ($plugin_name == 'faqs') {
+            // FAQ
+            $this->nc3FrameExportFaqs($nc3_frame, $new_page_index, $frame_index_str);
         }
     }
 
@@ -5994,6 +5998,20 @@ trait MigrationNc3ExportTrait
 
         $frame_ini = "[blog]\n";
         $frame_ini .= "view_count = {$nc3_blog_frame_setting->articles_per_page}\n";
+        $this->storageAppend($save_folder . "/"     . $ini_filename, $frame_ini);
+    }
+
+    /**
+     * NC3：FAQのフレーム特有部分のエクスポート
+     */
+    private function nc3FrameExportFaqs(Nc3Frame $nc3_frame, int $new_page_index, string $frame_index_str): void
+    {
+        $ini_filename = "frame_" . $frame_index_str . '.ini';
+
+        $save_folder = $this->getImportPath('pages/') . $this->zeroSuppress($new_page_index);
+
+        $frame_ini = "[faq]\n";
+        $frame_ini .= "narrowing_down_type = \"". FaqNarrowingDownType::dropdown . "\"\n";
         $this->storageAppend($save_folder . "/"     . $ini_filename, $frame_ini);
     }
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -168,6 +168,8 @@ use App\Enums\DatabaseNoticeEmbeddedTag;
 use App\Enums\DatabaseSortFlag;
 use App\Enums\DayOfWeek;
 use App\Enums\FacilityDisplayType;
+use App\Enums\FaqFrameConfig;
+use App\Enums\FaqNarrowingDownType;
 use App\Enums\FaqSequenceConditionType;
 use App\Enums\FormColumnType;
 use App\Enums\FormMode;
@@ -5713,6 +5715,17 @@ trait MigrationTrait
         }
         // Frames 登録
         $frame = $this->importPluginFrame($page, $frame_ini, $display_sequence, $bucket);
+
+        // frame_configs 登録
+        if (!empty($faqs)) {
+            // 絞り込み機能
+            $narrowing_down_type = $this->getArrayValue($frame_ini, 'faq', 'narrowing_down_type', FaqNarrowingDownType::none);
+
+            $frame_config = FrameConfig::updateOrCreate(
+                ['frame_id' => $frame->id, 'name' => FaqFrameConfig::faq_narrowing_down_type],
+                ['value' => $narrowing_down_type]
+            );
+        }
 
         // bucketあり
         if (!empty($bucket)) {


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
