### PR TITLE
[管理画面等] php8.1対応

### DIFF
--- a/app/Enums/CsvCharacterCode.php
+++ b/app/Enums/CsvCharacterCode.php
@@ -12,6 +12,7 @@ final class CsvCharacterCode extends EnumsBase
     // 定数メンバ
     const auto = 'auto';
     const sjis_win = 'SJIS-win';
+    const cp932 = 'CP932';
     const utf_8 = 'UTF-8';
 
     // key/valueの連想配列
@@ -39,5 +40,16 @@ final class CsvCharacterCode extends EnumsBase
     {
         $enum = self::getSelectMembers();
         return $enum[$key];
+    }
+
+    /**
+     * Shift-JISか
+     */
+    public static function isShiftJis($character_code): bool
+    {
+        if ($character_code == self::sjis_win || $character_code == self::cp932) {
+            return true;
+        }
+        return false;
     }
 }

--- a/app/Models/Common/Page.php
+++ b/app/Models/Common/Page.php
@@ -246,10 +246,11 @@ class Page extends Model
      */
     public function getPermanentlinkClassname()
     {
-        if (empty(trim($this->permanent_link, '/'))) {
+        $permanent_link = $this->permanent_link ?? '';
+        if (empty(trim($permanent_link, '/'))) {
             return "home";
         }
-        return str_replace('/', '-', trim($this->permanent_link, '/'));
+        return str_replace('/', '-', trim($permanent_link, '/'));
     }
 
     /**
@@ -473,7 +474,7 @@ class Page extends Model
      */
     public function getSimpleLayout()
     {
-        return str_replace('|', '', $this->layout);
+        return str_replace('|', '', (string)$this->layout);
     }
 
     /**

--- a/app/Models/Core/Configs.php
+++ b/app/Models/Core/Configs.php
@@ -93,7 +93,7 @@ class Configs extends Model
     /**
      * 設定の任意クラス(値)を抽出（カンマ設定時はランダムで１つ設定）
      */
-    public static function getConfigsRandValue($configs, $key, $default = null)
+    public static function getConfigsRandValue($configs, $key, $default = '')
     {
         $value = self::getConfigsValue($configs, $key, $default);
 

--- a/app/Plugins/Manage/CodeManage/CodeManage.php
+++ b/app/Plugins/Manage/CodeManage/CodeManage.php
@@ -900,7 +900,7 @@ class CodeManage extends ManagePluginBase
         // 読み込み
         $fp = fopen($csv_full_path, 'r');
         // CSVファイル：Shift-JIS -> UTF-8変換時のみ
-        if ($character_code == CsvCharacterCode::sjis_win) {
+        if (CsvCharacterCode::isShiftJis($character_code)) {
             // ストリームフィルタ内で、Shift-JIS -> UTF-8変換
             $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
         }

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1671,7 +1671,8 @@ class UserManage extends ManagePluginBase
         // 読み込み
         $fp = fopen($csv_full_path, 'r');
         // CSVファイル：Shift-JIS -> UTF-8変換時のみ
-        if ($character_code == CsvCharacterCode::sjis_win) {
+        // if ($character_code == CsvCharacterCode::sjis_win) {
+        if (CsvCharacterCode::isShiftJis($character_code)) {
             // ストリームフィルタ内で、Shift-JIS -> UTF-8変換
             $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
         }
@@ -1867,7 +1868,7 @@ class UserManage extends ManagePluginBase
             // --- 権限(コンテンツ権限 & 管理権限)
             $view_user_roles_col_no = array_search('view_user_roles', $import_column_col_no);
             // 配列に変換する。nullの場合[0 => ""]になる
-            $csv_view_user_roles = explode(UsersTool::CHECKBOX_SEPARATOR, $csv_columns[$view_user_roles_col_no]);
+            $csv_view_user_roles = explode(UsersTool::CHECKBOX_SEPARATOR, (string)$csv_columns[$view_user_roles_col_no]);
             // 配列値の入力値をトリム (preg_replace(/u)で置換. /u = UTF-8 として処理)
             $csv_view_user_roles = StringUtils::trimInput($csv_view_user_roles);
 

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3291,7 +3291,7 @@ class DatabasesPlugin extends UserPluginBase
         // 読み込み
         $fp = fopen($csv_full_path, 'r');
         // CSVファイル：Shift-JIS -> UTF-8変換時のみ
-        if ($character_code == CsvCharacterCode::sjis_win) {
+        if (CsvCharacterCode::isShiftJis($character_code)) {
             // ストリームフィルタ内で、Shift-JIS -> UTF-8変換
             $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
         }

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -2688,7 +2688,7 @@ class LearningtasksPlugin extends UserPluginBase
         // 読み込み
         $fp = fopen($csv_full_path, 'r');
         // CSVファイル：Shift-JIS -> UTF-8変換時のみ
-        if ($character_code == CsvCharacterCode::sjis_win) {
+        if (CsvCharacterCode::isShiftJis($character_code)) {
             // ストリームフィルタ内で、Shift-JIS -> UTF-8変換
             $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
         }

--- a/app/Utilities/Csv/CsvUtils.php
+++ b/app/Utilities/Csv/CsvUtils.php
@@ -46,11 +46,11 @@ class CsvUtils
     public static function getCharacterCodeAuto($csv_full_path)
     {
         // 全体ではなく0～1024までを取得
-        $contents = file_get_contents($csv_full_path, null, null, 0, 1024);
+        $contents = file_get_contents($csv_full_path, false, null, 0, 1024);
 
         // 文字エンコーディングをsjis-win, UTF-8の順番で自動検出. 対象文字コード外の場合、false戻る
         $character_code = mb_detect_encoding($contents, CsvCharacterCode::sjis_win . ", " . CsvCharacterCode::utf_8);
-        // \Log::debug(var_export($character_code, true));
+        // \Log::error(var_export($character_code, true));
 
         return $character_code;
     }

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -148,7 +148,7 @@ use App\Models\Core\UsersColumns;
             <label class="col-md-4 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$users_column->column_name}} @if ($users_column->required)<span class="badge badge-danger">必須</span> @endif</label>
             <div class="col-md-8">
                 @include('auth.registe_form_input_' . $users_column->column_type, ['user_obj' => $users_column, 'label_id' => 'user-column-'.$users_column->id])
-                <div class="small {{ $users_column->caption_color }}">{!! nl2br($users_column->caption) !!}</div>
+                <div class="small {{ $users_column->caption_color }}">{!! nl2br((string)$users_column->caption) !!}</div>
             </div>
         </div>
     @endforeach

--- a/resources/views/plugins/manage/reservation/edit.blade.php
+++ b/resources/views/plugins/manage/reservation/edit.blade.php
@@ -150,7 +150,7 @@ use App\Models\User\Reservations\ReservationsFacility;
                         <div class="col-md-4">
                             <label>利用開始時間</label>
                             <div class="input-group date" id="start_time" data-target-input="nearest">
-                                <input type="text" name="start_time" value="{{ old('start_time', substr($facility->start_time, 0, -3)) }}" class="form-control datetimepicker-input @if ($errors->has('start_time')) border-danger @endif" data-target="#start_time">
+                                <input type="text" name="start_time" value="{{ old('start_time', substr((string)$facility->start_time, 0, -3)) }}" class="form-control datetimepicker-input @if ($errors->has('start_time')) border-danger @endif" data-target="#start_time">
                                 <div class="input-group-append" data-target="#start_time" data-toggle="datetimepicker">
                                     <div class="input-group-text"><i class="fas fa-clock"></i></div>
                                 </div>
@@ -161,7 +161,7 @@ use App\Models\User\Reservations\ReservationsFacility;
                         <div class="col-md-4">
                             <label>利用終了時間</label>
                             <div class="input-group date" id="end_time" data-target-input="nearest">
-                                <input type="text" name="end_time" value="{{ old('end_time', substr($facility->end_time, 0, -3)) }}" class="form-control datetimepicker-input @if ($errors->has('end_time')) border-danger @endif" data-target="#end_time">
+                                <input type="text" name="end_time" value="{{ old('end_time', substr((string)$facility->end_time, 0, -3)) }}" class="form-control datetimepicker-input @if ($errors->has('end_time')) border-danger @endif" data-target="#end_time">
                                 <div class="input-group-append" data-target="#end_time" data-toggle="datetimepicker">
                                     <div class="input-group-text"><i class="fas fa-clock"></i></div>
                                 </div>

--- a/resources/views/plugins/manage/reservation/index.blade.php
+++ b/resources/views/plugins/manage/reservation/index.blade.php
@@ -61,7 +61,7 @@
                             @endif
                         </td>
                         <td class="d-block d-sm-table-cell"><span class="d-sm-none">施設管理者：</span>{{ $facility->facility_manager_name }}</td>
-                        <td class="d-block d-sm-table-cell"><span class="d-sm-none">補足：</span>{{ str_limit(strip_tags($facility->supplement),36,'...') }}</td>
+                        <td class="d-block d-sm-table-cell"><span class="d-sm-none">補足：</span>{{ str_limit(strip_tags((string)$facility->supplement),36,'...') }}</td>
                         <td class="d-block d-sm-table-cell"><span class="d-sm-none">表示順：</span>{{$facility->display_sequence}}</td>
                         <td class="d-block d-sm-table-cell"><span class="d-sm-none">重複予約：</span>{{ PermissionType::getDescription($facility->is_allow_duplicate) }}</td>
                         <td class="d-block d-sm-table-cell"><span class="d-sm-none">権限で予約制限：</span>{{ ReservationLimitedByRole::getDescription($facility->is_limited_by_role) }}</td>

--- a/tests/Browser/User/ReservationsPluginTest.php
+++ b/tests/Browser/User/ReservationsPluginTest.php
@@ -119,6 +119,7 @@ class ReservationsPluginTest extends DuskTestCase
 
             $browser->visit('plugin/reservations/editBooking/' . $this->test_frame->page_id . '/' . $this->test_frame->id .
                             '?facility_id=1&target_date=' . $monday_1->format('Y-m-d') . '#frame-' . $this->test_frame->id)
+                    ->pause(500)
                     ->type('start_datetime', '10:00')
                     ->type('end_datetime', '12:00')
                     ->type('columns_value[1]', 'テストの予約①')


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

php8.1になり、標準関数の引数に型指定がつき（trim、str_replace、nl2br、strip_tags等）、チェックがきつくなったことで nullを渡すとエラーが起きてました。
修正対応しました。

* 対応
    * [bugfix: [管理画面系] php8.1対応](https://github.com/opensource-workshop/connect-cms/pull/1751/commits/b8a1fce3dd47eca87caadb28db68dfc843e9bd3b)
    * [bugfix: [ユーザ管理] インポート時のphp8.1エラー対応](https://github.com/opensource-workshop/connect-cms/pull/1751/commits/3e86a03784f718fdb6be813ef2b7d99ea6f9abd8)
    * [bugfix: [コード管理] インポート時の文字コード自動判別のcp932対応](https://github.com/opensource-workshop/connect-cms/pull/1751/commits/31510c069f64dca5dd61d5a74b118ddbdb59b430)
    * [add: [課題管理] 試験日時インポート時の文字コード自動判別のcp932対応](https://github.com/opensource-workshop/connect-cms/pull/1751/commits/4c3f2cc5adc8da9a3223fcbe6c236b0f3e957ef6)
    * [add: [データベース] インポート時の文字コード自動判別のcp932対応](https://github.com/opensource-workshop/connect-cms/pull/1751/commits/0ce9073e20ec962f0aa2866f3f6eba18bebe57a7)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1752

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
