### PR TITLE
[フォーム] 閲覧パスワード設定追加

### DIFF
--- a/app/Enums/FormAccessLimitType.php
+++ b/app/Enums/FormAccessLimitType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * フォームの閲覧制限タイプ
+ */
+final class FormAccessLimitType extends EnumsBase
+{
+    // 定数メンバ
+    const none = 0;
+    const password = 1;
+
+    // key/valueの連想配列
+    const enum = [
+        self::none => '制限しない',
+        self::password => 'パスワードで閲覧制限する',
+    ];
+
+    /**
+     * 初期値
+     */
+    public static function getDefault()
+    {
+        return self::none;
+    }
+}

--- a/app/Models/User/Forms/Forms.php
+++ b/app/Models/User/Forms/Forms.php
@@ -24,6 +24,8 @@ class Forms extends Model
         'bucket_id',
         'forms_name',
         'form_mode',
+        'access_limit_type',
+        'form_password',
         'entry_limit',
         'entry_limit_over_message',
         'display_control_flag',

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -422,7 +422,6 @@ class FormsPlugin extends UserPluginBase
                 // フォーム
                 return $this->view('forms', [
                     'request' => $request,
-                    'frame_id' => $frame_id,
                     'form' => $form,
                     'forms_columns' => $forms_columns,
                     'forms_columns_id_select' => $forms_columns_id_select,
@@ -432,7 +431,6 @@ class FormsPlugin extends UserPluginBase
                 // アンケート
                 return $this->view('index_tandem', [
                     'request' => $request,
-                    'frame_id' => $frame_id,
                     'form' => $form,
                     'forms_columns' => $forms_columns,
                     'forms_columns_id_select' => $forms_columns_id_select,

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -371,8 +371,6 @@ class FormsPlugin extends UserPluginBase
                 $forms_columns_value_for_time_to = $request->forms_columns_value_for_time_to;
 
                 foreach ($tmp_forms_columns as $tmp_forms_column) {
-                    // $tmp_array[$tmp_forms_column->id] = isset($forms_columns_value[$tmp_forms_column->id]) ? $forms_columns_value[$tmp_forms_column->id] : null;
-                    // var_dump($tmp_forms_column->id);
 
                     if (! isset($forms_columns_value[$tmp_forms_column->id])) {
                         // 入力なし
@@ -404,7 +402,6 @@ class FormsPlugin extends UserPluginBase
                             $forms_columns_value[$tmp_forms_column->id] = $request->input($tmp_forms_column->column_name, null);
                         }
 
-                        // var_dump($tmp_forms_column->id);
                         $request->merge([
                             "forms_columns_value" => $forms_columns_value,
                             "forms_columns_value_confirmation" => $forms_columns_value_confirmation,
@@ -414,21 +411,10 @@ class FormsPlugin extends UserPluginBase
                     }
                 }
             }
-
-            // foreach ($forms_columns as $forms_column) {
-            //     var_dump($forms_column->id);
-            //     if (isset($forms_column->group)) {
-            //         foreach ($forms_column->group as $group_row) {
-            //             var_dump($group_row->id);
-            //         }
-            //     }
-            // }
         } else {
             // フレームに紐づくフォーム親データがない場合
             $setting_error_messages[] = 'フレームの設定画面から、使用するフォームを選択するか、作成してください。';
         }
-
-        // var_dump('index', $request->forms_columns_value, $frame_id, $request->frame_id);
 
         if (empty($setting_error_messages)) {
             // 表示テンプレートを呼び出す

--- a/config/app.php
+++ b/config/app.php
@@ -323,6 +323,7 @@ $app_array = [
         'FormsRegisterTargetPlugin' => \App\Enums\FormsRegisterTargetPlugin::class,
         'WebsiteType' => \App\Enums\WebsiteType::class,
         'BlogNarrowingDownType' => \App\Enums\BlogNarrowingDownType::class,
+        'FormAccessLimitType' => \App\Enums\FormAccessLimitType::class,
 
         // utils
         'DateUtils' => \App\Utilities\Date\DateUtils::class,

--- a/database/migrations/2023_06_26_094629_add_access_limit_type_form_password_from_forms.php
+++ b/database/migrations/2023_06_26_094629_add_access_limit_type_form_password_from_forms.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAccessLimitTypeFormPasswordFromForms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->integer('access_limit_type')->default(0)->comment('閲覧制限タイプ')->after('form_mode');
+            $table->string('form_password')->nullable()->comment('閲覧パスワード')->after('access_limit_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('access_limit_type');
+            $table->dropColumn('form_password');
+        });
+    }
+}

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -202,7 +202,7 @@
     </div>
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass(true)}} pt-0">表示期間</label>
+        <label class="{{$frame->getSettingLabelClass()}} pt-0">表示期間</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
                 <label>表示期間の制御</label><br>
@@ -219,7 +219,7 @@
     </div>
 
     <div class="form-group row collapse" id="collapse_display_control{{$frame_id}}">
-        <label class="{{$frame->getSettingLabelClass(true)}} pt-0"></label>
+        <label class="{{$frame->getSettingLabelClass()}} pt-0"></label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
                 <label>表示開始日時</label>
@@ -254,7 +254,7 @@
     </div>
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass(true)}} pt-0">登録期間</label>
+        <label class="{{$frame->getSettingLabelClass()}} pt-0">登録期間</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
                 <label>登録期間の制御</label><br>
