### PR TITLE
[移行ツール] NC3移行エクスポート時にNC3絵文字の削除で不要に前後の文字や画像を消す不具合を修正

### DIFF
--- a/app/Utilities/Migration/MigrationUtils.php
+++ b/app/Utilities/Migration/MigrationUtils.php
@@ -256,17 +256,32 @@ class MigrationUtils
     /**
      * HTML からNC3絵文字を削除
      *
+     * ・まずimgタグを取得
+     * ・imgタグから 目的のclass = "nc-title-icon" を取得
+     * ・該当imgを消す
+     * ※ いきなり imgタグから 目的のclass = "nc-title-icon" を取得 すると、正規表現の加減で、1行の「imgタグ(NC3絵文字)Pタグimgタグ(NC3絵文字)」が間違って取得されるため。
+     *
      * @link https://regexper.com/#%2F%3Cimg.*%3F%28class%5Cs*%3D%5Cs*%5B%5C%22%5C'%5Dnc-title-icon%5B%5C%22%5C'%5D%29.*%3F%3E%2Fi
      * @link https://www.php.net/manual/ja/reference.pcre.pattern.modifiers.php
      */
     public static function deleteNc3Emoji($content)
     {
-        $pattern = '/<img.*?(class\s*=\s*[\"\']nc-title-icon[\"\']).*?>/i';
-        preg_match_all($pattern, $content, $matches);
-
-        foreach ($matches[0] as $matche) {
-            $content = str_replace($matche, '', $content);
+        // ・まずimgタグを取得
+        $imgs = self::getContentImageTag($content);
+        if (!$imgs) {
+            return $content;
         }
+
+        foreach ($imgs[0] as $img) {
+            // ・imgタグから 目的のclass = "nc-title-icon" を取得
+            $pattern = '/<img.*?(class\s*=\s*[\"\']nc-title-icon[\"\']).*?>/i';
+            preg_match_all($pattern, $img, $matches);
+            foreach ($matches[0] as $matche) {
+                // ・該当imgを消す
+                $content = str_replace($matche, '', $content);
+            }
+        }
+
         return $content;
     }
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
