### PR TITLE
[ユーザ管理] ユーザの種類毎に別々の項目を持てるよう対応 OW-1657

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,8 +85,11 @@ cc_lang_ja_messages_input_user_name="表示されるユーザ名を入力しま�
 # VerifyCsrfToken except.
 VERIFY_CSRF_TOKEN_EXCEPT=""
 
-# Use the container (beta)
+# (BETA) Use the container
 USE_CONTAINER_BETA=false
+
+# Use the UsersColumnsSet
+USE_USERS_COLUMNS_SET=false
 
 # PHP BIN path used when QUEUE_CONNECTION=database. Automatic judgment when null. e.g.) QUEUE_PHP_BIN=/usr/local/php/7.4/bin/php
 QUEUE_PHP_BIN=

--- a/.env.example
+++ b/.env.example
@@ -88,7 +88,7 @@ VERIFY_CSRF_TOKEN_EXCEPT=""
 # (BETA) Use the container
 USE_CONTAINER_BETA=false
 
-# Use the UsersColumnsSet
+# Set to true if you want to have an item for each user type. (WARNING) If true is set to false after operation, please maintain user information appropriately.
 USE_USERS_COLUMNS_SET=false
 
 # PHP BIN path used when QUEUE_CONNECTION=database. Automatic judgment when null. e.g.) QUEUE_PHP_BIN=/usr/local/php/7.4/bin/php

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -103,7 +103,7 @@ class RegisterController extends Controller
 
         foreach ($users_columns as $users_column) {
             // バリデータールールをセット
-            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, null, $columns_set_id);
+            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $columns_set_id, null);
         }
 
         // 入力値チェック

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -69,7 +69,7 @@ class RegisterController extends Controller
             'column' => [
                 'name'           => 'required|string|max:255',
                 'userid'         => 'required|max:255|unique:users',
-                'email'          => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique(null, $columns_set_id)],
+                'email'          => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($columns_set_id, null)],
                 'password'       => 'required|string|min:6|confirmed',
                 'status'         => 'required',
                 'columns_set_id' => ['required'],
@@ -89,7 +89,7 @@ class RegisterController extends Controller
         // ユーザ自動登録の場合（認証されていない）は、メールアドレスも必須にする。
         if (!Auth::user()) {
             // change: ユーザーの追加項目に対応
-            $validator_array['column']['email'] = ['required', 'email', 'max:255', new CustomValiUserEmailUnique(null, $columns_set_id)];
+            $validator_array['column']['email'] = ['required', 'email', 'max:255', new CustomValiUserEmailUnique($columns_set_id, null)];
 
             // bugfix: 個人情報保護方針への同意を求める場合、必須にする
             $user_register_requre_privacy = Configs::where('name', 'user_register_requre_privacy')->where('additional1', $columns_set_id)->first();

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -4,22 +4,22 @@ namespace App\Http\Controllers\Auth;
 
 use App\Enums\UserColumnType;
 use App\Enums\UserStatus;
-use App\Http\Controllers\Controller;
-//use App\Providers\RouteServiceProvider;
-use App\User;
 //use Illuminate\Foundation\Auth\RegistersUsers;
 use App\Http\Controllers\Auth\RegistersUsers;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Validator;
-
-use Illuminate\Support\Facades\Auth;
+use App\Http\Controllers\Controller;
 use App\Models\Core\Configs;
 use App\Models\Core\Section;
 use App\Models\Core\UserSection;
 use App\Models\Core\UsersInputCols;
 use App\Plugins\Manage\UserManage\UsersTool;
+//use App\Providers\RouteServiceProvider;
 use App\Rules\CustomValiUserEmailUnique;
+use App\User;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
 
 class RegisterController extends Controller
 {
@@ -33,7 +33,6 @@ class RegisterController extends Controller
     | provide this functionality without requiring any additional code.
     |
     */
-
     use RegistersUsers;
 
     /**
@@ -57,34 +56,32 @@ class RegisterController extends Controller
     /**
      * Get a validator for an incoming registration request.
      *
-     * @param  array  $data
+     * @param array $data
      * @return \Illuminate\Contracts\Validation\Validator
      */
     protected function validator(array $data)
     {
+        // columns_set_id はhidden等で必ずセットされる想定
+        $columns_set_id = Arr::get($data, 'columns_set_id');
+
         // change: ユーザーの追加項目に対応
-        // $validate_rule = [
-        //     'name'     => 'required|string|max:255',
-        //     'userid'   => 'required|max:255|unique:users',
-        //     'email'    => 'nullable|email|max:255|unique:users',
-        //     'password' => 'required|string|min:6|confirmed',
-        //     'status'   => 'required',
-        // ];
         $validator_array = [
             'column' => [
-                'name'     => 'required|string|max:255',
-                'userid'   => 'required|max:255|unique:users',
-                'email'    => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique(null)],
-                'password' => 'required|string|min:6|confirmed',
-                'status'   => 'required',
+                'name'           => 'required|string|max:255',
+                'userid'         => 'required|max:255|unique:users',
+                'email'          => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique(null, $columns_set_id)],
+                'password'       => 'required|string|min:6|confirmed',
+                'status'         => 'required',
+                'columns_set_id' => ['required'],
             ],
             // 項目名
             'message' => [
-                'name' => 'ユーザ名',
-                'userid' => 'ログインID',
-                'email' => 'eメール',
-                'password' => 'パスワード',
-                'status' => '状態',
+                'name'                         => 'ユーザ名',
+                'userid'                       => 'ログインID',
+                'email'                        => 'eメール',
+                'password'                     => 'パスワード',
+                'status'                       => '状態',
+                'columns_set_id'               => '項目セット',
                 'user_register_requre_privacy' => '個人情報保護方針への同意',
             ]
         ];
@@ -92,40 +89,29 @@ class RegisterController extends Controller
         // ユーザ自動登録の場合（認証されていない）は、メールアドレスも必須にする。
         if (!Auth::user()) {
             // change: ユーザーの追加項目に対応
-            // $validate_rule['email'] = 'required|string|email|max:255|unique:users';
-            // $validate_rule['user_register_requre_privacy'] = 'required';
-            $validator_array['column']['email'] = ['required', 'email', 'max:255', new CustomValiUserEmailUnique(null)];
+            $validator_array['column']['email'] = ['required', 'email', 'max:255', new CustomValiUserEmailUnique(null, $columns_set_id)];
 
             // bugfix: 個人情報保護方針への同意を求める場合、必須にする
-            $user_register_requre_privacy = Configs::where('name', 'user_register_requre_privacy')->first();
+            $user_register_requre_privacy = Configs::where('name', 'user_register_requre_privacy')->where('additional1', $columns_set_id)->first();
             if (!empty($user_register_requre_privacy) && $user_register_requre_privacy->value == '1') {
                 $validator_array['column']['user_register_requre_privacy'] = 'required';
             }
         }
 
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($columns_set_id);
 
         foreach ($users_columns as $users_column) {
             // バリデータールールをセット
-            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, null);
+            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, null, $columns_set_id);
         }
 
         // 入力値チェック
-        // $validator = Validator::make($data, $validate_rule);
         $validator = Validator::make($data, $validator_array['column']);
 
         // 項目名
         // change: ユーザーの追加項目に対応
-        // $validator->setAttributeNames([
-        //     'name'                         => 'ユーザ名',
-        //     'userid'                       => 'ログインID',
-        //     'email'                        => 'eメールアドレス',
-        //     'password'                     => 'パスワード',
-        //     'user_register_requre_privacy' => '個人情報保護方針への同意',
-        // ]);
         $validator->setAttributeNames($validator_array['message']);
-        // dd($validator->errors());
         return $validator;
     }
 
@@ -142,26 +128,30 @@ class RegisterController extends Controller
             $this->redirectTo = '/';
         }
 
+        // columns_set_id はhidden等で必ずセットされる想定
+        $columns_set_id = Arr::get($data, 'columns_set_id');
+
         // 設定の取得
-        $configs = Configs::get();
+        $configs = Configs::where('category', 'user_register')->where('additional1', $columns_set_id)->get();
 
         $status = $this->userStatus($data, $configs);
 
         // ユーザ登録
         $user = User::create([
-            'name' => $data['name'],
-            'email' => $data['email'],
-            'userid' => $data['userid'],
+            'name'           => $data['name'],
+            'email'          => $data['email'],
+            'userid'         => $data['userid'],
             // change to laravel6.
             // 'password' => bcrypt($data['password']),
-            'password' => Hash::make($data['password']),
-            'status' => $status,
+            'password'       => Hash::make($data['password']),
+            'status'         => $status,
+            'columns_set_id' => $columns_set_id,
         ]);
 
         // ユーザーの追加項目の登録.
         // ----------------------------------
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($columns_set_id);
 
         // users_input_cols 登録
         foreach ($users_columns as $users_column) {
@@ -216,7 +206,7 @@ class RegisterController extends Controller
      * 登録するユーザーステータスを取得する
      *
      * @param array $data
-     * @param Conllection　$configs 設定値
+     * @param Collection $configs 設定値
      * @return ユーザステータス
      */
     private function userStatus(array $data, Collection $configs) : int

--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -61,6 +61,11 @@ trait RegistersUsers
                 $query->where('category', 'user_register')
                     ->where('additional1', $columns_set_id);
             })
+            // （全ての自動ユーザ登録設定で共通設定. additional1=all. 項目セット名とか）
+            ->orWhere(function ($query) {
+                $query->where('category', 'user_register')
+                    ->where('additional1', 'all');
+            })
             ->get();
 
         // ユーザ登録の権限チェック

--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Auth;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Auth\RedirectsUsers;
 use Illuminate\Support\Facades\Validator;
@@ -12,6 +11,7 @@ use Illuminate\Support\Facades\Validator;
 // Connect-CMS 用設定データ
 use App\User;
 use App\Models\Core\Configs;
+use App\Models\Core\UsersColumnsSet;
 use App\Models\Core\UsersRoles;
 use App\Traits\ConnectCommonTrait;
 use App\Traits\ConnectMailTrait;
@@ -38,35 +38,54 @@ trait RegistersUsers
      * Show the application registration form.
      * ユーザー登録画面表示（自動登録）
      *
+     * @param  \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
-    public function showRegistrationForm()
+    public function showRegistrationForm(Request $request)
     {
+        // ユーザー登録の許可
+        $user_register_enables = Configs::where('category', 'user_register')
+            ->where('name', 'user_register_enable')
+            ->where('value', '1')
+            ->get();
+
+        $user_register_enable = $user_register_enables->first();
+        // ユーザー登録の許可が１つもない場合(null)、画面表示は出来ないため、columns_set_id=0でもOK
+        $columns_set_id_default = $user_register_enable ? $user_register_enable->additional1 : 0;
+
+        $columns_set_id = $request->input('columns_set_id', $columns_set_id_default);
+
         // ユーザー登録関連設定の取得
-        $configs = Configs::where('category', 'general')->orWhere('category', 'user_register')->get();
+        $configs = Configs::where('category', 'general')
+            ->orWhere(function ($query) use ($columns_set_id) {
+                $query->where('category', 'user_register')
+                    ->where('additional1', $columns_set_id);
+            })
+            ->get();
+
         $configs_array = array();
         foreach ($configs as $config) {
             $configs_array[$config['name']] = $config['value'];
         }
         $configs = $configs_array;
 
-        // ログインしているユーザー情報を取得
-        //$user = Auth::user();
-
         // ユーザ登録の権限チェック
-        //if (isset($user) && ($user->role == 1 || $user->role == 3)) {
         if ($this->isCan('admin_user')) {
             // ユーザ登録の権限があればOK
-        } elseif ($configs_array['user_register_enable'] != "1") {
+        // } elseif ($configs_array['user_register_enable'] != "1") {
+        } elseif ($user_register_enables->isEmpty()) {
             // 未ログインの場合は、ユーザー登録が許可されていなければ、認証エラーとする。
             abort(403);
         }
 
-        //// ユーザの追加項目.
+        // ユーザ登録が有効な項目セット
+        $columns_sets = UsersColumnsSet::whereIn('id', $user_register_enables->pluck('additional1'))->get();
+
+        // *** ユーザの追加項目
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($columns_set_id);
         // カラムの選択肢
-        $users_columns_id_select = UsersTool::getUsersColumnsSelects();
+        $users_columns_id_select = UsersTool::getUsersColumnsSelects($columns_set_id);
         // カラムの登録データ
         $input_cols = null;
 
@@ -75,16 +94,18 @@ trait RegistersUsers
         $base_theme = Configs::getConfigsValue($tmp_configs, 'base_theme', null);
         $additional_theme = Configs::getConfigsValue($tmp_configs, 'additional_theme', null);
         $themes = [
-                    'css' => $base_theme,
-                    'js' => $base_theme,
-                    'additional_css' => $additional_theme,
-                    'additional_js' => $additional_theme,
+            'css' => $base_theme,
+            'js' => $base_theme,
+            'additional_css' => $additional_theme,
+            'additional_js' => $additional_theme,
         ];
 
         // フォームの初期値として空のユーザオブジェクトを渡す。
         return view('auth.register', [
             "user" => new User(),
             "configs" => $configs,
+            'columns_set_id' => $columns_set_id,
+            'columns_sets' => $columns_sets,
             'users_columns' => $users_columns,
             'users_columns_id_select' => $users_columns_id_select,
             'input_cols' => $input_cols,
@@ -95,9 +116,23 @@ trait RegistersUsers
     }
 
     /**
+     * ユーザー登録画面 再表示（自動登録）
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function reShowRegistrationForm(Request $request)
+    {
+        // old()に全inputをセット
+        $request->flash();
+
+        return redirect(route('show_register_form') . "?columns_set_id=$request->columns_set_id");
+    }
+
+    /**
      * Handle a registration request for the application.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
     public function register(Request $request)
@@ -106,7 +141,13 @@ trait RegistersUsers
 
         // 設定の取得
         // $configs = Configs::where('category', 'user_register')->get();
-        $configs = Configs::get();
+        // $configs = Configs::get();
+        $configs = Configs::where('category', 'general')
+            ->orWhere(function ($query) use ($request) {
+                $query->Where('category', 'user_register')
+                    ->Where('additional1', $request->columns_set_id);
+            })
+            ->get();
 
         // ユーザ登録の権限チェック
         //if (isset($user) && ($user->role == 1 || $user->role == 3)) {
@@ -114,7 +155,6 @@ trait RegistersUsers
             // ユーザ登録の権限があればOK
         } elseif (Configs::getConfigsValue($configs, 'user_register_enable') != "1") {
             // 未ログインの場合は、ユーザー登録が許可されていなければ、認証エラーとする。
-            //Log::debug("register 403.");
             abort(403);
         }
 
@@ -189,7 +229,6 @@ trait RegistersUsers
         if (!Auth::user() || !$this->isCan('admin_user')) {
             // session()->flash('flash_message_for_header', 'ユーザ登録が完了しました。登録したログインID、パスワードでログインしてください。');
 
-
             // 登録者に仮登録メールを送信する
             if (Configs::getConfigsValue($configs, 'user_register_temporary_regist_mail_flag')) {
                 // *** 仮登録
@@ -254,7 +293,6 @@ trait RegistersUsers
         // 作成したユーザでのログイン処理は行わない。mod by nagahara@opensource-workshop.jp
         // $this->guard()->login($user);
 
-        //Log::debug("register end brfore.");
         return $this->registered($request, $user)
                         ?: redirect($this->redirectPath())->with('flash_message', 'ユーザ登録しました。続けて参加グループを設定してください。');
     }
@@ -318,13 +356,6 @@ trait RegistersUsers
      */
     public function confirmToken(Request $request)
     {
-        // 設定の取得
-        $configs = Configs::where('category', 'user_register')->get();
-
-        // 仮登録機能OFFは、エラー画面へ
-        if (!Configs::getConfigsValue($configs, 'user_register_temporary_regist_mail_flag')) {
-            abort(403, '権限がありません');
-        }
         $id = (string) $request->route('id');
         $token = (string) $request->route('token');
 
@@ -337,7 +368,14 @@ trait RegistersUsers
             ]);
         }
 
-        // dd($request->route('id'));
+        // 設定の取得
+        $configs = Configs::where('category', 'user_register')->where('additional1', $user->columns_set_id)->get();
+
+        // 仮登録機能OFFは、エラー画面へ
+        if (!Configs::getConfigsValue($configs, 'user_register_temporary_regist_mail_flag')) {
+            abort(403, '権限がありません');
+        }
+
         // 項目のエラーチェック(トークンチェック)
         $validator = Validator::make(
             ['token' => $token],
@@ -381,13 +419,6 @@ trait RegistersUsers
      */
     public function storeToken(Request $request)
     {
-        // 設定の取得
-        $configs = Configs::get();
-
-        // 仮登録機能OFFは、エラー画面へ
-        if (!Configs::getConfigsValue($configs, 'user_register_temporary_regist_mail_flag')) {
-            abort(403, '権限がありません');
-        }
         $id = (string) $request->route('id');
         $token = (string) $request->route('token');
 
@@ -400,7 +431,15 @@ trait RegistersUsers
             ]);
         }
 
-        // dd($request->route('id'));
+        // 設定の取得
+        // $configs = Configs::get();
+        $configs = Configs::where('category', 'user_register')->where('additional1', $user->columns_set_id)->get();
+
+        // 仮登録機能OFFは、エラー画面へ
+        if (!Configs::getConfigsValue($configs, 'user_register_temporary_regist_mail_flag')) {
+            abort(403, '権限がありません');
+        }
+
         // 項目のエラーチェック(トークンチェック)
         $validator = Validator::make(
             ['token' => $token],

--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -63,12 +63,6 @@ trait RegistersUsers
             })
             ->get();
 
