### PR TITLE
[移行ツール] NC3移行エクスポートのトップページ・ルームトップのヘッダ・フッター・左・右エリアのフレーム出力見直し

### DIFF
--- a/app/Models/Migration/Nc3/Nc3Frame.php
+++ b/app/Models/Migration/Nc3/Nc3Frame.php
@@ -23,7 +23,7 @@ class Nc3Frame extends Model
      * NC3 header_type -> Connect-CMS frame_design 変換用テーブル
      * 定義のないものは 'default' になる想定
      */
-    protected $frame_designs = [
+    const frame_designs = [
         'none'          => 'none',
         'default'       => 'default',
         'primary'       => 'primary',
@@ -36,12 +36,12 @@ class Nc3Frame extends Model
     /**
      *  フレームテンプレートの変換
      */
-    public function getFrameDesign($default = 'default')
+    public static function getFrameDesign($header_type, $default = 'default')
     {
         // NC3 テンプレート変換配列にあれば、その値。
         // なければ default を返す。
-        if (array_key_exists($this->header_type, $this->frame_designs)) {
-            return $this->frame_designs[$this->header_type];
+        if (array_key_exists($header_type, self::frame_designs)) {
+            return self::frame_designs[$header_type];
         }
         return $default;
     }

--- a/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config_nc3.sample.ini
@@ -146,7 +146,7 @@ cc_import_plugins[] = "slideshows"
 nc3_export_pages = true
 
 ; 全ページレイアウトを出力する場合 true を指定
-;export_full_page_layout = true
+export_full_page_layout = true
 
 ; エクスポート対象のNC3ページIDを絞る（指定がなければすべて対象）
 ; トップページ


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* NC3移行で、NC3側のページ左エリアで下記表示をする。
    * サイト全体　　：空　　　　（非表示）
    * パブリック共通：空　　　　（非表示）
    * ルーム共通　　：メニュー１（表示）
    * 当ページのみ　：メニュー２（非表示）
* 移行すると、非表示のメニュー２が移行される不具合を修正。
* 関連修正
    * [change: 移行ツール, NC3移行設定の全ページレイアウトを出力するを初期値trueに変更](https://github.com/opensource-workshop/connect-cms/pull/1744/commits/ac3ae8b88af411fe3085e311e2081fd534e9a10b)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