@@ -271,7 +271,7 @@
     </div>
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass(true)}} pt-0"></label>
+        <label class="{{$frame->getSettingLabelClass()}} pt-0"></label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
                 <label>登録開始日時</label>
@@ -337,7 +337,7 @@
     </div>
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass(true)}} pt-0"></label>
+        <label class="{{$frame->getSettingLabelClass()}} pt-0"></label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
                 <label>メールの添付ファイル制御</label><br>

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -79,7 +79,7 @@
     </div>
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass(true)}} pt-0">フォームモード</label>
+        <label class="{{$frame->getSettingLabelClass()}}">フォームモード</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
                 @foreach (FormMode::getMembers() as $enum_value => $enum_label)

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -362,7 +362,7 @@
         <div class="{{$frame->getSettingInputClass()}}">
             <div class="custom-control custom-checkbox">
                 <input type="hidden" name="use_temporary_regist_mail_flag" value="0">
-                <input type="checkbox" name="use_temporary_regist_mail_flag" value="1" class="custom-control-input" id="use_temporary_regist_mail_flag" @if(old('use_temporary_regist_mail_flag', $form->use_temporary_regist_mail_flag)) checked=checked @endif>
+                <input type="checkbox" name="use_temporary_regist_mail_flag" value="1" class="custom-control-input" id="use_temporary_regist_mail_flag" @if(old('use_temporary_regist_mail_flag', $form->use_temporary_regist_mail_flag)) checked=checked @endif data-toggle="collapse" data-target="#collapse_temporary_regist{{$frame_id}}" aria-expanded="false" aria-controls="collapse_temporary_regist{{$frame_id}}">
                 <label class="custom-control-label" for="use_temporary_regist_mail_flag">登録者に仮登録メールを送信する</label>
             </div>
             <div>
@@ -374,39 +374,41 @@
         </div>
     </div>
 
-    <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}"></label>
-        <div class="{{$frame->getSettingInputClass()}}">
-            <label class="control-label">仮登録メール件名</label>
-            <input type="text" name="temporary_regist_mail_subject" value="{{old('temporary_regist_mail_subject', $form->temporary_regist_mail_subject)}}" class="form-control" placeholder="（例）仮登録のお知らせと本登録のお願い">
-            <small class="text-muted">
-                ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
-                ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
-                ※ [[to_datetime]] を記述すると該当部分に登録日時が入ります。<br>
-            </small>
+    <div class="collapse" id="collapse_temporary_regist{{$frame_id}}">
+        <div class="form-group row">
+            <label class="{{$frame->getSettingLabelClass()}}"></label>
+            <div class="{{$frame->getSettingInputClass()}}">
+                <label class="control-label">仮登録メール件名</label>
+                <input type="text" name="temporary_regist_mail_subject" value="{{old('temporary_regist_mail_subject', $form->temporary_regist_mail_subject)}}" class="form-control" placeholder="（例）仮登録のお知らせと本登録のお願い">
+                <small class="text-muted">
+                    ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                    ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
+                    ※ [[to_datetime]] を記述すると該当部分に登録日時が入ります。<br>
+                </small>
+            </div>
         </div>
-    </div>
 
-    <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}"></label>
-        <div class="{{$frame->getSettingInputClass()}}">
-            <label class="control-label">仮登録メールフォーマット</label>
-            <textarea name="temporary_regist_mail_format" class="form-control" rows=5 placeholder="（例）仮登録を受け付けました。&#13;&#10;引き続き、下記のURLへアクセスしていただき、本登録を行ってください。&#13;&#10;&#13;&#10;↓本登録URL&#13;&#10;[[entry_url]]&#13;&#10;&#13;&#10;※お使いのメールソフトによっては、URLが途中で切れてアクセスできない場合があります。&#13;&#10;　その場合はクリックされるのではなくURLをブラウザのアドレス欄にコピー＆ペーストしてアクセスしてください。&#13;&#10;----------------------------------&#13;&#10;[[body]]&#13;&#10;----------------------------------">{{old('temporary_regist_mail_format', $form->temporary_regist_mail_format)}}</textarea>
-            @include('plugins.common.errors_inline', ['name' => 'temporary_regist_mail_format'])
-            <small class="text-muted">
-                ※ [[entry_url]] を記述すると本登録URLが入ります。本登録URLの有効期限は仮登録後60分です。<br>
-                ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
-                ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
-                ※ [[to_datetime]] を記述すると該当部分に登録日時が入ります。<br>
-                ※ [[body]] を記述すると該当部分に登録内容が入ります。
-            </small>
+        <div class="form-group row">
+            <label class="{{$frame->getSettingLabelClass()}}"></label>
+            <div class="{{$frame->getSettingInputClass()}}">
+                <label class="control-label">仮登録メールフォーマット</label>
+                <textarea name="temporary_regist_mail_format" class="form-control" rows=5 placeholder="（例）仮登録を受け付けました。&#13;&#10;引き続き、下記のURLへアクセスしていただき、本登録を行ってください。&#13;&#10;&#13;&#10;↓本登録URL&#13;&#10;[[entry_url]]&#13;&#10;&#13;&#10;※お使いのメールソフトによっては、URLが途中で切れてアクセスできない場合があります。&#13;&#10;　その場合はクリックされるのではなくURLをブラウザのアドレス欄にコピー＆ペーストしてアクセスしてください。&#13;&#10;----------------------------------&#13;&#10;[[body]]&#13;&#10;----------------------------------">{{old('temporary_regist_mail_format', $form->temporary_regist_mail_format)}}</textarea>
+                @include('plugins.common.errors_inline', ['name' => 'temporary_regist_mail_format'])
+                <small class="text-muted">
+                    ※ [[entry_url]] を記述すると本登録URLが入ります。本登録URLの有効期限は仮登録後60分です。<br>
+                    ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
+                    ※ [[form_name]] を記述すると該当部分にフォーム名が入ります。<br>
+                    ※ [[to_datetime]] を記述すると該当部分に登録日時が入ります。<br>
+                    ※ [[body]] を記述すると該当部分に登録内容が入ります。
+                </small>
+            </div>
         </div>
