### PR TITLE
[テーマ管理]WYSIWYGのテンプレート編集機能を追加しました。

### DIFF
--- a/app/Plugins/Manage/ThemeManage/ThemeManage.php
+++ b/app/Plugins/Manage/ThemeManage/ThemeManage.php
@@ -32,6 +32,8 @@ class ThemeManage extends ManagePluginBase
         $role_ckeck_table["create"]      = array('admin_site');
         $role_ckeck_table["editCss"]     = array('admin_site');
         $role_ckeck_table["saveCss"]     = array('admin_site');
+        $role_ckeck_table["editTemplate"] = array('admin_site');
+        $role_ckeck_table["saveTemplate"] = array('admin_site');
         $role_ckeck_table["editJs"]      = array('admin_site');
         $role_ckeck_table["saveJs"]      = array('admin_site');
         $role_ckeck_table["editName"]    = array('admin_site');
@@ -308,7 +310,7 @@ class ThemeManage extends ManagePluginBase
         }
 
         // ディレクトリの存在チェック
-        if (File::isDirectory(public_path() . '/themes/Users/' . $request->dir_name)) {
+        if (File::isDirectory(public_path() . '/themes/Users/' . basename($request->dir_name))) {
             $validator->errors()->add('dir_name', 'このディレクトリは存在します。');
             return $this->index($request, $id, $validator->errors());
         }
@@ -381,6 +383,74 @@ class ThemeManage extends ManagePluginBase
             "plugin_name" => "theme",
             "dir_name"    => $dir_name,
             "css"         => $css,
+        ]);
+    }
+
+    /**
+     * テンプレート編集画面
+     *
+     * @method_title テンプレート編集
+     * @method_desc ユーザ・テーマ毎のテンプレートを画面で編集できます。
+     * @method_detail 保存したテンプレートは選択したテーマで反映されます。
+     */
+    public function editTemplate($request, $id)
+    {
+        // httpメソッド確認
+        if (!$request->isMethod('post')) {
+            abort(403, '権限がありません。');
+        }
+
+        // ディレクトリ名
+        $dir_name = basename($request->dir_name);
+
+        // ディレクトリの存在チェック
+        if (!File::isDirectory(public_path() . '/themes/Users/' . basename($request->dir_name) . '/wysiwyg')) {
+            $result = File::makeDirectory(public_path() . '/themes/Users/' . basename($request->dir_name) . '/wysiwyg', 0775);
+        }
+
+        // ファイル名
+        $template_path = public_path() . '/themes/Users/' . $dir_name . '/wysiwyg/templates.txt';
+
+        // ファイルを存在チェックし、なければ空で作成する。
+        if (!File::exists($template_path)) {
+            $result = File::put($template_path, '');
+        }
+
+        // テンプレートファイル取得
+        $template = File::get($template_path);
+
+        return view('plugins.manage.theme.theme_template_edit', [
+            "function"    => __FUNCTION__,
+            "plugin_name" => "theme",
+            "dir_name"    => $dir_name,
+            "template"         => $template,
+        ]);
+    }
+
+    /**
+     * テンプレート保存画面
+     */
+    public function saveTemplate($request, $id)
+    {
+        // httpメソッド確認
+        if (!$request->isMethod('post')) {
+            abort(403, '権限がありません。');
+        }
+
+        // ディレクトリ名
+        $dir_name = basename($request->dir_name);
+
+        // テンプレート
+        $template = $request->template;
+
+        // template.txt ファイルの保存
+        $result = File::put(public_path() . '/themes/Users/' . $dir_name . '/wysiwyg/templates.txt', $template);
+
+        return view('plugins.manage.theme.theme_template_edit', [
+            "function"    => __FUNCTION__,
+            "plugin_name" => "theme",
+            "dir_name"    => $dir_name,
+            "template"         => $template,
         ]);
     }
 

--- a/config/version.php
+++ b/config/version.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'cc_version' => '1.9.3',
+    'cc_version' => '1.9.4',
 
     'show_cc_version' => true,
 ];

--- a/resources/views/plugins/manage/theme/theme.blade.php
+++ b/resources/views/plugins/manage/theme/theme.blade.php
@@ -23,6 +23,11 @@
     <input type="hidden" name="dir_name" value="">
 </form>
 
+<form action="{{url('/')}}/manage/theme/editTemplate" method="post" name="form_template" class="d-inline">
+    {{ csrf_field() }}
+    <input type="hidden" name="dir_name" value="">
+</form>
+
 <form action="{{url('/')}}/manage/theme/editJs" method="post" name="form_js" class="d-inline">
     {{ csrf_field() }}
     <input type="hidden" name="dir_name" value="">
@@ -44,6 +49,12 @@
     {
         form_css.dir_name.value = dir_name;
         form_css.submit();
+    }
+    // CSS 編集画面へ
+    function view_template_edit(dir_name)
+    {
+        form_template.dir_name.value = dir_name;
+        form_template.submit();
     }
     // Javascript 編集画面へ
     function view_js_edit(dir_name)
@@ -73,6 +84,7 @@
                <a href="javascript:view_css_edit('{{$dir['dir']}}');" id="css_edit_{{$loop->iteration}}">［CSS編集］</a>
                <a href="javascript:view_js_edit('{{$dir['dir']}}');" id="js_edit_{{$loop->iteration}}">［JavaScript編集］</a>
                <a href="javascript:view_list_images('{{$dir['dir']}}');" id="image_edit_{{$loop->iteration}}">［画像管理］</a>
+               <a href="javascript:view_template_edit('{{$dir['dir']}}');" id="template_edit_{{$loop->iteration}}">［テンプレート編集］</a>
                <a href="javascript:view_name_edit('{{$dir['dir']}}');" id="name_edit_{{$loop->iteration}}">［テーマ編集］</a>
         </li>
     @endforeach

--- a/resources/views/plugins/manage/theme/theme_template_edit.blade.php
+++ b/resources/views/plugins/manage/theme/theme_template_edit.blade.php
@@ -1,0 +1,35 @@
+{{--
+ * テンプレート編集テンプレート
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category テーマ管理
+ --}}
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<div class="card mb-3">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.theme.theme_manage_tab')
+    </div>
+    <div class="card-body">
+
+        <form action="{{url('/')}}/manage/theme/saveTemplate" method="POST">
+            {{csrf_field()}}
+            <input name="dir_name" type="hidden" value="{{$dir_name}}" />
+            <textarea name="template" class="form-control" rows=20 placeholder="（例）&#13;.navbar-dark .navbar-brand {&#13;    color: #ffff00; # デフォルトのヘッダーバー文字色を黄色にします。 &#13;}">{{$template}}</textarea>
+            <div class="form-group mt-3">
+                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/')}}/manage/theme/'"><i class="fas fa-times"></i> キャンセル</button>
+                <button type="submit" class="btn btn-primary form-horizontal">
+                    <i class="fas fa-check"></i> テンプレートファイル保存
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+@endsection


### PR DESCRIPTION
管理機能のテーマ管理にて、WYSIWYGのテンプレートを編集できる機能を追加しました。

# 概要
WYSIWYGにテンプレート機能があるが、管理画面での編集ができなかったので、機能を追加しました。

# レビュー完了希望日
急いではいません。

# 参考
* https://github.com/opensource-workshop/connect-cms-ideas/issues/10

# DB変更の有無
無し

# チェックリスト
- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