-        $configs_array = array();
-        foreach ($configs as $config) {
-            $configs_array[$config['name']] = $config['value'];
-        }
-        $configs = $configs_array;
-
         // ユーザ登録の権限チェック
         if ($this->isCan('admin_user')) {
             // ユーザ登録の権限があればOK

--- a/app/Models/Core/UsersColumns.php
+++ b/app/Models/Core/UsersColumns.php
@@ -5,6 +5,7 @@ namespace App\Models\Core;
 use Illuminate\Database\Eloquent\Model;
 
 use App\UserableNohistory;
+use App\Enums\UserColumnType;
 
 class UsersColumns extends Model
 {
@@ -13,6 +14,7 @@ class UsersColumns extends Model
 
     // 更新する項目の定義
     protected $fillable = [
+        'columns_set_id',
         'column_type',
         'column_name',
         'required',
@@ -35,9 +37,9 @@ class UsersColumns extends Model
     public static function isChoicesColumnType($column_type)
     {
         // ラジオとチェックボックスは選択肢にラベルを使っているため、項目名のラベルにforを付けない
-        if ($column_type == \UserColumnType::radio ||
-                $column_type == \UserColumnType::checkbox ||
-                $column_type == \UserColumnType::agree) {
+        if ($column_type == UserColumnType::radio ||
+                $column_type == UserColumnType::checkbox ||
+                $column_type == UserColumnType::agree) {
             return true;
         }
         return false;

--- a/app/Models/Core/UsersColumnsSet.php
+++ b/app/Models/Core/UsersColumnsSet.php
@@ -5,18 +5,19 @@ namespace App\Models\Core;
 use Illuminate\Database\Eloquent\Model;
 
 use App\UserableNohistory;
+use App\Traits\ConnectModelDisplaySequenceTrait;
 
-class UsersColumnsSelects extends Model
+class UsersColumnsSet extends Model
 {
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
+    use ConnectModelDisplaySequenceTrait;
 
-    // 更新する項目の定義
+    /**
+     * create()やupdate()で入力を受け付ける ホワイトリスト
+     */
     protected $fillable = [
-        'columns_set_id',
-        'users_columns_id',
-        'value',
-        'agree_description',
+        'name',
         'display_sequence',
     ];
 }

--- a/app/Models/User/Reservations/ReservationsColumnsSet.php
+++ b/app/Models/User/Reservations/ReservationsColumnsSet.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 use App\UserableNohistory;
+use App\Traits\ConnectModelDisplaySequenceTrait;
 
 class ReservationsColumnsSet extends Model
 {
@@ -14,6 +15,7 @@ class ReservationsColumnsSet extends Model
 
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
+    use ConnectModelDisplaySequenceTrait;
 
     /**
      * create()やupdate()で入力を受け付ける ホワイトリスト

--- a/app/Models/User/Reservations/ReservationsFacility.php
+++ b/app/Models/User/Reservations/ReservationsFacility.php
@@ -20,10 +20,12 @@ use App\Enums\ReservationLimitedByRole;
 use App\Enums\ShowType;
 
 use App\Traits\ConnectRoleTrait;
+use App\Traits\ConnectModelDisplaySequenceTrait;
 
 class ReservationsFacility extends Model
 {
     use ConnectRoleTrait;
+    use ConnectModelDisplaySequenceTrait;
 
     // 平日
     const weekday = DayOfWeek::mon.'|'.DayOfWeek::tue.'|'.DayOfWeek::wed.'|'.DayOfWeek::thu.'|'.DayOfWeek::fri;

--- a/app/Plugins/Manage/ReservationManage/ReservationManage.php
+++ b/app/Plugins/Manage/ReservationManage/ReservationManage.php
@@ -227,8 +227,8 @@ class ReservationManage extends ManagePluginBase
             return redirect()->back()->withErrors($validator)->withInput();
         }
 
-        // 表示順が空なら、自分を省いた最後の番号+1 をセット
-        $display_sequence = $this->getSaveDisplaySequence(ReservationsFacility::query(), $request->display_sequence, $id);
+        // 表示順が空なら、施設カテゴリ内で自分を省いた最後の番号+1 をセット
+        $display_sequence = ReservationsFacility::getSaveDisplaySequence(ReservationsFacility::where('reservations_categories_id', $request->reservations_categories_id), $request->display_sequence, $id);
 
         // 配列のnull要素のみ取り除く
         $filter_not_null = function ($var) {
@@ -264,21 +264,6 @@ class ReservationManage extends ManagePluginBase
 
         // 一覧画面に戻る
         return redirect("/manage/reservation")->with('flash_message', $message);
-    }
-
-    /**
-     * 登録する表示順を取得
-     */
-    private function getSaveDisplaySequence($query, $display_sequence, $id)
-    {
-        // 表示順が空なら、自分を省いた最後の番号+1 をセット
-        if (!is_null($display_sequence)) {
-            $display_sequence = intval($display_sequence);
-        } else {
-            $max_display_sequence = $query->where('id', '<>', $id)->max('display_sequence');
-            $display_sequence = empty($max_display_sequence) ? 1 : $max_display_sequence + 1;
-        }
-        return $display_sequence;
     }
 
     /**
@@ -498,7 +483,7 @@ class ReservationManage extends ManagePluginBase
         }
 
         // 表示順が空なら、自分を省いた最後の番号+1 をセット
-        $display_sequence = $this->getSaveDisplaySequence(ReservationsColumnsSet::query(), $request->display_sequence, $id);
+        $display_sequence = ReservationsColumnsSet::getSaveDisplaySequence(ReservationsColumnsSet::query(), $request->display_sequence, $id);
 
         $columns_set = ReservationsColumnsSet::firstOrNew(['id' => $id]);
         $columns_set->name             = $request->name;

--- a/app/Plugins/Manage/ReservationManage/ReservationManage.php
+++ b/app/Plugins/Manage/ReservationManage/ReservationManage.php
@@ -758,7 +758,7 @@ class ReservationManage extends ManagePluginBase
         }
 
         // 更新データは上記update後に取得しないと、title_flagが更新されない
-        $column = ReservationsColumn::where('id', $request->column_id)->first();
+        $column = ReservationsColumn::where('id', $request->column_id)->where('columns_set_id', $request->columns_set_id)->first();
 
         // タイトル指定
         $column->title_flag = $title_flag;

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -16,6 +16,7 @@ use App\Models\Core\ApiSecret;
 use App\Models\Core\Configs;
 use App\Models\Core\ConfigsLoginPermits;
 use App\Models\Core\Plugins;
+use App\Models\Core\UsersColumnsSet;
 use App\Models\Common\Categories;
 use App\Models\Common\Frame;
 use App\Models\Common\Group;
@@ -1284,9 +1285,11 @@ class SiteManage extends ManagePluginBase
         $pdf->addPage();
         $pdf->Bookmark('ユーザ設定', 0, 0, '', '', array(0, 0, 0));
 
+        $columns_sets = UsersColumnsSet::get();
+
         // フレーム設定
         $sections = [
-            ['user_regist', compact('configs'), '自動ユーザ登録設定'],
+            ['user_regist', compact('configs', 'columns_sets'), '自動ユーザ登録設定'],
         ];
         $this->outputSection($pdf, $sections);
 

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -674,6 +674,14 @@ class UserManage extends ManagePluginBase
         // カラムの登録データ
         $input_cols = null;
 
+        // ユーザー登録関連設定の取得
+        $configs = Configs::where('category', 'general')
+            ->orWhere(function ($query) use ($columns_set_id) {
+                $query->where('category', 'user_register')
+                    ->where('additional1', $columns_set_id);
+            })
+            ->get();
+
         return view('plugins.manage.user.regist', [
             "function" => __FUNCTION__,
             "plugin_name" => "user",
@@ -686,6 +694,7 @@ class UserManage extends ManagePluginBase
             'input_cols' => $input_cols,
             'sections' => Section::orderBy('display_sequence')->get(),
             'user_section' => new UserSection(),
+            'configs' => $configs,
         ]);
     }
 
@@ -726,6 +735,14 @@ class UserManage extends ManagePluginBase
         $users_columns_id_select = UsersTool::getUsersColumnsSelects($columns_set_id);
         // カラムの登録データ
         $input_cols = UsersTool::getUsersInputCols([$id]);
+
+        // ユーザー登録関連設定の取得
+        $configs = Configs::where('category', 'general')
+            ->orWhere(function ($query) use ($columns_set_id) {
+                $query->where('category', 'user_register')
+                    ->where('additional1', $columns_set_id);
+            })
+            ->get();
 
         // 削除できる
         $can_deleted = true;
@@ -773,6 +790,7 @@ class UserManage extends ManagePluginBase
             'sections' => Section::orderBy('display_sequence')->get(),
             'user_section' => UserSection::where('user_id', $user->id)->firstOrNew(),
             'can_deleted' => $can_deleted,
+            'configs' => $configs,
         ]);
     }
 

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -795,15 +795,13 @@ class UserManage extends ManagePluginBase
             }
         }
 
-        $user = User::find($id);
-
         // 項目のエラーチェック
         $validator_array = [
             'column' => [
                 'name'           => 'required|string|max:255',
                 // ログインID
                 'userid'         => ['required', 'max:255', Rule::unique('users', 'userid')->ignore($id)],
-                'email'          => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($user->columns_set_id, $id)],
+                'email'          => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($request->columns_set_id, $id)],
                 'password'       => 'nullable|string|min:6|confirmed',
                 'status'         => 'required',
                 'columns_set_id' => ['required'],
@@ -819,11 +817,11 @@ class UserManage extends ManagePluginBase
         ];
 
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns($user->columns_set_id);
+        $users_columns = UsersTool::getUsersColumns($request->columns_set_id);
 
         foreach ($users_columns as $users_column) {
             // バリデータールールをセット
-            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $user->columns_set_id, $id);
+            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $request->columns_set_id, $id);
         }
 
         // 項目のエラーチェック
@@ -831,6 +829,7 @@ class UserManage extends ManagePluginBase
         $validator->setAttributeNames($validator_array['message']);
 
         // 更新前のステータス
+        $user = User::find($id);
         $before_status = $user ? $user->status : null;
 
         // 任意のバリデーションを追加
@@ -887,6 +886,8 @@ class UserManage extends ManagePluginBase
 
         // ユーザデータの更新
         User::where('id', $id)->update($update_array);
+        // 更新後を再取得
+        $user = User::find($id);
 
         // ユーザーの追加項目.
         // id（行 id）が渡ってきたら、詳細データは一度消す。その後、登録と同じ処理にする。delete -> insert

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2,10 +2,8 @@
 
 namespace App\Plugins\Manage\UserManage;
 
-// use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
@@ -15,6 +13,7 @@ use Illuminate\Validation\Rule;
 use App\Models\Core\Configs;
 use App\Models\Core\UsersColumns;
 use App\Models\Core\UsersColumnsSelects;
+use App\Models\Core\UsersColumnsSet;
 use App\Models\Core\UsersRoles;
 use App\Models\Core\UsersInputCols;
 use App\Models\Core\UsersLoginHistories;
@@ -45,6 +44,7 @@ use App\Models\Core\UserSection;
  * ユーザ管理クラス
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category ユーザ管理
  * @package Controller
@@ -62,43 +62,50 @@ class UserManage extends ManagePluginBase
     {
         // 権限チェックテーブル
         $role_check_table = [];
-        $role_check_table["index"]              = ['admin_user'];
-        $role_check_table["search"]             = ['admin_user'];
-        $role_check_table["clearSearch"]        = ['admin_user'];
-        $role_check_table["regist"]             = ['admin_user'];
-        $role_check_table["edit"]               = ['admin_user'];
-        $role_check_table["update"]             = ['admin_user'];
-        $role_check_table["destroy"]            = ['admin_user'];
-        $role_check_table["originalRole"]       = ['admin_user'];
-        $role_check_table["saveOriginalRoles"]  = ['admin_user'];
-        $role_check_table["deleteOriginalRole"] = ['admin_user'];
-        $role_check_table["groups"]             = ['admin_user'];
-        $role_check_table["saveGroups"]         = ['admin_user'];
-        $role_check_table["autoRegist"]         = ['admin_user'];
-        $role_check_table["autoRegistUpdate"]   = ['admin_user'];
-        $role_check_table["downloadCsv"]        = ['admin_user'];
-        $role_check_table["downloadCsvFormat"]  = ['admin_user'];
-        $role_check_table["import"]             = ['admin_site'];
-        $role_check_table["uploadCsv"]          = ['admin_user'];
-        $role_check_table["bulkDelete"]         = ['admin_user'];
-        $role_check_table["bulkDestroy"]        = ['admin_user'];
-        $role_check_table["loginHistory"]       = ['admin_user'];
-        $role_check_table["mail"]               = ['admin_user'];
-        $role_check_table["mailSend"]           = ['admin_user'];
+        $role_check_table["index"]                 = ['admin_user'];
+        $role_check_table["search"]                = ['admin_user'];
+        $role_check_table["clearSearch"]           = ['admin_user'];
+        $role_check_table["regist"]                = ['admin_user'];
+        $role_check_table["edit"]                  = ['admin_user'];
+        $role_check_table["update"]                = ['admin_user'];
+        $role_check_table["destroy"]               = ['admin_user'];
+        $role_check_table["originalRole"]          = ['admin_user'];
+        $role_check_table["saveOriginalRoles"]     = ['admin_user'];
+        $role_check_table["deleteOriginalRole"]    = ['admin_user'];
+        $role_check_table["groups"]                = ['admin_user'];
+        $role_check_table["saveGroups"]            = ['admin_user'];
+        $role_check_table["autoRegist"]            = ['admin_user'];
+        $role_check_table["autoRegistUpdate"]      = ['admin_user'];
+        $role_check_table["downloadCsv"]           = ['admin_user'];
+        $role_check_table["downloadCsvFormat"]     = ['admin_user'];
+        $role_check_table["import"]                = ['admin_user'];
+        $role_check_table["uploadCsv"]             = ['admin_user'];
+        $role_check_table["bulkDelete"]            = ['admin_user'];
+        $role_check_table["bulkDestroy"]           = ['admin_user'];
+        $role_check_table["loginHistory"]          = ['admin_user'];
+        $role_check_table["mail"]                  = ['admin_user'];
+        $role_check_table["mailSend"]              = ['admin_user'];
+        // 項目セット
+        $role_check_table["columnSets"]            = ['admin_site'];
+        $role_check_table["registColumnSet"]       = ['admin_site'];
+        $role_check_table["storeColumnSet"]        = ['admin_site'];
+        $role_check_table["editColumnSet"]         = ['admin_site'];
+        $role_check_table["updateColumnSet"]       = ['admin_site'];
+        $role_check_table["destroyColumnSet"]      = ['admin_site'];
         // 項目設定
-        $role_check_table["editColumns"]          = ['admin_site'];
-        $role_check_table["addColumn"]            = ['admin_site'];
-        $role_check_table["updateColumn"]         = ['admin_site'];
-        $role_check_table["updateColumnSequence"] = ['admin_site'];
-        $role_check_table["deleteColumn"]         = ['admin_site'];
+        $role_check_table["editColumns"]           = ['admin_site'];
+        $role_check_table["addColumn"]             = ['admin_site'];
+        $role_check_table["updateColumn"]          = ['admin_site'];
+        $role_check_table["updateColumnSequence"]  = ['admin_site'];
+        $role_check_table["deleteColumn"]          = ['admin_site'];
         // 項目詳細設定
-        $role_check_table["editColumnDetail"]     = ['admin_site'];
-        $role_check_table["updateColumnDetail"]   = ['admin_site'];
-        $role_check_table["addSelect"]            = ['admin_site'];
-        $role_check_table["updateSelect"]         = ['admin_site'];
-        $role_check_table["updateSelectSequence"] = ['admin_site'];
-        $role_check_table["updateAgree"]          = ['admin_site'];
-        $role_check_table["deleteSelect"]         = ['admin_site'];
+        $role_check_table["editColumnDetail"]      = ['admin_site'];
+        $role_check_table["updateColumnDetail"]    = ['admin_site'];
+        $role_check_table["addSelect"]             = ['admin_site'];
+        $role_check_table["updateSelect"]          = ['admin_site'];
+        $role_check_table["updateSelectSequence"]  = ['admin_site'];
+        $role_check_table["updateAgree"]           = ['admin_site'];
+        $role_check_table["deleteSelect"]          = ['admin_site'];
         $role_check_table["addSection"]            = ['admin_site'];
         $role_check_table["updateSection"]         = ['admin_site'];
         $role_check_table["updateSectionSequence"] = ['admin_site'];
@@ -110,15 +117,15 @@ class UserManage extends ManagePluginBase
     /**
      * データgetで取得
      */
-    private function getUsers($request, $users_columns)
+    private function getUsers($request, $users_columns, int $columns_set_id)
     {
-        return $this->getUsersPaginate($request, null, $users_columns, false);
+        return $this->getUsersPaginate($request, null, $users_columns, $columns_set_id, false);
     }
 
     /**
      * データ取得(paginate or get)
      */
-    private function getUsersPaginate($request, $page, $users_columns, $is_paginate = true)
+    private function getUsersPaginate($request, $page, $users_columns, int $columns_set_id, $is_paginate = true)
     {
         /* 権限が指定されている場合は、権限を保持しているユーザID を抜き出しておき、後で whereIn する。
         ----------------------------------------------------------------------------------------------*/
@@ -184,13 +191,13 @@ class UserManage extends ManagePluginBase
         // ゲスト権限が指定されている場合
         if ($request->session()->has('user_search_condition.guest')) {
             $guest_users = User::select('users.id as users_id', DB::raw('count(users_roles.role_value) AS count'))
-                               ->leftJoin('users_roles', function ($join) {
-                                   $join->on('users_roles.users_id', '=', 'users.id')
-                                        ->whereIn('target', ['base', 'manage']);
-                               })
-                               ->having('count', 0)
-                               ->groupBy('users.id')
-                               ->get();
+                ->leftJoin('users_roles', function ($join) {
+                    $join->on('users_roles.users_id', '=', 'users.id')
+                        ->whereIn('target', ['base', 'manage']);
+                })
+                ->having('count', 0)
+                ->groupBy('users.id')
+                ->get();
             // 他のユーザ絞り込みがある場合は、結果のマージ
             if (empty($in_users)) {
                 $in_users = $guest_users;
@@ -228,23 +235,35 @@ class UserManage extends ManagePluginBase
         }
 
         // 最終ログイン日 のサブクエリ
-        $sub_query_users_login_histories = UsersLoginHistories::select('users_id', DB::raw('MAX(logged_in_at) AS max_logged_in_at'))
-                ->groupBy('users_id');
+        $sub_query_users_login_histories = UsersLoginHistories::select('users_id', DB::raw('MAX(logged_in_at) AS max_logged_in_at'))->groupBy('users_id');
 
         // ユーザデータ取得
         // $users_query = User::select('users.*');
         // ユーザー追加項目のソートなし
         if (empty($sort_column_id)) {
-            $users_query = User::select('users.*', 'users_login_histories.max_logged_in_at')
-                ->leftjoin(DB::raw("({$sub_query_users_login_histories->toSql()}) AS users_login_histories"), 'users_login_histories.users_id', '=', 'users.id');
+            $users_query = User::
+                select(
+                    'users.*',
+                    'users_login_histories.max_logged_in_at',
+                    'users_columns_sets.name as columns_set_name'
+                )
+                ->leftJoin(DB::raw("({$sub_query_users_login_histories->toSql()}) AS users_login_histories"), 'users_login_histories.users_id', '=', 'users.id')
+                ->leftJoin("users_columns_sets", 'users_columns_sets.id', '=', 'users.columns_set_id');
         } else {
             // ユーザー追加項目のソートあり
-            $users_query = User::select('users.*', 'users_input_cols.value', 'users_login_histories.max_logged_in_at')
-                ->leftjoin('users_input_cols', function ($join) use ($sort_column_id) {
+            $users_query = User::
+                select(
+                    'users.*',
+                    'users_input_cols.value',
+                    'users_login_histories.max_logged_in_at',
+                    'users_columns_sets.name as columns_set_name'
+                )
+                ->leftJoin('users_input_cols', function ($join) use ($sort_column_id) {
                     $join->on('users_input_cols.users_id', '=', 'users.id')
                         ->where('users_input_cols.users_columns_id', '=', $sort_column_id);
                 })
-                ->leftjoin(DB::raw("({$sub_query_users_login_histories->toSql()}) AS users_login_histories"), 'users_login_histories.users_id', '=', 'users.id');
+                ->leftJoin(DB::raw("({$sub_query_users_login_histories->toSql()}) AS users_login_histories"), 'users_login_histories.users_id', '=', 'users.id')
+                ->leftJoin("users_columns_sets", 'users_columns_sets.id', '=', 'users.columns_set_id');
         }
 
         // 所属型の項目をEager Loading
@@ -307,6 +326,11 @@ class UserManage extends ManagePluginBase
             }
         }
 
+        // 項目セット
+        if ($columns_set_id) {
+            $users_query->where('users.columns_set_id', $columns_set_id);
+        }
+
         // 表示順
         $sort = 'created_at_asc';
         if ($request->session()->has('user_search_condition.sort')) {
@@ -353,9 +377,9 @@ class UserManage extends ManagePluginBase
         $roles = null;
         if ($user_ids) {
             $roles = UsersRoles::whereIn('users_id', $user_ids)
-                               ->where('target', 'manage')
-                               ->orWhere('target', 'base')
-                               ->get();
+                ->where('target', 'manage')
+                ->orWhere('target', 'base')
+                ->get();
         }
 
         // ユーザ権限データをユーザデータへマージ
@@ -376,13 +400,13 @@ class UserManage extends ManagePluginBase
         $original_roles = null;
         if ($user_ids) {
             $original_roles = UsersRoles::select('users_roles.*', 'configs.name', 'configs.value')
-                                        ->leftJoin('configs', function ($join) {
-                                            $join->on('configs.name', '=', 'users_roles.role_name')
-                                                 ->where('configs.category', '=', 'original_role');
-                                        })
-                                        ->whereIn('users_id', $user_ids)
-                                        ->where('target', 'original_role')
-                                        ->get();
+                ->leftJoin('configs', function ($join) {
+                    $join->on('configs.name', '=', 'users_roles.role_name')
+                            ->where('configs.category', '=', 'original_role');
+                })
+                ->whereIn('users_id', $user_ids)
+                ->where('target', 'original_role')
+                ->get();
         }
 
         // 役割をユーザデータへマージ
@@ -403,14 +427,14 @@ class UserManage extends ManagePluginBase
         if ($user_ids) {
             // グループ取得
             $group_users = Group::select('groups.*', 'group_users.user_id', 'group_users.group_role')
-                                ->leftJoin('group_users', function ($join) {
-                                    $join->on('groups.id', '=', 'group_users.group_id')
-                                        ->whereNull('group_users.deleted_at');
-                                })
-                                ->whereIn('group_users.user_id', $user_ids)
-                                ->orderBy('group_users.user_id', 'asc')
-                                ->orderBy('groups.name', 'asc')
-                                ->get();
+                ->leftJoin('group_users', function ($join) {
+                    $join->on('groups.id', '=', 'group_users.group_id')
+                        ->whereNull('group_users.deleted_at');
+                })
+                ->whereIn('group_users.user_id', $user_ids)
+                ->orderBy('group_users.user_id', 'asc')
+                ->orderBy('groups.name', 'asc')
+                ->get();
         }
 
         if ($group_users) {
@@ -420,17 +444,16 @@ class UserManage extends ManagePluginBase
                 $tmp_group[$val->user_id][] = $val;
             }
             foreach ($users as &$user) {
-//                $user->group_users = $group_users->where('user_id', $user->id);
                 // 取得方法を変更
                 $user->group_users = (isset($tmp_group[$user->id])) ? $tmp_group[$user->id] : [];
             }
         }
 
-
-        //$users = DB::table('users')
-        //         ->orderBy('id', 'asc')
-        //         ->paginate(10);
-        //Log::debug($users);
+        $input_cols = UsersInputCols::whereIn('users_id', $user_ids)->get();
+        foreach ($users as $user) {
+            // （シリアライズで参照渡しになり）項目値をセット
+            $user->inputs_column_value = $input_cols->where('users_id', $user->id)->pluck('value')->implode('|');
+        }
 
         return $users;
     }
@@ -469,13 +492,16 @@ class UserManage extends ManagePluginBase
         /* データの取得（検索）
         ----------------------------------------------*/
 
+        // 項目セットID
+        $columns_set_id = $this->getColumnsSetIdFromRequestOrSession($request, 'user.columns_set_id');
+
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($columns_set_id);
         // カラムの選択肢
-        $users_columns_id_select = UsersTool::getUsersColumnsSelects();
+        $users_columns_id_select = UsersTool::getUsersColumnsSelects($columns_set_id);
 
         // User データの取得
-        $users = $this->getUsersPaginate($request, $page, $users_columns);
+        $users = $this->getUsersPaginate($request, $page, $users_columns, $columns_set_id, true);
 
         // ユーザーの追加項目データ
         $input_cols = UsersTool::getUsersInputCols($users->pluck('id')->all());
@@ -493,6 +519,8 @@ class UserManage extends ManagePluginBase
             "function" => __FUNCTION__,
             "plugin_name" => "user",
             "users" => $users,
+            'columns_set_id' => $columns_set_id,
+            'columns_sets' => UsersColumnsSet::get(),
             "users_columns" => $users_columns,
             "users_columns_id_select" => $users_columns_id_select,
             "input_cols" => $input_cols,
@@ -500,6 +528,45 @@ class UserManage extends ManagePluginBase
             "sections" => Section::orderBy('display_sequence')->get(),
             "has_auth_role_admin_system" => $has_auth_role_admin_system,
         ]);
+    }
+
+    /**
+     * columns_set_idを、セッションorリクエストから取得
+     * @see ManagePluginBase copy from getPaginatePageFromRequestOrSession()
+     */
+    private function getColumnsSetIdFromRequestOrSession(\Illuminate\Http\Request $request, string $session_name): int
+    {
+        $variable = 'columns_set_id';
+        $columns_set_id = $this->getColumnsSetIdManageDefault();
+
+        if ($request->session()->has($session_name)) {
+            $columns_set_id = $request->session()->get($session_name);
+        }
+        if ($request->filled($variable)) {
+            $columns_set_id = $request->$variable;
+        }
+
+        if ($request->filled($variable)) {
+            session([$session_name => $request->$variable]);
+        }
+
+        return $columns_set_id;
+    }
+
+    /**
+     * ユーザ管理の columns_set_id の初期値を取得
+     */
+    private function getColumnsSetIdManageDefault(): int
+    {
+        if (config('connect.USE_USERS_COLUMNS_SET')) {
+            // 0:ユーザ一覧（全て）
+            $columns_set_id = 0;
+        } else {
+            // 1:ユーザ一覧（基本）
+            $columns_set_id = 1;
+        }
+
+        return $columns_set_id;
     }
 
     /**
@@ -532,9 +599,11 @@ class UserManage extends ManagePluginBase
             "sort"               => $request->input('user_search_condition.sort'),
         ];
 
-        //// ユーザーの追加項目.
+        // *** ユーザーの追加項目
+        // 項目セットID
+        $columns_set_id = $this->getColumnsSetIdFromRequestOrSession($request, 'user.columns_set_id');
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($columns_set_id);
 
         foreach ($users_columns as $users_column) {
             $value = "";
@@ -574,26 +643,34 @@ class UserManage extends ManagePluginBase
      */
     public function regist($request, $id)
     {
+        // post ＆ URLのなかに'/manage/user/edit'が含まれている場合、oldに値をセット。
+        // 入力エラー時はリダイレクトでget通信がくるので、その時は通さない
+        if ($request->isMethod('post') && strpos($request->url(), '/manage/user/regist') !== false) {
+            // old()に全inputをセット
+            $request->flash();
+        }
+
         // ユーザデータの空枠
         $user = new User();
 
         // 役割設定取得
         $original_role_configs = Configs::select('configs.*', 'users_roles.role_value')
-                                        ->leftJoin('users_roles', function ($join) use ($id) {
-                                            $join->on('users_roles.role_name', '=', 'configs.name')
-                                                ->where('users_roles.users_id', '=', $id)
-                                                ->where('users_roles.target', '=', 'original_role');
-                                        })
-                                        ->where('category', 'original_role')
-                                        ->orderBy('additional1', 'asc')
-                                        ->get();
+            ->leftJoin('users_roles', function ($join) use ($id) {
+                $join->on('users_roles.role_name', '=', 'configs.name')
+                    ->where('users_roles.users_id', '=', $id)
+                    ->where('users_roles.target', '=', 'original_role');
+            })
+            ->where('category', 'original_role')
+            ->orderBy('additional1', 'asc')
+            ->get();
 
-        //// ユーザの追加項目.
+        // *** ユーザの追加項目
+        // 項目セットID
+        $columns_set_id = $request->input('columns_set_id', $this->getColumnsSetIdManageDefault());
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($columns_set_id);
         // カラムの選択肢
-        $users_columns_id_select = UsersTool::getUsersColumnsSelects();
-        // dd($users_columns, $users_columns_id_select);
+        $users_columns_id_select = UsersTool::getUsersColumnsSelects($columns_set_id);
         // カラムの登録データ
         $input_cols = null;
 
@@ -602,6 +679,8 @@ class UserManage extends ManagePluginBase
             "plugin_name" => "user",
             "user" => $user,
             "original_role_configs" => $original_role_configs,
+            'columns_set_id' => $columns_set_id,
+            'columns_sets' => UsersColumnsSet::get(),
             'users_columns' => $users_columns,
             'users_columns_id_select' => $users_columns_id_select,
             'input_cols' => $input_cols,
@@ -615,9 +694,12 @@ class UserManage extends ManagePluginBase
      */
     public function edit($request, $id)
     {
-        // bugfix: これがあると、なぜか管理プラグインではoldが設定されない
-        // セッション初期化などのLaravel 処理。
-        // $request->flash();
+        // post ＆ URLのなかに'/manage/user/edit'が含まれている場合、oldに値をセット。
+        // 入力エラー時はリダイレクトでget通信がくるので、その時は通さない
+        if ($request->isMethod('post') && strpos($request->url(), '/manage/user/edit') !== false) {
+            // old()に全inputをセット
+            $request->flash();
+        }
 
         // ユーザデータ取得
         $user = User::where('id', $id)->first();
@@ -627,20 +709,21 @@ class UserManage extends ManagePluginBase
 
         // 役割設定取得
         $original_role_configs = Configs::select('configs.*', 'users_roles.role_value')
-                                        ->leftJoin('users_roles', function ($join) use ($id) {
-                                            $join->on('users_roles.role_name', '=', 'configs.name')
-                                                 ->where('users_roles.users_id', '=', $id)
-                                                 ->where('users_roles.target', '=', 'original_role');
-                                        })
-                                        ->where('category', 'original_role')
-                                        ->orderBy('additional1', 'asc')
-                                        ->get();
+            ->leftJoin('users_roles', function ($join) use ($id) {
+                $join->on('users_roles.role_name', '=', 'configs.name')
+                    ->where('users_roles.users_id', '=', $id)
+                    ->where('users_roles.target', '=', 'original_role');
+            })
+            ->where('category', 'original_role')
+            ->orderBy('additional1', 'asc')
+            ->get();
 
+        // 項目セットID
+        $columns_set_id = $request->input('columns_set_id', $user->columns_set_id);
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($columns_set_id);
         // カラムの選択肢
-        $users_columns_id_select = UsersTool::getUsersColumnsSelects();
-        // dd($users_columns, $users_columns_id_select);
+        $users_columns_id_select = UsersTool::getUsersColumnsSelects($columns_set_id);
         // カラムの登録データ
         $input_cols = UsersTool::getUsersInputCols([$id]);
 
@@ -682,6 +765,8 @@ class UserManage extends ManagePluginBase
             "user" => $user,
             "users_roles" => $users_roles,
             "original_role_configs" => $original_role_configs,
+            'columns_set_id' => $columns_set_id,
+            'columns_sets' => UsersColumnsSet::get(),
             'users_columns' => $users_columns,
             'users_columns_id_select' => $users_columns_id_select,
             'input_cols' => $input_cols,
@@ -710,58 +795,42 @@ class UserManage extends ManagePluginBase
             }
         }
 
+        $user = User::find($id);
+
         // 項目のエラーチェック
-        // change: ユーザーの追加項目に対応
-        // $validator = Validator::make($request->all(), [
-        //     'name'     => 'required|string|max:255',
-        //     'email'    => ['nullable', 'email', 'max:255', Rule::unique('users')->ignore($id)],
-        //     'password' => 'nullable|string|min:6|confirmed',
-        //     'status'   => 'required',
-        // ]);
-        // $validator->setAttributeNames([
-        //     'name'     => 'ユーザ名',
-        //     'email'    => 'eメール',
-        //     'password' => 'パスワード',
-        //     'status'   => '状態',
-        // ]);
         $validator_array = [
             'column' => [
-                'name' => 'required|string|max:255',
+                'name'           => 'required|string|max:255',
                 // ログインID
-                'userid' => [
-                    'required',
-                    'max:255',
-                    Rule::unique('users', 'userid')->ignore($id),
-                ],
-                'email' => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($id)],
-                'password' => 'nullable|string|min:6|confirmed',
-                'status' => 'required',
+                'userid'         => ['required', 'max:255', Rule::unique('users', 'userid')->ignore($id)],
+                'email'          => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($id, $user->columns_set_id)],
+                'password'       => 'nullable|string|min:6|confirmed',
+                'status'         => 'required',
+                'columns_set_id' => ['required'],
             ],
             'message' => [
-                'name' => 'ユーザ名',
-                'userid' => 'ログインID',
-                'email' => 'eメール',
-                'password' => 'パスワード',
-                'status' => '状態',
+                'name'           => 'ユーザ名',
+                'userid'         => 'ログインID',
+                'email'          => 'eメール',
+                'password'       => 'パスワード',
+                'status'         => '状態',
+                'columns_set_id' => '項目セット',
             ]
         ];
 
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($user->columns_set_id);
 
         foreach ($users_columns as $users_column) {
             // バリデータールールをセット
-            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $id);
+            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $id, $user->columns_set_id);
         }
 
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), $validator_array['column']);
         $validator->setAttributeNames($validator_array['message']);
