### PR TITLE
[移行ツール] NC2・NC3のサイト概要の移行対応

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -956,6 +956,14 @@ trait MigrationNc3ExportTrait
         $salt = str_replace(array("\r\n", "\r", "\n"), "", $yaml['Security']['salt']);  // salt末尾に改行あり。改行削除
         $basic_ini .= "nc3_security_salt = \"" . $salt . "\"\n";
 
+        // サイト概要
+        $meta_description = Nc3SiteSetting::getNc3SiteSettingValueByKey($site_settings, 'Meta.description');
+        // NC初期設定のサイト概要は除去
+        $meta_description = str_replace('CMS,Netcommons,NetCommons3,CakePHP', '', $meta_description);
+        // ダブルクォーテーション対策
+        $meta_description = str_replace('"', '\"', $meta_description);
+        $basic_ini .= "description = \"" . $meta_description . "\"\n";
+
         // basic.ini ファイル保存
         $this->storagePut($this->getImportPath('basic/basic.ini'), $basic_ini);
     }

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -1390,6 +1390,9 @@ trait MigrationTrait
 
             // nc3_security_salt
             MigrationUtils::updateConfig('nc3_security_salt', $basic_ini, 'migration');
+
+            // サイト概要
+            MigrationUtils::updateConfig('description', $basic_ini, 'meta');
         }
     }
 
@@ -8065,6 +8068,15 @@ trait MigrationTrait
         // $default_theme_public = $configs->where('conf_name', 'default_theme_public')->first();
         // $default_theme_public = empty($default_theme_public) ? '' : $default_theme_public->conf_value;
         // $basic_ini .= "default_theme_public = \"" . $default_theme_public . "\"\n";
+
+        // サイト概要
+        $meta_description_config = $configs->firstWhere('conf_name', 'meta_description') ?? new Nc2Config();
+        $meta_description = $meta_description_config->conf_value;
+        // NC初期設定のサイト概要は除去
+        $meta_description = str_replace('CMS,Netcommons,Maple', '', $meta_description);
+        // ダブルクォーテーション対策
+        $meta_description = str_replace('"', '\"', $meta_description);
+        $basic_ini .= "description = \"" . $meta_description . "\"\n";
 
         // basic,ini ファイル保存
         //Storage::put($this->getImportPath('basic/basic.ini'), $basic_ini);


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。
移行エクスポート時に、NC初期設定のサイト概要は、移行後は不適当な説明になる事から、除去しています。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
