### PR TITLE
[スライダー] 項目設定画面をlgでもPC表示と同じにする修正＋スマホ表示の見直し

### DIFF
--- a/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
@@ -64,14 +64,14 @@
                     <div class="table-responsive">
                         <table class="table table-hover table-sm">
                             <thead>
-                                <tr class="d-none d-xl-table-row">
-                                    <th class="text-center text-nowrap align-middle d-block d-xl-table-cell">表示順</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-xl-table-cell">表示</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-xl-table-cell">画像<label class="badge badge-danger">必須</label></th>
-                                    <th class="text-center text-nowrap align-middle d-block d-xl-table-cell">リンクURL</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-xl-table-cell">キャプション</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-xl-table-cell">リンクターゲット</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-xl-table-cell">削除</th>
+                                <tr class="d-none d-lg-table-row">
+                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">表示順</th>
+                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">表示</th>
+                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">画像 <label class="badge badge-danger">必須</label></th>
+                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">リンクURL</th>
+                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">キャプション</th>
+                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">リンクターゲット</th>
+                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">削除</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
@@ -7,7 +7,7 @@
 --}}
 <tr>
     {{-- 表示順 --}}
-    <td class="d-none d-xl-display d-xl-table-cell text-nowrap" style="text-align:center; vertical-align:middle;">
+    <td class="d-none d-lg-display d-lg-table-cell text-nowrap" style="text-align:center; vertical-align:middle;">
         {{-- 上移動 --}}
         <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->first) disabled @endif onclick="javascript:submit_display_sequence({{ $item->id }}, {{ $item->display_sequence }}, 'up')">
             <i class="fas fa-arrow-up"></i>
@@ -19,7 +19,7 @@
         </button>
     </td>
     {{-- 表示フラグ--}}
-    <td class="d-none d-xl-display d-xl-table-cell" style="text-align:center; vertical-align:middle;">
+    <td class="d-none d-lg-display d-lg-table-cell" style="text-align:center; vertical-align:middle;">
         <div class="custom-control custom-checkbox">
             <input
                 type="checkbox"
@@ -35,12 +35,12 @@
         </div>
     </td>
     {{-- 画像ファイル --}}
-    <td class="d-block d-xl-table-cell align-middle">
+    <td class="d-block d-table-cell align-middle">
         {{-- 画像選択ボタン --}}
         <label class="input-group-btn d-flex align-items-center justify-content-center">
             <span class="btn btn-primary text-nowrap" style="cursor: hand; cursor:pointer;">
                 画像選択<input type="file" name="image_files[{{ $item->id }}]" style="display:none" @change="setImageResource({{ $item->id }}, arguments[0])">
-                <label class="badge badge-danger d-xl-none">必須</label>
+                <label class="badge badge-danger d-lg-none">必須</label>
             </span>
         </label>
         @include('plugins.common.errors_inline', ['name' => 'image_files.' . $item->id])
@@ -78,42 +78,42 @@
         </div>
     </td>
     {{-- リンクURL --}}
-    <td class="d-block d-xl-table-cell align-middle">
-        <strong class="d-xl-none">リンクURL：</strong>
-        <input 
-            type="text" 
-            name="link_urls[{{ $item->id }}]" 
-            class="form-control @if ($errors && $errors->has("link_urls.$item->id")) border-danger @endif" 
+    <td class="d-block d-lg-table-cell align-middle">
+        <strong class="d-lg-none">リンクURL：</strong>
+        <input
+            type="text"
+            name="link_urls[{{ $item->id }}]"
+            class="form-control @if ($errors && $errors->has("link_urls.$item->id")) border-danger @endif"
             value="{{ old("link_urls.$item->id", $item->link_url) }}"
             placeholder="例：https://connect-cms.jp/"
         >
         @include('common.errors_inline', ['name' => "link_urls.$item->id"])
     </td>
     {{-- キャプション --}}
-    <td class="d-block d-xl-table-cell align-middle">
-        <strong class="d-xl-none">キャプション：</strong>
-        <input 
-            type="text" 
-            name="captions[{{ $item->id }}]" 
-            class="form-control @if ($errors && $errors->has("captions.$item->id")) border-danger @endif" 
+    <td class="d-block d-lg-table-cell align-middle">
+        <strong class="d-lg-none">キャプション：</strong>
+        <input
+            type="text"
+            name="captions[{{ $item->id }}]"
+            class="form-control @if ($errors && $errors->has("captions.$item->id")) border-danger @endif"
             value="{{ old("captions.$item->id", $item->caption) }}"
         >
         @include('common.errors_inline', ['name' => "captions.$item->id"])
     </td>
     {{-- リンクターゲット --}}
-    <td class="d-block d-xl-table-cell align-middle">
-        <strong class="d-xl-none">リンクターゲット：</strong>
-        <input 
-            type="text" 
-            name="link_targets[{{ $item->id }}]" 
-            class="form-control @if ($errors && $errors->has("link_targets.$item->id")) border-danger @endif" 
+    <td class="d-block d-lg-table-cell align-middle">
+        <strong class="d-lg-none">リンクターゲット：</strong>
+        <input
+            type="text"
+            name="link_targets[{{ $item->id }}]"
+            class="form-control @if ($errors && $errors->has("link_targets.$item->id")) border-danger @endif"
             value="{{ old("link_targets.$item->id", $item->link_target) }}"
             placeholder="例：_blank、_self等"
         >
         @include('common.errors_inline', ['name' => "link_targets.$item->id"])
     </td>
     {{-- 削除ボタン --}}
