### PR TITLE
[メールの埋め込みタグ] 共通のメール設定画面の説明を任意に変更できるように対応

### DIFF
--- a/app/Enums/NoticeEmbeddedTag.php
+++ b/app/Enums/NoticeEmbeddedTag.php
@@ -10,15 +10,25 @@ use App\Enums\EnumsBase;
 class NoticeEmbeddedTag extends EnumsBase
 {
     // 定数メンバ
+    /** サイト名 */
     const site_name = 'site_name';
+    /** 処理名 */
     const method = 'method';
+    /** タイトル */
     const title = 'title';
+    /** 本文 */
     const body = 'body';
+    /** URL */
     const url = 'url';
+    /** 削除時のコメント */
     const delete_comment = 'delete_comment';
+    /** 登録者 */
     const created_name = 'created_name';
+    /** 登録日時 */
     const created_at = 'created_at';
+    /** 更新者 */
     const updated_name = 'updated_name';
+    /** 更新日時 */
     const updated_at = 'updated_at';
 
     // key/valueの連想配列

--- a/resources/views/plugins/common/description_frame_mails_common.blade.php
+++ b/resources/views/plugins/common/description_frame_mails_common.blade.php
@@ -6,6 +6,7 @@
  * @category プラグイン共通
  *
  * @param $embedded_tags   埋め込みタグの内容
+ * @param $caption         埋め込みタグの説明
 --}}
 @php
     $caption = $caption ?? '埋め込みタグを記述すると件名、本文の該当部分に対応した内容が入ります。';

--- a/resources/views/plugins/common/description_frame_mails_common.blade.php
+++ b/resources/views/plugins/common/description_frame_mails_common.blade.php
@@ -7,11 +7,13 @@
  *
  * @param $embedded_tags   埋め込みタグの内容
 --}}
-
+@php
+    $caption = $caption ?? '埋め込みタグを記述すると件名、本文の該当部分に対応した内容が入ります。';
+@endphp
 <div class="card bg-light mt-1">
     <div class="card-body px-2 pt-0 pb-1">
         <div class="small">
-            埋め込みタグを記述すると件名、本文の該当部分に対応した内容が入ります。<br />
+            {{$caption}}<br />
             <table class="table table-striped table-sm table-bordered">
                 <thead>
                     <tr>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
