### PR TITLE
[スライドショー] 高さ指定のレスポンシブ対応

### DIFF
--- a/resources/views/plugins/user/slideshows/default/slideshows.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows.blade.php
@@ -38,7 +38,7 @@
                                     src="{{url('/')}}/file/{{ $item->uploads_id }}"
                                     class="d-block w-100"
                                     loading="lazy"
-                                    @if (!empty($slideshow->height)) style="object-fit: contain; height: {{$slideshow->height}}px;" @endif
+                                    @if (!empty($slideshow->height)) style="object-fit: cover; height: {{$slideshow->height}}px;" @endif
                                 >
                             </a>
                         @else
@@ -47,7 +47,7 @@
                                 src="{{url('/')}}/file/{{ $item->uploads_id }}"
                                 class="d-block w-100"
                                 loading="lazy"
-                                @if (!empty($slideshow->height)) style="object-fit: contain; height: {{$slideshow->height}}px;" @endif
+                                @if (!empty($slideshow->height)) style="object-fit: cover; height: {{$slideshow->height}}px;" @endif
                             >
                         @endif
                         {{-- キャプション ※設定があれば表示 --}}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

スライドショー高さ指定は、PC・スマホで同じ値を指定するため、PCでは良い表示でも、スマホ表示だと上下に白い余白が入る事がありました。
また、スライドショー高さなしで設定しても、PC表示時に複数画像の高さX幅が異なると、比率が異なり、画像毎に高さが変わる事がありました。

上記を改善するため、スライド画像のCSSを `style="object-fit: contain;` から `style="object-fit: cover;` に見直しました。

# 修正後画面 `style="object-fit: cover;` 高さ 200px指定
## PC

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/709fb00e-59e8-4102-ba32-5fb072abd247)

## スマホ

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/666934be-7939-4123-82cf-687c21146bb6)

# 参考：修正前画面 `style="object-fit: contain;` 高さ 200px指定
## PC

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/46000645-6723-4716-b501-b1f4a5683f51)
※ 高さ指定すると、幅が横いっぱいにならず、左右に白い余白できる。

## スマホ

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/83ec70af-54ed-420c-8c69-bb7d89305805)
※ 高さ指定すると、他のスライド画像につられて上下に白い余白が出来る


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

軽微な改修なので急ぎません

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* 1行追加でOK！CSSだけで画像をトリミングできる「object-fit」プロパティー | Webクリエイターボックス
https://www.webcreatorbox.com/tech/object-fit

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
