### PR TITLE
[移行ツール] @updateのpage.iniは@update処理に対応してないためサンプル削除

### DIFF
--- a/app/Traits/Migration/sample/migration/@update/pages/0007/page.ini
+++ b/app/Traits/Migration/sample/migration/@update/pages/0007/page.ini
@@ -1,6 +1,0 @@
-[page_base]
-page_name = "保護者からの連絡受付"
-permanent_link = "/保護者からの連絡受付"
-base_display_flag = 1
-nc2_page_id = "19"
-nc2_room_id = "1"


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

wikiの[Migration-from-NC2](https://github.com/opensource-workshop/connect-cms/wiki/Migration-from-NC2#インポートファイルの上書き設定) ページを修正・調査していたところ、移行ツールの`@update`はframeのみ対応が判明したため、対応していないサンプルの@updateのpage.iniは削除しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
