### PR TITLE
[移行ツール] NC3移行エクスポート＋nc3.2.0より古い場合、ページの階層がうまく移行できない不具合修正

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -3230,7 +3230,7 @@ trait MigrationNc3ExportTrait
                 $registration_ini .= "option_value               = \"" . $option_value                    . "\"\n"; // |区切り
                 $registration_ini .= "required                   = "   . $registration_question->is_require   . "\n";
                 $registration_ini .= "frame_col                  = "   . 0                                . "\n";
-                $registration_ini .= "caption                    = \"" . $registration_question->description  . "\"\n";
+                $registration_ini .= "caption                    = '" . $registration_question->description  . "'\n";
                 $registration_ini .= "caption_color              = \"" . "text-dark"                      . "\"\n";
                 $registration_ini .= "minutes_increments         = "   . 10                               . "\n";
                 $registration_ini .= "minutes_increments_from    = "   . 10                               . "\n";

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -574,8 +574,7 @@ trait MigrationNc3ExportTrait
             $older_than_nc3_2_0 = $this->getMigrationConfig('basic', 'older_than_nc3_2_0');
             if ($older_than_nc3_2_0) {
                 // nc3.2.0より古い場合は、sort_key が無いため parent_id, lft でソートすると、ページの並び順を再現できた。
-                $nc3_top_page_query->orderBy('pages.parent_id')
-                                    ->orderBy('pages.lft');
+                $nc3_top_page_query->orderBy('pages.lft');
             } else {
                 // 通常
                 $nc3_top_page_query->orderBy('pages.sort_key');
@@ -618,10 +617,9 @@ trait MigrationNc3ExportTrait
                 // @see https://github.com/NetCommons3/Pages/commit/77840e492352a21f7300ab1fa877f47f94f0bd1c
                 // @see https://github.com/NetCommons3/Rooms/commit/8edfd1ea18f4b45f5aee7f961d0480048e2d6fc9
                 //
-                // ※ 若い親IDのページを先に移行しないと、MigrationMappingに親ページID達がなくマッチングできず、移行後にページ階層を再現できないため、parent_idのソート必要。
+                // ※ 若い親IDのページを先に移行しないと、MigrationMappingに親ページID達がなくマッチングできず、移行後にページ階層を再現できないため、若い親IDを上に並べる。
                 // nc3.2.0より新しければ、sort_keyで対応され、親ページID達が先に登録されるため、parent_idのソートは不要と思う。
-                $nc3_pages_query->orderBy('pages.parent_id')
-                                ->orderBy('pages.lft');
+                $nc3_pages_query->orderBy('pages.lft');
             } else {
                 // 通常
                 $nc3_pages_query->orderBy('pages.sort_key')

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -4789,6 +4789,9 @@ trait MigrationNc3ExportTrait
                         $this->putError(3, "Image file not exists: " . $nc3_uploads_path . $photo_upload->path . $photo_upload->id . '/' . $photo_upload->real_file_name);
                     }
 
+                    $nc3_photoalbum_photo->title = str_replace(array("\r\n", "\r", "\n"), "", $nc3_photoalbum_photo->title);
+                    $nc3_photoalbum_photo->description = str_replace(array("\r\n", "\r", "\n"), "", $nc3_photoalbum_photo->description);
+
                     $tsv_record['photo_id']          = $nc3_photoalbum_photo->id;
                     $tsv_record['upload_id']         = $photo_upload->id;
                     $tsv_record['video_upload_id']   = '';

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -3623,7 +3623,7 @@ trait MigrationNc3ExportTrait
                 $tsv .= $cabinet_file->is_folder . "\t";            // [9] is_folder
                 $tsv .= "\t";                                       // [10] 表示順（インポートで使ってない）
                 $tsv .= $cabinet->room_id . "\t";
-                $tsv .= str_replace("\t", '', $cabinet_file->description) . "\t";
+                $tsv .= str_replace(array("\r\n", "\r", "\n", "\t"), '', $cabinet_file->description) . "\t";
                 $tsv .= $this->getCCDatetime($cabinet_file->created)                                  . "\t";   // [13]
                 $tsv .= Nc3User::getNc3HandleFromNc3UserId($nc3_users, $cabinet_file->created_user)   . "\t";   // [14]
                 $tsv .= Nc3User::getNc3LoginIdFromNc3UserId($nc3_users, $cabinet_file->created_user)  . "\t";   // [15]

--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -4882,6 +4882,9 @@ trait MigrationNc3ExportTrait
                     if (!empty($slides_tsv)) {
                         $slides_tsv .= "\n";
                     }
+
+                    $nc3_photoalbum_photo->description = str_replace(array("\r\n", "\r", "\n"), "", $nc3_photoalbum_photo->description);
+
                     $slides_tsv .= "\t";                                        // image_path
                     $slides_tsv .= $photo_upload->id . "\t";                    // uploads_id
                     $slides_tsv .= "\t";                                        // link_url


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [bugfix: 移行ツール, NC3移行エクスポート＋nc3.2.0より古い場合、ページの階層がうまく移行できない不具合修正](https://github.com/opensource-workshop/connect-cms/commit/18ac9a8341b7aa2b7a753bb433e98881f68b6f36)
* 関連修正
    * [bugfix: 移行ツール, NC3移行エクスポートで登録フォームのキャプションにダブルクォーテーションが含まれるとエラーになる不具合修正](https://github.com/opensource-workshop/connect-cms/commit/6ce324efbf37d218fa4d57ca5d3e60071e01893d)
    * [bugfix: 移行ツール, NC3移行エクスポートでキャビネットのファイルの説明に改行が含まれるとエラーになる不具合修正](https://github.com/opensource-workshop/connect-cms/commit/4730f8cffa2c6a6c9acf3408c44b0dcd89dbe6e6)
    * [bugfix: 移行ツール, NC3移行エクスポートでフォトアルバムのファイルのタイトルと説明に改行が含まれるとエラーになる不具合修正](https://github.com/opensource-workshop/connect-cms/commit/4692edc1924cfa26d83a861b8424439b28b20ca8)
    * [bugfix: 移行ツール, NC3移行エクスポートでスライダーのファイルの説明に改行が含まれるとエラーになる不具合修正](https://github.com/opensource-workshop/connect-cms/commit/87e677d02b42c980d5f72e9d5f0c6e0ffb807ce4)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし


# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
