### PR TITLE
[ユーザ情報] 項目毎に自動ユーザ登録時の表示指定、マイページの表示指定、マイページの編集指定を設定できるように対応

### DIFF
--- a/app/Enums/EditType.php
+++ b/app/Enums/EditType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * 編集タイプ
+ */
+final class EditType extends EnumsBase
+{
+    // 定数メンバ
+    const ng = 0;
+    const ok = 1;
+
+    // key/valueの連想配列
+    const enum = [
+        self::ng => '編集不可',
+        self::ok => '編集可',
+    ];
+}

--- a/app/Enums/UserColumnType.php
+++ b/app/Enums/UserColumnType.php
@@ -18,6 +18,13 @@ final class UserColumnType extends EnumsBase
     const mail = 'mail';
     const agree = 'agree';
     const affiliation = 'affiliation';
+    const created_at = 'created_at';
+    const updated_at = 'updated_at';
+    // 以下固定カラム. 追加・削除不可
+    const user_name = 'user_name';
+    const login_id = 'login_id';
+    const user_email = 'user_email';
+    const user_password = 'password';
 
     // key/valueの連想配列
     const enum = [
@@ -29,5 +36,24 @@ final class UserColumnType extends EnumsBase
         self::mail => 'メールアドレス型',
         self::agree => '同意型',
         self::affiliation => '所属型',
+        self::created_at => '登録日時型（自動更新）',
+        self::updated_at => '更新日時型（自動更新）',
     ];
+
+    // key/valueの連想配列
+    const enum_fixed = [
+        self::user_name     => 'ユーザ名',
+        self::login_id      => 'ログインID',
+        self::user_email    => 'メールアドレス',
+        self::user_password => 'パスワード',
+        self::created_at    => '登録日時',
+    ];
+
+    /**
+     * 固定項目の対応した和名を返す
+     */
+    public static function getDescriptionFixed($key): string
+    {
+        return static::enum_fixed[$key];
+    }
 }

--- a/app/Enums/UserRegisterNoticeEmbeddedTag.php
+++ b/app/Enums/UserRegisterNoticeEmbeddedTag.php
@@ -20,11 +20,11 @@ final class UserRegisterNoticeEmbeddedTag extends NoticeEmbeddedTag
     // key/valueの連想配列
     const enum = [
         self::site_name => 'サイト名',
-        self::body => '本文（ユーザ名, ログインID, eメールアドレス, 項目設定の追加項目全て, 個人情報保護方針への同意 を含む）',
+        self::body => '本文（ユーザ名, ログインID, メールアドレス, 項目設定の追加項目全て, 個人情報保護方針への同意 を含む）',
         self::user_name => 'ユーザ名',
         self::login_id => 'ログインID',
         self::password => 'パスワード（ユーザ管理画面からユーザ登録した場合のみ、使える埋め込みタグです。）',
-        self::email => 'eメールアドレス',
+        self::email => 'メールアドレス',
         self::user_register_requre_privacy => '個人情報保護方針への同意（トップページから自動ユーザ登録した場合のみ、使える埋め込みタグです。）',
         self::to_datetime => '登録日時',
     ];

--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -8,7 +8,6 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Auth\RedirectsUsers;
 use Illuminate\Support\Facades\Validator;
 
-// Connect-CMS 用設定データ
 use App\User;
 use App\Models\Core\Configs;
 use App\Models\Core\UsersColumnsSet;
@@ -82,7 +81,7 @@ trait RegistersUsers
 
         // *** ユーザの追加項目
         // ユーザーのカラム
-        $users_columns = UsersTool::getUsersColumns($columns_set_id);
+        $users_columns = UsersTool::getUsersColumnsRegister($columns_set_id);
         // カラムの選択肢
         $users_columns_id_select = UsersTool::getUsersColumnsSelects($columns_set_id);
         // カラムの登録データ