-    </div>
 
-    <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">仮登録後のメッセージ</label>
-        <div class="{{$frame->getSettingInputClass()}}">
-            <textarea name="temporary_regist_after_message" class="form-control" rows=5 placeholder="（例）仮登録を受け付けました。&#13;&#10;メールを送信しましたので内容をご確認の上、本登録を行ってください。">{{old('temporary_regist_after_message', $form->temporary_regist_after_message)}}</textarea>
+        <div class="form-group row">
+            <label class="{{$frame->getSettingLabelClass()}}">仮登録後のメッセージ</label>
+            <div class="{{$frame->getSettingInputClass()}}">
+                <textarea name="temporary_regist_after_message" class="form-control" rows=5 placeholder="（例）仮登録を受け付けました。&#13;&#10;メールを送信しましたので内容をご確認の上、本登録を行ってください。">{{old('temporary_regist_after_message', $form->temporary_regist_after_message)}}</textarea>
+            </div>
         </div>
     </div>
 
@@ -588,6 +590,11 @@
     @if (old('access_limit_type', $access_limit_type) == FormAccessLimitType::password)
         // 閲覧パスワード
         $('#collapse_form_password{{$frame_id}}').collapse('show')
+    @endif
+
+    @if(old('use_temporary_regist_mail_flag', $form->use_temporary_regist_mail_flag))
+        // 仮登録メール
+        $('#collapse_temporary_regist{{$frame_id}}').collapse('show')
     @endif
 
     @if (old('numbering_use_flag', $form->numbering_use_flag))

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -71,7 +71,7 @@
     {{ csrf_field() }}
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">フォーム名 <label class="badge badge-danger">必須</label></label>
+        <label class="{{$frame->getSettingLabelClass()}}">フォーム名 <span class="badge badge-danger">必須</span></label>
         <div class="{{$frame->getSettingInputClass()}}">
             <input type="text" name="forms_name" value="{{old('forms_name', $form->forms_name)}}" class="form-control">
             @include('plugins.common.errors_inline', ['name' => 'forms_name'])

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -207,18 +207,18 @@
             <div class="col pl-0">
                 <label>表示期間の制御</label><br>
                 <div class="custom-control custom-radio custom-control-inline">
-                    <input type="radio" value="0" id="display_control_flag_0" name="display_control_flag" class="custom-control-input" @if(old('display_control_flag', $form->display_control_flag) == 0) checked="checked" @endif>
+                    <input type="radio" value="0" id="display_control_flag_0" name="display_control_flag" class="custom-control-input" @if(old('display_control_flag', $form->display_control_flag) == 0) checked="checked" @endif data-toggle="collapse" data-target="#collapse_display_control{{$frame_id}}.show">
                     <label class="custom-control-label" for="display_control_flag_0">表示期間で制御しない</label>
                 </div>
                 <div class="custom-control custom-radio custom-control-inline">
-                    <input type="radio" value="1" id="display_control_flag_1" name="display_control_flag" class="custom-control-input" @if(old('display_control_flag', $form->display_control_flag) == 1) checked="checked" @endif>
+                    <input type="radio" value="1" id="display_control_flag_1" name="display_control_flag" class="custom-control-input" @if(old('display_control_flag', $form->display_control_flag) == 1) checked="checked" @endif data-toggle="collapse" data-target="#collapse_display_control{{$frame_id}}:not(.show)" aria-expanded="true" aria-controls="collapse_display_control{{$frame_id}}">
                     <label class="custom-control-label" for="display_control_flag_1">表示期間で制御する</label>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="form-group row">
+    <div class="form-group row collapse" id="collapse_display_control{{$frame_id}}">
         <label class="{{$frame->getSettingLabelClass(true)}} pt-0"></label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
@@ -232,7 +232,8 @@
                 @include('plugins.common.errors_inline', ['name' => 'display_from'])
                 <small class="text-muted">
                     ※ 未入力の場合、開始日時で表示制限しません。<br>
-                    ※ 開始日時になった瞬間に公開します。例えば14:00の場合、14:00に公開します。
+                    ※ 開始日時になった瞬間に公開します。例えば14:00の場合、14:00に公開します。<br>
+                    <br><!-- 項目が縦中央によるため、改行でそろえる -->
                 </small>
             </div>
             <div class="col pl-0">
@@ -590,6 +591,11 @@
     @if (old('access_limit_type', $access_limit_type) == FormAccessLimitType::password)
         // 閲覧パスワード
         $('#collapse_form_password{{$frame_id}}').collapse('show')
