### PR TITLE
[フレーム] 非公開・限定公開・ログイン後非表示のプレビュー対応

### DIFF
--- a/app/Models/Common/Frame.php
+++ b/app/Models/Common/Frame.php
@@ -235,17 +235,18 @@ class Frame extends Model
     {
         // 非ログインまたはフレーム編集権限を持たない、且つ、非表示条件（非公開、又は、限定公開、又は、ログイン後非表示）にマッチした場合はフレームを非表示にする
 
+        if (Auth::check() && Auth::user()->can('role_arrangement') && app('request')->input('mode') != 'preview') {
+            // 表示
+            return false;
+        }
+
         if (
-            // !Auth::check() &&
-            (!Auth::check() || !Auth::user()->can('role_arrangement')) &&
+            $this->content_open_type == ContentOpenType::always_close ||
             (
-                $this->content_open_type == ContentOpenType::always_close ||
-                (
-                    $this->content_open_type == ContentOpenType::limited_open &&
-                    !Carbon::now()->between($this->content_open_date_from, $this->content_open_date_to)
-                ) ||
-                (Auth::check() && $this->content_open_type == ContentOpenType::login_close)
-            )
+                $this->content_open_type == ContentOpenType::limited_open &&
+                !Carbon::now()->between($this->content_open_date_from, $this->content_open_date_to)
+            ) ||
+            (Auth::check() && $this->content_open_type == ContentOpenType::login_close)
         ) {
             // 非表示
             return true;

--- a/app/Models/Common/Frame.php
+++ b/app/Models/Common/Frame.php
@@ -240,8 +240,7 @@ class Frame extends Model
             return false;
         }
 
-        if (
-            $this->content_open_type == ContentOpenType::always_close ||
+        if ($this->content_open_type == ContentOpenType::always_close ||
             (
                 $this->content_open_type == ContentOpenType::limited_open &&
                 !Carbon::now()->between($this->content_open_date_from, $this->content_open_date_to)


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

非公開・限定公開・ログイン後非表示設定時に、プレビュー表示しても表示されていたため、対応しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1780

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
