### PR TITLE
[祝日管理] 2025年を登録しても一覧に表示できないバグ修正 OW-1907

### DIFF
--- a/app/Plugins/Manage/HolidayManage/HolidayManage.php
+++ b/app/Plugins/Manage/HolidayManage/HolidayManage.php
@@ -17,6 +17,7 @@ use App\Plugins\Manage\ManagePluginBase;
  * 祝日管理クラス
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 祝日管理
  * @package Controller
@@ -120,12 +121,28 @@ class HolidayManage extends ManagePluginBase
         // 独自設定祝日を加味する。
         $holidays = YasumiHoliday::addConnectHolidays($this->getPosts($request), $holidays);
 
+        // 表示年リストの初期値
+        $holiday_date_max = Holiday::max('holiday_date');
+        if (empty($holiday_date_max))  {
+            // 現在年＋１
+            $year_list_initial = date("Y") + 1;
+        } else {
+            $holiday_date_max = new Carbon($holiday_date_max);
+            if ($holiday_date_max->year > (date("Y") + 1)) {
+                // 登録の最大年
+                $year_list_initial = $holiday_date_max->year;
+            } else {
+                $year_list_initial = date("Y") + 1;
+            }
+        }
+
         // 画面の呼び出し
         return view('plugins.manage.holiday.index', [
             "function"    => __FUNCTION__,
             "plugin_name" => "holiday",
             "configs"     => $configs_array,
             "holidays"    => $holidays,
+            "year_list_initial" => $year_list_initial,
         ]);
     }
 

--- a/app/Plugins/Manage/HolidayManage/HolidayManage.php
+++ b/app/Plugins/Manage/HolidayManage/HolidayManage.php
@@ -123,7 +123,7 @@ class HolidayManage extends ManagePluginBase
 
         // 表示年リストの初期値
         $holiday_date_max = Holiday::max('holiday_date');
-        if (empty($holiday_date_max))  {
+        if (empty($holiday_date_max)) {
             // 現在年＋１
             $year_list_initial = date("Y") + 1;
         } else {

--- a/resources/views/plugins/manage/holiday/index.blade.php
+++ b/resources/views/plugins/manage/holiday/index.blade.php
@@ -32,7 +32,7 @@
                 <label for="year" class="col-md-2 col-form-label text-md-right">表示年</label>
                 <div class="col-md-10">
                 <select class="form-control" name="year" onChange="submitFormYear()">
-                    @for ($i = date("Y") + 1; $i >= 2000; $i--)
+                    @for ($i = $year_list_initial; $i >= 2000; $i--)
                     <option value="{{$i}}"@if (Session::get('holiday_year') == $i) selected @endif>{{$i}}年</option>
                     @endfor
                 </select>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

## 修正前

### 画面
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/7eafba51-c608-4374-b71d-ad098d2ad9a3)

### holidaysテーブル

<body>
<table><tr><th colspan="14">holidays</th></tr><tr><th>id</th><th>holiday_date</th><th>holiday_name</th><th>holiday_key</th><th>status</th><th>created_id</th><th>created_name</th><th>created_at</th><th>updated_id</th><th>updated_name</th><th>updated_at</th><th>deleted_id</th><th>deleted_name</th><th>deleted_at</th></tr><tr class="odd"><td>1</td><td>2026-05-06</td><td>お休み</td><td>2026-05-06</td><td>0</td><td>&nbsp;</td><td>admin3</td><td>2023-06-17 11:56:09.000</td><td>&nbsp;</td><td>&nbsp;</td><td>2023-06-17 11:56:09.000</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>
</table>

## 修正後

### 画面
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/0123a75f-d4dc-4b59-baec-5ef46211ae42)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/wiki/Holidays

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