+    @endif
+
+    @if(old('display_control_flag', $form->display_control_flag) == 1)
+        // 表示期間
+        $('#collapse_display_control{{$frame_id}}').collapse('show')
     @endif
 
     @if(old('use_temporary_regist_mail_flag', $form->use_temporary_regist_mail_flag))

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -74,7 +74,7 @@
         <label class="{{$frame->getSettingLabelClass()}}">フォーム名 <label class="badge badge-danger">必須</label></label>
         <div class="{{$frame->getSettingInputClass()}}">
             <input type="text" name="forms_name" value="{{old('forms_name', $form->forms_name)}}" class="form-control">
-            @if ($errors && $errors->has('forms_name')) <div class="text-danger">{{$errors->first('forms_name')}}</div> @endif
+            @include('plugins.common.errors_inline', ['name' => 'forms_name'])
         </div>
     </div>
 
@@ -148,11 +148,11 @@
         <label class="{{$frame->getSettingLabelClass()}}">登録制限数</label>
         <div class="{{$frame->getSettingInputClass()}}">
             <input type="text" name="entry_limit" value="{{old('entry_limit', $form->entry_limit)}}" class="form-control">
+            @include('plugins.common.errors_inline', ['name' => 'entry_limit'])
             <small class="text-muted">
                 ※ 未入力か 0 の場合、登録数を制限しません。<br>
                 ※ 制限する場合、本登録数で制限します。
-            </small><br>
-            @if ($errors && $errors->has('entry_limit')) <div class="text-danger">{{$errors->first('entry_limit')}}</div> @endif
+            </small>
         </div>
     </div>
 
@@ -186,39 +186,31 @@
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
                 <label>表示開始日時</label>
-
                 <div class="input-group" id="display_from{{$frame_id}}" data-target-input="nearest">
                     <input class="form-control datetimepicker-input" type="text" name="display_from" value="{{old('display_from', $form->display_from)}}" data-target="#display_from{{$frame_id}}">
                     <div class="input-group-append" data-target="#display_from{{$frame_id}}" data-toggle="datetimepicker">
                         <div class="input-group-text"><i class="far fa-clock"></i></div>
                     </div>
                 </div>
-
+                @include('plugins.common.errors_inline', ['name' => 'display_from'])
                 <small class="text-muted">
                     ※ 未入力の場合、開始日時で表示制限しません。<br>
                     ※ 開始日時になった瞬間に公開します。例えば14:00の場合、14:00に公開します。
                 </small>
-                @if ($errors && $errors->has('display_from'))
-                    <div class="text-danger">{{$errors->first('display_from')}}</div>
-                @endif
             </div>
             <div class="col pl-0">
                 <label>表示終了日時</label>
-
                 <div class="input-group" id="display_to{{$frame_id}}" data-target-input="nearest">
                     <input class="form-control datetimepicker-input" type="text" name="display_to" value="{{old('display_to', $form->display_to)}}" data-target="#display_to{{$frame_id}}">
                     <div class="input-group-append" data-target="#display_to{{$frame_id}}" data-toggle="datetimepicker">
                         <div class="input-group-text"><i class="far fa-clock"></i></div>
                     </div>
                 </div>
-
+                @include('plugins.common.errors_inline', ['name' => 'display_to'])
                 <small class="text-muted">
                     ※ 未入力の場合、終了日時で表示制限しません。<br>
                     ※ 終了日時になった瞬間に表示終了します。例えば15:00の場合、14:59まで表示します。
                 </small>
-                @if ($errors && $errors->has('display_to'))
-                    <div class="text-danger">{{$errors->first('display_to')}}</div>
-                @endif
             </div>
         </div>
     </div>
@@ -245,39 +237,31 @@
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
                 <label>登録開始日時</label>
-
                 <div class="input-group" id="regist_from{{$frame_id}}" data-target-input="nearest">
                     <input class="form-control datetimepicker-input" type="text" name="regist_from" value="{{old('regist_from', $form->regist_from)}}" data-target="#regist_from{{$frame_id}}">
                     <div class="input-group-append" data-target="#regist_from{{$frame_id}}" data-toggle="datetimepicker">
                         <div class="input-group-text"><i class="far fa-clock"></i></div>
                     </div>
                 </div>
-
+                @include('plugins.common.errors_inline', ['name' => 'regist_from'])
                 <small class="text-muted">
                     ※ 未入力の場合、開始日時で登録制限しません。<br>
                     ※ 開始日時になった瞬間に登録開始します。例えば14:00の場合、14:00に登録開始します。
                 </small>
-                @if ($errors && $errors->has('regist_from'))
-                    <div class="text-danger">{{$errors->first('regist_from')}}</div>
-                @endif
             </div>
             <div class="col pl-0">
                 <label>登録終了日時</label>
-
                 <div class="input-group" id="regist_to{{$frame_id}}" data-target-input="nearest">
                     <input class="form-control datetimepicker-input" type="text" name="regist_to" value="{{old('regist_to', $form->regist_to)}}" data-target="#regist_to{{$frame_id}}">
                     <div class="input-group-append" data-target="#regist_to{{$frame_id}}" data-toggle="datetimepicker">
                         <div class="input-group-text"><i class="far fa-clock"></i></div>
                     </div>
                 </div>
