### PR TITLE
[リンクリスト] 登録変更時にメッセージを表示＋登録後は一覧画面に遷移するよう見直し

### DIFF
--- a/app/Plugins/User/Linklists/LinklistsPlugin.php
+++ b/app/Plugins/User/Linklists/LinklistsPlugin.php
@@ -347,8 +347,16 @@ class LinklistsPlugin extends UserPluginBase
         // データ保存
         $post->save();
 
-        // 登録後はリダイレクトして編集画面を開く。
-        return new Collection(['redirect_path' => url('/') . "/plugin/linklists/edit/" . $page_id . "/" . $frame_id . "/" . $post->id . "#frame-" . $frame_id]);
+        if ($post_id) {
+            $message = '変更しました。';
+        } else {
+            $message = '登録しました。';
+        }
+        session()->flash("flash_message_for_frame{$frame_id}", $message);
+
+        // 登録後はリダイレクトして初期画面を開く。
+        // return new Collection(['redirect_path' => url('/') . "/plugin/linklists/edit/" . $page_id . "/" . $frame_id . "/" . $post->id . "#frame-" . $frame_id]);
+        return new Collection(['redirect_path' => url($this->page->permanent_link) . "#frame-" . $frame_id]);
     }
 
     /**

--- a/resources/views/plugins/user/linklists/default/edit.blade.php
+++ b/resources/views/plugins/user/linklists/default/edit.blade.php
@@ -13,13 +13,8 @@
 @include('plugins.common.errors_form_line')
 
 {{-- 投稿用フォーム --}}
-@if (empty($post->id))
-    <form action="{{url('/')}}/redirect/plugin/linklists/save/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="POST" class="" name="form_post{{$frame_id}}">
-        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/linklists/edit/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
-@else
-    <form action="{{url('/')}}/redirect/plugin/linklists/save/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}" method="POST" class="" name="form_post{{$frame_id}}">
-        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/linklists/edit/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame_id}}">
-@endif
+<form action="{{url('/')}}/redirect/plugin/linklists/save/{{$page->id}}/{{$frame_id}}@isset($post->id)/{{$post->id}}@endisset#frame-{{$frame->id}}" method="POST" name="form_post{{$frame_id}}">
+    <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/linklists/edit/{{$page->id}}/{{$frame_id}}@isset($post->id)/{{$post->id}}@endisset#frame-{{$frame_id}}">
     {{ csrf_field() }}
     <div class="form-group row">
         <label class="col-md-2 control-label text-md-right">タイトル <label class="badge badge-danger">必須</label></label>

--- a/resources/views/plugins/user/linklists/default/edit.blade.php
+++ b/resources/views/plugins/user/linklists/default/edit.blade.php
@@ -17,7 +17,7 @@
     <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/linklists/edit/{{$page->id}}/{{$frame_id}}@isset($post->id)/{{$post->id}}@endisset#frame-{{$frame_id}}">
     {{ csrf_field() }}
     <div class="form-group row">
-        <label class="col-md-2 control-label text-md-right">タイトル <label class="badge badge-danger">必須</label></label>
+        <label class="col-md-2 control-label text-md-right">タイトル <span class="badge badge-danger">必須</span></label>
         <div class="col-md-10">
             <input type="text" name="title" value="{{old('title', $post->title)}}" class="form-control @if ($errors->has('title')) border-danger @endif">
             @include('plugins.common.errors_inline', ['name' => 'title'])
@@ -25,7 +25,7 @@
     </div>
 
     <div class="form-group row">
-        <label class="col-md-2 control-label text-md-right">URL</label>
+        <label class="col-md-2 control-label text-md-right">URL <span class="badge badge-danger">必須</span></label>
         <div class="col-md-10">
             <input type="text" name="url" value="{{old('url', $post->url)}}" class="form-control @if ($errors->has('url')) border-danger @endif">
             @include('plugins.common.errors_inline', ['name' => 'url'])

--- a/resources/views/plugins/user/linklists/default/index.blade.php
+++ b/resources/views/plugins/user/linklists/default/index.blade.php
@@ -9,6 +9,9 @@
 
 @section("plugin_contents_$frame->id")
 
+{{-- 登録後メッセージ表示 --}}
+@include('plugins.common.flash_message_for_frame')
+
 @if (isset($frame) && $frame->bucket_id)
     {{-- バケツあり --}}
 @else


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 件名通りです。
* 関連修正
    * [change: リンクリスト, 編集画面のURLに必須タグが抜けていたため追加](https://github.com/opensource-workshop/connect-cms/commit/b85d69e434ab327772810a83be876542ab8dfa29)

## 修正後画面
### リンク変更後は一覧画面に遷移＋変更後メッセージ表示（登録も同様）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/b8b80a0e-bfe2-443d-8205-b3d69488c19b)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