--- a/app/Http/Middleware/ConnectLog.php
+++ b/app/Http/Middleware/ConnectLog.php
@@ -197,7 +197,7 @@ class ConnectLog
 
             // ユーザ登録
             if ($configs->where('name', 'save_log_type_register')->where('value', '1')->isNotEmpty() && $type == 'Register') {
-                // ログインID とeメールアドレスを記録する。
+                // ログインID とメールアドレスを記録する。
                 $tmp_value = array();
                 if ($request->filled('userid')) {
                     $tmp_value[] = 'userid:' . $request->input("userid");

--- a/app/Models/Core/UsersColumns.php
+++ b/app/Models/Core/UsersColumns.php
@@ -3,6 +3,7 @@
 namespace App\Models\Core;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 
 use App\UserableNohistory;
 use App\Enums\UserColumnType;
@@ -17,6 +18,10 @@ class UsersColumns extends Model
         'columns_set_id',
         'column_type',
         'column_name',
+        'is_fixed_column',
+        'is_show_auto_regist',
+        'is_show_my_page',
+        'is_edit_my_page',
         'required',
         'caption',
         'caption_color',
@@ -34,7 +39,7 @@ class UsersColumns extends Model
     /**
      * 選択肢系のカラム型か
      */
-    public static function isChoicesColumnType($column_type)
+    public static function isChoicesColumnType($column_type): bool
     {
         // ラジオとチェックボックスは選択肢にラベルを使っているため、項目名のラベルにforを付けない
         if ($column_type == UserColumnType::radio ||
@@ -43,5 +48,108 @@ class UsersColumns extends Model
             return true;
         }
         return false;
+    }
+
+    /**
+     * 固定項目のカラム型か
+     */
+    public static function isFixedColumnType($column_type): bool
+    {
+        if ($column_type == UserColumnType::user_name ||
+                $column_type == UserColumnType::login_id ||
+                $column_type == UserColumnType::user_email ||
+                $column_type == UserColumnType::user_password) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * ループで非表示のカラム型か
+     */
+    public static function isLoopNotShowColumnType($column_type): bool
+    {
+        if ($column_type == UserColumnType::user_name ||
+            $column_type == UserColumnType::login_id ||
+            $column_type == UserColumnType::user_email ||
+            $column_type == UserColumnType::user_password ||
+            $column_type == UserColumnType::created_at ||
+            $column_type == UserColumnType::updated_at
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * ループで非表示のカラム型 取得
+     */
+    public static function loopNotShowColumnTypes(): array
+    {
+        return [
+            UserColumnType::user_name,
+            UserColumnType::login_id,
+            UserColumnType::user_email,
+            UserColumnType::user_password,
+            UserColumnType::created_at,
+            UserColumnType::updated_at,
+        ];
+    }
+
+    /**
+     * コレクションからラベル名取得
+     */
+    private static function getLabelFromCollection(Collection $users_columns, string $column_type, string $default): string
+    {
+        $column = $users_columns->firstWhere('column_type', $column_type);
+        return $column->column_name ?? $default;
+    }
+
+    /**
+     * ログインIDのラベル取得
+     */
+    public static function getLabelLoginId(Collection $users_columns): string
+    {
+        return self::getLabelFromCollection($users_columns, UserColumnType::login_id, 'ログインID');
+    }
+
+    /**
+     * ユーザ名のラベル取得
+     */
+    public static function getLabelUserName(Collection $users_columns): string
+    {
+        return self::getLabelFromCollection($users_columns, UserColumnType::user_name, 'ユーザ名');
+    }
+
+    /**
+     * メールアドレスのラベル取得
+     */
+    public static function getLabelUserEmail(Collection $users_columns): string
+    {
+        return self::getLabelFromCollection($users_columns, UserColumnType::user_email, 'メールアドレス');
+    }
+
+    /**
+     * パスワードのラベル取得
+     */
+    public static function getLabelUserPassword(Collection $users_columns): string
+    {
+        return self::getLabelFromCollection($users_columns, UserColumnType::user_password, 'パスワード');
+    }
+
+    /**
+     * 登録日時のラベル取得
+     */
+    public static function getLabelCreatedAt(Collection $users_columns): string
+    {
+        return self::getLabelFromCollection($users_columns, UserColumnType::created_at, '登録日時');
+    }
+
+    /**
+     * 更新日時のラベル取得
+     */
+    public static function getLabelUpdatedAt(Collection $users_columns): string
+    {
+        return self::getLabelFromCollection($users_columns, UserColumnType::updated_at, '更新日時');
     }
 }

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2801,7 +2801,9 @@ class UserManage extends ManagePluginBase
 
         // 項目の更新処理
         $column->caption = $request->caption;
-        $column->caption_color = $request->caption_color;
+        if ($request->caption_color) {
+            $column->caption_color = $request->caption_color;
+        }
         $column->place_holder = $request->place_holder;
         $column->is_show_auto_regist = $request->is_show_auto_regist ? EditType::ok : EditType::ng;
         $column->is_show_my_page = $request->is_show_my_page ? ShowType::show : ShowType::not_show;

--- a/app/Plugins/Mypage/IndexMypage/IndexMypage.php
+++ b/app/Plugins/Mypage/IndexMypage/IndexMypage.php
@@ -3,9 +3,9 @@
 namespace app\Plugins\Mypage\IndexMypage;
 
 use Illuminate\Support\Facades\Auth;
-use App\User;
 use App\Models\Core\UsersInputCols;
 use App\Plugins\Mypage\MypagePluginBase;
+use App\Plugins\Manage\UserManage\UsersTool;
 
 /**
  * マイページ画面インデックスクラス
@@ -18,11 +18,11 @@ class IndexMypage extends MypagePluginBase
     public function getPublicFunctions()
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
-        $functions = array();
+        $functions = [];
         $functions['get']  = [
-                              'passPdfDownload',
-                              'certPdfDownload',
-                            ];
+            'passPdfDownload',
+            'certPdfDownload',
+        ];
         return $functions;
     }
 
@@ -46,6 +46,10 @@ class IndexMypage extends MypagePluginBase
             ->orderBy('users_id', 'asc')
             ->orderBy('users_columns_id', 'asc')
             ->get();
+
+        // ユーザーのカラム
+        $users_columns = UsersTool::getUsersColumns($user->columns_set_id);
+
         // 管理画面プラグインの戻り値の返し方
         // view 関数の第一引数に画面ファイルのパス、第二引数に画面に渡したいデータを名前付き配列で渡し、その結果のHTML。
         return view('plugins.mypage.index.index', [
@@ -55,6 +59,7 @@ class IndexMypage extends MypagePluginBase
             "id"              => $user->id,
             "user"            => $user,
             "user_input_cols" => $user_input_cols,
+            "users_columns"   => $users_columns,
         ]);
     }
 }

--- a/app/Plugins/Mypage/IndexMypage/IndexMypage.php
+++ b/app/Plugins/Mypage/IndexMypage/IndexMypage.php
@@ -19,6 +19,9 @@ use App\Plugins\Manage\UserManage\UsersTool;
  */
 class IndexMypage extends MypagePluginBase
 {
+    /**
+     * 関数定義（コアから呼び出す）
+     */
     public function getPublicFunctions()
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
@@ -31,7 +34,7 @@ class IndexMypage extends MypagePluginBase
     }
 
     /**
-     *  ページ初期表示
+     * ページ初期表示
      *
      * @return view
      * @method_title マイページ
@@ -42,15 +45,8 @@ class IndexMypage extends MypagePluginBase
     {
         // ログインしているユーザー情報を取得
         $user = Auth::user();
-        $user_input_cols = UsersInputCols::select('users_input_cols.*', 'users_columns.column_type', 'users_columns.column_name', 'users_columns.display_sequence', 'uploads.client_original_name')
-            ->leftJoin('users_columns', 'users_columns.id', '=', 'users_input_cols.users_columns_id')
-            ->leftJoin('uploads', 'uploads.id', '=', 'users_input_cols.value')
-            ->where('users_id', $user->id)
-            ->orderBy('display_sequence', 'asc')
-            ->orderBy('users_id', 'asc')
-            ->orderBy('users_columns_id', 'asc')
-            ->get();
-
+        // カラムの登録データ
+        $input_cols = UsersTool::getUsersInputCols([$user->id]);
         // ユーザーのカラム
         $users_columns = UsersTool::getUsersColumns($user->columns_set_id);
 
@@ -62,7 +58,7 @@ class IndexMypage extends MypagePluginBase
             "function"        => __FUNCTION__,
             "id"              => $user->id,
             "user"            => $user,
-            "user_input_cols" => $user_input_cols,
+            "input_cols"      => $input_cols,
             "users_columns"   => $users_columns,
         ]);
     }

--- a/app/Plugins/Mypage/IndexMypage/IndexMypage.php
+++ b/app/Plugins/Mypage/IndexMypage/IndexMypage.php
@@ -10,6 +10,10 @@ use App\Plugins\Manage\UserManage\UsersTool;
 /**
  * マイページ画面インデックスクラス
  *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category マイページ
+ * @package Controller
  * @plugin_title マイページ
  * @plugin_desc マイページの初めに開く画面です。自分の情報を確認できます。
  */

--- a/app/Plugins/Mypage/IndexMypage/IndexMypage.php
+++ b/app/Plugins/Mypage/IndexMypage/IndexMypage.php
@@ -3,7 +3,7 @@
 namespace app\Plugins\Mypage\IndexMypage;
 
 use Illuminate\Support\Facades\Auth;
-use App\Models\Core\UsersInputCols;
+use App\Enums\ShowType;
 use App\Plugins\Mypage\MypagePluginBase;
 use App\Plugins\Manage\UserManage\UsersTool;
 
@@ -49,6 +49,7 @@ class IndexMypage extends MypagePluginBase
         $input_cols = UsersTool::getUsersInputCols([$user->id]);
         // ユーザーのカラム
         $users_columns = UsersTool::getUsersColumns($user->columns_set_id);
+        $users_columns = $users_columns->where('is_show_my_page', ShowType::show);
 
         // 管理画面プラグインの戻り値の返し方
         // view 関数の第一引数に画面ファイルのパス、第二引数に画面に渡したいデータを名前付き配列で渡し、その結果のHTML。

--- a/app/Plugins/Mypage/LoginHistoryMypage/LoginHistoryMypage.php
+++ b/app/Plugins/Mypage/LoginHistoryMypage/LoginHistoryMypage.php
@@ -11,6 +11,10 @@ use App\Plugins\Mypage\MypagePluginBase;
 /**
  * ログイン履歴マイページクラス
  *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ログイン履歴
+ * @package Controller
  * @plugin_title ログイン履歴
  * @plugin_desc 自分のログイン履歴を確認できます。
  */
@@ -30,8 +34,8 @@ class LoginHistoryMypage extends MypagePluginBase
 
         // ログイン履歴取得
         $users_login_histories = UsersLoginHistories::where('users_id', $user->id)
-                ->orderBy('logged_in_at', 'desc')
-                ->paginate(10, ["*"]);
+            ->orderBy('logged_in_at', 'desc')
+            ->paginate(10, ["*"]);
 
         // 画面呼び出し
         return view('plugins.mypage.loginhistory.list', [

--- a/app/Plugins/Mypage/ProfileMypage/ProfileMypage.php
+++ b/app/Plugins/Mypage/ProfileMypage/ProfileMypage.php
@@ -8,13 +8,26 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
 use App\User;
+use App\Models\Core\Section;
+use App\Models\Core\UsersColumns;
+use App\Models\Core\UsersInputCols;
+use App\Models\Core\UserSection;
 
 use App\Plugins\Mypage\MypagePluginBase;
+
+use App\Enums\EditType;
+use App\Enums\UserColumnType;
+use App\Plugins\Manage\UserManage\UsersTool;
+use App\Rules\CustomValiUserEmailUnique;
 
 /**
  * プロフィールマイページクラス
  * @see \app\Plugins\Manage\UserManage\UserManage to copy
  *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category プロフィール
+ * @package Controller
  * @plugin_title プロフィール
  * @plugin_desc 自分の情報を変更できます。
  */
@@ -31,14 +44,26 @@ class ProfileMypage extends MypagePluginBase
     {
         // ログインしているユーザー情報を取得
         $user = Auth::user();
+        // ユーザーのカラム
+        $users_columns = UsersTool::getUsersColumns($user->columns_set_id);
+        $users_columns = $users_columns->where('is_edit_my_page', EditType::ok);
+        // カラムの選択肢
+        $users_columns_id_select = UsersTool::getUsersColumnsSelects($user->columns_set_id);
+        // カラムの登録データ
+        $input_cols = UsersTool::getUsersInputCols([$user->id]);
 
         // 画面呼び出し
         return view('plugins.mypage.profile.edit', [
-            'themes'                => $request->themes,
-            "function"              => __FUNCTION__,
-            "plugin_name"           => "profile",
-            "id"                    => $user->id,
-            "user"                  => $user,
+            'themes'                  => $request->themes,
+            "function"                => __FUNCTION__,
+            "plugin_name"             => "profile",
+            "id"                      => $user->id,
+            "user"                    => $user,
+            "users_columns"           => $users_columns,
+            "users_columns_id_select" => $users_columns_id_select,
+            "input_cols"              => $input_cols,
+            'sections'                => Section::orderBy('display_sequence')->get(),
+            'user_section'            => UserSection::where('user_id', $user->id)->firstOrNew(),
         ]);
     }
 
@@ -47,34 +72,65 @@ class ProfileMypage extends MypagePluginBase
      */
     public function update($request, $id)
     {
-        // 項目のエラーチェック
-        $validator = Validator::make($request->all(), [
-            'email' => ['nullable', 'email', 'max:255', Rule::unique('users')->ignore($id)],
-            // 入力があったら、ここで現在のパスワードチェック
-            'now_password' => [
-                'nullable',
-                function ($attribute, $value, $fail) {
-                    $is_pass = Hash::check($value, Auth::user()->password);
-                    // nc2移行ユーザログイン対応 v1.0.0以前
-                    $is_nc2_pass = Hash::check(md5($value), Auth::user()->password);
-                    if (!$is_nc2_pass) {
-                        // nc2移行ユーザログイン対応 v1.0.0よりあと
-                        $is_nc2_pass = md5($value) === Auth::user()->password;
-                    }
-                    // どちらもNGなら現在パスワード間違い
-                    if ($is_pass == false && $is_nc2_pass == false) {
-                        $fail(':attributeが違います。');
-                    }
-                },
-            ],
-            'new_password' => 'nullable|string|min:6|confirmed',
-        ]);
+        $user = User::where('id', $id)->first();
 
-        $validator->setAttributeNames([
-            'email' => 'eメール',
-            'now_password' => '現在のパスワード',
-            'new_password' => '新しいパスワード',
-        ]);
+        // ユーザーのカラム
+        $users_columns = UsersTool::getUsersColumns($user->columns_set_id);
+        $users_columns = $users_columns->where('is_edit_my_page', EditType::ok);
+
+        // 項目のエラーチェック
+        $validator_array = [
+            'column'  => [],
+            'message' => [
+                'name'         => UsersColumns::getLabelUserName($users_columns),
+                'userid'       => UsersColumns::getLabelLoginId($users_columns),
+                'email'        => UsersColumns::getLabelUserEmail($users_columns),
+                'password'     => UsersColumns::getLabelUserPassword($users_columns),
+                'now_password' => '現在のパスワード',
+                'new_password' => '新しいパスワード',
+            ]
+        ];
+
+        foreach ($users_columns as $users_column) {
+            if ($users_column->column_type == UserColumnType::user_name) {
+                $validator_array['column']['name'] = 'required|string|max:255';
+            } elseif ($users_column->column_type == UserColumnType::login_id) {
+                $validator_array['column']['userid'] = ['required', 'max:255', Rule::unique('users', 'userid')->ignore($id)];
+            } elseif ($users_column->column_type == UserColumnType::user_email) {
+                // $validator_array['column']['email'] = ['nullable', 'email', 'max:255', Rule::unique('users')->ignore($id)];
+                $validator_array['column']['email'] = ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($request->columns_set_id, $id)];
+            } elseif ($users_column->column_type == UserColumnType::user_password) {
+                // 入力があったら、ここで現在のパスワードチェック
+                $validator_array['column']['now_password'] = [
+                    'nullable',
+                    function ($attribute, $value, $fail) {
+                        $is_pass = Hash::check($value, Auth::user()->password);
+                        // nc2移行ユーザログイン対応 v1.0.0以前
+                        $is_nc2_pass = Hash::check(md5($value), Auth::user()->password);
+                        if (!$is_nc2_pass) {
+                            // nc2移行ユーザログイン対応 v1.0.0よりあと
+                            $is_nc2_pass = md5($value) === Auth::user()->password;
+                        }
+                        // どちらもNGなら現在パスワード間違い
+                        if ($is_pass == false && $is_nc2_pass == false) {
+                            $fail(':attributeが違います。');
+                        }
+                    },
+                ];
+                $validator_array['column']['new_password'] = 'nullable|string|min:6|confirmed';
+            } elseif ($users_column->column_type == UserColumnType::created_at) {
+                // チェックしない
+            } elseif ($users_column->column_type == UserColumnType::updated_at) {
+                // チェックしない
+            } else {
+                // バリデータールールをセット
+                $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $user->columns_set_id, $id);
+            }
+        }
+
+        // 項目のエラーチェック
+        $validator = Validator::make($request->all(), $validator_array['column']);
+        $validator->setAttributeNames($validator_array['message']);
 
         $validator->sometimes("now_password", 'required', function ($input) {
             // 新しいパスワード又は、新しいパスワードの確認に入力あったら、上記の現在のパスワード必須
@@ -90,21 +146,67 @@ class ProfileMypage extends MypagePluginBase
             return back()->withErrors($validator)->withInput();
         }
 
-        // 更新内容の配列
-        $update_array = [
-            'email' => $request->email,
-        ];
+        foreach ($users_columns as $users_column) {
+            if ($users_column->column_type == UserColumnType::user_name) {
+                $user->name = $request->name;
+            } elseif ($users_column->column_type == UserColumnType::login_id) {
+                $user->userid = $request->userid;
+            } elseif ($users_column->column_type == UserColumnType::user_email) {
+                $user->email = $request->email;
+            } elseif ($users_column->column_type == UserColumnType::user_password) {
+                // パスワードの入力があれば、更新
+                if (!empty($request->new_password)) {
+                    // change to laravel6.
+                    // $update_array['password'] = bcrypt($request->new_password);
+                    $user->password = Hash::make($request->new_password);
+                }
+            } elseif ($users_column->column_type == UserColumnType::created_at) {
+                // 入力なし
+            } elseif ($users_column->column_type == UserColumnType::updated_at) {
+                // 入力なし
+            } else {
+                // users_input_cols 登録
+                $value = "";
+                if (!isset($request->users_columns_value[$users_column->id])) {
+                    // 値なし
+                    $value = null;
+                } elseif (is_array($request->users_columns_value[$users_column->id])) {
+                    $value = implode(UsersTool::CHECKBOX_SEPARATOR, $request->users_columns_value[$users_column->id]);
+                } else {
+                    $value = $request->users_columns_value[$users_column->id];
+                }
 
-        // パスワードの入力があれば、更新
-        if (!empty($request->new_password)) {
-            // change to laravel6.
-            // $update_array['password'] = bcrypt($request->new_password);
-            $update_array['password'] = Hash::make($request->new_password);
+                // 所属型は個別のテーブルに書き込む
+                if ($users_column->column_type === UserColumnType::affiliation) {
+                    // 値無しは所属情報を削除
+                    if (empty($value)) {
+                        UserSection::where('user_id', $user->id)->delete();
+                    } else {
+                        UserSection::updateOrCreate(
+                            ['user_id' => $user->id],
+                            ['section_id' => $value]
+                        );
+                        // users_input_cols には　名称を設定する
+                        $value = Section::find($value)->name;
+                    }
+                }
+
+                // ユーザーの追加項目
+                // 値無しは削除
+                if (empty($value)) {
+                    UsersInputCols::where('users_id', $user->id)->where('users_columns_id', $users_column->id)->delete();
+                } else {
+                    UsersInputCols::updateOrCreate(
+                        ['users_id' => $user->id, 'users_columns_id' => $users_column->id],
+                        ['value' => $value]
+                    );
+                }
+            }
         }
 
         // ユーザデータの更新
-        User::where('id', $id)
-            ->update($update_array);
+        $user->save();
+
         $message = '更新しました。';
 
         // 更新後は初期画面へ

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -404,6 +404,11 @@ trait MigrationTrait
             UsersColumns::truncate();
             UsersColumnsSelects::truncate();
             UsersInputCols::truncate();
+
+            // 消してしまった初期の項目の再登録
+            // php artisan db:seed --class=DefaultUsersColumnsTableSeeder --force
+            Artisan::call('db:seed --class=DefaultUsersColumnsTableSeeder --force');
+
             MigrationMapping::where('target_source_table', 'users')->delete();
         }
 
@@ -1618,13 +1623,17 @@ trait MigrationTrait
             }
 
             $column_type = $this->getArrayValue($ini, 'users_columns_base', 'column_type');
+
+            $max_display_sequence = UsersColumns::where('columns_set_id', 1)->max('display_sequence');
+            $display_sequence = empty($max_display_sequence) ? 0 : $max_display_sequence;
+
             $users_column = UsersColumns::create([
                 'columns_set_id'   => 1,
                 'column_type'      => $column_type,
                 'column_name'      => $this->getArrayValue($ini, 'users_columns_base', 'column_name'),
                 'required'         => intval($this->getArrayValue($ini, 'users_columns_base', 'required', 0)),
                 'caption'          => $this->getArrayValue($ini, 'users_columns_base', 'caption'),
-                'display_sequence' => intval($this->getArrayValue($ini, 'users_columns_base', 'display_sequence')),
+                'display_sequence' => $display_sequence + intval($this->getArrayValue($ini, 'users_columns_base', 'display_sequence')),
             ]);
 
             $users_column->nc2_item_id = $nc2_item_id;

--- a/config/app.php
+++ b/config/app.php
@@ -323,6 +323,7 @@ $app_array = [
         'WebsiteType' => \App\Enums\WebsiteType::class,
         'BlogNarrowingDownType' => \App\Enums\BlogNarrowingDownType::class,
         'FormAccessLimitType' => \App\Enums\FormAccessLimitType::class,
+        'EditType' => \App\Enums\EditType::class,
 
         // utils
         'DateUtils' => \App\Utilities\Date\DateUtils::class,

--- a/database/migrations/2023_08_10_112746_add_fixed_column_name_display_edit_type_from_users_columns.php
+++ b/database/migrations/2023_08_10_112746_add_fixed_column_name_display_edit_type_from_users_columns.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFixedColumnNameDisplayEditTypeFromUsersColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users_columns', function (Blueprint $table) {
+            $table->integer('is_fixed_column')->default(0)->comment('固定項目か')->after('column_name');
+            $table->integer('is_show_auto_regist')->default(1)->comment('自動登録で登録可')->after('is_fixed_column');
+            $table->integer('is_show_my_page')->default(1)->comment('マイページで表示する')->after('is_show_auto_regist');
+            $table->integer('is_edit_my_page')->default(0)->comment('マイページで変更可')->after('is_show_my_page');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users_columns', function (Blueprint $table) {
+            $table->dropColumn('is_fixed_column');
+            $table->dropColumn('is_show_auto_regist');
+            $table->dropColumn('is_show_my_page');
+            $table->dropColumn('is_edit_my_page');
+        });
+    }
+}

--- a/database/migrations/2023_08_10_114737_migration_fixed_column_from_users_columns.php
+++ b/database/migrations/2023_08_10_114737_migration_fixed_column_from_users_columns.php
@@ -1,0 +1,102 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+use App\Enums\UserColumnType;
+use App\Models\Core\UsersColumns;
+use App\Models\Core\UsersColumnsSet;
+
+class MigrationFixedColumnFromUsersColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $columns_sets = UsersColumnsSet::get();
+        foreach ($columns_sets as $columns_set) {
+            if (UsersColumns::where('columns_set_id', $columns_set->id)->where('column_type', UserColumnType::user_name)->count() == 0) {
+
+                // 固定項目を項目順の頭に追加して、追加項目はその後の表示順に更新する事で、現在の並び順を再現する。
+
+                $users_columns = UsersColumns::where('columns_set_id', $columns_set->id)->orderBy('display_sequence')->get();
+
+                UsersColumns::insert([
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::user_name,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_name),
+                        'is_fixed_column'       => 1,
+                        'is_show_auto_regist'   => 1,
+                        'is_show_my_page'       => 1,
+                        'is_edit_my_page'       => 0,
+                        'required'              => 1,
+                        'display_sequence'      => 1,
+                    ],
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::login_id,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::login_id),
+                        'is_fixed_column'       => 1,                           // (画面からいじれない項目)
+                        'is_show_auto_regist'   => 1,
+                        'is_show_my_page'       => 1,
+                        'is_edit_my_page'       => 0,
+                        'required'              => 1,                           // 設定するけど is_fixed_column=1 はおそらく参照しない
+                        'display_sequence'      => 2,
+                    ],
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::user_email,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_email),
+                        'is_fixed_column'       => 1,
+                        'is_show_auto_regist'   => 1,
+                        'is_show_my_page'       => 1,
+                        'is_edit_my_page'       => 1,
+                        'required'              => 1,
+                        'display_sequence'      => 3,
+                    ],
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::user_password,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_password),
+                        'is_fixed_column'       => 1,
+                        'is_show_auto_regist'   => 1,
+                        'is_show_my_page'       => 0,
+                        'is_edit_my_page'       => 1,
+                        'required'              => 1,
+                        'display_sequence'      => 4,
+                    ],
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::created_at,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::created_at),
+                        'is_fixed_column'       => 0,
+                        'is_show_auto_regist'   => 0,
+                        'is_show_my_page'       => 1,
+                        'is_edit_my_page'       => 0,
+                        'required'              => 0,
+                        'display_sequence'      => 5,
+                    ],
+                ]);
+
+                foreach ($users_columns as $users_column) {
+                    $users_column->display_sequence = $users_column->display_sequence + 5;
+                    $users_column->save();
+                }
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,8 @@ class DatabaseSeeder extends Seeder
         $this->call(DefaultPagesTableSeeder::class);
         $this->call(DefaultUsersTableSeeder::class);
         $this->call(DefaultUsersRolesTableSeeder::class);