-
+                @include('plugins.common.errors_inline', ['name' => 'regist_to'])
                 <small class="text-muted">
                     ※ 未入力の場合、終了日時で登録制限しません。<br>
                     ※ 終了日時になった瞬間に登録終了します。例えば15:00の場合、14:59まで登録できます。
                 </small>
-                @if ($errors && $errors->has('regist_to'))
-                    <div class="text-danger">{{$errors->first('regist_to')}}</div>
-                @endif
             </div>
         </div>
     </div>
@@ -298,7 +282,7 @@
         <div class="{{$frame->getSettingInputClass()}}">
             <label class="control-label">送信するメールアドレス（複数ある場合はカンマで区切る）</label>
             <input type="text" name="mail_send_address" value="{{old('mail_send_address', $form->mail_send_address)}}" class="form-control">
-            @if ($errors && $errors->has('mail_send_address')) <div class="text-danger">{{$errors->first('mail_send_address')}}</div> @endif
+            @include('plugins.common.errors_inline', ['name' => 'mail_send_address'])
         </div>
     </div>
 
@@ -310,7 +294,7 @@
                 <input type="checkbox" name="user_mail_send_flag" value="1" class="custom-control-input" id="user_mail_send_flag" @if(old('user_mail_send_flag', $form->user_mail_send_flag)) checked=checked @endif>
                 <label class="custom-control-label" for="user_mail_send_flag">登録者にメール送信する</label>
             </div>
-            @if ($errors && $errors->has('user_mail_send_flag')) <div class="text-danger">{{$errors->first('user_mail_send_flag')}}</div> @endif
+            @include('plugins.common.errors_inline', ['name' => 'user_mail_send_flag'])
         </div>
     </div>
 
@@ -371,6 +355,7 @@
         <div class="{{$frame->getSettingInputClass()}}">
             <label class="control-label">仮登録メールフォーマット</label>
             <textarea name="temporary_regist_mail_format" class="form-control" rows=5 placeholder="（例）仮登録を受け付けました。&#13;&#10;引き続き、下記のURLへアクセスしていただき、本登録を行ってください。&#13;&#10;&#13;&#10;↓本登録URL&#13;&#10;[[entry_url]]&#13;&#10;&#13;&#10;※お使いのメールソフトによっては、URLが途中で切れてアクセスできない場合があります。&#13;&#10;　その場合はクリックされるのではなくURLをブラウザのアドレス欄にコピー＆ペーストしてアクセスしてください。&#13;&#10;----------------------------------&#13;&#10;[[body]]&#13;&#10;----------------------------------">{{old('temporary_regist_mail_format', $form->temporary_regist_mail_format)}}</textarea>
+            @include('plugins.common.errors_inline', ['name' => 'temporary_regist_mail_format'])
             <small class="text-muted">
                 ※ [[entry_url]] を記述すると本登録URLが入ります。本登録URLの有効期限は仮登録後60分です。<br>
                 ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
@@ -378,7 +363,6 @@
                 ※ [[to_datetime]] を記述すると該当部分に登録日時が入ります。<br>
                 ※ [[body]] を記述すると該当部分に登録内容が入ります。
             </small>
-            @if ($errors && $errors->has('temporary_regist_mail_format')) <div class="text-danger">{{$errors->first('temporary_regist_mail_format')}}</div> @endif
         </div>
     </div>
 
@@ -501,7 +485,7 @@
                         </div>
                     </div>
                 @endforeach
-                @if ($errors && $errors->has('target_plugins_frames')) <div class="text-danger">{{$errors->first('target_plugins_frames')}}</div> @endif
+                @include('plugins.common.errors_inline', ['name' => 'target_plugins_frames'])
             </div>
         </div>
     </div>

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -66,8 +66,8 @@
 @if (!$form->id && !$create_flag)
 @else
 
-{{-- create_flag がtrue の場合、新規作成するためにforms_id を空にする --}}
-<form action="{{url('/')}}/plugin/forms/saveBuckets/{{$page->id}}/{{$frame_id}}@if($create_flag)/{{$form->id}}@endif#frame-{{$frame_id}}" method="POST">
+{{-- create_flag がtrue の場合、新規作成するためにforms_id をセットしない --}}
+<form action="{{url('/')}}/plugin/forms/saveBuckets/{{$page->id}}/{{$frame_id}}@if(!$create_flag)/{{$form->id}}@endif#frame-{{$frame_id}}" method="POST">
     {{ csrf_field() }}
 
     <div class="form-group row">

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -490,7 +490,7 @@
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-checkbox">
                 <input type="hidden" name="other_plugins_register_use_flag" value="0">
-                <input type="checkbox" name="other_plugins_register_use_flag" value="1" class="custom-control-input" id="other_plugins_register_use_flag" @if(old('other_plugins_register_use_flag', $form->other_plugins_register_use_flag)) checked=checked @endif  data-toggle="collapse" data-target="#collapse_other_plugins{{$frame_id}}" aria-expanded="false" aria-controls="collapse_other_plugins{{$frame_id}}">
+                <input type="checkbox" name="other_plugins_register_use_flag" value="1" class="custom-control-input" id="other_plugins_register_use_flag" @if(old('other_plugins_register_use_flag', $form->other_plugins_register_use_flag)) checked=checked @endif data-toggle="collapse" data-target="#collapse_other_plugins{{$frame_id}}" aria-expanded="false" aria-controls="collapse_other_plugins{{$frame_id}}">
                 <label class="custom-control-label" for="other_plugins_register_use_flag">他プラグイン連携機能を使用する</label>
             </div>
         </div>

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -130,7 +130,7 @@
                         @switch($enum_value)
                             @case(FormAccessLimitType::none)
                                 <input type="radio" value="{{$enum_value}}" id="access_limit_type_{{$enum_value}}" name="access_limit_type" class="custom-control-input" {{$checked}}
