### PR TITLE
[コア] 既存プラグインにオプションテンプレートを追加できるよう対応

### DIFF
--- a/app/Http/Controllers/Core/DefaultController.php
+++ b/app/Http/Controllers/Core/DefaultController.php
@@ -541,12 +541,10 @@ class DefaultController extends ConnectController
             }
 
             $finder = View::getFinder();
-            $plugin_view_path = $finder->getPaths()[0].'/plugins/user/' . $action_core_frame->plugin_name;
-
-            // テンプレート・ディレクトリがない場合はオプションプラグインのテンプレートディレクトリを探す
-            if (!file_exists($plugin_view_path)) {
-                $plugin_view_path = $finder->getPaths()[0].'/plugins_option/user/' . $action_core_frame->plugin_name;
-            }
+            // 通常プラグインのテンプレートディレクトリ
+            $plugin_view_paths[] = $finder->getPaths()[0].'/plugins/user/' . $action_core_frame->plugin_name;
+            // オプションプラグインのテンプレートディレクトリ
+            $plugin_view_paths[] = $finder->getPaths()[0].'/plugins_option/user/' . $action_core_frame->plugin_name;
 
             // テンプレートソート時に順番が書いていない場合用の変数。通常の順番が1からと想定し、空のものは1000から開始
             $tmp_display_sequence = 1000;
@@ -554,45 +552,53 @@ class DefaultController extends ConnectController
             // テンプレートソート用配列
             $sort_array = array();
 