+        $this->call(DefaultUsersColumnsSetTableSeeder::class);
+        $this->call(DefaultUsersColumnsTableSeeder::class);
         $this->call(DefaultConfigsTableSeeder::class);
         $this->call(DefaultPluginsTableSeeder::class);
         $this->call(DefaultReservationsTableSeeder::class);

--- a/database/seeders/DefaultUsersColumnsSetTableSeeder.php
+++ b/database/seeders/DefaultUsersColumnsSetTableSeeder.php
@@ -36,6 +36,5 @@ class DefaultUsersColumnsSetTableSeeder extends Seeder
                 'display_sequence' => 1,
             ]);
         }
-
     }
 }

--- a/database/seeders/DefaultUsersColumnsTableSeeder.php
+++ b/database/seeders/DefaultUsersColumnsTableSeeder.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+use App\Enums\UserColumnType;
+use App\Models\Core\UsersColumns;
+use App\Models\Core\UsersColumnsSet;
+
+/**
+ * UsersColumnsSet系のSeeder
+ *
+ * 基本は、下記マイグレーションでデータ投入します。
+ * database\migrations\2023_08_10_114737_migration_fixed_column_from_users_columns.php
+ * DefaultUsersColumnsSetTableSeeder の後に実行する必要があります。
+ *
+ * もしDBの全データ削除（Truncate）した場合等に、基本データを投入するためのSeederです。
+ */
+class DefaultUsersColumnsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $columns_sets = UsersColumnsSet::get();
+        foreach ($columns_sets as $columns_set) {
+            if (UsersColumns::where('columns_set_id', $columns_set->id)->where('column_type', UserColumnType::user_name)->count() == 0) {
+                UsersColumns::insert([
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::user_name,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_name),
+                        'is_fixed_column'       => 1,
+                        'is_show_auto_regist'   => 1,
+                        'is_show_my_page'       => 1,
+                        'is_edit_my_page'       => 0,
+                        'required'              => 1,
+                        'display_sequence'      => 1,
+                    ],
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::login_id,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::login_id),
+                        'is_fixed_column'       => 1,                           // (画面からいじれない項目)
+                        'is_show_auto_regist'   => 1,
+                        'is_show_my_page'       => 1,
+                        'is_edit_my_page'       => 0,
+                        'required'              => 1,                           // 設定するけど is_fixed_column=1 はおそらく参照しない
+                        'display_sequence'      => 2,
+                    ],
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::user_email,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_email),
+                        'is_fixed_column'       => 1,
+                        'is_show_auto_regist'   => 1,
+                        'is_show_my_page'       => 1,
+                        'is_edit_my_page'       => 1,
+                        'required'              => 1,
+                        'display_sequence'      => 3,
+                    ],
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::user_password,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_password),
+                        'is_fixed_column'       => 1,
+                        'is_show_auto_regist'   => 1,
+                        'is_show_my_page'       => 0,
+                        'is_edit_my_page'       => 1,
+                        'required'              => 1,
+                        'display_sequence'      => 4,
+                    ],
+                    [
+                        'columns_set_id'        => $columns_set->id,
+                        'column_type'           => UserColumnType::created_at,
+                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::created_at),
+                        'is_fixed_column'       => 0,
+                        'is_show_auto_regist'   => 0,
+                        'is_show_my_page'       => 1,
+                        'is_edit_my_page'       => 0,
+                        'required'              => 0,
+                        'display_sequence'      => 5,
+                    ],
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/DefaultUsersColumnsTableSeeder.php
+++ b/database/seeders/DefaultUsersColumnsTableSeeder.php
@@ -29,6 +29,11 @@ class DefaultUsersColumnsTableSeeder extends Seeder
         $columns_sets = UsersColumnsSet::get();
         foreach ($columns_sets as $columns_set) {
             if (UsersColumns::where('columns_set_id', $columns_set->id)->where('column_type', UserColumnType::user_name)->count() == 0) {
+
+                // 固定項目を項目順の頭に追加して、追加項目はその後の表示順に更新する事で、現在の並び順を再現する。
+
+                $users_columns = UsersColumns::where('columns_set_id', $columns_set->id)->orderBy('display_sequence')->get();
+
                 UsersColumns::insert([
                     [
                         'columns_set_id'        => $columns_set->id,
@@ -86,6 +91,11 @@ class DefaultUsersColumnsTableSeeder extends Seeder
                         'display_sequence'      => 5,
                     ],
                 ]);
+
+                foreach ($users_columns as $users_column) {
+                    $users_column->display_sequence = $users_column->display_sequence + 5;
+                    $users_column->save();
+                }
             }
         }
     }

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -102,109 +102,121 @@ use App\Models\Core\UsersColumns;
         <input type="hidden" name="columns_set_id" value="{{$columns_set_id}}">
     @endif
 
