### PR TITLE
[フォトアルバム] 右・左エリア = スマホ表示と同等にする

### DIFF
--- a/resources/views/plugins/user/photoalbums/card/index_folder.blade.php
+++ b/resources/views/plugins/user/photoalbums/card/index_folder.blade.php
@@ -2,14 +2,24 @@
  * フォトアルバム画面テンプレート（フォルダ）
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォトアルバム・プラグイン
 --}}
 {{-- データ一覧にアルバムが含まれる場合 --}}
 @if ($photoalbum_contents->where('is_folder', 1)->isNotEmpty())
+@php
+if ($frame->isExpandNarrow()) {
+    // 右・左エリア = スマホ表示と同等にする
+    $col_class = 'col-12';
+} else {
+    // メインエリア・フッターエリア
+    $col_class = 'col-md-4';
+}
+@endphp
 <div class="row">
     @foreach($photoalbum_contents->where('is_folder', 1) as $photoalbum_content)
-    <div class="col-md-4">
+    <div class="{{$col_class}}">
         <div class="card ml-3 mb-3 mt-3 p-0 mx-auto">
             <a href="{{url('/')}}/plugin/photoalbums/changeDirectory/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}/#frame-{{$frame->id}}" class="text-center">
                 {{-- カバー画像が指定されていれば使用し、指定されていなければ、グレーのカバーを使用 --}}

--- a/resources/views/plugins/user/photoalbums/default/bucket.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/bucket.blade.php
@@ -2,6 +2,7 @@
  * フォトアルバム・バケツ編集画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォトアルバム・プラグイン
 --}}
@@ -51,7 +52,7 @@
         <div class="form-group row">
             <label class="{{$frame->getSettingLabelClass()}}" for="upload-max-size">画像の最大サイズ</label>
             <div class="{{$frame->getSettingInputClass()}}">
-                <select class="form-control col-md-3 @if ($errors && $errors->has('image_upload_max_size')) border-danger @endif" name="image_upload_max_size" id="upload-max-size">
+                <select class="form-control @if(!$frame->isExpandNarrow()) col-md-3 @endif @if ($errors && $errors->has('image_upload_max_size')) border-danger @endif" name="image_upload_max_size" id="upload-max-size">
                     @foreach (UploadMaxSize::getMembers() as $key=>$value)
                     <option value="{{$key}}" @if(old("image_upload_max_size", $photoalbum->image_upload_max_size) == $key) selected="selected" @endif>
                         {{ $value }}
@@ -65,7 +66,7 @@
         <div class="form-group row">
             <label class="{{$frame->getSettingLabelClass()}}" for="upload-max-size">画像アップロード時の最大変換サイズ</label>
             <div class="{{$frame->getSettingInputClass()}}">
-                <select class="form-control col-md-6 @if ($errors && $errors->has('image_upload_max_px')) border-danger @endif" name="image_upload_max_px" id="image_upload_max_px">
+                <select class="form-control @if(!$frame->isExpandNarrow()) col-md-6 @endif @if ($errors && $errors->has('image_upload_max_px')) border-danger @endif" name="image_upload_max_px" id="image_upload_max_px">
                     @foreach (ResizedImageSize::getMembers() as $key=>$value)
                     <option value="{{$key}}" @if(old("image_upload_max_px", $photoalbum->image_upload_max_px) == $key) selected="selected" @endif>
                         {{ $value }}
@@ -79,7 +80,7 @@
         <div class="form-group row">
             <label class="{{$frame->getSettingLabelClass()}}" for="upload-max-size">動画の最大サイズ</label>
             <div class="{{$frame->getSettingInputClass()}}">
-                <select class="form-control col-md-3 @if ($errors && $errors->has('video_upload_max_size')) border-danger @endif" name="video_upload_max_size" id="upload-max-size">
+                <select class="form-control @if(!$frame->isExpandNarrow()) col-md-3 @endif @if ($errors && $errors->has('video_upload_max_size')) border-danger @endif" name="video_upload_max_size" id="upload-max-size">
                     @foreach (UploadMaxSize::getMembers() as $key=>$value)
                     <option value="{{$key}}" @if(old("video_upload_max_size", $photoalbum->video_upload_max_size) == $key) selected="selected" @endif>
                         {{ $value }}
