### PR TITLE
[DB初期データ]  base_themeのcategory見直し

### DIFF
--- a/database/seeders/DefaultConfigsTableSeeder.php
+++ b/database/seeders/DefaultConfigsTableSeeder.php
@@ -94,7 +94,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_theme',
                         'value'=>null,
-                        'category'=>'user_register',
+                        'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
                     ],


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

seederのbase_themeのcategory値を`user_register` から`general`に念のため修正。
base_themeを取得する場合は、name="base_theme"で取得されていたため、修正前でも影響なしでした。
また、どうも設定変更時に`general`に更新されるようです。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