-                                data-toggle="collapse" data-target="#collapse_form_password{{$frame_id}}.show">
+                                    data-toggle="collapse" data-target="#collapse_form_password{{$frame_id}}.show">
                                 @break
                             @case(FormAccessLimitType::password)
                                 <input type="radio" value="{{$enum_value}}" id="access_limit_type_{{$enum_value}}" name="access_limit_type" class="custom-control-input" {{$checked}}

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -67,11 +67,7 @@
 @else
 
 {{-- create_flag がtrue の場合、新規作成するためにforms_id を空にする --}}
-@if ($create_flag)
-<form action="{{url('/')}}/plugin/forms/saveBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" class="">
-@else
-<form action="{{url('/')}}/plugin/forms/saveBuckets/{{$page->id}}/{{$frame_id}}/{{$form->id}}#frame-{{$frame_id}}" method="POST" class="">
-@endif
+<form action="{{url('/')}}/plugin/forms/saveBuckets/{{$page->id}}/{{$frame_id}}@if($create_flag)/{{$form->id}}@endif#frame-{{$frame_id}}" method="POST">
     {{ csrf_field() }}
 
     <div class="form-group row">

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -110,7 +110,44 @@
                 @endif
                 <label class="custom-control-label" for="data_save_flag">データを保存する（チェックを外すと、サイト上にデータを保持しません）</label>
             </div>
-            @if ($errors && $errors->has('data_save_flag')) <div class="text-danger">{{$errors->first('data_save_flag')}}</div> @endif
+            @include('plugins.common.errors_inline', ['name' => 'data_save_flag'])
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">閲覧制限</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="col pl-0">
+                @foreach (FormAccessLimitType::getMembers() as $enum_value => $enum_label)
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @php
+                            $access_limit_type = $form->access_limit_type ?? FormAccessLimitType::getDefault();
+                            $checked = '';
+                            if (old('access_limit_type', $access_limit_type) == $enum_value) {
+                                $checked = 'checked="checked"';
+                            }
+                        @endphp
+                        @switch($enum_value)
+                            @case(FormAccessLimitType::none)
+                                <input type="radio" value="{{$enum_value}}" id="access_limit_type_{{$enum_value}}" name="access_limit_type" class="custom-control-input" {{$checked}}
+                                data-toggle="collapse" data-target="#collapse_form_password{{$frame_id}}.show">
+                                @break
+                            @case(FormAccessLimitType::password)
+                                <input type="radio" value="{{$enum_value}}" id="access_limit_type_{{$enum_value}}" name="access_limit_type" class="custom-control-input" {{$checked}}
+                                    data-toggle="collapse" data-target="#collapse_form_password{{$frame_id}}:not(.show)" aria-expanded="true" aria-controls="collapse_form_password{{$frame_id}}">
+                                @break
+                        @endswitch
+                        <label class="custom-control-label" for="access_limit_type_{{$enum_value}}" id="label_access_limit_type_{{$enum_value}}">{{$enum_label}}</label>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+    <div class="form-group row collapse" id="collapse_form_password{{$frame_id}}">
+        <label class="{{$frame->getSettingLabelClass()}}">閲覧パスワード</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <input type="text" name="form_password" value="{{old('form_password', $form->form_password)}}" class="form-control">
+            @include('plugins.common.errors_inline', ['name' => 'form_password'])
         </div>
     </div>
 
@@ -545,6 +582,12 @@
         v_numbering_prefix: document.getElementById('numbering_prefix').value
       }
     })
+
+    {{-- 初期状態で開くもの --}}
+    @php $access_limit_type = $form->access_limit_type ?? FormAccessLimitType::getDefault(); @endphp
+    @if (old('access_limit_type', $access_limit_type) == FormAccessLimitType::password)
+        $('#collapse_form_password{{$frame_id}}').collapse('show')
+    @endif
 </script>
 @endif
 @endsection

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -490,13 +490,13 @@
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-checkbox">
                 <input type="hidden" name="other_plugins_register_use_flag" value="0">
-                <input type="checkbox" name="other_plugins_register_use_flag" value="1" class="custom-control-input" id="other_plugins_register_use_flag" @if(old('other_plugins_register_use_flag', $form->other_plugins_register_use_flag)) checked=checked @endif>
+                <input type="checkbox" name="other_plugins_register_use_flag" value="1" class="custom-control-input" id="other_plugins_register_use_flag" @if(old('other_plugins_register_use_flag', $form->other_plugins_register_use_flag)) checked=checked @endif  data-toggle="collapse" data-target="#collapse_other_plugins{{$frame_id}}" aria-expanded="false" aria-controls="collapse_other_plugins{{$frame_id}}">
                 <label class="custom-control-label" for="other_plugins_register_use_flag">他プラグイン連携機能を使用する</label>
             </div>
         </div>
     </div>
 
