### PR TITLE
[移行ツール] NC3移行エクスポート時、Wysiwyg内HTMLからNC3絵文字を削除

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -6103,7 +6103,7 @@ trait MigrationNc3ExportTrait
         // imgタグの不要属性 除去
         // <img class="img-responsive nc3-img nc3-img-block" title="" src="../../uploads/upload_00059.jpg" alt="" data-size="big" data-position="" data-imgid="59" />
 
-        $pattern = '/<img.*?(data-size\s*=\s*[\"|\'].*?[\"|\']).*?>/i';
+        $pattern = '/<img.*?(data-size\s*=\s*[\"\'].*?[\"\']).*?>/i';
         $match_cnt = preg_match_all($pattern, $content, $matches);
         if ($match_cnt) {
             // [1] に中身のみ入ってくる。
@@ -6113,7 +6113,7 @@ trait MigrationNc3ExportTrait
             }
         }
 
-        $pattern = '/<img.*?(data-position\s*=\s*[\"|\'].*?[\"|\']).*?>/i';
+        $pattern = '/<img.*?(data-position\s*=\s*[\"\'].*?[\"\']).*?>/i';
         $match_cnt = preg_match_all($pattern, $content, $matches);
         if ($match_cnt) {
             // [1] に中身のみ入ってくる。
@@ -6123,7 +6123,7 @@ trait MigrationNc3ExportTrait
             }
         }
 
-        $pattern = '/<img.*?(data-imgid\s*=\s*[\"|\'].*?[\"|\']).*?>/i';
+        $pattern = '/<img.*?(data-imgid\s*=\s*[\"\'].*?[\"\']).*?>/i';
         $match_cnt = preg_match_all($pattern, $content, $matches);
         if ($match_cnt) {
             // [1] に中身のみ入ってくる。
@@ -6133,7 +6133,7 @@ trait MigrationNc3ExportTrait
             }
         }
 
-        $pattern = '/<img.*?(class\s*=\s*[\"|\'].*?[\"|\']).*?>/i';
+        $pattern = '/<img.*?(class\s*=\s*[\"\'].*?[\"\']).*?>/i';
         $match_cnt = preg_match_all($pattern, $content, $matches);
         if ($match_cnt) {
             // [1] に中身のみ入ってくる。
@@ -6153,7 +6153,7 @@ trait MigrationNc3ExportTrait
         }
 
         // nc3ではimgにaltとtitleが自動設定されるため、titleが空なら消す
-        $pattern = '/<img.*?title\s*=\s*[\"|\'](.*?)[\"|\'].*?>/i';
+        $pattern = '/<img.*?title\s*=\s*[\"\'](.*?)[\"\'].*?>/i';
         $match_cnt = preg_match_all($pattern, $content, $matches);
         if ($match_cnt) {
             // [1] に中身のみ入ってくる。

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -6211,6 +6211,9 @@ trait MigrationNc3ExportTrait
         // Google Analytics タグ部分を削除
         $content = MigrationUtils::deleteGATag($content);
 
+        // NC3絵文字を削除
+        $content = MigrationUtils::deleteNc3Emoji($content);
+
         // HTML content の保存
         if ($save_folder) {
             $content = $this->exportStrReplace($content, 'contents');

--- a/app/Utilities/Migration/MigrationUtils.php
+++ b/app/Utilities/Migration/MigrationUtils.php
@@ -254,6 +254,23 @@ class MigrationUtils
     }
 
     /**
+     * HTML からNC3絵文字を削除
+     *
+     * @link https://regexper.com/#%2F%3Cimg.*%3F%28class%5Cs*%3D%5Cs*%5B%5C%22%5C'%5Dnc-title-icon%5B%5C%22%5C'%5D%29.*%3F%3E%2Fi
+     * @link https://www.php.net/manual/ja/reference.pcre.pattern.modifiers.php
+     */
+    public static function deleteNc3Emoji($content)
+    {
+        $pattern = '/<img.*?(class\s*=\s*[\"\']nc-title-icon[\"\']).*?>/i';
+        preg_match_all($pattern, $content, $matches);
+
+        foreach ($matches[0] as $matche) {
+            $content = str_replace($matche, '', $content);
+        }
+        return $content;
+    }
+
+    /**
      * サイト基本設定をインポート
      */
     public static function updateConfig($name, $ini, $category = 'general')


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: 移行ツール, NC3移行エクスポート時、Wysiwyg内HTMLからNC3絵文字を削除](https://github.com/opensource-workshop/connect-cms/commit/5a8eba216edb4df2f460326054ffea4081ab1ba5)
* 関連修正
    * [refactor: 移行ツール, cleaningContent()の正規表現の条件見直し（[]内でor条件の場合|は不要）](https://github.com/opensource-workshop/connect-cms/commit/5f5d847541c924e6e816186504642ae4cea214d8)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
