### PR TITLE
[アップロードファイル] (beta)ユーザパブリックファイルの一覧画面追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,9 @@ QUEUE_PHP_BIN=
 # Specify the plug-in name that disables the serial number clear function of serial number management. e.g.) PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR="forms"
 PLUGIN_NAME_TO_DISABLE_SERIAL_NUMBER_CLEAR=""
 
+# (BETA) File management by specifying a directory under public, e.g.) MANAGE_USERDIR_PUBLIC_TARGET="uploads"
+#MANAGE_USERDIR_PUBLIC_TARGET="uploads"
+
 # --- Databases Plugin option
 DATABASES_FORCE_SHOW_COLUMN_ON_DETAIL=false
 # (BETA) If you want to show registered count about column on search conditions, set it true.

--- a/app/Models/Common/Uploads.php
+++ b/app/Models/Common/Uploads.php
@@ -5,6 +5,7 @@ namespace App\Models\Common;
 use App\Models\Core\Configs;
 use App\Enums\ImageMimetype;
 use App\UserableNohistory;
+use App\Utilities\File\FileUtils;
 use Illuminate\Database\Eloquent\Model;
 use Intervention\Image\Facades\Image;
 
@@ -23,12 +24,7 @@ class Uploads extends Model
      */
     public function getFormatSize($r = 0)
     {
-        $size = $this->size;
-        $units = array("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB");
-        for ($i = 0; $size >= 1024 && $i < 4; $i++) {
-            $size /= 1024;
-        }
-        return round($size, $r).$units[$i];
+        return FileUtils::getFormatSize($this->size, $r);
     }
 
     /**
@@ -123,7 +119,7 @@ class Uploads extends Model
      */
     public function getIsImageAttribute() : bool
     {
-        return in_array($this->mimetype, ImageMimetype::getMemberKeys()) ? true : false;
+        return FileUtils::isImage($this->mimetype);
     }
 
     /**

--- a/app/Utilities/File/FileUtils.php
+++ b/app/Utilities/File/FileUtils.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Utilities\File;
+
+use App\Enums\ImageMimetype;
+
+class FileUtils
+{
+    /**
+     * サイズのフォーマット
+     */
+    public static function getFormatSize($size, $r = 0)
+    {
+        $units = array("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB");
+        for ($i = 0; $size >= 1024 && $i < 4; $i++) {
+            $size /= 1024;
+        }
+        return round($size, $r).$units[$i];
+    }
+
+    /**
+     * 画像ファイルならtrueを返す
+     *
+     * @return boolean
+     */
+    public static function isImage($mimetype) : bool
+    {
+        return in_array($mimetype, ImageMimetype::getMemberKeys()) ? true : false;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -327,6 +327,7 @@ $app_array = [
         // utils
         'DateUtils' => \App\Utilities\Date\DateUtils::class,
         'StringUtils' => \App\Utilities\String\StringUtils::class,
+        'FileUtils' => \App\Utilities\File\FileUtils::class,
 
         // Models
         'Plugins' => \App\Models\Core\Plugins::class,

--- a/config/connect.php
+++ b/config/connect.php
@@ -170,4 +170,7 @@ return [
     'DATABASES_FORCE_SHOW_COLUMN_ON_DETAIL' => env('DATABASES_FORCE_SHOW_COLUMN_ON_DETAIL', false),
     // 絞り込み項目の登録済み件数を表示する(beta)
     'DATABASES_SHOW_SEARCH_COLUMN_COUNT' => env('DATABASES_SHOW_SEARCH_COLUMN_COUNT', false),
+
+    // public配下のディレクトリを指定してファイル管理. null時は機能自体使わない(beta)
+    'MANAGE_USERDIR_PUBLIC_TARGET' => env('MANAGE_USERDIR_PUBLIC_TARGET', null),
 ];

--- a/resources/views/plugins/manage/uploadfile/uploadfile_manage_tab.blade.php
+++ b/resources/views/plugins/manage/uploadfile/uploadfile_manage_tab.blade.php
@@ -32,6 +32,16 @@
                     <span class="nav-link"><span class="active">アップロードファイル編集</span></span>
                 @endif
                 </li>
+
+                @if (config('connect.MANAGE_USERDIR_PUBLIC_TARGET'))
+                    <li role="presentation" class="nav-item">
+                    @if ($function == "userdirPublic")
+                        <span class="nav-link"><span class="active">ユーザパブリックファイル一覧</span></span>
+                    @else
+                        <a href="{{url('/manage/uploadfile/userdirPublic')}}" class="nav-link">ユーザパブリックファイル一覧</a></li>
+                    @endif
+                    </li>
+                @endif
             </ul>
         </div>
     </nav>

--- a/resources/views/plugins/manage/uploadfile/userdir_public.blade.php
+++ b/resources/views/plugins/manage/uploadfile/userdir_public.blade.php
@@ -1,0 +1,153 @@
+{{--
+ * ユーザパブリックファイル管理の編集テンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category アップロードファイル管理
+--}}
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<script type="text/javascript">
+    /** 全選択チェックボックスの押下時 */
+    function change_all() {
+        // チェックボックスすべてON/OFF
+        $('input[type=checkbox][id^=delete_files]').prop("checked", $('#select_all').prop("checked"));
+        controlSelectedContentsAndButtons();
+    };
+
+    /** 選択リスト（selected-contents）の更新＆ボタンの活性化制御 */
+    function controlSelectedContentsAndButtons() {
+        // 選択リストを初期化
+        $('#selected-contents').html('');
+
+        if ($('input[type="checkbox"][name="delete_files[]"]:checked').length > 0){
+            // 選択済みコンテンツが1件以上ある場合：ボタン活性化＆選択リストにコンテンツを詰める
+            $('input[type="checkbox"][name="delete_files[]"]:checked').each(function(){
+                $('#selected-contents').append('<li>' + $(this).data('name') + '</li>');
+            })
+            $('.btn-delete').prop('disabled', false);
+        } else {
+            // 選択済みコンテンツが0件の場合：ボタンdisable化
+            $('.btn-delete').prop('disabled', true);
+        }
+    }
+
+    /** 削除 */
+    function deleteContents() {
+        if (window.confirm('データを削除します。\nよろしいですか？')) {
+            form_user_dir_public.submit();
+        }
+    }
+</script>
+
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.uploadfile.uploadfile_manage_tab')
+    </div>
+
+    {{-- 登録後メッセージ表示 --}}
+    @include('plugins.common.flash_message')
+
+    {{-- 任意エラーメッセージ表示 --}}
+    @if (session('flash_error_message'))
+        <div class="alert alert-danger">
+            <i class="fas fa-exclamation-triangle"></i> {!! session('flash_error_message') !!}
+        </div>
+    @endif
+
+    <form action="{{url('/manage/uploadfile/deleteUserdirPublic')}}" name="form_user_dir_public" method="POST">
+        {{ csrf_field() }}
+
+        <div>
+            <span class="badge badge-secondary">public/{{$manage_userdir_public_target}}</span>
+        </div>
+
+        <div class="bg-light p-2 text-right">
+            <span class="mr-2">チェックした項目を</span>
+            <button class="btn btn-danger btn-sm btn-delete" type="button" data-toggle="modal" data-target="#delete-confirm" disabled><i class="fas fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span></button>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table text-nowrap">
+            <thead>
+                <th>
+                    {{-- 全選択チェック --}}
+                    <div class="custom-control custom-checkbox">
+                        <input type="checkbox" class="custom-control-input" id="select_all" onclick="change_all()">
+                        <label class="custom-control-label" for="select_all"></label>
+                    </div>
+                </th>
+                <th nowrap>ファイル名</th>
+                <th nowrap>サイズ</th>
+                <th nowrap>作成日時</th>
+            </thead>
+            <tbody>
+                @forelse($files as $file)
+                <tr>
+                    <td class="align-middle">
+                        <div class="custom-control custom-checkbox">
+                            <input type="checkbox" class="custom-control-input" id="delete_files{{$loop->iteration}}" name="delete_files[]" value="{{$file->getPathname()}}" data-name="{{$file->getRelativePathname()}}" onclick="controlSelectedContentsAndButtons()">
+                            <label class="custom-control-label" for="delete_files{{$loop->iteration}}"></label>
+                        </div>
+                    </td>
+                    <td>
+                        <a href="{{url('/')}}/{{$manage_userdir_public_target}}/{{$file->getRelativePathname()}}" target="_blank">
+                            {{$file->getRelativePathname()}}
+                            @if ( FileUtils::isImage(File::mimeType($file->getPathname())) )
+                                {{-- 画像ファイルの場合、サムネイル画像を表示 --}}
+                                <img src="{{url('/')}}/{{$manage_userdir_public_target}}/{{$file->getRelativePathname()}}" class="w-10" loading="lazy">
+                            @endif
+                        </a>
+                    </td>
+                    <td>{{ FileUtils::getFormatSize($file->getSize()) }}</td>
+                    <td>{{ new Carbon($file->getCTime()) }}</td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="4">ファイルがありません</td>
+                </tr>
+                @endforelse
+            </tbody>
+            </table>
+        </div>
+    </form>
+
+    {{-- 削除確認モーダルウィンドウ --}}
+    <div class="modal" id="delete-confirm" tabindex="-1" role="dialog" aria-labelledby="delete-title" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                {{-- ヘッダー --}}
+                <div class="modal-header">
+                    <h5 class="modal-title" id="delete-title">削除確認</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {{-- メインコンテンツ --}}
+                <div class="modal-body">
+                    <div class="card border-danger">
+                        <div class="card-body">
+                            <div class="text-danger">以下のデータを削除します。<br>元に戻すことはできないため、よく確認して実行してください。</div>
+                            <ul class="text-danger" id="selected-contents"></ul>
+                        </div>
+                        <div class="text-center mb-2">
+                            {{-- キャンセルボタン --}}
+                            <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                                <i class="fas fa-times"></i> キャンセル
+                            </button>
+                            {{-- 削除ボタン --}}
+                            <button type="button" class="btn btn-danger" onclick="deleteContents()"><i class="fas fa-check"></i> 本当に削除する</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+@endsection


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

public配下のディレクトリを１つ指定してファイル管理できる機能です。
指定ディレクトリのファイルを削除できます。
当機能はbeta機能です。

## `.env` 設定例

```
MANAGE_USERDIR_PUBLIC_TARGET="uploads"
```

## （設定後）管理機能＞管理者メニュー＞アップロードファイル＞ユーザパブリックファイル一覧

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/2e3ef79b-3003-4b95-b8f7-f28b04f08d73)

### 削除ボタン押下

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/8d20860a-87c8-4a45-acb9-c9e560855668)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