-    <div class="form-group row">
+    <div class="form-group row collapse" id="collapse_other_plugins{{$frame_id}}">
         <label class="{{$frame->getSettingLabelClass()}}">対象ページ - フレーム</label>
         <div class="{{$frame->getSettingInputClass(false, true)}}">
             <ul class="nav nav-pills" role="tablist">
@@ -593,6 +593,11 @@
     @if (old('numbering_use_flag', $form->numbering_use_flag))
         // 採番プレフィックス
         $('#app_numbering_prefix_{{$frame_id}}').collapse('show')
+    @endif
+
+    @if(old('other_plugins_register_use_flag', $form->other_plugins_register_use_flag))
+        // 対象ページ - フレーム
+        $('#collapse_other_plugins{{$frame_id}}').collapse('show')
     @endif
 </script>
 @endif

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -464,13 +464,13 @@
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="custom-control custom-checkbox">
                 <input type="hidden" name="numbering_use_flag" value="0">
-                <input type="checkbox" name="numbering_use_flag" value="1" class="custom-control-input" id="numbering_use_flag" @if(old('numbering_use_flag', $form->numbering_use_flag)) checked=checked @endif>
+                <input type="checkbox" name="numbering_use_flag" value="1" class="custom-control-input" id="numbering_use_flag" @if(old('numbering_use_flag', $form->numbering_use_flag)) checked=checked @endif data-toggle="collapse" data-target="#app_numbering_prefix_{{$frame_id}}" aria-expanded="false" aria-controls="app_numbering_prefix_{{$frame_id}}">
                 <label class="custom-control-label" for="numbering_use_flag">採番機能を使用する</label>
             </div>
         </div>
     </div>
 
-    <div id="app_{{ $frame->id }}" class="form-group row">
+    <div id="app_numbering_prefix_{{ $frame->id }}" class="form-group row collapse">
         <label class="{{$frame->getSettingLabelClass()}}"></label>
         <div class="{{$frame->getSettingInputClass()}}">
             <label class="control-label">採番プレフィックス</label>