-    <td class="d-block d-xl-table-cell align-middle d-flex align-items-center justify-content-center">
+    <td class="d-block d-lg-table-cell align-middle d-flex align-items-center justify-content-center">
         <button
             class="btn btn-danger cc-font-90 text-nowrap"
             onclick="javascript:return submit_delete_item({{ $item->id }});"

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
@@ -6,15 +6,15 @@
  * @category スライドショー・プラグイン
 --}}
 <tr>
-    <td class="d-none d-xl-display d-xl-table-cell"></td>
-    <td class="d-none d-xl-display d-xl-table-cell"></td>
+    <td class="d-none d-lg-display d-lg-table-cell"></td>
+    <td class="d-none d-lg-display d-lg-table-cell"></td>
     {{-- 画像ファイル --}}
-    <td class="d-block d-xl-table-cell align-middle">
+    <td class="d-table-cell align-middle">
         {{-- 画像選択ボタン --}}
         <label class="input-group-btn d-flex align-items-center justify-content-center">
             <span class="btn btn-primary text-nowrap" style="cursor: hand; cursor:pointer;">
                 画像選択<input type="file" name="image_file" style="display:none" @change="setImageResource('add', arguments[0])">
-                <label class="badge badge-danger d-xl-none">必須</label>
+                <label class="badge badge-danger d-lg-none">必須</label>
             </span>
         </label>
         @include('plugins.common.errors_inline', ['name' => 'image_file'])
@@ -55,8 +55,8 @@
         </div>
     </td>
     {{-- リンクURL --}}
-    <td class="d-block d-xl-table-cell align-middle">
-        <strong class="d-xl-none">リンクURL：</strong>
+    <td class="d-block d-lg-table-cell align-middle">
+        <strong class="d-lg-none">リンクURL：</strong>
         <input
             type="text"
             name="link_url"
@@ -67,8 +67,8 @@
         @include('common.errors_inline', ['name' => 'link_url'])
     </td>
     {{-- キャプション --}}
-    <td class="d-block d-xl-table-cell align-middle">
-        <strong class="d-xl-none">キャプション：</strong>
+    <td class="d-block d-lg-table-cell align-middle">
+        <strong class="d-lg-none">キャプション：</strong>
         <input
             type="text"
             name="caption"
@@ -78,8 +78,8 @@
         @include('common.errors_inline', ['name' => 'caption'])
     </td>
     {{-- リンクターゲット --}}
-    <td class="d-block d-xl-table-cell align-middle">
-        <strong class="d-xl-none">リンクターゲット：</strong>
+    <td class="d-block d-lg-table-cell align-middle">
+        <strong class="d-lg-none">リンクターゲット：</strong>
         <input
             type="text"
             name="link_target"
@@ -90,7 +90,7 @@
         @include('common.errors_inline', ['name' => 'link_target'])
     </td>
     {{-- ＋ボタン --}}
-    <td class="d-block d-xl-table-cell align-middle d-flex align-items-center justify-content-center">
+    <td class="d-block d-lg-table-cell align-middle d-flex align-items-center justify-content-center">
         <button
             class="btn btn-success cc-font-90 text-nowrap"
             onclick="javascript:submit_add_item();"
@@ -104,9 +104,9 @@
 
 @if (!empty(config('connect.PDF_THUMBNAIL_API_URL')))
 <tr>
-    <td class="d-none d-xl-display d-xl-table-cell"></td>
-    <td class="d-none d-xl-display d-xl-table-cell"></td>
-    <td class="d-block d-xl-table-cell align-middle">
+    <td class="d-none d-lg-display d-lg-table-cell"></td>
+    <td class="d-none d-lg-display d-lg-table-cell"></td>
+    <td class="d-table-cell align-middle">
         <label class="input-group-btn d-flex align-items-center justify-content-center" data-toggle="modal" data-target="#modalPdfAdd">
             <span class="btn btn-primary text-nowrap" style="cursor: hand; cursor:pointer;">
                 PDF選択
@@ -158,13 +158,13 @@
         </div>
     </td>
     {{-- リンクURL --}}
-    <td class="d-block d-xl-table-cell align-middle"></td>
+    <td class="d-none d-lg-display d-lg-table-cell"></td>
     {{-- キャプション --}}
-    <td class="d-block d-xl-table-cell align-middle"></td>
+    <td class="d-none d-lg-display d-lg-table-cell"></td>
     {{-- リンクターゲット --}}
-    <td class="d-block d-xl-table-cell align-middle"></td>
+    <td class="d-none d-lg-display d-lg-table-cell"></td>
     {{-- ＋ボタン --}}
-    <td class="d-block d-xl-table-cell align-middle d-flex align-items-center justify-content-center">
+    <td class="d-block d-lg-table-cell align-middle d-flex align-items-center justify-content-center">
         <button
             class="btn btn-success cc-font-90 text-nowrap"
             onclick="javascript:submit_add_pdf();"


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

スライダーの項目設定画面はxl(横幅≥1200px)以上でないとPC表示になりませんでした。
スマホ表示は、スライダーの順番変更、表示・非表示が設定できなかったため、lg(横幅≥992px)までPC表示にする見直しをしました。
また、スマホ表示が見ずらかったため、見直しました。

## 修正後画面
### 項目設定 PC表示 lg(横幅≥992px)

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/88eb2625-97cf-4405-b452-0f0086d363dc)

### 項目設定  スマホ表示 (横幅 992px より小さい)

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/cf9bf478-84f2-43d4-a41a-bdec5e543d0c)
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/2803c558-b08c-4640-9994-fc7d3da61887)

## （参考）修正前 スマホ表示 lg(横幅 992px)

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/7db76ebe-154b-4968-9af8-9162a4ebcaaa)
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/99382b69-9cfd-435c-a62e-20b38af1b3c6)
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/bcd19f97-48b9-4024-83ab-ea8b2aca9c6b)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

* https://v4.bootstrap-guide.com/utilities/display

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
