### PR TITLE
[フレーム] ログイン後非表示機能を追加 OW-1656

### DIFF
--- a/app/Enums/ContentOpenType.php
+++ b/app/Enums/ContentOpenType.php
@@ -13,11 +13,13 @@ final class ContentOpenType extends EnumsBase
     const always_open = 1;
     const always_close = 2;
     const limited_open = 3;
+    const login_close = 4;
 
     // key/valueの連想配列
     const enum = [
         self::always_open => '公開',
         self::always_close => '非公開',
         self::limited_open => '限定公開',
+        self::login_close => 'ログイン後非表示',
     ];
 }

--- a/app/Models/Common/Frame.php
+++ b/app/Models/Common/Frame.php
@@ -233,17 +233,17 @@ class Frame extends Model
      */
     public function isInvisiblePrivateFrame()
     {
-        // 非ログインまたはフレーム編集権限を持たない、且つ、非表示条件（非公開、又は、限定公開）にマッチした場合はフレームを非表示にする
+        // 非ログインまたはフレーム編集権限を持たない、且つ、非表示条件（非公開、又は、限定公開、又は、ログイン後非表示）にマッチした場合はフレームを非表示にする
 
         if (
-            // !Auth::check() &&
             (!Auth::check() || !Auth::user()->can('role_arrangement')) &&
             (
                 $this->content_open_type == ContentOpenType::always_close ||
                 (
                     $this->content_open_type == ContentOpenType::limited_open &&
                     !Carbon::now()->between($this->content_open_date_from, $this->content_open_date_to)
-                )
+                ) ||
+                (Auth::check() && $this->content_open_type == ContentOpenType::login_close)
             )
         ) {
             // 非表示

--- a/app/Models/Common/Frame.php
+++ b/app/Models/Common/Frame.php
@@ -236,6 +236,7 @@ class Frame extends Model
         // 非ログインまたはフレーム編集権限を持たない、且つ、非表示条件（非公開、又は、限定公開、又は、ログイン後非表示）にマッチした場合はフレームを非表示にする
 
         if (
+            // !Auth::check() &&
             (!Auth::check() || !Auth::user()->can('role_arrangement')) &&
             (
                 $this->content_open_type == ContentOpenType::always_close ||


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# 修正後画面
## フレーム編集（設定画面）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/51eb9ae6-b6cf-45a9-8309-0056b0205776)

## ログイン後（プラグイン管理者）

プラグイン管理者であればログイン後でも表示されます（非公開と同様）
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/d3b653ad-ad75-4742-9fec-51b78f281df6)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし
# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