@@ -577,7 +577,7 @@
 </div>
 <script>
     new Vue({
-      el: "#app_{{ $frame->id }}",
+      el: "#app_numbering_prefix_{{ $frame->id }}",
       data: {
         v_numbering_prefix: document.getElementById('numbering_prefix').value
       }
@@ -586,7 +586,13 @@
     {{-- 初期状態で開くもの --}}
     @php $access_limit_type = $form->access_limit_type ?? FormAccessLimitType::getDefault(); @endphp
     @if (old('access_limit_type', $access_limit_type) == FormAccessLimitType::password)
+        // 閲覧パスワード
         $('#collapse_form_password{{$frame_id}}').collapse('show')
+    @endif
+
+    @if (old('numbering_use_flag', $form->numbering_use_flag))
+        // 採番プレフィックス
+        $('#app_numbering_prefix_{{$frame_id}}').collapse('show')
     @endif
 </script>
 @endif

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -170,12 +170,12 @@
             <div class="col pl-0">
                 <label>表示期間の制御</label><br>
                 <div class="custom-control custom-radio custom-control-inline">
-                    <input type="radio" value="1" id="display_control_flag_1" name="display_control_flag" class="custom-control-input" @if(old('display_control_flag', $form->display_control_flag) == 1) checked="checked" @endif>
-                    <label class="custom-control-label" for="display_control_flag_1">表示期間で制御する</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
                     <input type="radio" value="0" id="display_control_flag_0" name="display_control_flag" class="custom-control-input" @if(old('display_control_flag', $form->display_control_flag) == 0) checked="checked" @endif>
                     <label class="custom-control-label" for="display_control_flag_0">表示期間で制御しない</label>
+                </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="1" id="display_control_flag_1" name="display_control_flag" class="custom-control-input" @if(old('display_control_flag', $form->display_control_flag) == 1) checked="checked" @endif>
+                    <label class="custom-control-label" for="display_control_flag_1">表示期間で制御する</label>
                 </div>
             </div>
         </div>
@@ -229,12 +229,12 @@
             <div class="col pl-0">
                 <label>登録期間の制御</label><br>
                 <div class="custom-control custom-radio custom-control-inline">
-                    <input type="radio" value="1" id="regist_control_flag_1" name="regist_control_flag" class="custom-control-input" @if(old('regist_control_flag', $form->regist_control_flag) == 1) checked="checked" @endif>
-                    <label class="custom-control-label" for="regist_control_flag_1">登録期間で制御する</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
                     <input type="radio" value="0" id="regist_control_flag_0" name="regist_control_flag" class="custom-control-input" @if(old('regist_control_flag', $form->regist_control_flag) == 0) checked="checked" @endif>
                     <label class="custom-control-label" for="regist_control_flag_0">登録期間で制御しない</label>
+                </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="1" id="regist_control_flag_1" name="regist_control_flag" class="custom-control-input" @if(old('regist_control_flag', $form->regist_control_flag) == 1) checked="checked" @endif>
+                    <label class="custom-control-label" for="regist_control_flag_1">登録期間で制御する</label>
                 </div>
             </div>
         </div>
@@ -320,12 +320,12 @@
             <div class="col pl-0">
                 <label>メールの添付ファイル制御</label><br>
                 <div class="custom-control custom-radio custom-control-inline">
-                    <input type="radio" value="1" id="mail_attach_flag_1" name="mail_attach_flag" class="custom-control-input" @if(old('mail_attach_flag', $form->mail_attach_flag) == 1) checked="checked" @endif>
-                    <label class="custom-control-label" for="mail_attach_flag_1">メールにファイルを添付する</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
                     <input type="radio" value="0" id="mail_attach_flag_0" name="mail_attach_flag" class="custom-control-input" @if(old('mail_attach_flag', $form->mail_attach_flag) == 0) checked="checked" @endif>
                     <label class="custom-control-label" for="mail_attach_flag_0">メールにファイルを添付しない</label>
+                </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="1" id="mail_attach_flag_1" name="mail_attach_flag" class="custom-control-input" @if(old('mail_attach_flag', $form->mail_attach_flag) == 1) checked="checked" @endif>
+                    <label class="custom-control-label" for="mail_attach_flag_1">メールにファイルを添付する</label>
                 </div>
                 <div>
                     <small class="text-muted">

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -259,18 +259,18 @@
             <div class="col pl-0">
                 <label>登録期間の制御</label><br>
                 <div class="custom-control custom-radio custom-control-inline">
-                    <input type="radio" value="0" id="regist_control_flag_0" name="regist_control_flag" class="custom-control-input" @if(old('regist_control_flag', $form->regist_control_flag) == 0) checked="checked" @endif>
+                    <input type="radio" value="0" id="regist_control_flag_0" name="regist_control_flag" class="custom-control-input" @if(old('regist_control_flag', $form->regist_control_flag) == 0) checked="checked" @endif data-toggle="collapse" data-target="#collapse_regist_control{{$frame_id}}.show">
                     <label class="custom-control-label" for="regist_control_flag_0">登録期間で制御しない</label>
                 </div>
                 <div class="custom-control custom-radio custom-control-inline">
-                    <input type="radio" value="1" id="regist_control_flag_1" name="regist_control_flag" class="custom-control-input" @if(old('regist_control_flag', $form->regist_control_flag) == 1) checked="checked" @endif>
+                    <input type="radio" value="1" id="regist_control_flag_1" name="regist_control_flag" class="custom-control-input" @if(old('regist_control_flag', $form->regist_control_flag) == 1) checked="checked" @endif data-toggle="collapse" data-target="#collapse_regist_control{{$frame_id}}:not(.show)" aria-expanded="true" aria-controls="collapse_regist_control{{$frame_id}}">
                     <label class="custom-control-label" for="regist_control_flag_1">登録期間で制御する</label>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="form-group row">
+    <div class="form-group row collapse" id="collapse_regist_control{{$frame_id}}">
         <label class="{{$frame->getSettingLabelClass()}} pt-0"></label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             <div class="col pl-0">
@@ -596,6 +596,11 @@
     @if(old('display_control_flag', $form->display_control_flag) == 1)
         // 表示期間
         $('#collapse_display_control{{$frame_id}}').collapse('show')
+    @endif
+
+    @if(old('regist_control_flag', $form->regist_control_flag) == 1)
+        // 登録期間
+        $('#collapse_regist_control{{$frame_id}}').collapse('show')
     @endif
 
     @if(old('use_temporary_regist_mail_flag', $form->use_temporary_regist_mail_flag))

--- a/resources/views/plugins/user/forms/default/index_password.blade.php
+++ b/resources/views/plugins/user/forms/default/index_password.blade.php
@@ -1,0 +1,44 @@
+{{--
+ * 閲覧パスワード画面テンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォーム・プラグイン
+--}}
+@extends('core.cms_frame_base')
+
+@section("plugin_contents_$frame->id")
+
+@include('plugins.common.errors_form_line')
+
+@if ($form->can_view_inputs_moderator)
+    @can('role_article')
+        <div class="row">
+            <p class="text-right col">
+                {{-- 集計結果ボタン --}}
+                <a href="{{url('/')}}/plugin/forms/aggregate/{{$page->id}}/{{$frame_id}}/{{$form->id}}#frame-{{$frame->id}}" class="btn btn-success"><i class="fas fa-list"></i> 集計結果</a>
+            </p>
+        </div>
+    @endcan
+@endif
+
+<form action="{{url('/')}}/redirect/plugin/forms/publicPassword/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="POST">
+    {{ csrf_field() }}
+    <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/forms/index/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
+
+    <div class="sr-only">{{$form->forms_name}}</div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">閲覧パスワード</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <input type="password" name="form_password" value="{{old('form_password')}}" class="form-control @if ($errors->has('form_password')) border-danger @endif">
+            @include('plugins.common.errors_inline', ['name' => 'form_password'])
+        </div>
+    </div>
+
+    {{-- ボタンエリア --}}
+    <div class="text-center">
+        <button class="btn btn-primary">{{__('messages.next')}} <i class="fas fa-chevron-right"></i></button>
+    </div>
+</form>
+@endsection


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [フォーム] 閲覧パスワード設定追加
* 関連修正
    * フォーム設定画面、設定ON・OFFで設定項目のおりたたみ対応
    * フォーム, ラジオでON・OFF時、左側はOFFで統一する #737

# 修正後画面
## フォーム設定（閲覧パスワード）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/4ede9a38-4a34-443d-baf6-db48c47289e4)

## フォーム初期表示（パスワードで閲覧制限するON）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/5707c5de-ab5e-41bc-9b2a-d7881156ef3e)



# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

あり
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