-            // テンプレート・ディレクトリをループ
-            $file_list = scandir($plugin_view_path);
-            foreach ($file_list as $file) {
-                if (in_array($file, array('.', '..'))) {
+            foreach ($plugin_view_paths as $plugin_view_path) {
+                // テンプレート・ディレクトリがない場合は飛ばす
+                if (!file_exists($plugin_view_path)) {
                     continue;
                 }
-                // テンプレートディレクトリを探す
-                //if (is_dir(($finder->getPaths()[0].'/plugins/user/' . $action_core_frame->plugin_name . '/' . $file))) {
-                if (strpos($plugin_view_path, 'plugins_option') === false) {
-                    $template_dir = $finder->getPaths()[0].'/plugins/user/' . $action_core_frame->plugin_name . '/' . $file;
-                } else {
-                    $template_dir = $finder->getPaths()[0].'/plugins_option/user/' . $action_core_frame->plugin_name . '/' . $file;
-                }
-                if (is_dir($template_dir)) {
-                    if (File::exists($template_dir."/template.ini")) {
-                        // テンプレート設定ファイルがある場合、テンプレート設定ファイルからテンプレート名を探す。設定がなければディレクトリ名をテンプレート名とする。
-                        $template_inis = parse_ini_file($template_dir."/template.ini");
-                        $template_name = $template_inis['template_name'];
-                        if (empty($template_name)) {
-                            $template_name = $file;
-                        }
-                    } else {
-                        // テンプレート設定ファイルがない場合、テンプレートディレクトリ名をテンプレート名とする
-                        $template_name = $file;
-                        $template_inis = array();
+
+                // テンプレート・ディレクトリをループ
+                $file_list = scandir($plugin_view_path);
+                foreach ($file_list as $file) {
+                    if (in_array($file, array('.', '..'))) {
+                        continue;
                     }
-
-                    // テンプレート配列
-                    $target_frame_templates[$template_name] = $file;
-
-                    // テンプレートソート用配列
-                    if (array_key_exists('display_sequence', $template_inis)) {
-                        $sort_array[] = $template_inis['display_sequence'];
+                    // テンプレートディレクトリを探す
+                    //if (is_dir(($finder->getPaths()[0].'/plugins/user/' . $action_core_frame->plugin_name . '/' . $file))) {
+                    if (strpos($plugin_view_path, 'plugins_option') === false) {
+                        $template_dir = $finder->getPaths()[0].'/plugins/user/' . $action_core_frame->plugin_name . '/' . $file;
                     } else {
-                        $sort_array[] = $tmp_display_sequence;
-                        $tmp_display_sequence++;
+                        $template_dir = $finder->getPaths()[0].'/plugins_option/user/' . $action_core_frame->plugin_name . '/' . $file;
+                    }
+                    if (is_dir($template_dir)) {
+                        if (File::exists($template_dir."/template.ini")) {
+                            // テンプレート設定ファイルがある場合、テンプレート設定ファイルからテンプレート名を探す。設定がなければディレクトリ名をテンプレート名とする。
+                            $template_inis = parse_ini_file($template_dir."/template.ini");
+                            $template_name = $template_inis['template_name'];
+                            if (empty($template_name)) {
+                                $template_name = $file;
+                            }
+                        } else {
+                            // テンプレート設定ファイルがない場合、テンプレートディレクトリ名をテンプレート名とする
+                            $template_name = $file;
+                            $template_inis = array();
+                        }
+
+                        // テンプレート配列
+                        $target_frame_templates[$template_name] = $file;
+
+                        // テンプレートソート用配列
+                        if (array_key_exists('display_sequence', $template_inis)) {
+                            $sort_array[] = $template_inis['display_sequence'];
+                        } else {
+                            $sort_array[] = $tmp_display_sequence;
+                            $tmp_display_sequence++;
+                        }
                     }
                 }
             }
+
             // template.iniでtemplate_name(テンプレート名)が被ると array_multisort(): array sizes are inconsistentエラー出る
             // テンプレート名重複は設置ミスです。
             // Log::debug('[' . __METHOD__ . '] ' . __FILE__ . ' (line ' . __LINE__ . ')');

--- a/app/Http/Controllers/Core/DefaultController.php
+++ b/app/Http/Controllers/Core/DefaultController.php
@@ -3,22 +3,16 @@
 namespace App\Http\Controllers\Core;
 
 use Illuminate\Http\Request;
-use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\View;
-
-use DB;
-use File;
 
 use App\Http\Controllers\Core\ConnectController;
 
 use App\Models\Common\Frame;
 use App\Models\Common\Page;
 use App\Models\Core\Configs;
-// use App\Models\Core\Plugins;
 
 use App\Traits\ConnectCommonTrait;
 

--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -353,14 +353,14 @@ class UserPluginBase extends PluginBase
             return 'plugins.user.' . $this->frame->plugin_name . '.' . $this->frame->template . '.' . $blade_name;
         }
 
-        // デフォルトテンプレートのファイル存在チェック
-        if (File::exists(resource_path().'/views/plugins/user/' . $this->frame->plugin_name . "/default/" . $blade_name . ".blade.php")) {
-            return 'plugins.user.' . $this->frame->plugin_name . '.default.' . $blade_name;
-        }
-
         // オプションの指定したテンプレートのファイル存在チェック
         if (File::exists(resource_path().'/views/plugins_option/user/' . $this->frame->plugin_name . "/" . $this->frame->template . "/" . $blade_name . ".blade.php")) {
             return 'plugins_option.user.' . $this->frame->plugin_name . '.' . $this->frame->template . '.' . $blade_name;
+        }
+
+        // デフォルトテンプレートのファイル存在チェック
+        if (File::exists(resource_path().'/views/plugins/user/' . $this->frame->plugin_name . "/default/" . $blade_name . ".blade.php")) {
+            return 'plugins.user.' . $this->frame->plugin_name . '.default.' . $blade_name;
         }
 
         // オプションのデフォルトテンプレートのファイル存在チェック


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 既存プラグインにオプションのテンプレートを追加できるよう対応しました。
* resources\views\plugins_option配下に、既存プラグインのディレクトリを再現して、配下にテンプレートを配置すると、フレーム編集画面から設定できます。
* （例：新着）
    * 新着のオプションディレクトリを作成 resources\views\plugins_option\user\whatsnews\
    * その配下にオプションテンプレート`seminar`を配置
        * resources\views\plugins_option\user\whatsnews\seminar\whatsnews.blade.php
    * フレーム編集のテンプレートに`seminar`出てくる。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/168afa89-0892-46f3-b0ef-85565bc8f69e)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