-    <div class="form-group row">
-        <label for="name" class="col-md-4 col-form-label text-md-right">ユーザ名 <label class="badge badge-danger">必須</label></label>
-
-        <div class="col-md-8">
-            <input id="name" type="text" class="form-control @if ($errors->has('name')) border-danger @endif" name="name" value="{{ old('name', $user->name) }}" placeholder="{{ __('messages.input_user_name') }}" required>
-            @include('plugins.common.errors_inline', ['name' => 'name'])
-        </div>
-    </div>
-
-    <div class="form-group row">
-        <label for="userid" class="col-md-4 col-form-label text-md-right">ログインID <label class="badge badge-danger">必須</label></label>
-
-        <div class="col-md-8">
-            <input id="userid" type="text" class="form-control @if ($errors->has('userid')) border-danger @endif" name="userid" value="{{ old('userid', $user->userid) }}" placeholder="{{ __('messages.input_login_id') }}" required>
-            @include('plugins.common.errors_inline', ['name' => 'userid'])
-        </div>
-    </div>
-
-    @if (Auth::user() && Auth::user()->can('admin_user'))
-        {{-- 管理者によるユーザ登録 --}}
-        <div class="form-group row">
-            <label for="email" class="col-md-4 col-form-label text-md-right">eメールアドレス</label>
-
-            <div class="col-md-8">
-                <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email', $user->email) }}" placeholder="{{ __('messages.input_email') }}">
-                @include('plugins.common.errors_inline', ['name' => 'email'])
-                @if (!$is_function_edit)
-                    <small class="text-muted">
-                        ※ 登録時にeメールアドレスがある場合、登録メール送信画面に移動します。<br />
-                    </small>
-                @endif
-            </div>
-        </div>
-    @else
-        {{-- 自動登録 --}}
-        <div class="form-group row">
-            <label for="email" class="col-md-4 col-form-label text-md-right">eメールアドレス <label class="badge badge-danger">必須</label></label>
-
-            <div class="col-md-8">
-                <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email', $user->email) }}" placeholder="{{ __('messages.input_email') }}" required>
-                @include('plugins.common.errors_inline', ['name' => 'email'])
-            </div>
-        </div>
-    @endif
-
-    <div class="form-group row">
-        @if ($is_function_edit)
-            <label for="password" class="col-md-4 col-form-label text-md-right">パスワード</label>
-        @else
-            <label for="password" class="col-md-4 col-form-label text-md-right">パスワード <label class="badge badge-danger">必須</label></label>
-        @endif
-
-        <div class="col-md-8">
-            @if ($is_function_edit)
-                <input id="password" type="password" class="form-control @if ($errors->has('password')) border-danger @endif" name="password" autocomplete="new-password" placeholder="{{ __('messages.input_password') }}">
-            @else
-                <input id="password" type="password" class="form-control @if ($errors->has('password')) border-danger @endif" name="password" autocomplete="new-password" required placeholder="{{ __('messages.input_password') }}">
-            @endif
-
-            @if ($errors->has('password'))
-                @foreach ($errors->get('password') as $error)
-                    <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$error}}</div>
-                @endforeach
-            @endif
-        </div>
-    </div>
-
-    <div class="form-group row">
-        @if ($is_function_edit)
-            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">確認用パスワード</label>
-        @else
-            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">確認用パスワード <label class="badge badge-danger">必須</label></label>
-        @endif
-
-        <div class="col-md-8">
-            @if ($is_function_edit)
-                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" placeholder="{{ __('messages.input_password_confirm') }}">
-            @else
-                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required placeholder="{{ __('messages.input_password_confirm') }}">
-            @endif
-        </div>
-    </div>
-
     {{-- ユーザーの追加カラム --}}
-    @foreach($users_columns as $users_column)
-        @php
-            // ラジオとチェックボックスは選択肢にラベルを使っているため、項目名のラベルにforを付けない
-            if (UsersColumns::isChoicesColumnType($users_column->column_type)) {
-                $label_for = '';
-                $label_class = 'pt-0';
-            } else {
-                $label_for = 'for=user-column-' . $users_column->id;
-                $label_class = '';
-            }
-        @endphp
-
-        <div class="form-group row">
-            <label class="col-md-4 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$users_column->column_name}} @if ($users_column->required)<span class="badge badge-danger">必須</span> @endif</label>
-            <div class="col-md-8">
-                @include('auth.registe_form_input_' . $users_column->column_type, ['user_obj' => $users_column, 'label_id' => 'user-column-'.$users_column->id])
-                <div class="small {{ $users_column->caption_color }}">{!! nl2br((string)$users_column->caption) !!}</div>
+    @foreach($users_columns as $column)
+        @if ($column->column_type == UserColumnType::user_name)
+            {{-- ユーザ名 --}}
+            <div class="form-group row">
+                <label for="name" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                <div class="col-md-8">
+                    <input id="name" type="text" class="form-control @if ($errors->has('name')) border-danger @endif" name="name" value="{{ old('name', $user->name) }}" placeholder="{{ $column->place_holder ?? __('messages.input_user_name') }}" required>
+                    @include('plugins.common.errors_inline', ['name' => 'name'])
+                    <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                </div>
             </div>
-        </div>
+
+        @elseif ($column->column_type == UserColumnType::login_id)
+            {{-- ログインID --}}
+            <div class="form-group row">
+                <label for="userid" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                <div class="col-md-8">
+                    <input id="userid" type="text" class="form-control @if ($errors->has('userid')) border-danger @endif" name="userid" value="{{ old('userid', $user->userid) }}" placeholder="{{ $column->place_holder ?? __('messages.input_login_id') }}" required>
+                    @include('plugins.common.errors_inline', ['name' => 'userid'])
+                    <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                </div>
+            </div>
+
+        @elseif ($column->column_type == UserColumnType::user_email)
+            {{-- メールアドレス --}}
+            @if (Auth::user() && Auth::user()->can('admin_user'))
+                {{-- 管理者によるユーザ登録 --}}
+                <div class="form-group row">
+                    <label for="email" class="col-md-4 col-form-label text-md-right">{{$column->column_name}}</label>
+                    <div class="col-md-8">
+                        <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email', $user->email) }}" placeholder="{{ $column->place_holder ?? __('messages.input_email') }}">
+                        @include('plugins.common.errors_inline', ['name' => 'email'])
+                        @if (!$is_function_edit)
+                            <small class="text-muted">
+                                ※ 登録時に{{$column->column_name}}がある場合、登録メール送信画面に移動します。<br />
+                            </small>
+                        @endif
+                        <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                    </div>
+                </div>
+            @else
+                {{-- 自動登録 --}}
+                <div class="form-group row">
+                    <label for="email" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                    <div class="col-md-8">
+                        <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email', $user->email) }}" placeholder="{{ $column->place_holder ?? __('messages.input_email') }}" required>
+                        @include('plugins.common.errors_inline', ['name' => 'email'])
+                        <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                    </div>
+                </div>
+            @endif
+
+        @elseif ($column->column_type == UserColumnType::user_password)
+            {{-- パスワード --}}
+            <div class="form-group row">
+                @if ($is_function_edit)
+                    <label for="password" class="col-md-4 col-form-label text-md-right">{{$column->column_name}}</label>
+                @else
+                    <label for="password" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                @endif
+                <div class="col-md-8">
+                    @if ($is_function_edit)
+                        <input id="password" type="password" class="form-control @if ($errors->has('password')) border-danger @endif" name="password" autocomplete="new-password" placeholder="{{ $column->place_holder ?? __('messages.input_password') }}">
+                    @else
+                        <input id="password" type="password" class="form-control @if ($errors->has('password')) border-danger @endif" name="password" autocomplete="new-password" required placeholder="{{ $column->place_holder ?? __('messages.input_password') }}">
+                    @endif
+                    @if ($errors->has('password'))
+                        @foreach ($errors->get('password') as $error)
+                            <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$error}}</div>
+                        @endforeach
+                    @endif
+                </div>
+            </div>
+
+            <div class="form-group row">
+                @if ($is_function_edit)
+                    <label for="password-confirm" class="col-md-4 col-form-label text-md-right">確認用{{$column->column_name}}</label>
+                @else
+                    <label for="password-confirm" class="col-md-4 col-form-label text-md-right">確認用{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                @endif
+                <div class="col-md-8">
+                    @if ($is_function_edit)
+                        <input id="password-confirm" type="password" class="form-control" name="password_confirmation" placeholder="{{ $column->place_holder ?? __('messages.input_password_confirm') }}">
+                    @else
+                        <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required placeholder="{{ $column->place_holder ?? __('messages.input_password_confirm') }}">
+                    @endif
+                    <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                </div>
+            </div>
+
+        @elseif ($column->column_type == UserColumnType::created_at)
+            {{-- 表示しない --}}
+        @elseif ($column->column_type == UserColumnType::updated_at)
+            {{-- 表示しない --}}
+        @else
+            @php
+                // ラジオとチェックボックスは選択肢にラベルを使っているため、項目名のラベルにforを付けない
+                if (UsersColumns::isChoicesColumnType($column->column_type)) {
+                    $label_for = '';
+                    $label_class = 'pt-0';
+                } else {
+                    $label_for = 'for=user-column-' . $column->id;
+                    $label_class = '';
+                }
+            @endphp
+
+            <div class="form-group row">
+                <label class="col-md-4 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$column->column_name}} @if ($column->required)<span class="badge badge-danger">必須</span> @endif</label>
+                <div class="col-md-8">
+                    @include('auth.registe_form_input_' . $column->column_type, ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
+                    <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                </div>
+            </div>
+        @endif
     @endforeach
 
     {{-- 未ログイン（自動登録）時に個人情報保護方針への同意関係が設定されている場合 --}}

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -46,7 +46,7 @@ use App\Models\Core\UsersColumns;
 
     @if (Auth::user() && Auth::user()->can('admin_user'))
         <div class="form-group row">
-            <label for="name" class="col-md-4 col-form-label text-md-right">状態 <label class="badge badge-danger">必須</label></label>
+            <label for="name" class="col-md-4 col-form-label text-md-right">状態 <span class="badge badge-danger">必須</span></label>
             <div class="col-md-8 d-sm-flex align-items-center">
                 @foreach (UserStatus::getMembers() as $enum_value => $enum_label)
                     <div class="custom-control custom-radio custom-control-inline">
@@ -107,7 +107,7 @@ use App\Models\Core\UsersColumns;
         @if ($column->column_type == UserColumnType::user_name)
             {{-- ユーザ名 --}}
             <div class="form-group row">
-                <label for="name" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                <label for="name" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-8">
                     <input id="name" type="text" class="form-control @if ($errors->has('name')) border-danger @endif" name="name" value="{{ old('name', $user->name) }}" placeholder="{{ $column->place_holder ?? __('messages.input_user_name') }}" required>
                     @include('plugins.common.errors_inline', ['name' => 'name'])
@@ -118,7 +118,7 @@ use App\Models\Core\UsersColumns;
         @elseif ($column->column_type == UserColumnType::login_id)
             {{-- ログインID --}}
             <div class="form-group row">
-                <label for="userid" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                <label for="userid" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-8">
                     <input id="userid" type="text" class="form-control @if ($errors->has('userid')) border-danger @endif" name="userid" value="{{ old('userid', $user->userid) }}" placeholder="{{ $column->place_holder ?? __('messages.input_login_id') }}" required>
                     @include('plugins.common.errors_inline', ['name' => 'userid'])
@@ -146,7 +146,7 @@ use App\Models\Core\UsersColumns;
             @else
                 {{-- 自動登録 --}}
                 <div class="form-group row">
-                    <label for="email" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                    <label for="email" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <span class="badge badge-danger">必須</span></label>
                     <div class="col-md-8">
                         <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email', $user->email) }}" placeholder="{{ $column->place_holder ?? __('messages.input_email') }}" required>
                         @include('plugins.common.errors_inline', ['name' => 'email'])
@@ -161,13 +161,13 @@ use App\Models\Core\UsersColumns;
                 @if ($is_function_edit)
                     <label for="password" class="col-md-4 col-form-label text-md-right">{{$column->column_name}}</label>
                 @else
-                    <label for="password" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                    <label for="password" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <span class="badge badge-danger">必須</span></label>
                 @endif
                 <div class="col-md-8">
                     @if ($is_function_edit)
-                        <input id="password" type="password" class="form-control @if ($errors->has('password')) border-danger @endif" name="password" autocomplete="new-password" placeholder="{{ $column->place_holder ?? __('messages.input_password') }}">
+                        <input id="password" type="password" class="form-control @if ($errors->has('password')) border-danger @endif" name="password" autocomplete="new-password" placeholder="{{ __('messages.input_password') }}">
                     @else
-                        <input id="password" type="password" class="form-control @if ($errors->has('password')) border-danger @endif" name="password" autocomplete="new-password" required placeholder="{{ $column->place_holder ?? __('messages.input_password') }}">
+                        <input id="password" type="password" class="form-control @if ($errors->has('password')) border-danger @endif" name="password" autocomplete="new-password" required placeholder="{{ __('messages.input_password') }}">
                     @endif
                     @if ($errors->has('password'))
                         @foreach ($errors->get('password') as $error)
@@ -181,13 +181,13 @@ use App\Models\Core\UsersColumns;
                 @if ($is_function_edit)
                     <label for="password-confirm" class="col-md-4 col-form-label text-md-right">確認用{{$column->column_name}}</label>
                 @else
-                    <label for="password-confirm" class="col-md-4 col-form-label text-md-right">確認用{{$column->column_name}} <label class="badge badge-danger">必須</label></label>
+                    <label for="password-confirm" class="col-md-4 col-form-label text-md-right">確認用{{$column->column_name}} <span class="badge badge-danger">必須</span></label>
                 @endif
                 <div class="col-md-8">
                     @if ($is_function_edit)
-                        <input id="password-confirm" type="password" class="form-control" name="password_confirmation" placeholder="{{ $column->place_holder ?? __('messages.input_password_confirm') }}">
+                        <input id="password-confirm" type="password" class="form-control" name="password_confirmation" placeholder="{{ __('messages.input_password_confirm') }}">
                     @else
-                        <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required placeholder="{{ $column->place_holder ?? __('messages.input_password_confirm') }}">
+                        <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required placeholder="{{ __('messages.input_password_confirm') }}">
                     @endif
                     <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
                 </div>
@@ -223,7 +223,7 @@ use App\Models\Core\UsersColumns;
     @if (!Auth::user())
         @if (Configs::getConfigsValue($configs, "user_register_requre_privacy") == 1)
             <div class="form-group row">
-                <label for="password-confirm" class="col-md-4 col-form-label text-md-right pt-0">個人情報保護方針への同意  <label class="badge badge-danger">必須</label></label>
+                <label for="password-confirm" class="col-md-4 col-form-label text-md-right pt-0">個人情報保護方針への同意  <span class="badge badge-danger">必須</span></label>
 
                 <div class="col-md-8">
                     <div class="custom-control custom-checkbox custom-control-inline">

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -57,7 +57,10 @@
                         @endif
                         <label class="custom-control-label" for="user_register_enable_off" id="label_user_register_enable_off">許可しない</label>
                     </div>
-                    <small class="form-text text-muted">自動ユーザ登録を使用するかどうかを選択</small>
+                    <small class="form-text text-muted">
+                        ※ 自動ユーザ登録を使用するかどうかを選択<br />
+                        ※ 自動ユーザ登録時に登録させる項目は [ <a href="{{ url('/manage/user/editColumns/'. $columns_set_id) }}">項目設定</a> ] の「詳細」からそれぞれ設定してください。<br />
+                    </small>
                 </div>
             </div>
 

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -5,6 +5,9 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category ユーザ管理
 --}}