-        // Log::debug(var_export($request->all(), true));
-        // Log::debug(var_export($validator_array, true));
 
         // 更新前のステータス
-        $user = User::find($id);
         $before_status = $user ? $user->status : null;
 
         // 任意のバリデーションを追加
@@ -802,10 +871,11 @@ class UserManage extends ManagePluginBase
 
         // 更新内容の配列
         $update_array = [
-            'name'     => $request->name,
-            'email'    => $request->email,
-            'userid'   => $request->userid,
-            'status'   => $request->status,
+            'name'           => $request->name,
+            'email'          => $request->email,
+            'userid'         => $request->userid,
+            'status'         => $request->status,
+            'columns_set_id' => $request->columns_set_id,
         ];
 
         // パスワードの入力があれば、更新
@@ -1192,22 +1262,32 @@ class UserManage extends ManagePluginBase
      */
     public function autoRegist($request, $id)
     {
+        if (!$id) {
+            abort(404, 'URLにIDが含まれてません。');
+        }
+
         // Config データの取得
-        $configs = Configs::where('category', 'user_register')->get();
+        $configs = Configs::where('category', 'user_register')->where('additional1', $id)->get();
 
         return view('plugins.manage.user.auto_regist', [
             "function" => __FUNCTION__,
             "plugin_name" => "user",
             "configs" => $configs,
-            "users_columns" => UsersTool::getUsersColumns(),
+            'columns_set_id' => $id,
+            'columns_sets' => UsersColumnsSet::get(),
+            "users_columns" => UsersTool::getUsersColumns($id),
         ]);
     }
 
     /**
      * 自動ユーザ登録設定 更新
      */
