### PR TITLE
[FrameConfig] saveFrameConfigs()時、checkbox_separatorを指定できるように対応, また配列の空要素を削除するよう対応

### DIFF
--- a/app/Models/Core/FrameConfig.php
+++ b/app/Models/Core/FrameConfig.php
@@ -6,8 +6,6 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-use Illuminate\Support\Facades\Log;
-
 use App\UserableNohistory;
 
 class FrameConfig extends Model
@@ -70,18 +68,22 @@ class FrameConfig extends Model
      * @param int $frame_id フレームID
      * @param array $frame_config_names フレーム設定のname配列
      */
-    public static function saveFrameConfigs(\Illuminate\Http\Request $request, int $frame_id, array $frame_config_names) : void
+    public static function saveFrameConfigs(\Illuminate\Http\Request $request, int $frame_id, array $frame_config_names, ?string $checkbox_separator = self::CHECKBOX_SEPARATOR) : void
     {
         foreach ($frame_config_names as $key => $name) {
 
+            $request_value = $request->$name;
+            // arrayならarray_filter()でarrayの空要素削除
+            $request_value = is_array($request_value) ? array_filter($request_value) : $request_value;
+
             // 必須入力チェック
             // チェックボックスの場合、すべて選択しない場合があるので除外する
-            if (!is_array($request->$name) && $request->$name != '0' && empty($request->$name)) {
+            if (!is_array($request_value) && $request_value != '0' && empty($request_value)) {
                 continue;
             }
 
             // 配列の設定値はパイプ区切りにする
-            $value = is_array($request->$name) ? implode(self::CHECKBOX_SEPARATOR, $request->$name) : $request->$name;
+            $value = is_array($request_value) ? implode($checkbox_separator, $request_value) : $request_value;
 
             self::updateOrCreate(
                 ['frame_id' => $frame_id, 'name' => $name],

--- a/app/Models/Core/FrameConfig.php
+++ b/app/Models/Core/FrameConfig.php
@@ -67,6 +67,7 @@ class FrameConfig extends Model
      * @param Illuminate\Http\Request $request リクエスト
      * @param int $frame_id フレームID
      * @param array $frame_config_names フレーム設定のname配列
+     * @param string $checkbox_separator チェックボックスの区切り文字
      */
     public static function saveFrameConfigs(\Illuminate\Http\Request $request, int $frame_id, array $frame_config_names, ?string $checkbox_separator = self::CHECKBOX_SEPARATOR) : void
     {


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

## 背景
* FrameConfigの値（配列指定の値）を新着で使う場合があり、値が `|` のままだと使えない（カンマにしたい）ため、修正対応しました。
    * 通常は `|` のままなので、今までの処理に影響がでないように修正しました。
* またFrameConfigの値を保存時（saveFrameConfigs()）、保存する値が配列の場合に空要素があると、不要な空要素まで保存していたため、取り除きました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
