### PR TITLE
[コア] twitter・facebookボタンの汎用化対応

### DIFF
--- a/resources/views/plugins/common/facebook.blade.php
+++ b/resources/views/plugins/common/facebook.blade.php
@@ -2,16 +2,15 @@
  * facebook ボタンテンプレート
  *
  * @param $post_title (プラグインで項目名が異なることがあるため、あえて明示的変数にしています)
+ * @param $share_connect_url
+ * @param $frame_config_name 取得するFrameConfigの設定名
  *
  * // 暗黙で利用
- * @param $frame
  * @param $frame_configs
- * @param $page
- * @param $post (インクルード元と名前が異なる場合は、インクルード元から名前指定の引数で渡すようにしてください)
 --}}
-@if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_facebook_button) == ShowType::show)
+@if (FrameConfig::getConfigValueAndOld($frame_configs, $frame_config_name) == ShowType::show)
 <a class="btn btn-sm btn-link btn-light border"
-    href="javascript:void window.open('{{urlencode("http://www.facebook.com/share.php?u=")}}{{url("/plugin/blogs/show/$page->id/$frame_id/$post->id&t=$post_title")}}','_blank');">
+    href="javascript:void window.open('{{urlencode("http://www.facebook.com/share.php?u=")}}{{url("$share_connect_url&t=$post_title")}}','_blank');">
     <h6 class="d-inline"><i class="fab fa-facebook-square"></i></h6>
 </a>
 @endif

--- a/resources/views/plugins/common/twitter.blade.php
+++ b/resources/views/plugins/common/twitter.blade.php
@@ -2,16 +2,15 @@
  * Twitter アイコンテンプレート
  *
  * @param $post_title (プラグインで項目名が異なることがあるため、あえて明示的変数にしています)
+ * @param $share_connect_url
+ * @param $frame_config_name 取得するFrameConfigの設定名
  *
  * // 暗黙で利用
- * @param $frame
  * @param $frame_configs
- * @param $page
- * @param $post (インクルード元と名前が異なる場合は、インクルード元から名前指定の引数で渡すようにしてください)
 --}}
-@if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_twitter_button) == ShowType::show)
+@if (FrameConfig::getConfigValueAndOld($frame_configs, $frame_config_name) == ShowType::show)
 <a class="btn btn-sm btn-link btn-light border"
-   href="javascript:void window.open('{{urlencode("http://twitter.com/intent/tweet?text=$post_title ")}}{{urlencode(url("/plugin/blogs/show/$page->id/$frame_id/$post->id"))}}','_blank');">
+   href="javascript:void window.open('{{urlencode("http://twitter.com/intent/tweet?text=$post_title ")}}{{urlencode(url($share_connect_url))}}','_blank');">
    <h6 class="d-inline"><i class="fab fa-twitter"></i></h6>
 </a>
 @endif

--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -182,12 +182,16 @@
 
                     {{-- Twitterボタン --}}
                     @include('plugins.common.twitter', [
-                        'post_title' => $post->post_title,
+                        'post_title'        => $post->post_title,
+                        'share_connect_url' => "/plugin/blogs/show/$page->id/$frame_id/$post->id",
+                        'frame_config_name' => BlogFrameConfig::blog_display_twitter_button,
                     ])
 
                     {{-- Facebookボタン --}}
                     @include('plugins.common.facebook', [
-                        'post_title' => $post->post_title,
+                        'post_title'        => $post->post_title,
+                        'share_connect_url' => "/plugin/blogs/show/$page->id/$frame_id/$post->id",
+                        'frame_config_name' => BlogFrameConfig::blog_display_facebook_button,
                     ])
 
                     {{-- タグ --}}

--- a/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
@@ -143,49 +143,35 @@
 
             {{-- Twitterアイコン表示 --}}
             <div class="form-group row">
-                <label class="{{$frame->getSettingLabelClass()}}">{{BlogFrameConfig::getDescription('blog_display_twitter_button')}}</label>
+                <label class="{{$frame->getSettingLabelClass()}}">{{BlogFrameConfig::getDescription(BlogFrameConfig::blog_display_twitter_button)}}</label>
                 <div class="{{$frame->getSettingInputClass(true)}}">
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_twitter_button) == '' ||
-                            FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_twitter_button) == ShowType::not_show)
-                            <input type="radio" value="{{ShowType::not_show}}" id="{{BlogFrameConfig::blog_display_twitter_button}}_0" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="{{ShowType::not_show}}" id="{{BlogFrameConfig::blog_display_twitter_button}}_0" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label text-nowrap" for="{{BlogFrameConfig::blog_display_twitter_button}}_0" id="label_{{BlogFrameConfig::blog_display_twitter_button}}_0">{{ShowType::getDescription(ShowType::not_show)}}</label>
-                    </div>
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_twitter_button) == ShowType::show)
-                            <input type="radio" value="{{ShowType::show}}" id="{{BlogFrameConfig::blog_display_twitter_button}}_1" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="{{ShowType::show}}" id="{{BlogFrameConfig::blog_display_twitter_button}}_1" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label text-nowrap" for="{{BlogFrameConfig::blog_display_twitter_button}}_1" id="label_{{BlogFrameConfig::blog_display_twitter_button}}_1">{{ShowType::getDescription(ShowType::show)}}</label>
-                    </div>
+                    @foreach (ShowType::getMembers() as $enum_value => $enum_label)
+                        <div class="custom-control custom-radio custom-control-inline">
+                            @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_twitter_button, ShowType::not_show) == $enum_value)
+                                <input type="radio" value="{{$enum_value}}" id="blog_display_twitter_button_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input" checked="checked">
+                            @else
+                                <input type="radio" value="{{$enum_value}}" id="blog_display_twitter_button_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input">
+                            @endif
+                            <label class="custom-control-label text-nowrap" for="blog_display_twitter_button_{{$enum_value}}">{{$enum_label}}</label>
+                        </div>
+                    @endforeach
                 </div>
             </div>
 
             {{-- Facebookアイコン表示 --}}
             <div class="form-group row">
