### PR TITLE
[連番管理] 連番取得functionの汎用化

### DIFF
--- a/app/Models/Common/Numbers.php
+++ b/app/Models/Common/Numbers.php
@@ -19,4 +19,31 @@ class Numbers extends Model
      * create()やupdate()で入力を受け付ける ホワイトリスト
      */
     protected $fillable = ['plugin_name', 'buckets_id', 'serial_number', 'prefix'];
+
+    /**
+     * 連番取得
+     */
+    public static function getNo($plugin_name = null, $buckets_id = null, $prefix = null): int
+    {
+        // 連番データは、払いだした最大の数値を保持している状態。
+
+        // firstOrCreate で最初の連番に 0 を指定して、取得した値をインクリメント
+        $numbers = self::firstOrCreate(
+            [
+                'plugin_name'   => $plugin_name,
+                'buckets_id'    => $buckets_id,
+                'prefix'        => $prefix
+            ],
+            [
+                'serial_number' => 0,
+            ]
+        );
+
+        // インクリメント
+        $numbers->increment('serial_number', 1);
+        // インクリメントでupdating()イベントが走らないため、saveを実行してupdated_id,updated_nameを自動セット
+        $numbers->save();
+
+        return $numbers->serial_number;
+    }
 }

--- a/app/Plugins/PluginBase.php
+++ b/app/Plugins/PluginBase.php
@@ -73,28 +73,9 @@ class PluginBase
     /**
      * 連番取得
      */
-    public function getNo($plugin_name = null, $buckets_id = null, $prefix = null)
+    protected function getNo($plugin_name = null, $buckets_id = null, $prefix = null): int
     {
-        // 連番データは、払いだした最大の数値を保持している状態。
-
-        // firstOrCreate で最初の連番に 0 を指定して、取得した値をインクリメント
-        $numbers = Numbers::firstOrCreate(
-            [
-                'plugin_name'   => $plugin_name,
-                'buckets_id'    => $buckets_id,
-                'prefix'        => $prefix
-            ],
-            [
-                'serial_number' => 0,
-            ]
-        );
-
-        // インクリメント
-        $numbers->increment('serial_number', 1);
-        // インクリメントでupdating()イベントが走らないため、saveを実行してupdated_id,updated_nameを自動セット
-        $numbers->save();
-
-        return $numbers->serial_number;
+        return Numbers::getNo($plugin_name, $buckets_id, $prefix);
     }
 
     /**


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

プラグインのコントローラー以外からも連番取得できるように、連番取得functionをModelに移動しました。
既存のフォームの採番に影響がでない事を確認しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