@@ -93,7 +94,7 @@
         </div>
         {{-- Submitボタン --}}
         <div class="form-group text-center">
-            <div class="row">
+            <div class="form-row">
                 <div class="col-3"></div>
                 <div class="col-6">
                     <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}'">

--- a/resources/views/plugins/user/photoalbums/default/index_folder.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_folder.blade.php
@@ -2,14 +2,26 @@
  * フォトアルバム画面テンプレート（フォルダ）
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォトアルバム・プラグイン
 --}}
 {{-- データ一覧にアルバムが含まれる場合 --}}
 @if ($photoalbum_contents->where('is_folder', 1)->isNotEmpty())
+@php
+if ($frame->isExpandNarrow()) {
+    // 右・左エリア = スマホ表示と同等にする
+    $left_class = 'col-12';
+    $right_class = 'col-12';
+} else {
+    // メインエリア・フッターエリア
+    $left_class = 'col-sm-4';
+    $right_class = 'col-sm-8';
+}
+@endphp
 <div class="row">
     @foreach($photoalbum_contents->where('is_folder', 1) as $photoalbum_content)
-    <div class="col-sm-4 mt-3">
+    <div class="{{$left_class}} mt-3">
         <div class="card sm-4">
             <a href="{{url('/')}}/plugin/photoalbums/changeDirectory/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}/#frame-{{$frame->id}}" class="text-center">
                 {{-- カバー画像が指定されていれば使用し、指定されていなければ、グレーのカバーを使用 --}}
@@ -29,7 +41,7 @@
             </a>
         </div>
     </div>
-    <div class="col-sm-8 mt-3">
+    <div class="{{$right_class}} mt-3">
         <div class="d-flex">
             @if ($download_check)
             <div class="custom-control custom-checkbox">

--- a/resources/views/plugins/user/photoalbums/default/index_image.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_image.blade.php
@@ -2,14 +2,24 @@
  * フォトアルバム画面テンプレート（画像・動画）
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォトアルバム・プラグイン
 --}}
 {{-- データ一覧に画像が含まれる場合 --}}
 @if ($photoalbum_contents->where('is_folder', 0)->isNotEmpty())
+@php
+if ($frame->isExpandNarrow()) {
+    // 右・左エリア = スマホ表示と同等にする
+    $col_class = 'col-12';
+} else {
+    // メインエリア・フッターエリア
+    $col_class = 'col-md-4';
+}
+@endphp
 <div class="row">
     @foreach($photoalbum_contents->where('is_folder', 0) as $photoalbum_content)
-    <div class="col-md-4">
+    <div class="{{$col_class}}">
         <div class="card mt-3 shadow-sm">
         @if ($photoalbum_content->upload->is_image)
             <img src="{{url('/')}}/file/{{$photoalbum_content->upload_id}}?size=small"


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# 修正後画面
## 右エリア配置のフォトアルバム（defaultテンプレート）
### 初期表示
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/c3ef4a0a-287b-4c85-9d2f-9dd8160c9817)

### 設定変更

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/97c4f6a6-0df5-4900-829b-220658d1e720)

## 右エリア配置のフォトアルバム（cardテンプレート）
### 初期表示

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/c2f8364a-8e6f-4648-962b-315622e2f0ed)

# 参考：修正前画面

## 右エリア配置のフォトアルバム（defaultテンプレート）
### 初期表示

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/7bee26e5-6bd5-4b83-b521-df3fd56fc84e)

### 設定変更
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/86027c66-1675-4a88-911f-ce850199f5b6)

## 右エリア配置のフォトアルバム（cardテンプレート）
### 初期表示
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/c471499d-31da-4fa0-b786-ec644905d2b6)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