-                <label class="{{$frame->getSettingLabelClass()}}">{{BlogFrameConfig::getDescription('blog_display_facebook_button')}}</label>
+                <label class="{{$frame->getSettingLabelClass()}}">{{BlogFrameConfig::getDescription(BlogFrameConfig::blog_display_facebook_button)}}</label>
                 <div class="{{$frame->getSettingInputClass(true)}}">
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_facebook_button) == '' ||
-                            FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_facebook_button) == ShowType::not_show)
-                            <input type="radio" value="{{ShowType::not_show}}" id="{{BlogFrameConfig::blog_display_facebook_button}}_0" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="{{ShowType::not_show}}" id="{{BlogFrameConfig::blog_display_facebook_button}}_0" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label text-nowrap" for="{{BlogFrameConfig::blog_display_facebook_button}}_0" id="label_{{BlogFrameConfig::blog_display_facebook_button}}_0">{{ShowType::getDescription(ShowType::not_show)}}</label>
-                    </div>
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_facebook_button) == ShowType::show)
-                            <input type="radio" value="{{ShowType::show}}" id="{{BlogFrameConfig::blog_display_facebook_button}}_1" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="{{ShowType::show}}" id="{{BlogFrameConfig::blog_display_facebook_button}}_1" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label text-nowrap" for="{{BlogFrameConfig::blog_display_facebook_button}}_1" id="label_{{BlogFrameConfig::blog_display_facebook_button}}_1">{{ShowType::getDescription(ShowType::show)}}</label>
-                    </div>
+                    @foreach (ShowType::getMembers() as $enum_value => $enum_label)
+                        <div class="custom-control custom-radio custom-control-inline">
+                            @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_facebook_button, ShowType::not_show) == $enum_value)
+                                <input type="radio" value="{{$enum_value}}" id="blog_display_facebook_button_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input" checked="checked">
+                            @else
+                                <input type="radio" value="{{$enum_value}}" id="blog_display_facebook_button_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input">
+                            @endif
+                            <label class="custom-control-label text-nowrap" for="blog_display_facebook_button_{{$enum_value}}">{{$enum_label}}</label>
+                        </div>
+                    @endforeach
                 </div>
             </div>
 

--- a/resources/views/plugins/user/blogs/default/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_show.blade.php
@@ -116,12 +116,16 @@
 
     {{-- Twitterボタン --}}
     @include('plugins.common.twitter', [
-        'post_title' => $post->post_title,
+        'post_title'        => $post->post_title,
+        'share_connect_url' => "/plugin/blogs/show/$page->id/$frame_id/$post->id",
+        'frame_config_name' => BlogFrameConfig::blog_display_twitter_button,
     ])
 
     {{-- Facebookボタン --}}
     @include('plugins.common.facebook', [
-        'post_title' => $post->post_title,
+        'post_title'        => $post->post_title,
+        'share_connect_url' => "/plugin/blogs/show/$page->id/$frame_id/$post->id",
+        'frame_config_name' => BlogFrameConfig::blog_display_facebook_button,
     ])
 
     {{-- タグ --}}

--- a/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
@@ -64,12 +64,16 @@
 
     {{-- Twitterボタン --}}
     @include('plugins.common.twitter', [
-        'post_title' => $post->post_title,
+        'post_title'        => $post->post_title,
+        'share_connect_url' => "/plugin/blogs/show/$page->id/$frame_id/$post->id",
+        'frame_config_name' => BlogFrameConfig::blog_display_twitter_button,
     ])
 
     {{-- Facebookボタン --}}
     @include('plugins.common.facebook', [
-        'post_title' => $post->post_title,
+        'post_title'        => $post->post_title,
+        'share_connect_url' => "/plugin/blogs/show/$page->id/$frame_id/$post->id",
+        'frame_config_name' => BlogFrameConfig::blog_display_facebook_button,
     ])
     {{-- タグ --}}
     @isset($post_tags)


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [refactor: twitter・facebookボタンの汎用化対応](https://github.com/opensource-workshop/connect-cms/commit/d3f95efd0ab9d2a06baa7d1d559c6827a817c641)
* 関連対応
    * [refactor: ブログ, 表示条件のTwitter・Twitterアイコン表示のコードのスリム化](https://github.com/opensource-workshop/connect-cms/commit/56c1fe417ce3e3a56b56022d84d8aaac94d8fa40)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
