### PR TITLE
[移行ツール] NC2移行エクスポート時、メニューのフレームタイトルを消さずに残すオプション追加

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -12526,7 +12526,7 @@ trait MigrationTrait
                     $frame_ini .= "frame_title = \"" . $nc2_block->block_name . "\"\n";
                 } else {
                     $frame_ini .= "frame_title = \"\"\n";
-                }                
+                }
             } else {
                 $frame_ini .= "frame_title = \"" . $nc2_block->block_name . "\"\n";
             }

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -12494,6 +12494,9 @@ trait MigrationTrait
             $nc2_blocks[] = $nc2_sort_block;
         }
 
+        // メニューのフレームタイトルを消さずに残す
+        $export_frame_title = $this->getMigrationConfig('menus', 'export_frame_title');
+
         // ページ内のブロック
         foreach ($nc2_blocks as $nc2_block) {
             $this->putMonitor(1, "Block", "block_id = " . $nc2_block->block_id);
@@ -12518,7 +12521,12 @@ trait MigrationTrait
 
             // フレームタイトル＆メニューの特別処理
             if ($nc2_block->getModuleName() == 'menu') {
-                $frame_ini .= "frame_title = \"\"\n";
+                if ($export_frame_title) {
+                    // メニューのフレームタイトルを残す
+                    $frame_ini .= "frame_title = \"" . $nc2_block->block_name . "\"\n";
+                } else {
+                    $frame_ini .= "frame_title = \"\"\n";
+                }                
             } else {
                 $frame_ini .= "frame_title = \"" . $nc2_block->block_name . "\"\n";
             }

--- a/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
+++ b/app/Traits/Migration/sample/migration_config/migration_config.sample.ini
@@ -348,6 +348,9 @@ nc2_export_registration_data = true;
 ; メニューをエクスポート対象外にする場合 true を指定
 ;export_ommit_menu = true
 
+; メニューのフレームタイトルを消さずに残す場合 true を指定
+;export_frame_title = true
+
 ; --- インポート
 ; エリアごとのメニューのインポート
 import_menu_area[] = "header"


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
なし


# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