+@php
+use App\Models\Core\UsersColumns;
+@endphp
 {{-- 管理画面ベース画面 --}}
 @extends('plugins.manage.manage')
 
@@ -12,18 +15,14 @@
 @section('manage_content')
 
 <script type="text/javascript">
-    /**
-     * 選択肢追加ボタン押下
-     */
+    /** 選択肢追加ボタン押下 */
     function submit_add_select(btn) {
         form_selects.action = "{{url('/')}}/manage/user/addSelect";
         btn.disabled = true;
         form_selects.submit();
     }
 
-    /**
-     * 表示順操作ボタン押下
-     */
+    /** 表示順操作ボタン押下 */
     function submit_display_sequence(select_id, display_sequence, display_sequence_operation) {
         form_selects.action = "{{url('/')}}/manage/user/updateSelectSequence";
         form_selects.select_id.value = select_id;
@@ -32,35 +31,27 @@
         form_selects.submit();
     }
 
-    /**
-     * 選択肢の更新ボタン押下
-     */
+    /** 選択肢の更新ボタン押下 */
     function submit_update_select(select_id) {
         form_selects.action = "{{url('/')}}/manage/user/updateSelect";
         form_selects.select_id.value = select_id;
         form_selects.submit();
     }
 
-    /**
-     * 同意内容の更新ボタン押下
-     */
+    /** 同意内容の更新ボタン押下 */
      function submit_update_agree(select_id) {
         form_selects.action = "{{url('/')}}/manage/user/updateAgree";
         form_selects.select_id.value = select_id;
         form_selects.submit();
     }
 
-    /**
-     * その他の設定の更新ボタン押下
-     */
+    /** その他の設定の更新ボタン押下 */
     function submit_update_column_detail() {
         form_selects.action = "{{url('/')}}/manage/user/updateColumnDetail";
         form_selects.submit();
     }
 
