### PR TITLE
[移行ツール] インポート時にNC3のブログ-一覧-カテゴリ指定リンクをConnectのリンクに自動置換対応

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -14491,10 +14491,15 @@ trait MigrationTrait
 
         if ($check_url_path) {
             if (stripos($check_url_path, '/blogs/blog_entries/view/') !== false) {
-                // (ブログ)
+                // (ブログ-記事)
                 //  nc3 http://localhost:8081/blogs/blog_entries/view/27/2e19fea842dd98fe341ad536771b90a8?frame_id=49
                 //  cc  http://localhost/plugin/blogs/show/16/49/26#frame-49
                 return $this->convertNc3PluginPermalinkToConnect($content, $url, $db_colum, '/blogs/blog_entries/view/', '/plugin/blogs/show/', 'blogs_post_from_key');
+            } elseif (stripos($check_url_path, '/blogs/blog_entries/index/') !== false && stripos($check_url_path, 'category_id') !== false ) {
+                // (ブログ-一覧-カテゴリ指定)
+                //  nc3 http://localhost:8081/blogs/blog_entries/index/8/category_id:6?frame_id=8
+                //  cc  http://localhost/plugin/blogs/search/1/9?categories_id=6#frame-9
+                return $this->convertNc3PluginPermalinkToConnectCategory($content, $url, $db_colum, '/blogs/blog_entries/index/', '/plugin/blogs/search/', 'categories_blogs');
             } elseif (stripos($check_url_path, '/multidatabases/multidatabase_contents/detail/') !== false) {
                 // (汎用DB)
                 //  nc3 http://localhost:8081/multidatabases/multidatabase_contents/detail/43/50ed8d82a743a87bb78e89f2a654b490?frame_id=43
@@ -14615,6 +14620,66 @@ trait MigrationTrait
     }
 
     /**
+     * nc3プラグインのカテゴリリンク１つをConnectのプラグインリンクに変換
+     */
+    private function convertNc3PluginPermalinkToConnectCategory(?string $content, string $url, string $db_colum, string $from_nc3_plugin_permalink, string $to_cc_plugin_permalink, string $content_target_source_table): ?string
+    {
+        // (ブログ-一覧-カテゴリ指定)
+        //  nc3 http://localhost:8081/blogs/blog_entries/index/8/category_id:6?frame_id=8
+        //      block_id=8, category_id=6
+        //      ※ ?frame_id=999 がないとnc3でもページ特定できない
+        //  cc  http://localhost/plugin/blogs/search/1/9?categories_id=6#frame-9
+        //      page_id=1, frame_id=9, post_id=9
+        //  (nc3) category_id    => MigrationMapping => (cc) category_id
+        //  (nc3) frame_id       => MigrationMapping => (cc) frame_id
+        //  (cc)  frame->id                          => (cc) frame->page_id
+
+        // &amp; => & 等のデコード
+        $check_url = htmlspecialchars_decode($url);
+        $check_url = str_replace('/setting', '', $check_url);
+
+        $check_url_path = parse_url($check_url, PHP_URL_PATH);
+        $check_url_query = parse_url($check_url, PHP_URL_QUERY);
+        // "frame_id=49" を ["frame_id" => "49"] に変換
+        parse_str($check_url_query, $check_url_query_array);
+
+        // デコードなし
+        $url_path = parse_url($url, PHP_URL_PATH);
+        $url_query = parse_url($url, PHP_URL_QUERY);
+
+        $frame_id = Arr::get($check_url_query_array, 'frame_id');
+        if (is_null($frame_id)) {
+            // frame_idなしは置換できない
+            $this->putError(3, $db_colum . '|プラグイン固有リンク|frame_idなしで置換できない', $url);
+            return $content;
+        }
+
+        // 不要文字を取り除き
+        // $path_tmp = str_replace('/blogs/blog_entries/index/', '', $check_url_path);
+        $path_tmp = str_replace($from_nc3_plugin_permalink, '', $check_url_path);
+        // /で分割
+        $src_params = explode('/', $path_tmp);
+
+        $category_id_str = $src_params[1];
+        $category_id_arr = explode(':', $category_id_str);
+        $category_id = $category_id_arr[1] ?? null;
+
+        // $map_category = MigrationMapping::where('target_source_table', 'categories_blogs')->where('source_key', $category_id)->first();
+        $map_category = MigrationMapping::where('target_source_table', $content_target_source_table)->where('source_key', $category_id)->first();
+        $map_frame   = MigrationMapping::where('target_source_table', 'frames')->where('source_key', $frame_id)->firstOrNew([]);
+        $frame       = Frame::find($map_frame->destination_key);
+
+        if ($map_category && $frame) {
+            // $content = str_replace("{$url_path}?{$url_query}", "/plugin/blogs/index/{$frame->page_id}/{$frame->id}?categories_id={$map_category->destination_key}#frame-{$frame->id}", $content);
+            $content = str_replace("{$url_path}?{$url_query}", "{$to_cc_plugin_permalink}{$frame->page_id}/{$frame->id}?categories_id={$map_category->destination_key}#frame-{$frame->id}", $content);
+        } else {
+            // frame_idなしは置換できない
+            $this->putError(3, $db_colum . "|プラグイン固有リンク|MigrationMapping(target_source_table={$content_target_source_table}|frames) or Frameデータなし", $url);
+        }
+        return $content;
+    }
+
+    /**
      * nc3プラグインリンク１つをConnectのファイルリンクに変換
      */
     private function convertNc3PluginPermalinkToConnectFile(?string $content, string $url, string $db_colum, string $from_nc3_plugin_permalink, string $content_target_source_table): ?string
@@ -14653,7 +14718,7 @@ trait MigrationTrait
     /**
      * nc3カレンダー系プラグインリンク１つをConnectのプラグインリンクに変換
      */
-    private function convertNc3PluginPermalinkCalToConnect(?string $content, string $url, string $db_colum, string $from_nc3_plugin_permalink, string $to_cc_plugin_permalink, string $content_target_source_table, ?bool $is_nc3_cal_plugin = false): ?string
+    private function convertNc3PluginPermalinkCalToConnect(?string $content, string $url, string $db_colum, string $from_nc3_plugin_permalink, string $to_cc_plugin_permalink, string $content_target_source_table): ?string
     {
         return $this->convertNc3PluginPermalinkToConnect($content, $url, $db_colum, $from_nc3_plugin_permalink, $to_cc_plugin_permalink, $content_target_source_table, true);
     }

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -14495,7 +14495,7 @@ trait MigrationTrait
                 //  nc3 http://localhost:8081/blogs/blog_entries/view/27/2e19fea842dd98fe341ad536771b90a8?frame_id=49
                 //  cc  http://localhost/plugin/blogs/show/16/49/26#frame-49
                 return $this->convertNc3PluginPermalinkToConnect($content, $url, $db_colum, '/blogs/blog_entries/view/', '/plugin/blogs/show/', 'blogs_post_from_key');
-            } elseif (stripos($check_url_path, '/blogs/blog_entries/index/') !== false && stripos($check_url_path, 'category_id') !== false ) {
+            } elseif (stripos($check_url_path, '/blogs/blog_entries/index/') !== false && stripos($check_url_path, 'category_id') !== false) {
                 // (ブログ-一覧-カテゴリ指定)
                 //  nc3 http://localhost:8081/blogs/blog_entries/index/8/category_id:6?frame_id=8
                 //  cc  http://localhost/plugin/blogs/search/1/9?categories_id=6#frame-9


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: [移行ツール] インポート時にNC3のブログ-一覧-カテゴリ指定リンクをConnectのリンクに自動置換対応](https://github.com/opensource-workshop/connect-cms/commit/5ecc85cfb0300b906001b6709aa80ba893c137f4)
* 関連修正
    * [delete: [移行ツール] NC3移行エクスポート, /cabinets/cabinet_files/download/ のリンク置換は、インポート側で既に行っていたため、現在動いてないプログラムを削除](https://github.com/opensource-workshop/connect-cms/commit/9bc276cfd1aebaa652c08cf7eddc74f07703a341) 

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
