### PR TITLE
[API共通] Slackリクエスト検証の共通処理を追加＆connect設定値にSLACK_SIGNING_SECRETを追加

### DIFF
--- a/app/Plugins/Api/ApiPluginBase.php
+++ b/app/Plugins/Api/ApiPluginBase.php
@@ -143,6 +143,6 @@ class ApiPluginBase extends PluginBase
         $hash = hash_hmac('sha256', $base_string, config('connect.SLACK_SIGNING_SECRET'));
 
         // ハッシュ（A，B）を比較する
-        return hash_equals($signature_hash , $hash);
+        return hash_equals($signature_hash, $hash);
     }
 }

--- a/app/Plugins/Api/ApiPluginBase.php
+++ b/app/Plugins/Api/ApiPluginBase.php
@@ -3,6 +3,7 @@
 namespace App\Plugins\Api;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 use App\Models\Core\ApiSecret;
 
@@ -78,6 +79,45 @@ class ApiPluginBase extends PluginBase
         }
 
         // 制限クリア」。
+        return array('code' => '', 'message' => '');
+    }
+
+    /**
+     * SlackのAPIリクエストを検証して、検証結果に応じたHTTPステータスコードとメッセージを配列で返す
+     *
+     * @param Request $request
+     * @return array
+     */
+    public function validateSlackAPI(Request $request) : array
+    {
+        // request内に署名ハッシュ値、タイムスタンプがない場合
+        if (!$request->header('x-slack-signature') || !$request->header('x-slack-request-timestamp')) {
+            $message = 'No x-slack-signature or x-slack-request-timestamp in header.';
+            $ret = array('code' => 400, 'message' => $message);
+            Log::error("[validateSlackAPI()] API $message", $ret);
+            return $ret;
+        }
+
+        // config('connect.SLACK_SIGNING_SECRET')が設定されていない場合
+        if (!config('connect.SLACK_SIGNING_SECRET')) {
+            $message = 'No SLACK_SIGNING_SECRET in .env.';
+            $ret = array('code' => 500, 'message' => $message);
+            Log::error("[validateSlackAPI()] API $message", $ret);
+            return $ret;
+        }
+
+        /**
+         * Slackの署名ハッシュ値と、request内容から生成したハッシュ値を比較して、一致しない場合
+         *  - （補足）Slackからはリクエストパラメータを自由に設定できない為、CC側のAPI共通チェックは利用できない
+         */
+        if (!$this->compareSlackHashes($request)) {
+            $message = 'Invalid request. Slack signature mismatch.';
+            $ret = array('code' => 403, 'message' => $message);
+            Log::error("[validateSlackAPI()] API $message", $ret);
+            return $ret;
+        }
+
+        // 制限クリア
         return array('code' => '', 'message' => '');
     }
 

--- a/app/Plugins/Api/ApiPluginBase.php
+++ b/app/Plugins/Api/ApiPluginBase.php
@@ -94,15 +94,11 @@ class ApiPluginBase extends PluginBase
         list($version, $signature_hash) = explode("=", $slack_signature);
 
         // request内容からハッシュ値生成用の基本文字列を生成
+        $version = 'v0';
         $timestamp = $request->header('x-slack-request-timestamp');
-        $body = $request->all();
-        $query = "";
-        foreach ($body as $key => $value) {
-            $query .= $key . '=' . urlencode($value). '&';
-        }
-        $query = rtrim($query,'&');
-        $base_string = $version . ':' . $timestamp . ':' . $query;
-
+        $body = $request->getContent();
+        $base_string = $version . ':' . $timestamp . ':' . $body;
+        
         // 基本文字列からハッシュ値（B）を作る
         $hash = hash_hmac('sha256', $base_string, config('connect.SLACK_SIGNING_SECRET'));
 

--- a/config/connect.php
+++ b/config/connect.php
@@ -90,6 +90,9 @@ return [
     // csrfチェックの除外設定
     'VERIFY_CSRF_TOKEN_EXCEPT' => env('VERIFY_CSRF_TOKEN_EXCEPT', ''),
 
+    // Slackの署名付きトークン
+    'SLACK_SIGNING_SECRET' => env('SLACK_SIGNING_SECRET', ''),
+
     // 外部APIを使って翻訳
     'TRANSLATE_API_URL' => env('TRANSLATE_API_URL', ''),
     'TRANSLATE_API_KEY' => env('TRANSLATE_API_KEY', ''),


### PR DESCRIPTION
# 概要
 - SlackAppからのリクエスト検証用の共通処理を追加
 - SlackAppからのリクエスト検証を行う為、Slackの秘密トークン保持用設定値を追加しました。

# レビュー完了希望日
なし

# 関連Pull requests/Issues
なし

# 参考
https://belltree.life/slack-verification/

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