-    /**
-     * 選択肢の削除ボタン押下
-     */
+    /** 選択肢の削除ボタン押下 */
      function submit_delete_select(select_id) {
         if (confirm('選択肢を削除します。\nよろしいですか？')){
             form_selects.action = "{{url('/')}}/manage/user/deleteSelect";
@@ -70,19 +61,14 @@
         return false;
     }
 
-
-    /**
-     * 組織追加ボタン押下
-     */
+    /** 組織追加ボタン押下 */
      function submit_add_section(btn) {
         form_selects.action = "{{url('/')}}/manage/user/addSection";
         btn.disabled = true;
         form_selects.submit();
     }
 
-    /**
-     * 表示順操作ボタン押下
-     */
+    /** 表示順操作ボタン押下 */
     function submit_section_display_sequence(section_id, display_sequence, display_sequence_operation) {
         form_selects.action = "{{url('/')}}/manage/user/updateSectionSequence";
         form_selects.section_id.value = section_id;
@@ -91,18 +77,14 @@
         form_selects.submit();
     }
 
-    /**
-     * 組織の更新ボタン押下
-     */
+    /** 組織の更新ボタン押下 */
     function submit_update_section(section_id) {
         form_selects.action = "{{url('/')}}/manage/user/updateSection";
         form_selects.section_id.value = section_id;
         form_selects.submit();
     }
 
-    /**
-     * 組織の削除ボタン押下
-     */
+    /** 組織の削除ボタン押下 */
      function submit_delete_section(section_id) {
         if (confirm('組織を削除します。\nよろしいですか？')){
             form_selects.action = "{{url('/')}}/manage/user/deleteSection";
@@ -158,7 +140,7 @@
                 $column->column_type == UserColumnType::checkbox
                 )
                 {{-- 選択肢の設定 --}}
-                <div class="card mb-4">
+                <div class="card form-group">
                     <h5 class="card-header">選択肢の設定</h5>
                     <div class="card-body">
 
@@ -246,7 +228,7 @@
 
             @if ($column->column_type == UserColumnType::agree)
                 {{-- 同意内容の設定 --}}
-                <div class="card mb-4">
+                <div class="card form-group">
                     <h5 class="card-header">同意内容の設定</h5>
                     <div class="card-body">
 
@@ -282,7 +264,7 @@
 
             @if ($column->column_type == UserColumnType::text || $column->column_type == UserColumnType::textarea || $column->column_type == UserColumnType::mail)
                 {{-- チェック処理の設定 --}}
-                <div class="card mb-4" id="div_rule">
+                <div class="card form-group" id="div_rule">
                     <h5 class="card-header">チェック処理の設定</h5>
                     <div class="card-body">
                         {{-- 1行文字列型／複数行文字列型のチェック群 --}}
@@ -373,12 +355,12 @@
                                 <label class="col-md-3 col-form-label text-md-right">正規表現</label>
                                 <div class="col-md-9 align-items-center">
                                     <input type="text" name="rule_regex" value="{{old('rule_regex', $column->rule_regex)}}" class="form-control">
+                                    @if ($errors && $errors->has('rule_regex')) <div class="text-danger">{{$errors->first('rule_regex')}}</div> @endif
                                     <small class="text-muted">
                                         ※ エラーメッセージは「正しい形式の＜項目名＞を指定してください。」と表示されるため、併せてキャプションの設定をする事をオススメします。<br>
                                         ※ （設定例：電話番号ハイフンあり）/0\d{1,4}-\d{1,4}-\d{4}/<br>
                                         ※ （設定例：指定ドメインのメールアドレスのみ）/@example\.com$/<br>
                                     </small>
-                                    @if ($errors && $errors->has('rule_regex')) <div class="text-danger">{{$errors->first('rule_regex')}}</div> @endif
                                 </div>
                             </div>
                         @endif
@@ -396,7 +378,7 @@
             {{-- 所属型 --}}
             @if ($column->column_type == UserColumnType::affiliation)
                 {{-- 選択肢の設定 --}}
-                <div class="card mb-4">
+                <div class="card form-group">
                     <h5 class="card-header">選択肢の設定</h5>
                     <div class="card-body">
 
@@ -495,32 +477,171 @@
                 </div>
             @endif
 
-            {{-- キャプション設定 --}}
-            <div class="card mb-4" id="div_caption">
-                <h5 class="card-header">キャプションの設定</h5>
+            @if ($column->column_type == UserColumnType::created_at || $column->column_type == UserColumnType::updated_at)
+                {{-- 表示しない --}}
+            @else
+                {{-- キャプション設定 --}}
+                <div class="card form-group" id="div_caption">
+                    <h5 class="card-header">キャプションの設定</h5>
+                    <div class="card-body">
+
+                        {{-- キャプション内容 --}}
+                        <div class="form-group row">
+                            <label class="col-md-3 col-form-label text-md-right pt-0">内容 </label>
+                            <div class="col-md-9 align-items-center">
+                                <textarea name="caption" class="form-control" rows="3">{{old('caption', $column->caption)}}</textarea>
+                            </div>
+                        </div>
+
+                        {{-- キャプション文字色 --}}
+                        <div class="form-group row">
+                            <label class="col-md-3 col-form-label text-md-right">文字色 </label>
+                            <div class="col-md-9 align-items-center">
+                                <select class="form-control" name="caption_color">
+                                    @foreach (Bs4TextColor::getMembers() as $key=>$value)
+                                        <option value="{{$key}}" class="{{ $key }}" @if($key == old('caption_color', $column->caption_color)) selected @endif>
+                                            {{ $value }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+
+                        {{-- ボタンエリア --}}
+                        <div class="form-group text-center">
+                            <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary database-horizontal">
+                                <i class="fas fa-check"></i> 更新
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                @if (
+                    $column->column_type == UserColumnType::text ||
+                    $column->column_type == UserColumnType::textarea ||
+                    $column->column_type == UserColumnType::mail ||
+                    $column->column_type == UserColumnType::user_name ||
+                    $column->column_type == UserColumnType::login_id ||
+                    $column->column_type == UserColumnType::user_email
+                    )
+                    {{-- プレースホルダ設定 --}}
+                    <div class="card form-group">
+                        <h5 class="card-header">プレースホルダの設定</h5>
+                        <div class="card-body">
+
+                            {{-- プレースホルダ内容 --}}
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right">内容 </label>
+                                <div class="col-md-9 align-items-center">
+                                    <input type="text" name="place_holder" class="form-control" value="{{old('place_holder', $column->place_holder)}}">
+                                    @if ($column->column_type == UserColumnType::user_name)
+                                        <small class="text-muted">※ 未設定の場合「{{__('messages.input_user_name')}}」（多言語対応）を表示します。設定した場合、英日どちらでも同じ設定値を表示します。</small>
+                                    @elseif ($column->column_type == UserColumnType::login_id)
+                                        <small class="text-muted">※ 未設定の場合「{{__('messages.input_login_id')}}」（多言語対応）を表示します。設定した場合、英日どちらでも同じ設定値を表示します。</small>
+                                    @elseif ($column->column_type == UserColumnType::user_email)
+                                        <small class="text-muted">※ 未設定の場合「{{__('messages.input_email')}}」（多言語対応）を表示します。設定した場合、英日どちらでも同じ設定値を表示します。</small>
+                                    @endif
+                                </div>
+                            </div>
+
+                            {{-- ボタンエリア --}}
+                            <div class="form-group text-center">
+                                <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
+                            </div>
+                        </div>
+                    </div>
+                @endif
+            @endif
+
+            {{-- 表示・編集設定 --}}
+            <div class="card form-group">
+                <h5 class="card-header">表示・編集設定</h5>
                 <div class="card-body">
 
-                    {{-- キャプション内容 --}}
-                    <div class="form-group row">
-                        <label class="col-md-3 col-form-label text-md-right pt-0">内容 </label>
-                        <div class="col-md-9 align-items-center">
-                            <textarea name="caption" class="form-control" rows="3">{{old('caption', $column->caption)}}</textarea>
-                        </div>
-                    </div>
-
-                    {{-- キャプション文字色 --}}
-                    <div class="form-group row">
-                        <label class="col-md-3 col-form-label text-md-right">文字色 </label>
-                        <div class="col-md-9 align-items-center">
-                            <select class="form-control" name="caption_color">
-                                @foreach (Bs4TextColor::getMembers() as $key=>$value)
-                                    <option value="{{$key}}" class="{{ $key }}" @if($key == old('caption_color', $column->caption_color)) selected @endif>
-                                        {{ $value }}
-                                    </option>
+                    @if ($column->column_type == UserColumnType::created_at || $column->column_type == UserColumnType::updated_at)
+                        {{-- 表示しない --}}
+                    @else
+                        {{-- 自動ユーザ登録時の表示指定 --}}
+                        <div class="form-group row">
+                            <label class="col-md-3 col-form-label text-md-right pt-0">自動ユーザ登録時の表示指定</label>
+                            <div class="col-md-9 align-items-center">
+                                @php
+                                    $show_auto_regist_disabled = '';
+                                    if (UsersColumns::isFixedColumnType($column->column_type) || $column->required == Required::on) {
+                                        $show_auto_regist_disabled = 'disabled';
+                                    }
+                                @endphp
+                                @if ($show_auto_regist_disabled)
+                                    <input type="hidden" name="is_show_auto_regist" value="{{$column->is_show_auto_regist}}">
+                                @endif
+                                @foreach (ShowType::getMembers() as $enum_value => $enum_label)
+                                    <div class="custom-control custom-radio custom-control-inline">
+                                        @if ($column->is_show_auto_regist == $enum_value)
+                                            <input type="radio" value="{{$enum_value}}" id="is_show_auto_regist_{{$enum_value}}" name="is_show_auto_regist" class="custom-control-input" checked="checked" {{$show_auto_regist_disabled}}>
+                                        @else
+                                            <input type="radio" value="{{$enum_value}}" id="is_show_auto_regist_{{$enum_value}}" name="is_show_auto_regist" class="custom-control-input" {{$show_auto_regist_disabled}}>
+                                        @endif
+                                        {{-- duskでradioの選択にlabelのid必要 --}}
+                                        <label class="custom-control-label" for="is_show_auto_regist_{{$enum_value}}" id="label_is_show_auto_regist_{{$enum_value}}">{{$enum_label}}</label>
+                                    </div>
                                 @endforeach
-                            </select>
+                                <br />
+                                <small class="text-muted">※ 自動ユーザ登録時に表示するか設定できます。<br /></small>
+                                @if ($column->required == Required::on)
+                                    <small class="text-danger">※ 必須入力の場合、表示指定を変更できません。<br /></small>
+                                @endif
+                            </div>
                         </div>
-                    </div>
+                    @endif
+
+                    @if ($column->column_type == UserColumnType::user_password)
+                        {{-- 表示しない --}}
+                        <input type="hidden" name="is_show_my_page" value="{{ShowType::not_show}}">
+                    @else
+                        {{-- マイページの表示指定 --}}
+                        <div class="form-group row">
+                            <label class="col-md-3 col-form-label text-md-right pt-0">マイページの表示指定</label>
+                            <div class="col-md-9 align-items-center">
+                                @foreach (ShowType::getMembers() as $enum_value => $enum_label)
+                                    <div class="custom-control custom-radio custom-control-inline">
+                                        @if ($column->is_show_my_page == $enum_value)
+                                            <input type="radio" value="{{$enum_value}}" id="is_show_my_page_{{$enum_value}}" name="is_show_my_page" class="custom-control-input" checked="checked">
+                                        @else
+                                            <input type="radio" value="{{$enum_value}}" id="is_show_my_page_{{$enum_value}}" name="is_show_my_page" class="custom-control-input">
+                                        @endif
+                                        {{-- duskでradioの選択にlabelのid必要 --}}
+                                        <label class="custom-control-label" for="is_show_my_page_{{$enum_value}}" id="label_is_show_my_page_{{$enum_value}}">{{$enum_label}}</label>
+                                    </div>
+                                @endforeach
+                                <br />
+                                <small class="text-muted">※ マイページでユーザ自身に表示するか設定できます。</small>
+                            </div>
+                        </div>
+                    @endif
+
+                    @if ($column->column_type == UserColumnType::created_at || $column->column_type == UserColumnType::updated_at)
+                        {{-- 表示しない --}}
+                    @else
+                        {{-- マイページの編集指定 --}}
+                        <div class="form-group row">
+                            <label class="col-md-3 col-form-label text-md-right pt-0">マイページの編集指定</label>
+                            <div class="col-md-9 align-items-center">
+                                @foreach (EditType::getMembers() as $enum_value => $enum_label)
+                                    <div class="custom-control custom-radio custom-control-inline">
+                                        @if ($column->is_edit_my_page == $enum_value)
+                                            <input type="radio" value="{{$enum_value}}" id="is_edit_my_page_{{$enum_value}}" name="is_edit_my_page" class="custom-control-input" checked="checked">
+                                        @else
+                                            <input type="radio" value="{{$enum_value}}" id="is_edit_my_page_{{$enum_value}}" name="is_edit_my_page" class="custom-control-input">
+                                        @endif
+                                        {{-- duskでradioの選択にlabelのid必要 --}}
+                                        <label class="custom-control-label" for="is_edit_my_page_{{$enum_value}}" id="label_is_edit_my_page_{{$enum_value}}">{{$enum_label}}</label>
+                                    </div>
+                                @endforeach
+                                <br />
+                                <small class="text-muted">※ マイページ＞マイプロフィール変更でユーザ自身に編集させるか設定できます。</small>
+                            </div>
+                        </div>
+                    @endif
 
                     {{-- ボタンエリア --}}
                     <div class="form-group text-center">
@@ -530,33 +651,6 @@
                     </div>
                 </div>
             </div>
-
-            @if (
-                $column->column_type == UserColumnType::text ||
-                $column->column_type == UserColumnType::textarea ||
-                $column->column_type == UserColumnType::mail
-                )
-                {{-- プレースホルダ設定 --}}
-                <div class="card mb-4">
-                    <h5 class="card-header">プレースホルダの設定</h5>
-                    <div class="card-body">
-
-                        {{-- プレースホルダ内容 --}}
-                        <div class="form-group row">
-                            <label class="col-md-3 col-form-label text-md-right">内容 </label>
-                            <div class="col-md-9 align-items-center">
-                                <input type="text" name="place_holder" class="form-control" value="{{old('place_holder', $column->place_holder)}}">
-                            </div>
-                        </div>
-
-                        {{-- ボタンエリア --}}
-                        <div class="form-group text-center">
-                            <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
-                        </div>
-                    </div>
-                </div>
-                <br>
-            @endif
 
             {{-- ボタンエリア --}}
             <div class="form-group text-center">

--- a/resources/views/plugins/manage/user/edit_columns.blade.php
+++ b/resources/views/plugins/manage/user/edit_columns.blade.php
@@ -12,27 +12,21 @@
 @section('manage_content')
 
 <script type="text/javascript">
-    /**
-     * 項目の追加
-     */
+    /** 項目の追加 */
     function submit_add_column(btn) {
         form_columns.action = "{{url('/')}}/manage/user/addColumn";
         btn.disabled = true;
         form_columns.submit();
     }
 
-    /**
-     * 項目の更新
-     */
+    /** 項目の更新 */
     function submit_update_column(column_id) {
         form_columns.action = "{{url('/')}}/manage/user/updateColumn";
         form_columns.column_id.value = column_id;
         form_columns.submit();
     }
 
-    /**
-     * 項目の表示順操作
-     */
+    /** 項目の表示順操作 */
     function submit_display_sequence(column_id, display_sequence, display_sequence_operation) {
         form_columns.action = "{{url('/')}}/manage/user/updateColumnSequence";
         form_columns.column_id.value = column_id;
@@ -41,9 +35,7 @@
         form_columns.submit();
     }
 
-    /**
-     * 項目の削除ボタン押下
-     */
+    /** 項目の削除ボタン押下 */
      function submit_delete_column(column_id) {
         if (confirm('項目を削除します。\nよろしいですか？')){
             form_columns.action = "{{url('/')}}/manage/user/deleteColumn";
@@ -155,6 +147,6 @@
     .button-wrapper .btn:disabled {
       pointer-events: none;
     }
-    </style>
+</style>
 
 @endsection

--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -23,17 +23,29 @@
         <input class="form-control @if ($errors && $errors->has('column_name_'.$column->id)) border-danger @endif" type="text" name="column_name_{{ $column->id }}" value="{{ old('column_name_'.$column->id, $column->column_name)}}">
     </td>
     {{-- 入力データ型 --}}
-    <td>
-        <select class="form-control" name="column_type_{{ $column->id }}" id="column_type_{{ $column->id }}" style="min-width: 140px;">
-            <option value="" disabled>型を指定</option>
-            @foreach (UserColumnType::getMembers() as $key=>$value)
-                <option value="{{$key}}" @if ($key == old("column_type_$column->id", $column->column_type)) selected="selected" @endif>{{ $value }}</option>
-            @endforeach
-        </select>
+    <td class="align-middle">
+        @if ($column->is_fixed_column)
+            {{-- 固定項目 --}}
+            {{UserColumnType::getDescriptionFixed($column->column_type)}}
+            <input type="hidden" name="column_type_{{ $column->id }}" value="{{$column->column_type}}">
+        @else
+            <select class="form-control" name="column_type_{{ $column->id }}" id="column_type_{{ $column->id }}" style="min-width: 140px;">
+                <option value="" disabled>型を指定</option>
+                @foreach (UserColumnType::getMembers() as $key=>$value)
+                    <option value="{{$key}}" @if ($key == old("column_type_$column->id", $column->column_type)) selected="selected" @endif>{{ $value }}</option>
+                @endforeach
+            </select>
+        @endif
     </td>
     {{-- 必須 --}}
     <td class="align-middle text-center">
-        <input type="checkbox" name="required_{{ $column->id }}" value="1" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif>
+        @if ($column->is_fixed_column || $column->column_type == UserColumnType::created_at || $column->column_type == UserColumnType::updated_at)
+            {{-- 固定項目, 登録日時, 更新日時 --}}
+            <input type="hidden" name="required_{{ $column->id }}" @if (old('required_'.$column->id, $column->required) == Required::on) value="1" @else value="0" @endif>
+            <input type="checkbox" name="required_{{ $column->id }}" value="1" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif disabled>
+        @else
+            <input type="checkbox" name="required_{{ $column->id }}" value="1" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif>
+        @endif
     </td>
     {{-- 選択肢の設定ボタン --}}
     <td class="text-center px-2">
@@ -68,6 +80,11 @@
         {{-- 所属が登録されてたら項目の削除はさせない --}}
         @if ($column->column_type == UserColumnType::affiliation && $exists_user_sections)
             <div class="button-wrapper" data-toggle="tooltip" title="{{$column->column_name}}登録済みのユーザがいるため項目を削除できません。">
+                <button class="btn btn-danger cc-font-90 text-nowrap" disabled><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+            </div>
+        @elseif ($column->is_fixed_column)
+            {{-- 固定項目 --}}
+            <div class="button-wrapper" data-toggle="tooltip" title="ユーザに必ず必要な項目のため削除できません。">
                 <button class="btn btn-danger cc-font-90 text-nowrap" disabled><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
             </div>
         @else

--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -73,15 +73,15 @@ use App\Models\Core\UsersColumns;
 
                             {{-- ログインID --}}
                             <div class="form-group row">
-                                <label for="user_search_condition_userid" class="col-md-3 col-form-label text-md-right">ログインID</label>
+                                <label for="user_search_condition_userid" class="col-md-3 col-form-label text-md-right">{{ UsersColumns::getLabelLoginId($users_columns) }}</label>
                                 <div class="col-md-9">
                                     <input type="text" name="user_search_condition[userid]" id="user_search_condition_userid" value="{{Session::get('user_search_condition.userid')}}" class="form-control">
                                 </div>
                             </div>
 
-                            {{-- ユーザー名 --}}
+                            {{-- ユーザ名 --}}
                             <div class="form-group row">
-                                <label for="user_search_condition_name" class="col-md-3 col-form-label text-md-right">ユーザー名</label>
+                                <label for="user_search_condition_name" class="col-md-3 col-form-label text-md-right">{{ UsersColumns::getLabelUserName($users_columns) }}</label>
                                 <div class="col-md-9">
                                     <input type="text" name="user_search_condition[name]" id="user_search_condition_name" value="{{Session::get('user_search_condition.name')}}" class="form-control">
                                 </div>
@@ -118,33 +118,37 @@ use App\Models\Core\UsersColumns;
                                 </div>
                             </div>
 
-                            {{-- eメール --}}
+                            {{-- メールアドレス --}}
                             <div class="form-group row">
-                                <label for="user_search_condition_email" class="col-md-3 col-form-label text-md-right">eメール</label>
+                                <label for="user_search_condition_email" class="col-md-3 col-form-label text-md-right">{{ UsersColumns::getLabelUserEmail($users_columns) }}</label>
                                 <div class="col-md-9">
                                     <input type="text" name="user_search_condition[email]" id="user_search_condition_email" value="{{Session::get('user_search_condition.email')}}" class="form-control">
                                 </div>
                             </div>
 
-                            @foreach($users_columns as $users_column)
-                                @php
-                                    // ラジオとチェックボックスは選択肢にラベルを使っているため、項目名のラベルにforを付けない
-                                    if (UsersColumns::isChoicesColumnType($users_column->column_type)) {
-                                        $label_for = '';
-                                        $label_class = 'pt-0';
-                                    } else {
-                                        $label_for = 'for=user-column-' . $users_column->id;
-                                        $label_class = '';
-                                    }
-                                @endphp
+                            @foreach($users_columns as $column)
+                                @if (UsersColumns::isLoopNotShowColumnType($column->column_type))
+                                    {{-- 表示しない --}}
+                                @else
+                                    @php
+                                        // ラジオとチェックボックスは選択肢にラベルを使っているため、項目名のラベルにforを付けない
+                                        if (UsersColumns::isChoicesColumnType($column->column_type)) {
+                                            $label_for = '';
+                                            $label_class = 'pt-0';
+                                        } else {
+                                            $label_for = 'for=user-column-' . $column->id;
+                                            $label_class = '';
+                                        }
+                                    @endphp
 
-                                {{-- 通常の項目 --}}
-                                <div class="form-group row">
-                                    <label class="col-md-3 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$users_column->column_name}}</label>
-                                    <div class="col-md-9">
-                                        @include('plugins.manage.user.list_search_' . $users_column->column_type, ['user_obj' => $users_column, 'label_id' => 'user-column-'.$users_column->id])
+                                    {{-- 通常の項目 --}}
+                                    <div class="form-group row">
+                                        <label class="col-md-3 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$column->column_name}}</label>
+                                        <div class="col-md-9">
+                                            @include('plugins.manage.user.list_search_' . $column->column_type, ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
+                                        </div>
                                     </div>
-                                </div>
+                                @endif
                             @endforeach
 
                             {{-- コンテンツ権限 --}}
@@ -238,15 +242,19 @@ use App\Models\Core\UsersColumns;
                                 <label for="sort" class="col-md-3 col-form-label text-md-right">並べ替え</label>
                                 <div class="col-md-9">
                                     <select name="user_search_condition[sort]" id="sort" class="form-control">
-                                        <option value="created_at_asc"@if(Session::get('user_search_condition.sort') == "created_at_asc" || !Session::has('user_search_condition.sort')) selected @endif>登録日時 昇順</option>
-                                        <option value="created_at_desc"@if(Session::get('user_search_condition.sort') == "created_at_desc") selected @endif>登録日時 降順</option>
-                                        <option value="updated_at_asc"@if(Session::get('user_search_condition.sort') == "updated_at_asc") selected @endif>更新日時 昇順</option>
-                                        <option value="updated_at_desc"@if(Session::get('user_search_condition.sort') == "updated_at_desc") selected @endif>更新日時 降順</option>
-                                        <option value="userid_asc"@if(Session::get('user_search_condition.sort') == "userid_asc") selected @endif>ログインID 昇順</option>
-                                        <option value="userid_desc"@if(Session::get('user_search_condition.sort') == "userid_desc") selected @endif>ログインID 降順</option>
-                                        @foreach($users_columns as $users_column)
-                                            <option value="{{$users_column->id}}_asc" @if(Session::get('user_search_condition.sort') == $users_column->id . '_asc') selected @endif>{{  $users_column->column_name  }}(昇順)</option>
-                                            <option value="{{$users_column->id}}_desc" @if(Session::get('user_search_condition.sort') == $users_column->id . '_desc') selected @endif>{{  $users_column->column_name  }}(降順)</option>
+                                        <option value="created_at_asc"@if(Session::get('user_search_condition.sort') == "created_at_asc" || !Session::has('user_search_condition.sort')) selected @endif>{{ UsersColumns::getLabelCreatedAt($users_columns) }} 昇順</option>
+                                        <option value="created_at_desc"@if(Session::get('user_search_condition.sort') == "created_at_desc") selected @endif>{{ UsersColumns::getLabelCreatedAt($users_columns) }} 降順</option>
+                                        <option value="updated_at_asc"@if(Session::get('user_search_condition.sort') == "updated_at_asc") selected @endif>{{ UsersColumns::getLabelUpdatedAt($users_columns) }} 昇順</option>
+                                        <option value="updated_at_desc"@if(Session::get('user_search_condition.sort') == "updated_at_desc") selected @endif>{{ UsersColumns::getLabelUpdatedAt($users_columns) }} 降順</option>
+                                        <option value="userid_asc"@if(Session::get('user_search_condition.sort') == "userid_asc") selected @endif>{{ UsersColumns::getLabelLoginId($users_columns) }} 昇順</option>
+                                        <option value="userid_desc"@if(Session::get('user_search_condition.sort') == "userid_desc") selected @endif>{{ UsersColumns::getLabelLoginId($users_columns) }} 降順</option>
+                                        @foreach($users_columns as $column)
+                                            @if (UsersColumns::isLoopNotShowColumnType($column->column_type))
+                                                {{-- 表示しない --}}
+                                            @else
+                                                <option value="{{$column->id}}_asc" @if(Session::get('user_search_condition.sort') == $column->id . '_asc') selected @endif>{{  $column->column_name  }}(昇順)</option>
+                                                <option value="{{$column->id}}_desc" @if(Session::get('user_search_condition.sort') == $column->id . '_desc') selected @endif>{{  $column->column_name  }}(降順)</option>
+                                            @endif
                                         @endforeach
                                         <option value="logged_in_at_asc"@if(Session::get('user_search_condition.sort') == "logged_in_at_asc") selected @endif>最終ログイン日時 昇順</option>
                                         <option value="logged_in_at_desc"@if(Session::get('user_search_condition.sort') == "logged_in_at_desc") selected @endif>最終ログイン日時 降順</option>
@@ -315,15 +323,19 @@ use App\Models\Core\UsersColumns;
             <table class="table table-hover cc-font-90">
             <thead>
                 <tr>
-                    <th nowrap>ログインID</th>
-                    <th nowrap>ユーザー名</th>
+                    <th nowrap>{{ UsersColumns::getLabelLoginId($users_columns) }}</th>
+                    <th nowrap>{{ UsersColumns::getLabelUserName($users_columns) }}</th>
                     <th nowrap><i class="fas fa-users"></i> グループ</th>
-                    <th nowrap>eメール</th>
+                    <th nowrap>{{ UsersColumns::getLabelUserEmail($users_columns) }}</th>
                     @if (config('connect.USE_USERS_COLUMNS_SET'))
                         <th nowrap>項目セット</th>
                     @endif
-                    @foreach($users_columns as $users_column)
-                        <th nowrap>{{$users_column->column_name}}</th>
+                    @foreach($users_columns as $column)
+                        @if (UsersColumns::isLoopNotShowColumnType($column->column_type))
+                            {{-- 表示しない --}}
+                        @else
+                            <th nowrap>{{$column->column_name}}</th>
+                        @endif
                     @endforeach
                     @if (empty($columns_set_id))
                         <th nowrap>項目セット値</th>
@@ -331,8 +343,8 @@ use App\Models\Core\UsersColumns;
                     <th nowrap>権限</th>
                     <th nowrap>役割設定</th>
                     <th nowrap>状態</th>
-                    <th nowrap>作成日時</th>
-                    <th nowrap>更新日時</th>
+                    <th nowrap>{{ UsersColumns::getLabelCreatedAt($users_columns) }}</th>
+                    <th nowrap>{{ UsersColumns::getLabelUpdatedAt($users_columns) }}</th>
                     <th nowrap>最終ログイン日時</th>
                 </tr>
             </thead>
@@ -387,7 +399,11 @@ use App\Models\Core\UsersColumns;
                         </td>
                     @endif
                     @foreach($users_columns as $users_column)
-                        <td>@include('plugins.manage.user.list_include_value')</td>
+                        @if (UsersColumns::isLoopNotShowColumnType($users_column->column_type))
+                            {{-- 表示しない --}}
+                        @else
+                            <td>@include('plugins.manage.user.list_include_value')</td>
+                        @endif
                     @endforeach
                     <td nowrap>
                         <h6>{!!$user->getRoleStringTag()!!}</h6>

--- a/resources/views/plugins/mypage/index/index.blade.php
+++ b/resources/views/plugins/mypage/index/index.blade.php
@@ -76,11 +76,11 @@
                                 </tr>
                             @else
                                 @php
-                                    $user_input_col = $user_input_cols->firstWhere('users_columns_id', $column->id);
+                                    $input_col = $input_cols->firstWhere('users_columns_id', $column->id);
                                 @endphp
                                 <tr class="input-cols">
-                                    <th>{{$user_input_col->column_name}}</th>
-                                    <td>{{$user_input_col->value}}</td>
+                                    <th>{{$input_col->column_name}}</th>
+                                    <td>{{$input_col->value}}</td>
                                 </tr>
                             @endif
                         @endforeach

--- a/resources/views/plugins/mypage/index/index.blade.php
+++ b/resources/views/plugins/mypage/index/index.blade.php
@@ -38,10 +38,6 @@
                             <td nowrap="nowrap">{{ $user->id }}</td>
                         </tr> --}}
                         @foreach($users_columns as $column)
-                            @if ($column->is_show_my_page == ShowType::not_show)
-                                @continue
-                            @endif
-
                             @if ($column->column_type == UserColumnType::user_name)
                                 {{-- ユーザ名 --}}
                                 <tr>

--- a/resources/views/plugins/mypage/index/index.blade.php
+++ b/resources/views/plugins/mypage/index/index.blade.php
@@ -33,31 +33,56 @@
             <div class="user-area form-group">
                 <table class="table table-hover cc-font-90">
                     <tbody>
-                        <tr>
+                        {{-- <tr>
                             <th style="width:20%;" nowrap="nowrap">ユーザID</th>
                             <td nowrap="nowrap">{{ $user->id }}</td>
-                        </tr>
-                        <tr>
-                            <th nowrap="nowrap">ログインID</th>
-                            <td nowrap="nowrap">{{ $user->userid }}</td>
-                        </tr>
-                        <tr>
-                            <th nowrap="nowrap">ユーザ名</th>
-                            <td nowrap="nowrap">{{ $user->name }}</td>
-                        </tr>
-                        <tr>
-                            <th nowrap="nowrap">メールアドレス</th>
-                            <td nowrap="nowrap">{{ $user->email }}</td>
-                        </tr>
-                        <tr>
-                            <th nowrap="nowrap">登録日時</th>
-                            <td nowrap="nowrap">{{ $user->created_at->format('Y/m/d H:i') }}</td>
-                        </tr>
-                        @foreach($user_input_cols as $user_input_col)
-                            <tr class="input-cols">
-                                <th>{{$user_input_col->column_name}}</th>
-                                <td>{{$user_input_col->value}}</td>
-                            </tr>
+                        </tr> --}}
+                        @foreach($users_columns as $column)
+                            @if ($column->is_show_my_page == ShowType::not_show)
+                                @continue
+                            @endif
+
+                            @if ($column->column_type == UserColumnType::user_name)
+                                {{-- ユーザ名 --}}
+                                <tr>
+                                    <th style="width:20%;" nowrap="nowrap">{{$column->column_name}}</th>
+                                    <td nowrap="nowrap">{{ $user->name }}</td>
+                                </tr>
+                            @elseif ($column->column_type == UserColumnType::login_id)
+                                {{-- ログインID --}}
+                                <tr>
+                                    <th style="width:20%;" nowrap="nowrap">{{$column->column_name}}</th>
+                                    <td nowrap="nowrap">{{ $user->userid }}</td>
+                                </tr>
+                            @elseif ($column->column_type == UserColumnType::user_email)
+                                {{-- メールアドレス --}}
+                                <tr>
+                                    <th style="width:20%;" nowrap="nowrap">{{$column->column_name}}</th>
+                                    <td nowrap="nowrap">{{ $user->email }}</td>
+                                </tr>
+                            @elseif ($column->column_type == UserColumnType::user_password)
+                                {{-- 表示しない --}}
+                            @elseif ($column->column_type == UserColumnType::created_at)
+                                {{-- 登録日時 --}}
+                                <tr>
+                                    <th style="width:20%;" nowrap="nowrap">{{$column->column_name}}</th>
+                                    <td nowrap="nowrap">{{ $user->created_at->format('Y/m/d H:i') }}</td>
+                                </tr>
+                            @elseif ($column->column_type == UserColumnType::updated_at)
+                                {{-- 更新日時 --}}
+                                <tr>
+                                    <th style="width:20%;" nowrap="nowrap">{{$column->column_name}}</th>
+                                    <td nowrap="nowrap">{{ $user->updated_at->format('Y/m/d H:i') }}</td>
+                                </tr>
+                            @else
+                                @php
+                                    $user_input_col = $user_input_cols->firstWhere('users_columns_id', $column->id);
+                                @endphp
+                                <tr class="input-cols">
+                                    <th>{{$user_input_col->column_name}}</th>
+                                    <td>{{$user_input_col->value}}</td>
+                                </tr>
+                            @endif
                         @endforeach
                     </tbody>
                 </table>

--- a/resources/views/plugins/mypage/index/index.blade.php
+++ b/resources/views/plugins/mypage/index/index.blade.php
@@ -75,8 +75,8 @@
                                     $input_col = $input_cols->firstWhere('users_columns_id', $column->id);
                                 @endphp
                                 <tr class="input-cols">
-                                    <th>{{$input_col->column_name}}</th>
-                                    <td>{{$input_col->value}}</td>
+                                    <th>{{$column->column_name}}</th>
+                                    <td>{{$input_col->value ?? ''}}</td>
                                 </tr>
                             @endif
                         @endforeach

--- a/resources/views/plugins/mypage/profile/edit_form.blade.php
+++ b/resources/views/plugins/mypage/profile/edit_form.blade.php
@@ -1,6 +1,9 @@
 {{--
  * copy by resources\views\auth\registe_form.blade.php
 --}}
+@php
+use App\Models\Core\UsersColumns;
+@endphp
 
 {{-- 共通エラーメッセージ 呼び出し --}}
 @include('plugins.common.errors_form_line')
@@ -11,46 +14,101 @@
 <form action="{{url('/')}}/mypage/profile/update/{{$id}}" class="form-horizontal" method="POST">
     {{ csrf_field() }}
 
-    <div class="form-group row">
-        <label for="email" class="col-md-4 col-form-label text-md-right">eメールアドレス</label>
+    @foreach($users_columns as $column)
+        @if ($column->column_type == UserColumnType::user_name)
+            {{-- ユーザ名 --}}
+            <div class="form-group row">
+                <label for="name" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <span class="badge badge-danger">必須</span></label>
+                <div class="col-md-8">
+                    <input id="name" type="text" class="form-control @if ($errors->has('name')) border-danger @endif" name="name" value="{{ old('name', $user->name) }}" placeholder="{{ $column->place_holder ?? __('messages.input_user_name') }}" required>
+                    @include('plugins.common.errors_inline', ['name' => 'name'])
+                    <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                </div>
+            </div>
 
-        <div class="col-md-8">
-            <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email', $user->email) }}" placeholder="メールアドレスを入力します。">
-            @include('plugins.common.errors_inline', ['name' => 'email'])
-        </div>
-    </div>
+        @elseif ($column->column_type == UserColumnType::login_id)
+            {{-- ログインID --}}
+            <div class="form-group row">
+                <label for="userid" class="col-md-4 col-form-label text-md-right">{{$column->column_name}} <span class="badge badge-danger">必須</span></label>
+                <div class="col-md-8">
+                    <input id="userid" type="text" class="form-control @if ($errors->has('userid')) border-danger @endif" name="userid" value="{{ old('userid', $user->userid) }}" placeholder="{{ $column->place_holder ?? __('messages.input_login_id') }}" required>
+                    @include('plugins.common.errors_inline', ['name' => 'userid'])
+                    <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                </div>
+            </div>
 
-    <div class="form-group row">
-        <label class="col-md-4 col-form-label text-md-right">現在のパスワード</label>
+        @elseif ($column->column_type == UserColumnType::user_email)
+            {{-- メールアドレス --}}
+            <div class="form-group row">
+                <label for="email" class="col-md-4 col-form-label text-md-right">{{$column->column_name}}</label>
 
-        <div class="col-md-8">
-            <input type="password" class="form-control @if ($errors->has('now_password')) border-danger @endif" name="now_password" autocomplete="new-password" placeholder="現在のパスワードを入力します。">
-            @include('plugins.common.errors_inline', ['name' => 'now_password'])
-        </div>
-    </div>
+                <div class="col-md-8">
+                    <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email', $user->email) }}" placeholder="{{ $column->place_holder ?? __('messages.input_email') }}">
+                    @include('plugins.common.errors_inline', ['name' => 'email'])
+                    <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                </div>
+            </div>
 
-    <div class="form-group row">
-        <label class="col-md-4 col-form-label text-md-right">新しいパスワード</label>
+        @elseif ($column->column_type == UserColumnType::user_password)
+            {{-- パスワード --}}
+            <div class="form-group row">
+                <label class="col-md-4 col-form-label text-md-right">現在の{{$column->column_name}}</label>
 
-        <div class="col-md-8">
-            <input type="password" class="form-control @if ($errors->has('new_password')) border-danger @endif" name="new_password" autocomplete="new-password" placeholder="新しいパスワードを入力します。">
-            @include('plugins.common.errors_inline', ['name' => 'new_password'])
-        </div>
-    </div>
+                <div class="col-md-8">
+                    <input type="password" class="form-control @if ($errors->has('now_password')) border-danger @endif" name="now_password" autocomplete="new-password" placeholder="現在のパスワードを入力します。">
+                    @include('plugins.common.errors_inline', ['name' => 'now_password'])
+                </div>
+            </div>
 
-    <div class="form-group row">
-        <label class="col-md-4 col-form-label text-md-right">新しいパスワードの確認</label>
+            <div class="form-group row">
+                <label class="col-md-4 col-form-label text-md-right">新しい{{$column->column_name}}</label>
 
-        <div class="col-md-8">
-            <input type="password" class="form-control @if ($errors->has('new_password_confirmation')) border-danger @endif" name="new_password_confirmation" placeholder="新しいパスワードと同じものを入力します。">
-            @include('plugins.common.errors_inline', ['name' => 'new_password_confirmation'])
-        </div>
-    </div>
+                <div class="col-md-8">
+                    <input type="password" class="form-control @if ($errors->has('new_password')) border-danger @endif" name="new_password" autocomplete="new-password" placeholder="新しいパスワードを入力します。">
+                    @include('plugins.common.errors_inline', ['name' => 'new_password'])
+                </div>
+            </div>
+
+            <div class="form-group row">
+                <label class="col-md-4 col-form-label text-md-right">新しい{{$column->column_name}}の確認</label>
+
+                <div class="col-md-8">
+                    <input type="password" class="form-control @if ($errors->has('new_password_confirmation')) border-danger @endif" name="new_password_confirmation" placeholder="新しいパスワードと同じものを入力します。">
+                    @include('plugins.common.errors_inline', ['name' => 'new_password_confirmation'])
+                    <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                </div>
+            </div>
+
+        @elseif ($column->column_type == UserColumnType::created_at)
+            {{-- 表示しない --}}
+        @elseif ($column->column_type == UserColumnType::updated_at)
+            {{-- 表示しない --}}
+        @else
+            @php
+                // ラジオとチェックボックスは選択肢にラベルを使っているため、項目名のラベルにforを付けない
+                if (UsersColumns::isChoicesColumnType($column->column_type)) {
+                    $label_for = '';
+                    $label_class = 'pt-0';
+                } else {
+                    $label_for = 'for=user-column-' . $column->id;
+                    $label_class = '';
+                }
+            @endphp
+
+            <div class="form-group row">
+                <label class="col-md-4 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$column->column_name}} @if ($column->required)<span class="badge badge-danger">必須</span> @endif</label>
+                <div class="col-md-8">
+                    @include('auth.registe_form_input_' . $column->column_type, ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
+                    <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                </div>
+            </div>
+        @endif
+    @endforeach
 
     <div class="form-group row text-center">
         <div class="col-sm-3"></div>
         <div class="col-sm-6">
-            <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i>
+            <button type="submit" class="btn btn-primary" @if($users_columns->isEmpty()) disabled @endif><i class="fas fa-check"></i>
                 更新
             </button>
         </div>

--- a/tests/Browser/Manage/users.csv
+++ b/tests/Browser/Manage/users.csv
@@ -1,4 +1,4 @@
-﻿id,ログインID,ユーザ名,グループ,eメールアドレス,パスワード,権限,役割設定,状態
+﻿id,ログインID,ユーザ名,グループ,メールアドレス,パスワード,権限,役割設定,状態
 ,user01,user01システム管理者,,,user01,role_article_admin|role_arrangement|role_article|role_approval|role_reporter|admin_system|admin_site|admin_page|admin_user,,0
 ,user02,user02コンテンツ管理者,,,user02,role_article_admin,,0
 ,user03,user03プラグイン管理者,,,user03,role_arrangement,,0


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 項目毎に「自動ユーザ登録時の表示指定」による表示ON/OFF対応
* 項目毎に「マイページの表示指定」による表示ON/OFF対応
* 項目毎に「マイページの編集指定」による編集ON/OFF対応
* 任意項目・固定項目も含めた並び順変更に対応 

# 修正後画面
## ユーザ管理＞項目設定
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/bcaa3f79-fdc7-4e7c-8c74-1f59d5966275)

## ユーザ管理＞項目設定＞項目詳細設定

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/89f21dc5-bf13-46d6-a2b1-5c39399e4f49)

## マイページ（例：メールアドレス・登録日時　非表示）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/48340219-ff41-4983-b0c3-2102161e6bd5)

## プロフィール＞プロフィール変更（例：ユーザ名　編集可）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/928a402f-648d-4987-886a-28e12dd5c95c)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1792

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