-    public function autoRegistUpdate($request, $page_id = null)
+    public function autoRegistUpdate($request, $id)
     {
+        if (!$id) {
+            abort(404, 'URLにIDが含まれてません。');
+        }
+
         // httpメソッド確認
         if (!$request->isMethod('post')) {
             abort(403, '権限がありません。');
@@ -1250,7 +1330,7 @@ class UserManage extends ManagePluginBase
 
         // 自動ユーザ登録の使用
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_enable'],
+            ['name' => 'user_register_enable', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_enable
@@ -1259,7 +1339,7 @@ class UserManage extends ManagePluginBase
 
         // 管理者の承認
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_registration_require_approval'],
+            ['name' => 'user_registration_require_approval', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_registration_require_approval
@@ -1268,7 +1348,7 @@ class UserManage extends ManagePluginBase
 
         // 以下のアドレスにメール送信する
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_mail_send_flag'],
+            ['name' => 'user_register_mail_send_flag', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_mail_send_flag ?? 0
@@ -1277,7 +1357,7 @@ class UserManage extends ManagePluginBase
 
         // 送信するメールアドレス
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_mail_send_address'],
+            ['name' => 'user_register_mail_send_address', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_mail_send_address
@@ -1286,7 +1366,7 @@ class UserManage extends ManagePluginBase
 
         // 登録者にメール送信する
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_user_mail_send_flag'],
+            ['name' => 'user_register_user_mail_send_flag', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_user_mail_send_flag ?? 0
@@ -1295,7 +1375,7 @@ class UserManage extends ManagePluginBase
 
         // 登録者に仮登録メールを送信する
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_temporary_regist_mail_flag'],
+            ['name' => 'user_register_temporary_regist_mail_flag', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_temporary_regist_mail_flag ?? 0
@@ -1304,7 +1384,7 @@ class UserManage extends ManagePluginBase
 
         // 仮登録メール件名
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_temporary_regist_mail_subject'],
+            ['name' => 'user_register_temporary_regist_mail_subject', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_temporary_regist_mail_subject
@@ -1313,7 +1393,7 @@ class UserManage extends ManagePluginBase
 
         // 仮登録メールフォーマット
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_temporary_regist_mail_format'],
+            ['name' => 'user_register_temporary_regist_mail_format', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_temporary_regist_mail_format
@@ -1322,7 +1402,7 @@ class UserManage extends ManagePluginBase
 
         // 仮登録後のメッセージ
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_temporary_regist_after_message'],
+            ['name' => 'user_register_temporary_regist_after_message', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_temporary_regist_after_message
@@ -1331,7 +1411,7 @@ class UserManage extends ManagePluginBase
 
         // 本登録メール件名
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_mail_subject'],
+            ['name' => 'user_register_mail_subject', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_mail_subject
@@ -1340,7 +1420,7 @@ class UserManage extends ManagePluginBase
 
         // 本登録メールフォーマット
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_mail_format'],
+            ['name' => 'user_register_mail_format', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_mail_format
@@ -1349,7 +1429,7 @@ class UserManage extends ManagePluginBase
 
         // 本登録後のメッセージ
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_after_message'],
+            ['name' => 'user_register_after_message', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_after_message
@@ -1358,7 +1438,7 @@ class UserManage extends ManagePluginBase
 
         // 承認完了メール件名
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_approved_mail_subject'],
+            ['name' => 'user_register_approved_mail_subject', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_approved_mail_subject
@@ -1367,7 +1447,7 @@ class UserManage extends ManagePluginBase
 
         // 承認完了メールフォーマット
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_approved_mail_format'],
+            ['name' => 'user_register_approved_mail_format', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_approved_mail_format
@@ -1377,7 +1457,7 @@ class UserManage extends ManagePluginBase
         // *** ユーザ登録画面
         // 自動ユーザ登録時に個人情報保護方針への同意を求めるか
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_requre_privacy'],
+            ['name' => 'user_register_requre_privacy', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_requre_privacy
@@ -1386,7 +1466,7 @@ class UserManage extends ManagePluginBase
 
         // 自動ユーザ登録時に求める個人情報保護方針の表示内容
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_privacy_description'],
+            ['name' => 'user_register_privacy_description', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_privacy_description
@@ -1395,7 +1475,7 @@ class UserManage extends ManagePluginBase
 
         // 自動ユーザ登録時に求めるユーザ登録についての文言
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_description'],
+            ['name' => 'user_register_description', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $request->user_register_description
@@ -1406,7 +1486,7 @@ class UserManage extends ManagePluginBase
         // 空要素の削除
         $base_roles = array_filter($request->base_roles);
         $configs = Configs::updateOrCreate(
-            ['name' => 'user_register_base_roles'],
+            ['name' => 'user_register_base_roles', 'additional1' => $id],
             [
                 'category' => 'user_register',
                 'value' => $base_roles ? implode(',', $base_roles) : '',
@@ -1414,7 +1494,7 @@ class UserManage extends ManagePluginBase
         );
 
         // 自動ユーザ登録設定画面に戻る
-        return redirect("/manage/user/autoRegist")->with('flash_message', '更新しました。');
+        return redirect("/manage/user/autoRegist/$id")->with('flash_message', '更新しました。');
     }
 
     /**
@@ -1433,10 +1513,10 @@ class UserManage extends ManagePluginBase
     public function downloadCsv($request, $id = null, $sub_id = null, $data_output_flag = true)
     {
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($id);
 
         // User データの取得
-        $users = $this->getUsers($request, $users_columns);
+        $users = $this->getUsers($request, $users_columns, $id);
 
         /*
         ダウンロード前の配列イメージ。
@@ -1511,7 +1591,12 @@ class UserManage extends ManagePluginBase
         }
 
         // レスポンス
-        $filename = 'users.csv';
+        if (config('connect.USE_USERS_COLUMNS_SET')) {
+            $columns_set = UsersColumnsSet::findOrNew($id);
+            $filename = "users_$columns_set->name.csv";
+        } else {
+            $filename = 'users.csv';
+        }
         $headers = [
             'Content-Type' => 'text/csv',
             'content-Disposition' => 'attachment; filename="'.$filename.'"',
@@ -1527,8 +1612,6 @@ class UserManage extends ManagePluginBase
             $csv_data = substr($csv_data, 0, -1);
             $csv_data .= "\n";
         }
-
-        // Log::debug(var_export($request->character_code, true));
 
         // 文字コード変換
         if ($request->character_code == CsvCharacterCode::utf_8) {
@@ -1607,8 +1690,10 @@ class UserManage extends ManagePluginBase
     {
         // 管理画面プラグインの戻り値の返し方
         return view('plugins.manage.user.import', [
-            "function"      => __FUNCTION__,
-            "plugin_name"   => "user",
+            "function"       => __FUNCTION__,
+            "plugin_name"    => "user",
+            'columns_set_id' => $this->getColumnsSetIdManageDefault(),
+            'columns_sets'   => UsersColumnsSet::get(),
         ]);
     }
 
@@ -1619,18 +1704,20 @@ class UserManage extends ManagePluginBase
     {
         // csv
         $rules = [
-            'users_csv'  => [
+            'users_csv' => [
                 'required',
                 'file',
                 'mimes:csv,txt', // mimesの都合上text/csvなのでtxtも許可が必要
                 'mimetypes:application/csv,text/plain,text/csv',
             ],
+            'columns_set_id' => ['required'],
         ];
 
         // 画面エラーチェック
         $validator = Validator::make($request->all(), $rules);
         $validator->setAttributeNames([
-            'users_csv' => 'CSVファイル',
+            'users_csv'      => 'CSVファイル',
+            'columns_set_id' => '項目セット',
         ]);
 
         if ($validator->fails()) {
@@ -1641,14 +1728,12 @@ class UserManage extends ManagePluginBase
 
         // CSVファイル一時保存
         $path = $request->file('users_csv')->store('tmp');
-        // Log::debug(var_export(storage_path('app/') . $path, true));
         $csv_full_path = storage_path('app/') . $path;
 
         // ファイル拡張子取得
         $file_extension = $request->file('users_csv')->getClientOriginalExtension();
         // 小文字に変換
         $file_extension = strtolower($file_extension);
-        // Log::debug(var_export($file_extension, true));
 
         // 文字コード
         $character_code = $request->character_code;
@@ -1671,7 +1756,6 @@ class UserManage extends ManagePluginBase
         // 読み込み
         $fp = fopen($csv_full_path, 'r');
         // CSVファイル：Shift-JIS -> UTF-8変換時のみ
-        // if ($character_code == CsvCharacterCode::sjis_win) {
         if (CsvCharacterCode::isShiftJis($character_code)) {
             // ストリームフィルタ内で、Shift-JIS -> UTF-8変換
             $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
@@ -1687,11 +1771,10 @@ class UserManage extends ManagePluginBase
             // UTF-8のみBOMコードを取り除く
             $header_columns = CsvUtils::removeUtf8Bom($header_columns);
         }
-        // dd($csv_full_path);
         // \Log::debug('$header_columns:'. var_export($header_columns, true));
 
         // 任意カラムの取得
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($request->columns_set_id);
         // インポートカラムの取得
         $import_column = $this->getImportColumn($users_columns);
 
@@ -1711,8 +1794,7 @@ class UserManage extends ManagePluginBase
         $configs_original_role = Configs::where('category', 'original_role')->get();
 
         // データ項目のエラーチェック
-        // $error_msgs = CsvUtils::checkCvslines($fp, $users_columns, $cvs_rules);
-        $error_msgs = $this->checkCvslines($fp, $users_columns, $group, $import_column_col_no, $configs_original_role);
+        $error_msgs = $this->checkCvslines($fp, $users_columns, $group, $import_column_col_no, $configs_original_role, $request->columns_set_id);
         if (!empty($error_msgs)) {
             // 一時ファイルの削除
             fclose($fp);
@@ -1875,7 +1957,6 @@ class UserManage extends ManagePluginBase
             // ユーザ権限の更新（権限データの delete & insert）
             $users_roles_ids = UsersRoles::where('users_id', $user->id)->pluck('id');
             UsersRoles::destroy($users_roles_ids);
-            // dd($csv_view_user_roles);
 
             foreach ($csv_view_user_roles as $role_name) {
                 // bugfix: csv値がnullの場合、explodeすると[0 => ""]になったため対応
@@ -1895,7 +1976,6 @@ class UserManage extends ManagePluginBase
             $csv_user_original_roles_names = explode(UsersTool::CHECKBOX_SEPARATOR, $csv_columns[$user_original_roles_col_no] ?? '');
             // 配列値の入力値をトリム (preg_replace(/u)で置換. /u = UTF-8 として処理)
             $csv_user_original_roles_names = StringUtils::trimInput($csv_user_original_roles_names);
-            // dd($csv_user_original_roles_names);
 
             $user_original_roles = $configs_original_role->whereIn('value', $csv_user_original_roles_names);
 
@@ -1922,7 +2002,7 @@ class UserManage extends ManagePluginBase
     /**
      * CSVデータ行チェック
      */
-    private function checkCvslines($fp, $users_columns, $group, $import_column_col_no, $configs_original_role)
+    private function checkCvslines($fp, $users_columns, $group, $import_column_col_no, $configs_original_role, int $columns_set_id)
     {
         // 行頭（固定項目）
         $rules = [
@@ -1991,7 +2071,7 @@ class UserManage extends ManagePluginBase
             // ログインID
             $rules[1] = ['required', 'max:255', Rule::unique('users', 'userid')->ignore($users_id)];
             // eメールアドレス
-            $rules[4] = ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($users_id)];
+            $rules[4] = ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($users_id, $columns_set_id)];
             // パスワード
             if ($users_id) {
                 // ユーザ変更時
@@ -2007,7 +2087,7 @@ class UserManage extends ManagePluginBase
                 // $validator_array['message']['users_columns_value.' . $users_column->id] = $users_column->column_name;
 
                 // バリデータールールを取得
-                $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $users_id);
+                $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $users_id, $columns_set_id);
 
                 // バリデータールールあるか
                 if (isset($validator_array['column']['users_columns_value.' . $users_column->id])) {
@@ -2176,7 +2256,13 @@ class UserManage extends ManagePluginBase
      */
     private function sendMailApproved($user)
     {
-        $configs = Configs::get();
+        // $configs = Configs::get();
+        $configs = Configs::where('category', 'general')
+            ->orWhere(function ($query) use ($user) {
+                $query->where('category', 'user_register')
+                    ->where('additional1', $user->columns_set_id);
+            });
+
         // 登録者にメール送信する
         $user_register_user_mail_send_flag = Configs::getConfigsValue($configs, 'user_register_user_mail_send_flag');
 
@@ -2217,7 +2303,7 @@ class UserManage extends ManagePluginBase
         $user = User::where('id', $id)->first();
 
         // 本登録メール設定取得
-        $configs = Configs::where('category', 'user_register')->get();
+        $configs = Configs::where('category', 'user_register')->where('additional1', $user->columns_set_id)->get();
         $subject = Configs::getConfigsValue($configs, 'user_register_mail_subject', '');
         $body = Configs::getConfigsValue($configs, 'user_register_mail_format', '');
 
@@ -2256,6 +2342,131 @@ class UserManage extends ManagePluginBase
     }
 
     /**
+     * 項目セット一覧 初期表示
+     *
+     * @return view
+     * @method_title 項目セット一覧
+     * @method_desc ユーザの項目セット一覧を表示、登録します。
+     * @method_detail ユーザには、項目セットで設定した項目を割り当てることができます。
+     */
+    public function columnSets($request, $id = null)
+    {
+        $page = $this->getPaginatePageFromRequestOrSession($request, 'users_columns_set_page_condition.page', 'page');
+
+        /* データの取得
+        ----------------------------------------------*/
+
+        // 項目セット取得
+        $columns_sets = UsersColumnsSet::orderBy('display_sequence')->paginate(10, '*', 'page', $page);
+
+        $columns = UsersColumns::whereIn('columns_set_id', $columns_sets->pluck('id'))->get();
+
+        foreach ($columns_sets as $columns_set) {
+            // 項目名をセット
+            $columns_set->column_name = $columns->where('columns_set_id', $columns_set->id)
+                ->pluck('column_name')->implode(',');
+        }
+
+        return view('plugins.manage.user.column_sets', [
+            "function"      => __FUNCTION__,
+            "plugin_name"   => "user",
+            "columns_sets"  => $columns_sets,
+        ]);
+    }
+
+    /**
+     * 項目セット 登録画面表示
+     *
+     * @return view
+     * @method_title 項目設定
+     * @method_desc 施設の項目セットに項目を登録します。
+     * @method_detail 項目名や型、条件などを設定して項目を設定します。
+     */
+    public function registColumnSet($request)
+    {
+        return $this->editColumnSet($request, null, 'registColumnSet');
+    }
+
+    /**
+     * 項目セット 登録処理
+     */
+    public function storeColumnSet($request)
+    {
+        return $this->updateColumnSet($request, null);
+    }
+
+    /**
+     * 項目セット 変更画面表示
+     *
+     * @return view
+     */
+    public function editColumnSet($request, $id = null, $function = null)
+    {
+        $columns_set = UsersColumnsSet::firstOrNew(['id' => $id]);
+
+        $function = $function ?? 'editColumnSet';
+
+        return view('plugins.manage.user.edit_column_set', [
+            "function" => $function,
+            "plugin_name" => "user",
+            "columns_set" => $columns_set,
+        ]);
+    }
+
+    /**
+     * 項目セット 更新処理
+     */
+    public function updateColumnSet($request, $id)
+    {
+        // 項目のエラーチェック
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'max:191'],
+            'display_sequence' => ['nullable', 'numeric'],
+        ]);
+        $validator->setAttributeNames([
+            'name' => '項目セット名',
+            'display_sequence' => '表示順',
+        ]);
+
+        // エラーがあった場合は入力画面に戻る。
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        // 表示順が空なら、自分を省いた最後の番号+1 をセット
+        $display_sequence = UsersColumnsSet::getSaveDisplaySequence(UsersColumnsSet::query(), $request->display_sequence, $id);
+
+        $columns_set = UsersColumnsSet::firstOrNew(['id' => $id]);
+        $columns_set->name             = $request->name;
+        $columns_set->display_sequence = $display_sequence;
+        $columns_set->save();
+
+        if ($id) {
+            $message = '【 '. $request->name .' 】を変更しました。';
+        } else {
+            $message = '【 '. $request->name .' 】を登録しました。';
+        }
+
+        // 一覧画面に戻る
+        return redirect("/manage/user/columnSets")->with('flash_message', $message);
+    }
+
+    /**
+     * 項目セット 削除処理
+     */
+    public function destroyColumnSet($request, $id)
+    {
+        // 項目セットに紐づいてる項目・選択肢はあえて削除しない。
+
+        $columns_set = UsersColumnsSet::find($id);
+        $columns_set_name = $columns_set->name;
+        $columns_set->delete();
+
+        // 施設一覧画面に戻る
+        return redirect("/manage/user/columnSets")->with('flash_message', '【 '. $columns_set_name .' 】を削除しました。');
+    }
+
+    /**
      * 項目設定 初期表示
      *
      * @method_title 項目編集
@@ -2264,14 +2475,19 @@ class UserManage extends ManagePluginBase
      */
     public function editColumns($request, $id)
     {
+        $columns_set = UsersColumnsSet::find($id);
+        if (!$columns_set) {
+            abort(404, '項目セットデータがありません。');
+        }
+
         // ユーザーのカラム
-        $columns = UsersTool::getUsersColumns();
+        $columns = UsersTool::getUsersColumns($id);
 
         // カラムの選択肢
-        $users_columns_selects = UsersColumnsSelects::select('users_columns_selects.*')
-                ->orderBy('users_columns_selects.users_columns_id', 'asc')
-                ->orderBy('users_columns_selects.display_sequence', 'asc')
-                ->get();
+        $users_columns_selects = UsersColumnsSelects::where('columns_set_id', $id)
+            ->orderBy('users_columns_id', 'asc')
+            ->orderBy('display_sequence', 'asc')
+            ->get();
 
         foreach ($columns as &$column) {
             $column->select_count = $users_columns_selects->where('users_columns_id', $column->id)->count();
@@ -2279,9 +2495,10 @@ class UserManage extends ManagePluginBase
         }
 
         return view('plugins.manage.user.edit_columns', [
-            "function"       => __FUNCTION__,
-            "plugin_name"    => "user",
-            'columns'        => $columns,
+            "function"             => __FUNCTION__,
+            "plugin_name"          => "user",
+            'columns_set'          => $columns_set,
+            'columns'              => $columns,
             'exists_user_sections' => UserSection::exists(),
         ]);
     }
@@ -2312,11 +2529,12 @@ class UserManage extends ManagePluginBase
         }
 
         // 新規登録時の表示順を設定
-        $max_display_sequence = UsersColumns::max('display_sequence');
+        $max_display_sequence = UsersColumns::where('columns_set_id', $request->columns_set_id)->max('display_sequence');
         $max_display_sequence = $max_display_sequence ? $max_display_sequence + 1 : 1;
 
         // 項目の登録処理
         $column = new UsersColumns();
+        $column->columns_set_id = $request->columns_set_id;
         $column->column_name = $request->column_name;
         $column->column_type = $request->column_type;
         $column->required = $request->required ? Required::on : Required::off;
@@ -2325,7 +2543,7 @@ class UserManage extends ManagePluginBase
         $message = '項目【 '. $request->column_name .' 】を追加しました。';
 
         // 編集画面を呼び出す
-        return redirect("/manage/user/editColumns")->with('flash_message', $message);
+        return redirect("/manage/user/editColumns/$request->columns_set_id")->with('flash_message', $message);
     }
 
     /**
@@ -2353,7 +2571,7 @@ class UserManage extends ManagePluginBase
         }
 
         // 項目の更新処理
-        $column = UsersColumns::where('id', $request->column_id)->first();
+        $column = UsersColumns::where('id', $request->column_id)->where('columns_set_id', $request->columns_set_id)->first();
         $column->column_name = $request->$str_column_name;
         $column->column_type = $request->$str_column_type;
         $column->required = $request->$str_required ? Required::on : Required::off;
@@ -2361,7 +2579,7 @@ class UserManage extends ManagePluginBase
         $message = '項目【 '. $request->$str_column_name .' 】を更新しました。';
 
         // 編集画面を呼び出す
-        return redirect("/manage/user/editColumns")->with('flash_message', $message);
+        return redirect("/manage/user/editColumns/$request->columns_set_id")->with('flash_message', $message);
     }
 
     /**
@@ -2371,10 +2589,11 @@ class UserManage extends ManagePluginBase
     {
         // ボタンが押された行の施設データ
         $target_column = UsersColumns::where('id', $request->column_id)
+            ->where('columns_set_id', $request->columns_set_id)
             ->first();
 
         // ボタンが押された前（後）の施設データ
-        $query = UsersColumns::query();
+        $query = UsersColumns::where('columns_set_id', $request->columns_set_id);
         $pair_column = $request->display_sequence_operation == 'up' ?
             $query->where('display_sequence', '<', $request->display_sequence)->orderby('display_sequence', 'desc')->limit(1)->first() :
             $query->where('display_sequence', '>', $request->display_sequence)->orderby('display_sequence', 'asc')->limit(1)->first();
@@ -2392,7 +2611,7 @@ class UserManage extends ManagePluginBase
         $message = '項目【 '. $target_column->column_name .' 】の表示順を更新しました。';
 
         // 編集画面を呼び出す
-        return redirect("/manage/user/editColumns")->with('flash_message', $message);
+        return redirect("/manage/user/editColumns/$request->columns_set_id")->with('flash_message', $message);
     }
 
     /**
@@ -2421,7 +2640,7 @@ class UserManage extends ManagePluginBase
         $message = '項目【 '. $request->$str_column_name .' 】を削除しました。';
 
         // 編集画面を呼び出す
-        return redirect("/manage/user/editColumns")->with('flash_message', $message);
+        return redirect("/manage/user/editColumns/$request->columns_set_id")->with('flash_message', $message);
     }
 
     /**
@@ -2439,16 +2658,22 @@ class UserManage extends ManagePluginBase
             abort(404, 'カラムデータがありません。');
         }
 
+        $columns_set = UsersColumnsSet::find($column->columns_set_id);
+        if (!$columns_set) {
+            abort(404, '項目セットデータがありません。');
+        }
+
         $selects = UsersColumnsSelects::where('users_columns_id', $column->id)->orderby('display_sequence')->get();
         $select_agree = $selects->first() ?? new UsersColumnsSelects();
 
         return view('plugins.manage.user.edit_column_detail', [
-            "function"       => __FUNCTION__,
-            "plugin_name"    => "user",
-            'column'         => $column,
-            'selects'        => $selects,
-            'select_agree'   => $select_agree,
-            'sections' => Section::orderBy('display_sequence')->get(),
+            "function"     => __FUNCTION__,
+            "plugin_name"  => "user",
+            'columns_set'  => $columns_set,
+            'column'       => $column,
+            'selects'      => $selects,
+            'select_agree' => $select_agree,
+            'sections'     => Section::orderBy('display_sequence')->get(),
         ]);
     }
 
@@ -2501,7 +2726,7 @@ class UserManage extends ManagePluginBase
         }
 
 
-        $column = UsersColumns::where('id', $request->column_id)->first();
+        $column = UsersColumns::where('id', $request->column_id)->where('columns_set_id', $request->columns_set_id)->first();
 
         // 項目の更新処理
         $column->caption = $request->caption;
@@ -2553,6 +2778,7 @@ class UserManage extends ManagePluginBase
 
         // 施設の登録処理
         $select = new UsersColumnsSelects();
+        $select->columns_set_id = $request->columns_set_id;
         $select->users_columns_id = $request->column_id;
         $select->value = $request->select_name;
         $select->display_sequence = $max_display_sequence;
@@ -2602,7 +2828,7 @@ class UserManage extends ManagePluginBase
         $target_select = UsersColumnsSelects::where('id', $request->select_id)->first();
 
         // ボタンが押された前（後）の施設データ
-        $query = UsersColumnsSelects::where('users_columns_id', $request->column_id);
+        $query = UsersColumnsSelects::where('users_columns_id', $request->column_id)->where('columns_set_id', $request->columns_set_id);
         $pair_select = $request->display_sequence_operation == 'up' ?
             $query->where('display_sequence', '<', $request->display_sequence)->orderby('display_sequence', 'desc')->limit(1)->first() :
             $query->where('display_sequence', '>', $request->display_sequence)->orderby('display_sequence', 'asc')->limit(1)->first();

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -803,7 +803,7 @@ class UserManage extends ManagePluginBase
                 'name'           => 'required|string|max:255',
                 // ログインID
                 'userid'         => ['required', 'max:255', Rule::unique('users', 'userid')->ignore($id)],
-                'email'          => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($id, $user->columns_set_id)],
+                'email'          => ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($user->columns_set_id, $id)],
                 'password'       => 'nullable|string|min:6|confirmed',
                 'status'         => 'required',
                 'columns_set_id' => ['required'],
@@ -2071,7 +2071,7 @@ class UserManage extends ManagePluginBase
             // ログインID
             $rules[1] = ['required', 'max:255', Rule::unique('users', 'userid')->ignore($users_id)];
             // eメールアドレス
-            $rules[4] = ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($users_id, $columns_set_id)];
+            $rules[4] = ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($columns_set_id, $users_id)];
             // パスワード
             if ($users_id) {
                 // ユーザ変更時

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1286,7 +1286,13 @@ class UserManage extends ManagePluginBase
         }
 
         // Config データの取得
-        $configs = Configs::where('category', 'user_register')->where('additional1', $id)->get();
+        $configs = Configs::where('category', 'user_register')
+            ->where('additional1', $id)
+            ->orWhere(function ($query) {
+                $query->where('category', 'user_register')
+                    ->where('additional1', 'all');
+            })
+            ->get();
 
         return view('plugins.manage.user.auto_regist', [
             "function" => __FUNCTION__,
@@ -1509,6 +1515,15 @@ class UserManage extends ManagePluginBase
             [
                 'category' => 'user_register',
                 'value' => $base_roles ? implode(',', $base_roles) : '',
+            ]
+        );
+
+        // 項目セット名（全ての自動ユーザ登録設定で共通設定. additional1=all）
+        $configs = Configs::updateOrCreate(
+            ['name' => 'user_columns_set_label_name', 'additional1' => 'all'],
+            [
+                'category' => 'user_register',
+                'value' => $request->user_columns_set_label_name
             ]
         );
 

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -823,7 +823,7 @@ class UserManage extends ManagePluginBase
 
         foreach ($users_columns as $users_column) {
             // バリデータールールをセット
-            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $id, $user->columns_set_id);
+            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $user->columns_set_id, $id);
         }
 
         // 項目のエラーチェック
@@ -2087,7 +2087,7 @@ class UserManage extends ManagePluginBase
                 // $validator_array['message']['users_columns_value.' . $users_column->id] = $users_column->column_name;
 
                 // バリデータールールを取得
-                $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $users_id, $columns_set_id);
+                $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $columns_set_id, $users_id);
 
                 // バリデータールールあるか
                 if (isset($validator_array['column']['users_columns_value.' . $users_column->id])) {

--- a/app/Plugins/Manage/UserManage/UsersTool.php
+++ b/app/Plugins/Manage/UserManage/UsersTool.php
@@ -88,7 +88,7 @@ class UsersTool
      * @param int $user_id
      * @return array
      */
-    public static function getValidatorRule($validator_array, $users_column, $user_id = null, int $columns_set_id)
+    public static function getValidatorRule($validator_array, $users_column, int $columns_set_id, $user_id = null)
     {
         $validator_rule = null;
         // 必須チェック

--- a/app/Plugins/Manage/UserManage/UsersTool.php
+++ b/app/Plugins/Manage/UserManage/UsersTool.php
@@ -98,7 +98,7 @@ class UsersTool
         // メールアドレスチェック
         if ($users_column->column_type == UserColumnType::mail) {
             $validator_rule[] = 'email';
-            $validator_rule[] = new CustomValiUserEmailUnique($user_id, $columns_set_id);
+            $validator_rule[] = new CustomValiUserEmailUnique($columns_set_id, $user_id);
             if ($users_column->required == 0) {
                 $validator_rule[] = 'nullable';
             }

--- a/app/Rules/CustomValiUserEmailUnique.php
+++ b/app/Rules/CustomValiUserEmailUnique.php
@@ -3,11 +3,14 @@
 namespace App\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Lang;
 
 use App\Models\Core\UsersInputCols;
 use App\User;
 
 use App\Plugins\Manage\UserManage\UsersTool;
+
+use App\Enums\UserColumnType;
 
 /**
  * ユーザー情報のメールと、ユーザー追加項目のメールのユニークチェック
@@ -15,15 +18,18 @@ use App\Plugins\Manage\UserManage\UsersTool;
 class CustomValiUserEmailUnique implements Rule
 {
     protected $user_id;
+    /** 項目セットID */
+    protected $columns_set_id;
 
     /**
      * Create a new rule instance.
      *
      * @return void
      */
-    public function __construct($user_id = null)
+    public function __construct($user_id = null, ?int $columns_set_id)
     {
         $this->user_id = $user_id;
+        $this->columns_set_id = $columns_set_id;
     }
 
     /**
@@ -35,56 +41,41 @@ class CustomValiUserEmailUnique implements Rule
      */
     public function passes($attribute, $value)
     {
-        ////
-        //// ユーザ情報.
-        ////
+        // *** ユーザ情報
         // 自分以外でメール項目に同じメールがあるか
         $input_cols = User::where('id', '!=', $this->user_id)
-                ->where('email', $value)
-                ->first();
+            ->where('email', $value)
+            ->first();
 
         if (!empty($input_cols)) {
-            // \Log::debug('[' . __METHOD__ . '] ' . __FILE__ . ' (line ' . __LINE__ . ')');
             // 値ありはメール重複
             return false;
         }
 
-        ////
-        //// ユーザ追加項目.
-        ////
+        // *** ユーザ追加項目
         // カラム取得
-        $users_columns = UsersTool::getUsersColumns();
+        $users_columns = UsersTool::getUsersColumns($this->columns_set_id);
 
         $users_column_ids = [];
         foreach ($users_columns as $users_column) {
-            if ($users_column->column_type == \UserColumnType::mail) {
+            if ($users_column->column_type == UserColumnType::mail) {
                 // メールのカラムidのみ抽出
                 $users_column_ids[] = $users_column->id;
             }
         }
 
         if (empty($users_column_ids)) {
-            // \Log::debug('[' . __METHOD__ . '] ' . __FILE__ . ' (line ' . __LINE__ . ')');
             // 追加項目でメール項目がなければチェックしない（チェックOKとみなす）
             return true;
         }
 
-        // debug:確認したいSQLの前にこれを仕込んで
-        // \DB::enableQueryLog();
-
         // 自分以外でメール項目に同じメールがあるか
         $input_cols = UsersInputCols::where('users_id', '!=', $this->user_id)
-                ->whereIn('users_columns_id', $users_column_ids)
-                ->where('value', $value)
-                ->first();
-
-        // debug: sql dumpする
-        // \Log::debug(var_export(\DB::getQueryLog(), true));
+            ->whereIn('users_columns_id', $users_column_ids)
+            ->where('value', $value)
+            ->first();
 
         if (!empty($input_cols)) {
-            // \Log::debug('[' . __METHOD__ . '] ' . __FILE__ . ' (line ' . __LINE__ . ')');
-            // \Log::debug(var_export($input_cols, true));
-            // \Log::debug(var_export($this->user_id, true));
             // 値ありはメール重複
             return false;
         }
@@ -98,6 +89,6 @@ class CustomValiUserEmailUnique implements Rule
      */
     public function message()
     {
-        return \Lang::get('validation.unique');
+        return Lang::get('validation.unique');
     }
 }

--- a/app/Rules/CustomValiUserEmailUnique.php
+++ b/app/Rules/CustomValiUserEmailUnique.php
@@ -26,7 +26,7 @@ class CustomValiUserEmailUnique implements Rule
      *
      * @return void
      */
-    public function __construct($user_id = null, ?int $columns_set_id)
+    public function __construct(?int $columns_set_id, $user_id = null)
     {
         $this->user_id = $user_id;
         $this->columns_set_id = $columns_set_id;

--- a/app/Traits/ConnectModelDisplaySequenceTrait.php
+++ b/app/Traits/ConnectModelDisplaySequenceTrait.php
@@ -1,0 +1,28 @@
+<?php
+namespace App\Traits;
+
+/**
+ * display_sequenceの共通処理
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category model
+ * @package CommonTrait
+ */
+trait ConnectModelDisplaySequenceTrait
+{
+    /**
+     * 登録する表示順を取得
+     */
+    public static function getSaveDisplaySequence($query, $display_sequence, $id): int
+    {
+        // 表示順が空なら、自分を省いた最後の番号+1 をセット
+        if (!is_null($display_sequence)) {
+            $display_sequence = intval($display_sequence);
+        } else {
+            $max_display_sequence = $query->where('id', '<>', $id)->max('display_sequence');
+            $display_sequence = empty($max_display_sequence) ? 1 : $max_display_sequence + 1;
+        }
+        return $display_sequence;
+    }
+}

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -1619,6 +1619,7 @@ trait MigrationTrait
 
             $column_type = $this->getArrayValue($ini, 'users_columns_base', 'column_type');
             $users_column = UsersColumns::create([
+                'columns_set_id'   => 1,
                 'column_type'      => $column_type,
                 'column_name'      => $this->getArrayValue($ini, 'users_columns_base', 'column_name'),
                 'required'         => intval($this->getArrayValue($ini, 'users_columns_base', 'required', 0)),
@@ -1653,6 +1654,7 @@ trait MigrationTrait
                     $display_sequence = $i;
                     $display_sequence++;
                     $users_column_select = UsersColumnsSelects::create([
+                        'columns_set_id'   => 1,
                         'users_columns_id' => $users_column->id,
                         'value'            => $value,
                         'display_sequence' => $display_sequence,
@@ -1748,6 +1750,7 @@ trait MigrationTrait
                     $user->userid     = $user_item['userid'];
                     $user->password   = $user_item['password'];
                     $user->status     = $user_item['status'];
+                    $user->columns_set_id = 1;
                     $user->created_at = $user_item['created_at'];
                     $user->updated_at = $user_item['updated_at'];
                     $user->save();

--- a/app/User.php
+++ b/app/User.php
@@ -30,7 +30,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'userid', 'password', 'status', 'add_token', 'add_token_created_at',
+        'name', 'email', 'userid', 'password', 'status', 'columns_set_id', 'add_token', 'add_token_created_at',
     ];
 
     /**

--- a/config/connect.php
+++ b/config/connect.php
@@ -159,6 +159,9 @@ return [
     // Use the container (beta)
     'USE_CONTAINER_BETA' => env('USE_CONTAINER_BETA', false),
 
+    // ユーザの項目セットを使う
+    'USE_USERS_COLUMNS_SET' => env('USE_USERS_COLUMNS_SET', false),
+
     // QUEUE_CONNECTION=database 時に使われるPHP BINのパス. null時は自動判定
     'QUEUE_PHP_BIN' => env('QUEUE_PHP_BIN', null),
 

--- a/database/migrations/2023_07_27_103458_create_users_columns_sets_table.php
+++ b/database/migrations/2023_07_27_103458_create_users_columns_sets_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersColumnsSetsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     * @see database\migrations\2021_11_16_175426_create_reservations_columns_sets_table.php is copy
+     */
+    public function up()
+    {
+        Schema::create('users_columns_sets', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->integer('display_sequence')->default('0');
+            $table->integer('created_id')->nullable();
+            $table->string('created_name')->nullable();
+            $table->timestamp('created_at')->nullable();
+            $table->integer('updated_id')->nullable();
+            $table->string('updated_name')->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->integer('deleted_id')->nullable();
+            $table->string('deleted_name')->nullable();
+            $table->timestamp('deleted_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users_columns_sets');
+    }
+}

--- a/database/migrations/2023_07_27_105520_add_users_columns_set_id.php
+++ b/database/migrations/2023_07_27_105520_add_users_columns_set_id.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUsersColumnsSetId extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     * @see database\migrations\2021_11_18_175953_add_reservations_columns_set_id.php is copy
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('columns_set_id')->comment('項目セットID')->after('status');
+        });
+
+        Schema::table('users_columns', function (Blueprint $table) {
+            $table->integer('columns_set_id')->comment('項目セットID')->after('id');
+        });
+
+        Schema::table('users_columns_selects', function (Blueprint $table) {
+            $table->integer('columns_set_id')->comment('項目セットID')->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('columns_set_id');
+        });
+
+        Schema::table('users_columns', function (Blueprint $table) {
+            $table->dropColumn('columns_set_id');
+        });
+
+        Schema::table('users_columns_selects', function (Blueprint $table) {
+            $table->dropColumn('columns_set_id');
+        });
+    }
+}

--- a/database/migrations/2023_07_27_135430_init_and_migration_from_users_columns_sets.php
+++ b/database/migrations/2023_07_27_135430_init_and_migration_from_users_columns_sets.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+use App\Models\Core\UsersColumns;
+use App\Models\Core\UsersColumnsSelects;
+use App\Models\Core\UsersColumnsSet;
+use App\User;
+
+class InitAndMigrationFromUsersColumnsSets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     * @see database\migrations\2021_12_03_151901_init_and_migration_from_reservations_columns_set_and_reservations_category.php is copy
+     */
+    public function up()
+    {
+        // 項目セット
+        if (UsersColumnsSet::count() == 0) {
+            /* 初期データ登録
+            ----------------------------------------------*/
+
+            // 項目セット登録
+            // 項目セットのid=1は、基本データとして消せないように対応する。（idはfillable でガードされ、セットできないが、0件からのcreateのため、結果的にid=1になる）
+            $columns_set_basic = UsersColumnsSet::create([
+                'id'               => 1,
+                'name'             => '基本',
+                'display_sequence' => 1,
+            ]);
+
+            // 以下columns_set_id を Update
+            // - users
+            // - users_columns
+            // - users_columns_selects
+            UsersColumns::where('columns_set_id', 0)->update(['columns_set_id' => $columns_set_basic->id]);
+            UsersColumnsSelects::where('columns_set_id', 0)->update(['columns_set_id' => $columns_set_basic->id]);
+            User::where('columns_set_id', 0)->update(['columns_set_id' => $columns_set_basic->id]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2023_08_02_164909_update_user_register_from_configs.php
+++ b/database/migrations/2023_08_02_164909_update_user_register_from_configs.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\Core\Configs;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateUserRegisterFromConfigs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // ユーザ項目セット導入に伴い、複数の自動ユーザ登録設定を維持するための対応。additional1 = columns_set_id として扱う
+        Configs::where('category', 'user_register')->where('additional1', null)->update(['additional1' => 1]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/seeders/DefaultConfigsTableSeeder.php
+++ b/database/seeders/DefaultConfigsTableSeeder.php
@@ -24,6 +24,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_background_color',
                         'value'=>null,
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -31,6 +32,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_header_color',
                         'value'=>null,
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -38,6 +40,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_site_name',
                         'value'=>'Connect-CMS',
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -45,6 +48,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_header_hidden',
                         'value'=>'0',
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -52,6 +56,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_header_fix',
                         'value'=>'0',
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -59,6 +64,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_mousedown_off',
                         'value'=>'0',
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -66,6 +72,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_contextmenu_off',
                         'value'=>'0',
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -73,6 +80,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_touch_callout',
                         'value'=>'0',
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -80,6 +88,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_header_login_link',
                         'value'=>'1',
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -87,6 +96,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'user_register_enable',
                         'value'=>'0',
+                        'additional1' => 1,
                         'category'=>'user_register',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -94,6 +104,7 @@ class DefaultConfigsTableSeeder extends Seeder
                     [
                         'name'=>'base_theme',
                         'value'=>null,
+                        'additional1' => null,
                         'category'=>'general',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),
@@ -143,7 +154,8 @@ class DefaultConfigsTableSeeder extends Seeder
             $configs = Configs::create([
                 'name' => 'user_register_after_message',
                 'category' => 'user_register',
-                'value' => 'ユーザ登録が完了しました。登録したログインID、パスワードでログインしてください。'
+                'value' => 'ユーザ登録が完了しました。登録したログインID、パスワードでログインしてください。',
+                'additional1' => 1,
             ]);
         }
 
@@ -188,7 +200,8 @@ class DefaultConfigsTableSeeder extends Seeder
             $configs = Configs::create([
                 'name' => 'user_register_mail_subject',
                 'category' => 'user_register',
-                'value' => 'ユーザ登録が完了しました - [[site_name]]'
+                'value' => 'ユーザ登録が完了しました - [[site_name]]',
+                'additional1' => 1,
             ]);
         }
 
@@ -202,7 +215,8 @@ class DefaultConfigsTableSeeder extends Seeder
 [[body]]
 
 
-ユーザ登録が完了しました。登録したログインID、パスワードでログインしてください。'
+ユーザ登録が完了しました。登録したログインID、パスワードでログインしてください。',
+                'additional1' => 1,
             ]);
         }
 

--- a/database/seeders/DefaultUsersColumnsSetTableSeeder.php
+++ b/database/seeders/DefaultUsersColumnsSetTableSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+use App\Models\Core\UsersColumnsSet;
+
+/**
+ * UsersColumnsSet系のSeeder
+ *
+ * 基本は、下記マイグレーションでデータ投入します。
+ * database\migrations\2023_07_27_135430_init_and_migration_from_users_columns_sets.php
+ *
+ * もしDBの全データ削除（Truncate）した場合等に、基本データを投入するためのSeederです。
+ */
+class DefaultUsersColumnsSetTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // 項目セット
+        if (UsersColumnsSet::count() == 0) {
+            /* 初期データ登録
+            ----------------------------------------------*/
+
+            // 項目セット登録
+            // 項目セットのid=1は、基本データとして消せないように対応する。（idはfillable でガードされ、セットできないが、0件からのcreateのため、結果的にid=1になる）
+            $columns_set_basic = UsersColumnsSet::create([
+                'id'               => 1,
+                'name'             => '基本',
+                'display_sequence' => 1,
+            ]);
+        }
+
+    }
+}

--- a/database/seeders/DefaultUsersTableSeeder.php
+++ b/database/seeders/DefaultUsersTableSeeder.php
@@ -26,6 +26,7 @@ class DefaultUsersTableSeeder extends Seeder
                         // change to laravel6.
                         // 'password' => bcrypt('C-admin'),
                         'password' => Hash::make('C-admin'),
+                        'columns_set_id' => 1,
                         'remember_token' => '',
                         'created_at' => date('Y-m-d H:i:s'),
                         'updated_at' => date('Y-m-d H:i:s'),

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -358,14 +358,15 @@ use App\Models\Core\UsersColumns;
                 <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/user')}}'">
                     <i class="fas fa-times"></i> キャンセル
                 </button>
+                @if ($is_function_edit)
+                    <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> ユーザ変更</button>
+                @else
+                    <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> ユーザ登録</button>
+                @endif
             @else
                 <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/')}}'">
                     <i class="fas fa-times"></i> キャンセル
                 </button>
-            @endif
-            @if ($is_function_edit)
-                <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> ユーザ変更</button>
-            @else
                 {{-- ユーザ仮登録ON --}}
                 @if (Configs::getConfigsValue($configs, "user_register_temporary_regist_mail_flag") == 1)
                     <button type="submit" class="btn btn-info"><i class="fas fa-check"></i> ユーザ仮登録</button>

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -18,10 +18,29 @@ use App\Models\Core\UsersColumns;
     }
 @endphp
 
+<script>
+    /** 会員変更submit */
+    function changeSeminarUserIdAction() {
+        @if (Auth::user() && Auth::user()->can('admin_user'))
+            @if ($is_function_edit)
+                {{-- ユーザ管理-編集 --}}
+                document.forms['form_register'].action = '{{url('/manage/user/edit/')}}/{{$id}}';
+            @else
+                {{-- ユーザ管理-登録 --}}
+                document.forms['form_register'].action = '{{url('/manage/user/regist')}}';
+            @endif
+        @else
+            {{-- 自動ユーザ登録-再表示 --}}
+            document.forms['form_register'].action = '{{route('show_register_form.re_show')}}';
+        @endif
+        document.forms['form_register'].submit();
+    }
+</script>
+
 @if ($is_function_edit)
-    <form class="form-horizontal" method="POST" action="{{url('/manage/user/update/')}}/{{$id}}">
+    <form class="form-horizontal" method="POST" action="{{url('/manage/user/update/')}}/{{$id}}" name="form_register">
 @else
-    <form class="form-horizontal" method="POST" action="{{route('register')}}">
+    <form class="form-horizontal" method="POST" action="{{route('register')}}" name="form_register">
 @endif
     {{ csrf_field() }}
 
@@ -46,6 +65,41 @@ use App\Models\Core\UsersColumns;
         {{-- この値はUserを登録する際に使われず、サーバーサイドでシステム設定値をもとにステータスを決定する --}}
         {{-- see also : App\Http\Controllers\Auth userStatus() --}}
         <input type="hidden" value="{{UserStatus::active}}" name="status">
+    @endif
+
+    @if (config('connect.USE_USERS_COLUMNS_SET'))
+        @if (Auth::user() && Auth::user()->can('admin_user'))
+            {{-- 管理者によるユーザ登録 --}}
+            <div class="form-group row">
+                <label for="columns_set_id" class="col-md-4 col-form-label text-md-right">項目セット <span class="badge badge-danger">必須</span></label>
+                <div class="col-md-8">
+                    <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif" onchange="changeSeminarUserIdAction()">
+                        <option value=""></option>
+                        @foreach ($columns_sets as $columns_set)
+                            <option value="{{$columns_set->id}}" @if (old('columns_set_id', $user->columns_set_id) == $columns_set->id) selected="selected" @endif>{{$columns_set->name}}</option>
+                        @endforeach
+                    </select>
+                    @include('plugins.common.errors_inline', ['name' => 'columns_set_id'])
+                    <small class="form-text text-muted">※ 選択すると、項目セットの追加項目を自動切替します。</small>
+                </div>
+            </div>
+        @else
+            {{-- 自動登録 --}}
+            <div class="form-group row">
+                <label for="columns_set_id" class="col-md-4 col-form-label text-md-right">項目セット <span class="badge badge-danger">必須</span></label>
+                <div class="col-md-8">
+                    <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif" onchange="changeSeminarUserIdAction()">
+                        @foreach ($columns_sets as $columns_set)
+                            <option value="{{$columns_set->id}}" @if (old('columns_set_id', $columns_set_id) == $columns_set->id) selected="selected" @endif>{{$columns_set->name}}</option>
+                        @endforeach
+                    </select>
+                    @include('plugins.common.errors_inline', ['name' => 'columns_set_id'])
+                    <small class="form-text text-muted">※ 選択すると、項目セットの追加項目を自動切替します。</small>
+                </div>
+            </div>
+        @endif
+    @else
+        <input type="hidden" name="columns_set_id" value="{{$columns_set_id}}">
     @endif
 
     <div class="form-group row">
@@ -303,13 +357,13 @@ use App\Models\Core\UsersColumns;
         <div class="col-sm-3"></div>
         <div class="col-sm-6">
             @if (Auth::user() && Auth::user()->can('admin_user'))
-            <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/user')}}'">
-                <i class="fas fa-times"></i> キャンセル
-            </button>
+                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/user')}}'">
+                    <i class="fas fa-times"></i> キャンセル
+                </button>
             @else
-            <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/')}}'">
-                <i class="fas fa-times"></i> キャンセル
-            </button>
+                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/')}}'">
+                    <i class="fas fa-times"></i> キャンセル
+                </button>
             @endif
             @if ($is_function_edit)
                 <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> ユーザ変更</button>

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -209,7 +209,7 @@ use App\Models\Core\UsersColumns;
 
     {{-- 未ログイン（自動登録）時に個人情報保護方針への同意関係が設定されている場合 --}}
     @if (!Auth::user())
-        @if (isset($configs['user_register_requre_privacy']) && $configs['user_register_requre_privacy'] == 1)
+        @if (Configs::getConfigsValue($configs, "user_register_requre_privacy") == 1)
             <div class="form-group row">
                 <label for="password-confirm" class="col-md-4 col-form-label text-md-right pt-0">個人情報保護方針への同意  <label class="badge badge-danger">必須</label></label>
 
@@ -219,9 +219,7 @@ use App\Models\Core\UsersColumns;
                         <label class="custom-control-label" for="user_register_requre_privacy"> 以下の内容に同意します。</label>
                     </div>
                     @include('plugins.common.errors_inline', ['name' => 'user_register_requre_privacy'])
-                    @if (isset($configs['user_register_privacy_description']))
-                        {!!$configs['user_register_privacy_description']!!}
-                    @endif
+                    {!!Configs::getConfigsValue($configs, "user_register_requre_privacy", null)!!}
                 </div>
             </div>
         @endif
@@ -369,7 +367,7 @@ use App\Models\Core\UsersColumns;
                 <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> ユーザ変更</button>
             @else
                 {{-- ユーザ仮登録ON --}}
-                @if (isset($configs['user_register_temporary_regist_mail_flag']) && $configs['user_register_temporary_regist_mail_flag'] == 1)
+                @if (Configs::getConfigsValue($configs, "user_register_temporary_regist_mail_flag") == 1)
                     <button type="submit" class="btn btn-info"><i class="fas fa-check"></i> ユーザ仮登録</button>
                 @else
                     <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> ユーザ登録</button>

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -20,14 +20,14 @@ use App\Models\Core\UsersColumns;
 
 <script>
     /** 会員変更submit */
-    function changeSeminarUserIdAction() {
+    function changeSeminarUserIdAction(columns_set_id) {
         @if (Auth::user() && Auth::user()->can('admin_user'))
             @if ($is_function_edit)
                 {{-- ユーザ管理-編集 --}}
-                document.forms['form_register'].action = '{{url('/manage/user/edit/')}}/{{$id}}';
+                document.forms['form_register'].action = '{{url('/manage/user/edit/')}}/{{$id}}?columns_set_id=' + columns_set_id;
             @else
                 {{-- ユーザ管理-登録 --}}
-                document.forms['form_register'].action = '{{url('/manage/user/regist')}}';
+                document.forms['form_register'].action = '{{url('/manage/user/regist')}}?columns_set_id=' + columns_set_id;
             @endif
         @else
             {{-- 自動ユーザ登録-再表示 --}}
@@ -73,7 +73,7 @@ use App\Models\Core\UsersColumns;
             <div class="form-group row">
                 <label for="columns_set_id" class="col-md-4 col-form-label text-md-right">項目セット <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-8">
-                    <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif" onchange="changeSeminarUserIdAction()">
+                    <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif" onchange="changeSeminarUserIdAction(this.value)">
                         <option value=""></option>
                         @foreach ($columns_sets as $columns_set)
                             <option value="{{$columns_set->id}}" @if (old('columns_set_id', $user->columns_set_id) == $columns_set->id) selected="selected" @endif>{{$columns_set->name}}</option>

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -80,13 +80,13 @@ use App\Models\Core\UsersColumns;
                         @endforeach
                     </select>
                     @include('plugins.common.errors_inline', ['name' => 'columns_set_id'])
-                    <small class="form-text text-muted">※ 選択すると、項目セットの追加項目を自動切替します。</small>
+                    <small class="form-text text-muted">※ 選択すると、関連した項目に自動切替します。</small>
                 </div>
             </div>
         @else
             {{-- 自動登録 --}}
             <div class="form-group row">
-                <label for="columns_set_id" class="col-md-4 col-form-label text-md-right">項目セット <span class="badge badge-danger">必須</span></label>
+                <label for="columns_set_id" class="col-md-4 col-form-label text-md-right">{{Configs::getConfigsValue($configs, "user_columns_set_label_name", '項目セット')}} <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-8">
                     <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif" onchange="changeSeminarUserIdAction()">
                         @foreach ($columns_sets as $columns_set)
@@ -94,7 +94,7 @@ use App\Models\Core\UsersColumns;
                         @endforeach
                     </select>
                     @include('plugins.common.errors_inline', ['name' => 'columns_set_id'])
-                    <small class="form-text text-muted">※ 選択すると、項目セットの追加項目を自動切替します。</small>
+                    <small class="form-text text-muted">※ 選択すると、関連した項目に自動切替します。</small>
                 </div>
             </div>
         @endif

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -3,13 +3,13 @@
 @section('content')
 <main class="container mt-3" role="main">
 
-    @if(isset($configs["user_register_description"]))
+    @if (Configs::getConfigsValue($configs, "user_register_description"))
     <div class="row mb-3">
         <div class="col-md-9 mx-auto">
             <div class="card">
                 <div class="card-header bg-primary cc-primary-font-color">ユーザ登録について</div>
                 <div class="card-body">
-                    {!!$configs['user_register_description']!!}
+                    {!!Configs::getConfigsValue($configs, "user_register_description")!!}
                 </div>
             </div>
         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,7 +2,9 @@
  * メニュー表示画面
  *
  * @param obj $pages ページデータの配列
+ *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category メニュープラグイン
 --}}
@@ -287,7 +289,13 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                     @endif
                 @endif
                 {{-- @if (isset($configs['user_register_enable']) && ($configs['user_register_enable'] == '1')) --}}
-                @if (Configs::getConfigsValue($cc_configs, 'user_register_enable') == '1')
+                {{-- @if (Configs::getConfigsValue($cc_configs, 'user_register_enable') == '1') --}}
+                @php
+                    $user_register_enables = $cc_configs->where('category', 'user_register')
+                        ->where('name', 'user_register_enable')
+                        ->where('value', '1');
+                @endphp
+                @if ($user_register_enables->isNotEmpty())
                     <li><a class="nav-link" href="{{ route('show_register_form') }}">ユーザ登録</a></li>
                 @endif
             @else

--- a/resources/views/plugins/manage/reservation/column_sets.blade.php
+++ b/resources/views/plugins/manage/reservation/column_sets.blade.php
@@ -22,7 +22,7 @@
         @include('plugins.common.flash_message')
 
         {{-- 一覧エリア --}}
-        <div class="text-right mt-3"><span class="badge badge-pill badge-light">{{ $columns_sets->total() }} 件</span></div>
+        <div class="text-left"><span class="badge badge-pill badge-light">{{ $columns_sets->total() }} 件</span></div>
         <table class="table table-hover cc-font-90">
             <thead>
                 <tr class="d-none d-sm-table-row">

--- a/resources/views/plugins/manage/site/pdf/user_regist.blade.php
+++ b/resources/views/plugins/manage/site/pdf/user_regist.blade.php
@@ -2,6 +2,7 @@
  * サイト管理（サイト設計書）のサイト基本設定のテンプレート
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category サイト管理
  --}}
@@ -11,124 +12,129 @@
 <br />
 <h2 style="text-align: center; font-size: 28px;">ユーザ設定</h2>
 
-<br />
-<h4>自動ユーザ登録設定</h4>
+@foreach ($columns_sets as $columns_set)
+    @php
+        $configs_user_register = $configs->where('category', 'user_register')->where('additional1', $columns_set->id);
+    @endphp
+    <br />
+    <h4>自動ユーザ登録設定（ユーザ({{$columns_set->name}})）</h4>
 
-【自動ユーザ登録の使用】<br />
-<table border="0" class="table_css">
-    <tr nobr="true">
-        <th class="doc_th">設定項目</th>
-        <th class="doc_th">設定内容</th>
-    </tr>
-    <tr nobr="true">
-        <td>自動ユーザ登録の使用</td>
-        @if (Configs::getConfigsValue($configs, 'user_register_enable', null) == '1') <td>許可する</td> @else <td>許可しない</td> @endif
-    </tr>
-</table>
+    【自動ユーザ登録の使用】<br />
+    <table border="0" class="table_css">
+        <tr nobr="true">
+            <th class="doc_th">設定項目</th>
+            <th class="doc_th">設定内容</th>
+        </tr>
+        <tr nobr="true">
+            <td>自動ユーザ登録の使用</td>
+            @if (Configs::getConfigsValue($configs_user_register, 'user_register_enable', null) == '1') <td>許可する</td> @else <td>許可しない</td> @endif
+        </tr>
+    </table>
 
-<br /><br />
-【メール送信先】<br />
-<table border="0" class="table_css">
-    <tr nobr="true">
-        <th class="doc_th">設定項目</th>
-        <th class="doc_th">設定内容</th>
-    </tr>
-    <tr nobr="true">
-        <td>メール送信先</td>
-        @if (Configs::getConfigsValue($configs, 'user_register_mail_send_flag', null) == '1') <td>使用する</td> @else <td>使用しない</td> @endif
-    </tr>
-    <tr nobr="true">
-        <td>送信するメールアドレス</td>
-        <td>{{Configs::getConfigsValue($configs, 'user_register_mail_send_address', null)}}</td>
-    </tr>
-    <tr nobr="true">
-        <td>登録者にメール送信する</td>
-        @if (Configs::getConfigsValue($configs, 'user_register_user_mail_send_flag', null) == '1') <td>送信する</td> @else <td>送信しない</td> @endif
-    </tr>
-</table>
+    <br /><br />
+    【メール送信先】<br />
+    <table border="0" class="table_css">
+        <tr nobr="true">
+            <th class="doc_th">設定項目</th>
+            <th class="doc_th">設定内容</th>
+        </tr>
+        <tr nobr="true">
+            <td>メール送信先</td>
+            @if (Configs::getConfigsValue($configs_user_register, 'user_register_mail_send_flag', null) == '1') <td>使用する</td> @else <td>使用しない</td> @endif
+        </tr>
+        <tr nobr="true">
+            <td>送信するメールアドレス</td>
+            <td>{{Configs::getConfigsValue($configs_user_register, 'user_register_mail_send_address', null)}}</td>
+        </tr>
+        <tr nobr="true">
+            <td>登録者にメール送信する</td>
+            @if (Configs::getConfigsValue($configs_user_register, 'user_register_user_mail_send_flag', null) == '1') <td>送信する</td> @else <td>送信しない</td> @endif
+        </tr>
+    </table>
 
-<br /><br />
-【仮登録メール】<br />
-<table border="0" class="table_css">
-    <tr nobr="true">
-        <th class="doc_th">設定項目</th>
-        <th class="doc_th">設定内容</th>
-    </tr>
-    <tr nobr="true">
-        <td>登録者に仮登録メールを送信する</td>
-        @if (Configs::getConfigsValue($configs, 'user_register_temporary_regist_mail_flag', null) == '1') <td>送信する</td> @else <td>送信しない</td> @endif
-    </tr>
-    <tr nobr="true">
-        <td>仮登録メール件名</td>
-        <td>{{Configs::getConfigsValue($configs, 'user_register_temporary_regist_mail_subject', null)}}</td>
-    </tr>
-    <tr nobr="true">
-        <td>仮登録メールフォーマット</td>
-        <td>{!!nl2br(Configs::getConfigsValue($configs, 'user_register_temporary_regist_mail_format', null))!!}</td>
-    </tr>
-    <tr nobr="true">
-        <td>仮登録後のメッセージ</td>
-        <td>{{Configs::getConfigsValue($configs, 'user_register_temporary_regist_after_message', null)}}</td>
-    </tr>
-</table>
+    <br /><br />
+    【仮登録メール】<br />
+    <table border="0" class="table_css">
+        <tr nobr="true">
+            <th class="doc_th">設定項目</th>
+            <th class="doc_th">設定内容</th>
+        </tr>
+        <tr nobr="true">
+            <td>登録者に仮登録メールを送信する</td>
+            @if (Configs::getConfigsValue($configs_user_register, 'user_register_temporary_regist_mail_flag', null) == '1') <td>送信する</td> @else <td>送信しない</td> @endif
+        </tr>
+        <tr nobr="true">
+            <td>仮登録メール件名</td>
+            <td>{{Configs::getConfigsValue($configs_user_register, 'user_register_temporary_regist_mail_subject', null)}}</td>
+        </tr>
+        <tr nobr="true">
+            <td>仮登録メールフォーマット</td>
+            <td>{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_temporary_regist_mail_format', null))!!}</td>
+        </tr>
+        <tr nobr="true">
+            <td>仮登録後のメッセージ</td>
+            <td>{{Configs::getConfigsValue($configs_user_register, 'user_register_temporary_regist_after_message', null)}}</td>
+        </tr>
+    </table>
 
-<br /><br />
-【本登録メール】<br />
-<table border="0" class="table_css">
-    <tr nobr="true">
-        <th class="doc_th">設定項目</th>
-        <th class="doc_th">設定内容</th>
-    </tr>
-    <tr nobr="true">
-        <td>本登録メール件名</td>
-        <td>{{Configs::getConfigsValue($configs, 'user_register_mail_subject', null)}}</td>
-    </tr>
-    <tr nobr="true">
-        <td>本登録メールフォーマット</td>
-        <td>{!!nl2br(Configs::getConfigsValue($configs, 'user_register_mail_format', null))!!}</td>
-    </tr>
-    <tr nobr="true">
-        <td>本登録後のメッセージ</td>
-        <td>{{Configs::getConfigsValue($configs, 'user_register_after_message', null)}}</td>
-    </tr>
-    <tr nobr="true">
-        <td>ヘッダーバーの表示</td>
-        @if (Configs::getConfigsValue($configs, 'base_header_hidden', null) == '1') <td>表示しない</td> @else <td>表示する</td> @endif
-    </tr>
-</table>
+    <br /><br />
+    【本登録メール】<br />
+    <table border="0" class="table_css">
+        <tr nobr="true">
+            <th class="doc_th">設定項目</th>
+            <th class="doc_th">設定内容</th>
+        </tr>
+        <tr nobr="true">
+            <td>本登録メール件名</td>
+            <td>{{Configs::getConfigsValue($configs_user_register, 'user_register_mail_subject', null)}}</td>
+        </tr>
+        <tr nobr="true">
+            <td>本登録メールフォーマット</td>
+            <td>{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_mail_format', null))!!}</td>
+        </tr>
+        <tr nobr="true">
+            <td>本登録後のメッセージ</td>
+            <td>{{Configs::getConfigsValue($configs_user_register, 'user_register_after_message', null)}}</td>
+        </tr>
+        <tr nobr="true">
+            <td>ヘッダーバーの表示</td>
+            @if (Configs::getConfigsValue($configs_user_register, 'base_header_hidden', null) == '1') <td>表示しない</td> @else <td>表示する</td> @endif
+        </tr>
+    </table>
 
-<br /><br />
-【個人情報保護方針】<br />
-<table border="0" class="table_css">
-    <tr nobr="true">
-        <th class="doc_th">設定項目</th>
-        <th class="doc_th">設定内容</th>
-    </tr>
-    <tr nobr="true">
-        <td>個人情報保護方針への同意</td>
-        @if (Configs::getConfigsValue($configs, 'user_register_requre_privacy', null) == '1') <td>同意を求める</td> @else <td>同意を求めない</td> @endif
-    </tr>
-    <tr nobr="true">
-        <td>個人情報保護方針の表示内容</td>
-        <td>次行を参照</td>
-    </tr>
-    <tr nobr="true">
-        <td colspan="2">{!!nl2br(Configs::getConfigsValue($configs, 'user_register_privacy_description', null))!!}</td>
-    </tr>
-</table>
+    <br /><br />
+    【個人情報保護方針】<br />
+    <table border="0" class="table_css">
+        <tr nobr="true">
+            <th class="doc_th">設定項目</th>
+            <th class="doc_th">設定内容</th>
+        </tr>
+        <tr nobr="true">
+            <td>個人情報保護方針への同意</td>
+            @if (Configs::getConfigsValue($configs_user_register, 'user_register_requre_privacy', null) == '1') <td>同意を求める</td> @else <td>同意を求めない</td> @endif
+        </tr>
+        <tr nobr="true">
+            <td>個人情報保護方針の表示内容</td>
+            <td>次行を参照</td>
+        </tr>
+        <tr nobr="true">
+            <td colspan="2">{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_privacy_description', null))!!}</td>
+        </tr>
+    </table>
 
-<br /><br />
-【その他】<br />
-<table border="0" class="table_css">
-    <tr nobr="true">
-        <th class="doc_th">設定項目</th>
-        <th class="doc_th">設定内容</th>
-    </tr>
-    <tr nobr="true">
-        <td>ユーザ登録について</td>
-        <td>次行を参照</td>
-    </tr>
-    <tr nobr="true">
-        <td colspan="2">{!!nl2br(Configs::getConfigsValue($configs, 'user_register_description', null))!!}</td>
-    </tr>
-</table>
+    <br /><br />
+    【その他】<br />
+    <table border="0" class="table_css">
+        <tr nobr="true">
+            <th class="doc_th">設定項目</th>
+            <th class="doc_th">設定内容</th>
+        </tr>
+        <tr nobr="true">
+            <td>ユーザ登録について</td>
+            <td>次行を参照</td>
+        </tr>
+        <tr nobr="true">
+            <td colspan="2">{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_description', null))!!}</td>
+        </tr>
+    </table>
+@endforeach

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -1,5 +1,9 @@
 {{--
  * 自動ユーザ登録設定画面のテンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ユーザ管理
 --}}
 
 {{-- 管理画面ベース画面 --}}
@@ -21,8 +25,17 @@
         {{-- 登録後メッセージ表示 --}}
         @include('plugins.common.flash_message')
 
-        <form action="{{url('/')}}/manage/user/autoRegistUpdate" method="POST">
+        <form action="{{url('/')}}/manage/user/autoRegistUpdate/{{$columns_set_id}}" method="POST">
             {{csrf_field()}}
+
+            {{-- 項目セット --}}
+            <div class="form-group">
+                @foreach($columns_sets as $columns_set)
+                    <button type="button" class="btn @if($columns_set->id == $columns_set_id) btn-primary @else btn-outline-primary @endif btn-sm" onclick="location.href='{{url('/')}}/manage/user/autoRegist/{{$columns_set->id}}'">
+                        ユーザ({{$columns_set->name}})
+                    </button>
+                @endforeach
+            </div>
 
             {{-- 自動ユーザ登録の使用 --}}
             <div class="form-group row">

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -343,6 +343,17 @@
                 </div>
             </div>
 
+            @if (config('connect.USE_USERS_COLUMNS_SET'))
+                <div class="form-group row">
+                    <label class="col-md-3 col-form-label text-md-right">項目セット名</label>
+                    <div class="col">
+                        <input type="text" name="user_columns_set_label_name" value="{{Configs::getConfigsValueAndOld($configs, 'user_columns_set_label_name')}}" class="form-control">
+                        <small class="text-muted">※ 自動ユーザ登録時の項目セットの項目名を変更できます。未設定の場合「項目セット」を表示します。<br></small>
+                        <small class="text-danger">※ この設定は、全ての自動ユーザ登録設定で共通設定です。<br></small>
+                    </div>
+                </div>
+            @endif
+
             {{-- Submitボタン --}}
             <div class="form-group text-center">
                 <button type="submit" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>

--- a/resources/views/plugins/manage/user/column_sets.blade.php
+++ b/resources/views/plugins/manage/user/column_sets.blade.php
@@ -1,0 +1,57 @@
+{{--
+ * 項目セット一覧画面のメインテンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ユーザ管理
+--}}
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.user.user_manage_tab')
+    </div>
+    <div class="card-body">
+
+        {{-- 登録後メッセージ表示 --}}
+        @include('plugins.common.flash_message')
+
+        {{-- 一覧エリア --}}
+        <div class="text-left"><span class="badge badge-pill badge-light">{{ $columns_sets->total() }} 件</span></div>
+        <table class="table table-hover cc-font-90">
+            <thead>
+                <tr class="d-none d-sm-table-row">
+                    <th class="d-block d-sm-table-cell text-break">項目セット名</th>
+                    <th class="d-block d-sm-table-cell text-break">表示順</th>
+                    <th class="d-block d-sm-table-cell text-break">項目</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($columns_sets as $columns_set)
+                <tr>
+                    <td class="d-block d-sm-table-cell">
+                        <a href="{{url('/')}}/manage/user/editColumnSet/{{$columns_set->id}}"><i class="far fa-edit"></i></a>
+                        <span class="d-sm-none">項目セット名：</span>{{$columns_set->name}}
+                    </td>
+                    <td class="d-block d-sm-table-cell"><span class="d-sm-none">表示順：</span>{{$columns_set->display_sequence}}</td>
+                    <td class="d-block d-sm-table-cell">
+                        <span class="d-sm-none">項目：</span>
+                        <a href="{{url('/')}}/manage/user/editColumns/{{$columns_set->id}}"><i class="far fa-edit"></i></a>
+                        {{$columns_set->column_name}}
+                    </td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+
+        {{ $columns_sets->links() }}
+
+    </div>
+</div>
+
+@endsection

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -128,6 +128,7 @@
 
         <form action="" id="form_selects" name="form_selects" method="POST" class="form-horizontal">
             {{ csrf_field() }}
+            <input type="hidden" name="columns_set_id" value="{{$columns_set->id}}">
             <input type="hidden" name="column_id" value="{{ $column->id }}">
             <input type="hidden" name="select_id" value="">
             <input type="hidden" name="section_id" value="">
@@ -559,7 +560,7 @@
 
             {{-- ボタンエリア --}}
             <div class="form-group text-center">
-                <a href="{{url('/')}}/manage/user/editColumns" class="btn btn-secondary">
+                <a href="{{url('/')}}/manage/user/editColumns/{{$columns_set->id}}" class="btn btn-secondary">
                     <i class="fas fa-chevron-left"></i> 項目設定へ
                 </a>
             </div>

--- a/resources/views/plugins/manage/user/edit_column_set.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_set.blade.php
@@ -1,0 +1,102 @@
+{{--
+ * 項目セット登録・更新画面のテンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ユーザ管理
+--}}
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.user.user_manage_tab')
+
+        {{-- ボタンによってアクション切替 --}}
+        <script type="text/javascript">
+            function submitAction(url) {
+                form_column_set.action = url;
+                form_column_set.submit();
+            }
+        </script>
+    </div>
+    <div class="card-body">
+
+        @include('plugins.common.errors_form_line')
+
+        <div class="alert alert-info" role="alert">
+            <i class="fas fa-exclamation-circle"></i> ユーザ項目をまとめたセットを追加・変更します。
+        </div>
+
+        <form name="form_column_set" action="" method="POST" class="form-horizontal">
+            {{ csrf_field() }}
+
+            <div class="form-group form-row">
+                <label for="name" class="col-md-3 col-form-label text-md-right">項目セット名 <span class="badge badge-danger">必須</span></label>
+                <div class="col-md-9">
+                    <input type="text" name="name" id="name" value="{{old('name', $columns_set->name)}}" class="form-control @if ($errors->has('name')) border-danger @endif">
+                    @include('plugins.common.errors_inline', ['name' => 'name'])
+                </div>
+            </div>
+
+            <div class="form-group form-row">
+                <label for="display_sequence" class="col-md-3 col-form-label text-md-right">表示順</label>
+                <div class="col-md-9">
+                    <input type="text" name="display_sequence" id="display_sequence" value="{{old('display_sequence', $columns_set->display_sequence)}}" class="form-control @if ($errors->has('display_sequence')) border-danger @endif">
+                    @include('plugins.common.errors_inline', ['name' => 'display_sequence'])
+                    <small class="text-muted">※ 未指定時は最後に表示されるように自動登録します。</small>
+                </div>
+            </div>
+
+            <!-- Add or Update code Button -->
+            <div class="form-group text-center">
+                <div class="form-row">
+                    <div class="offset-xl-3 col-9 col-xl-6">
+                        <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/')}}/manage/user/columnSets'"><i class="fas fa-times"></i> キャンセル</button>
+                        @if ($columns_set->id)
+                            <button type="button" class="btn btn-primary form-horizontal mr-2" onclick="submitAction('{{url('/')}}/manage/user/updateColumnSet/{{$columns_set->id}}')">
+                                <i class="fas fa-check"></i> 変更確定
+                            </button>
+                        @else
+                            <button type="button" class="btn btn-primary form-horizontal mr-2" onclick="submitAction('{{url('/')}}/manage/user/storeColumnSet')">
+                                <i class="fas fa-check"></i> 登録確定
+                            </button>
+                        @endif
+                    </div>
+
+                    @if ($columns_set->id && $columns_set->id != 1)
+                        <div class="col-3 col-xl-3 text-right">
+                            <a data-toggle="collapse" href="#collapse{{$columns_set->id}}">
+                                <span class="btn btn-danger"><i class="fas fa-trash-alt"></i> 削除</span>
+                            </a>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </form>
+
+        <div id="collapse{{$columns_set->id}}" class="collapse">
+            <div class="card border-danger">
+                <div class="card-body">
+                    <span class="text-danger">データを削除します。<br>元に戻すことはできないため、よく確認して実行してください。</span>
+
+                    <div class="text-center">
+                        {{-- 削除ボタン --}}
+                        <form action="{{url('/')}}/manage/user/destroyColumnSet/{{$columns_set->id}}" method="POST">
+                            {{csrf_field()}}
+                            <button type="submit" class="btn btn-danger" onclick="return confirm('データを削除します。\nよろしいですか？')"><i class="fas fa-check"></i> 本当に削除する</button>
+                        </form>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+@endsection

--- a/resources/views/plugins/manage/user/edit_columns.blade.php
+++ b/resources/views/plugins/manage/user/edit_columns.blade.php
@@ -72,6 +72,7 @@
         {{-- 一覧フォーム --}}
         <form action="{{url('/')}}/manage/user/addColumn" id="form_columns" name="form_columns" method="POST">
             {{ csrf_field() }}
+            <input type="hidden" name="columns_set_id" value="{{$columns_set->id}}">
             <input type="hidden" name="column_id" value="">
             <input type="hidden" name="display_sequence" value="">
             <input type="hidden" name="display_sequence_operation" value="">
@@ -81,7 +82,11 @@
 
             {{-- メッセージエリア --}}
             <div class="alert alert-info">
-                <i class="fas fa-exclamation-circle"></i> ユーザ項目を追加・変更します。
+                @if (config('connect.USE_USERS_COLUMNS_SET'))
+                    <i class="fas fa-exclamation-circle"></i> ユーザ項目セット【 {{$columns_set->name}} 】の項目を追加・変更します。
+                @else
+                    <i class="fas fa-exclamation-circle"></i> ユーザ項目を追加・変更します。
+                @endif
             </div>
 
             {{-- エラーメッセージエリア --}}
@@ -126,9 +131,15 @@
 
             {{-- ボタンエリア --}}
             <div class="text-center">
-                <a href="{{url('/')}}/manage/user/editColumns" class="btn btn-secondary">
-                    <i class="fas fa-times"></i> キャンセル
-                </a>
+                @if (config('connect.USE_USERS_COLUMNS_SET'))
+                    <a href="{{url('/')}}/manage/user/columnSets" class="btn btn-secondary">
+                        <i class="fas fa-chevron-left"></i> 項目セット一覧へ
+                    </a>
+                @else
+                    <a href="{{url('/')}}/manage/user/editColumns/1" class="btn btn-secondary">
+                        <i class="fas fa-times"></i> キャンセル
+                    </a>
+                @endif
             </div>
         </form>
 

--- a/resources/views/plugins/manage/user/import.blade.php
+++ b/resources/views/plugins/manage/user/import.blade.php
@@ -1,5 +1,9 @@
 {{--
  * CSVインポート画面テンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ユーザ管理
 --}}
 
 {{-- 管理画面ベース画面 --}}
@@ -15,19 +19,22 @@
 </form>
 
 <script type="text/javascript">
-    {{-- ダウンロードのsubmit JavaScript --}}
-    function submit_download_shift_jis() {
+    /** ダウンロードのsubmit shift_jis */
+    function submit_download_shift_jis(columns_set_id) {
         if( !confirm('{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}でユーザをダウンロードします。\nよろしいですか？\n※ 抽出条件はユーザ一覧の絞り込み条件が適用されます。') ) {
             return;
         }
         user_download.character_code.value = '{{CsvCharacterCode::sjis_win}}';
+        user_download.action = "{{url('/')}}/manage/user/downloadCsv/" + columns_set_id;
         user_download.submit();
     }
-    function submit_download_utf_8() {
+    /** ダウンロードのsubmit utf_8 */
+    function submit_download_utf_8(columns_set_id) {
         if( !confirm('{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}でユーザをダウンロードします。\nよろしいですか？\n※ 抽出条件はユーザ一覧の絞り込み条件が適用されます。') ) {
             return;
         }
         user_download.character_code.value = '{{CsvCharacterCode::utf_8}}';
+        user_download.action = "{{url('/')}}/manage/user/downloadCsv/" + columns_set_id;
         user_download.submit();
     }
 </script>
@@ -57,12 +64,14 @@
 
         <script type="text/javascript">
             {{-- ダウンロードのsubmit JavaScript --}}
-            function submit_download_csv_format_shift_jis() {
+            function submit_download_csv_format_shift_jis(columns_set_id) {
                 database_download_csv_format.character_code.value = '{{CsvCharacterCode::sjis_win}}';
+                database_download_csv_format.action = "{{url('/')}}/manage/user/downloadCsvFormat/" + columns_set_id;
                 database_download_csv_format.submit();
             }
-            function submit_download_csv_format_utf_8() {
+            function submit_download_csv_format_utf_8(columns_set_id) {
                 database_download_csv_format.character_code.value = '{{CsvCharacterCode::utf_8}}';
+                database_download_csv_format.action = "{{url('/')}}/manage/user/downloadCsvFormat/" + columns_set_id;
                 database_download_csv_format.submit();
             }
         </script>
@@ -74,19 +83,48 @@
             <div class="form-group row">
                 <div class="col text-right">
                     <div class="btn-group">
-                        <a href="#" onclick="submit_download_csv_format_shift_jis(); return false;">
-                            CSVファイルのフォーマット
-                        </a>
-                        <button type="button" class="btn btn-sm btn-link dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <span class="sr-only">ドロップダウンボタン</span>
-                        </button>
-                        <div class="dropdown-menu dropdown-menu-right">
-                            <a class="dropdown-item" href="#" onclick="submit_download_csv_format_shift_jis(); return false;">CSVファイルのフォーマット（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
-                            <a class="dropdown-item" href="#" onclick="submit_download_csv_format_utf_8(); return false;">CSVファイルのフォーマット（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
-                        </div>
+                        @if (config('connect.USE_USERS_COLUMNS_SET'))
+                            <button type="button" class="btn btn-sm btn-link dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                CSVファイルのフォーマット
+                            </button>
+                            <div class="dropdown-menu dropdown-menu-right">
+                                @foreach($columns_sets as $columns_set)
+                                    <a class="dropdown-item" href="#" onclick="submit_download_csv_format_utf_8({{$columns_set->id}}); return false;">ユーザ一覧({{$columns_set->name}})ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                                    <a class="dropdown-item" href="#" onclick="submit_download_csv_format_utf_8({{$columns_set->id}}); return false;">ユーザ一覧({{$columns_set->name}})ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+                                @endforeach
+                            </div>
+                        @else
+                            <a href="#" onclick="submit_download_csv_format_shift_jis({{$columns_set_id}}); return false;" class="btn btn-sm btn-link">
+                                CSVファイルのフォーマット
+                            </a>
+                            <button type="button" class="btn btn-sm btn-link dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="sr-only">ドロップダウンボタン</span>
+                            </button>
+                            <div class="dropdown-menu dropdown-menu-right">
+                                <a class="dropdown-item" href="#" onclick="submit_download_csv_format_utf_8({{$columns_set_id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                                <a class="dropdown-item" href="#" onclick="submit_download_csv_format_utf_8({{$columns_set_id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+                            </div>
+                        @endif
                     </div>
                 </div>
             </div>
+
+            @if (config('connect.USE_USERS_COLUMNS_SET'))
+                <div class="form-group form-row">
+                    <label for="columns_set_id" class="col-md-3 col-form-label text-md-right">項目セット <span class="badge badge-danger">必須</span></label>
+                    <div class="col-md-9">
+                        <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif">
+                            <option value=""></option>
+                            @foreach ($columns_sets as $columns_set)
+                                <option value="{{$columns_set->id}}" @if (old('columns_set_id') == $columns_set->id) selected="selected" @endif>{{$columns_set->name}}</option>
+                            @endforeach
+                        </select>
+                        @include('plugins.common.errors_inline', ['name' => 'columns_set_id'])
+                    </div>
+                </div>
+            @else
+                <input type="hidden" name="columns_set_id" value="{{$columns_set_id}}">
+            @endif
 
             <div class="form-group form-row">
                 <label class="col-md-3 col-form-label text-md-right">CSVファイル <span class="badge badge-danger">必須</span></label>
@@ -108,19 +146,34 @@
                         <div class="col text-left">
                             {{-- (右側)ダウンロードボタン --}}
                             <div class="btn-group">
-                                <button type="button" class="btn btn-link" onclick="submit_download_shift_jis();">
-                                    <i class="fas fa-file-download"></i> ダウンロード
-                                </button>
-                                <button type="button" class="btn btn-link dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <span class="sr-only">ドロップダウンボタン</span>
-                                </button>
-                                <div class="dropdown-menu dropdown-menu-right">
-                                    <a class="dropdown-item" href="#" onclick="submit_download_shift_jis(); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
-                                    <a class="dropdown-item" href="#" onclick="submit_download_utf_8(); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
-                                    <a class="dropdown-item" href="https://manual.connect-cms.jp/manage/user/index.html" target="_brank">
-                                        <span class="btn btn-link"><i class="fas fa-question-circle"></i> オンラインマニュアル</span>
-                                    </a>
-                                </div>
+                                @if (config('connect.USE_USERS_COLUMNS_SET'))
+                                    <button type="button" class="btn btn-link dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                        <i class="fas fa-file-download"></i> ダウンロード
+                                    </button>
+                                    <div class="dropdown-menu dropdown-menu-right">
+                                        @foreach($columns_sets as $columns_set)
+                                            <a class="dropdown-item" href="#" onclick="submit_download_shift_jis({{$columns_set->id}}); return false;">ユーザ一覧({{$columns_set->name}})ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                                            <a class="dropdown-item" href="#" onclick="submit_download_utf_8({{$columns_set->id}}); return false;">ユーザ一覧({{$columns_set->name}})ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+                                        @endforeach
+                                        <a class="dropdown-item" href="https://manual.connect-cms.jp/manage/user/index.html" target="_brank">
+                                            <span class="btn btn-link"><i class="fas fa-question-circle"></i> オンラインマニュアル</span>
+                                        </a>
+                                    </div>
+                                @else
+                                    <button type="button" class="btn btn-link" onclick="submit_download_shift_jis({{$columns_set_id}});">
+                                        <i class="fas fa-file-download"></i> ダウンロード
+                                    </button>
+                                    <button type="button" class="btn btn-link dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                        <span class="sr-only">ドロップダウンボタン</span>
+                                    </button>
+                                    <div class="dropdown-menu dropdown-menu-right">
+                                        <a class="dropdown-item" href="#" onclick="submit_download_shift_jis({{$columns_set_id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}）</a>
+                                        <a class="dropdown-item" href="#" onclick="submit_download_utf_8({{$columns_set_id}}); return false;">ダウンロード（{{CsvCharacterCode::enum[CsvCharacterCode::utf_8]}}）</a>
+                                        <a class="dropdown-item" href="https://manual.connect-cms.jp/manage/user/index.html" target="_brank">
+                                            <span class="btn btn-link"><i class="fas fa-question-circle"></i> オンラインマニュアル</span>
+                                        </a>
+                                    </div>
+                                @endif
                             </div>
                         </div>
                     </small>

--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -58,14 +58,14 @@ use App\Models\Core\UsersColumns;
             <div class="card">
                 <button class="btn btn-link p-0 text-left collapsed" type="button" data-toggle="collapse" data-target="#search_collapse" aria-expanded="false" aria-controls="search_collapse">
                     <div class="card-header" id="user_search_condition">
-                        絞り込み条件 <i class="fas fa-angle-down"></i>
+                        絞り込み条件 <i class="fas fa-angle-down"></i>@if (Session::has('user_search_condition'))<span class="badge badge-pill badge-primary ml-2">条件設定中</span>@endif
                     </div>
                 </button>
-                @if (Session::has('user_search_condition'))
+                {{-- @if (Session::has('user_search_condition'))
                 <div id="search_collapse" class="collapse show" aria-labelledby="user_search_condition" data-parent="#search_accordion">
-                @else
+                @else --}}
                 <div id="search_collapse" class="collapse" aria-labelledby="user_search_condition" data-parent="#search_accordion">
-                @endif
+                {{-- @endif --}}
                     <div class="card-body border-bottom">
 
                         <form name="form_search" id="form_search" class="form-horizontal" method="post" action="{{url('/')}}/manage/user/search">

--- a/resources/views/plugins/manage/user/user_manage_tab.blade.php
+++ b/resources/views/plugins/manage/user/user_manage_tab.blade.php
@@ -2,6 +2,7 @@
  * 編集画面tabテンプレート
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category ユーザ管理
 --}}
@@ -37,13 +38,43 @@
                 @endif
                 </li>
 
-                <li role="presentation" class="nav-item">
-                    @if ($function == "editColumns")
-                        <span class="nav-link"><span class="active">項目設定</span></span>
-                    @else
-                        <a href="{{url('/manage/user/editColumns')}}" class="nav-link">項目設定</a></li>
+                @if (config('connect.USE_USERS_COLUMNS_SET'))
+                    <li role="presentation" class="nav-item">
+                        @if ($function == "columnSets")
+                            <span class="nav-link"><span class="active">項目セット一覧</span></span>
+                        @else
+                            <a href="{{url('/')}}/manage/user/columnSets" class="nav-link">項目セット一覧</a>
+                        @endif
+                    </li>
+
+                    <li role="presentation" class="nav-item">
+                        @if ($function == "registColumnSet")
+                            <span class="nav-link"><span class="active">項目セット登録</span></span>
+                        @else
+                            <a href="{{url('/')}}/manage/user/registColumnSet" class="nav-link">項目セット登録</a>
+                        @endif
+                    </li>
+
+                    @if ($function == "editColumnSet")
+                        <li role="presentation" class="nav-item">
+                            <span class="nav-link"><span class="active">項目セット変更</span></span>
+                        </li>
                     @endif
-                </li>
+
+                    @if ($function == "editColumns")
+                        <li role="presentation" class="nav-item">
+                            <span class="nav-link"><span class="active">項目設定</span></span>
+                        </li>
+                    @endif
+                @else
+                    <li role="presentation" class="nav-item">
+                        @if ($function == "editColumns")
+                            <span class="nav-link"><span class="active">項目設定</span></span>
+                        @else
+                            <a href="{{url('/manage/user/editColumns/1')}}" class="nav-link">項目設定</a></li>
+                        @endif
+                    </li>
+                @endif
 
                 @if ($function == 'editColumnDetail')
                     <li role="presentation" class="nav-item">
@@ -55,7 +86,7 @@
                 @if ($function == "autoRegist")
                     <span class="nav-link"><span class="active">自動ユーザ登録設定</span></span>
                 @else
-                    <a href="{{url('/manage/user/autoRegist')}}" class="nav-link">自動ユーザ登録設定</a></li>
+                    <a href="{{url('/manage/user/autoRegist/1')}}" class="nav-link">自動ユーザ登録設定</a></li>
                 @endif
                 </li>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::post('/password/reset', 'Auth\ResetPasswordController@reset')->name('pass
 
 //ユーザー登録
 Route::get('register', 'Auth\RegisterController@showRegistrationForm')->name('show_register_form');
+Route::post('register_re_display', 'Auth\RegisterController@reShowRegistrationForm')->name('show_register_form.re_show');
 
 // システム管理者 or ユーザ管理者の場合、OK
 //Route::group(['middleware' => ['auth', 'can:system_user-admin']], function () {


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* ユーザの種類毎に別々の項目を持てるよう対応
* 関連対応
    * [change: ユーザ管理, 検索条件設定中は検索条件を閉じるように変更](https://github.com/opensource-workshop/connect-cms/pull/1792/commits/50115d9d940c53a02b77fc77284c429216a97883)

# 設定方法

.envを修正します。
```.env
USE_USERS_COLUMNS_SET=true
```

# 修正後画面（USE_USERS_COLUMNS_SET=true）
## ユーザ管理＞ユーザ一覧（全て）

全てユーザを表示します。
追加項目をまとめたものを「項目セット」と呼んでいます。
項目セット毎に項目が異なるため、項目セット値の列で`|`区切りで一覧に表示しています。
項目セット毎に一覧を表示できるように、「絞り込み条件」の下にボタンを追加しました。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/4b9c7981-81da-42ba-9ff7-3f2c0a5aeb3a)

## ユーザ管理＞ユーザ一覧（学生）

項目セットの表示例です。ここでは項目セット＝学生の一覧を表示しています。
学生の追加項目も１項目づつ一覧に表示されます。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/999a9ce0-7207-468a-a754-22e8164fd604)

検索条件にも追加項目の検索項目あります。ユーザ一覧（全て）では追加項目は検索できません。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/fa3fbdab-d6f2-4fa8-9a91-d47c02ba6ca4)

## ユーザ管理＞ユーザ編集・登録

項目セットが追加になりました。
切り替えると、追加項目を自動切替します。
![localhost_manage_user_edit_153](https://github.com/opensource-workshop/connect-cms/assets/2756509/ba2a4afb-0dac-403b-965c-629fa1f6734c)

## ユーザ管理＞項目セット一覧

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/0104e6bb-975a-47f5-9009-642acbe704f1)

## ユーザ管理＞項目セット変更・登録

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/cf407638-e4aa-4e3b-aa28-c3802d8e8523)

## （参考）ユーザ管理＞項目セット一覧＞項目設定

※ いままであった項目設定と同じです。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/414c1065-3ebb-4b23-990d-402b1c756125)

## （参考）ユーザ管理＞項目セット一覧＞項目設定＞項目設定詳細

※ いままであった項目設定詳細と同じです。
![localhost_manage_user_editColumnDetail_6](https://github.com/opensource-workshop/connect-cms/assets/2756509/63f45506-a1bd-4da1-8a1f-7801d5098b1f)

## ユーザ管理＞自動ユーザ登録設定

項目セット毎に自動ユーザ登録設定を持てるよう対応しました。
例えば学生のユーザ登録は未承認で登録するけど、学校は承認してから登録する、などの設定が可能です。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/2110c30d-199c-42a1-9410-abbe04bcec73)

## ユーザ管理＞CSVインポート

項目セット　を追加しました。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/5f4911fd-5343-4efa-a250-079a1c33e6c8)

ダウンロードは、項目セット毎にダウンロードできるようにしました。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/5bbc82f9-b5db-4dab-aa41-35f331287822)

## ユーザ登録（自動登録）

項目セットを追加しました。切り替えると、追加項目も自動で切り替わります。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/0d91bc4e-790d-4236-989a-86d9a38e9f41)

## （参考）マイページ

項目セットを追加しても正しく表示できる事を確認。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/7981b916-f5a6-4033-8df3-fc2a47b5dea2)

# 修正後画面（USE_USERS_COLUMNS_SET=false、初期値はfalseです。）
## ユーザ管理＞ユーザ一覧

※ 今までと同じです。（横メニューで項目セット非表示です）
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/7dde983e-ffc5-4e63-9f8d-58bc345a19d0)

## ユーザ管理＞ユーザ編集・登録
※ 今までと同じです。（項目セット非表示）
![localhost_manage_user_edit_153](https://github.com/opensource-workshop/connect-cms/assets/2756509/924204ab-c0e2-4322-9604-fbef5bd04936)

## ユーザ管理＞項目設定

※ 今までと同じです。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/35af1b45-1284-4fe4-b542-273d0a442636)

## （参考）ユーザ管理＞項目設定＞項目設定詳細

※ 今までと同じです。
![localhost_manage_user_editColumnDetail_7](https://github.com/opensource-workshop/connect-cms/assets/2756509/1cd4e814-4f41-4931-bbc9-085ea1e727ae)

## ユーザ管理＞自動ユーザ登録設定

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/276234f7-fa7a-4a98-9121-39f340f2d68e)

## ユーザ管理＞CSVインポート

※ 今までと同じです。（項目セット非表示）
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/8ee3f682-0629-478e-8577-929448264a6a)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
