### PR TITLE
[ユーザ登録] 任意項目のオプションテンプレート追加対応・ユーザ項目セット, 任意項目に変数名を登録できるよう対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ composer-option*
 /database/seeders/Options/*
 /resources/views/plugins_option/*
 /resources/views/mail_option/*
+/resources/views/auth_option/*
 
 # Dusk
 /tests/tmp/*

--- a/app/Enums/EnumsBase.php
+++ b/app/Enums/EnumsBase.php
@@ -22,7 +22,8 @@ class EnumsBase
      */
     public static function getDescription($key): string
     {
-        return static::enum[$key];
+        $enum = static::getEnum();
+        return $enum[$key];
     }
 
     /**
@@ -30,7 +31,7 @@ class EnumsBase
      */
     public static function getMembers()
     {
-        return static::enum;
+        return static::getEnum();
     }
 
     /**
@@ -38,6 +39,36 @@ class EnumsBase
      */
     public static function getMemberKeys()
     {
-        return array_keys(static::enum);
+        return array_keys(static::getEnum());
+    }
+
+    /**
+     * enumを返す
+     */
+    private static function getEnum(): array
+    {
+        $class_name = self::getOptionClass();
+        if ($class_name) {
+            return $class_name::enum;
+        }
+
+        return static::enum;
+    }
+
+    /**
+     * オプションクラスを返す
+     */
+    protected static function getOptionClass(): ?string
+    {
+        // クラス名をnamespace 毎取得
+        $instance_name = explode('\\', get_called_class());
+        if (is_array($instance_name) && $instance_name[0] == 'App' && $instance_name[1] == 'Enums' && !empty($instance_name[2])) {
+            $class_name = "App\EnumsOption\\" . $instance_name[2] . "Option";
+            // オプションあり
+            if (class_exists($class_name)) {
+                return $class_name;
+            }
+        }
+        return null;
     }
 }

--- a/app/Enums/UserColumnType.php
+++ b/app/Enums/UserColumnType.php
@@ -7,7 +7,7 @@ use App\Enums\EnumsBase;
 /**
  * ユーザ項目区分
  */
-final class UserColumnType extends EnumsBase
+class UserColumnType extends EnumsBase
 {
     // 定数メンバ
     const text = 'text';
@@ -55,5 +55,28 @@ final class UserColumnType extends EnumsBase
     public static function getDescriptionFixed($key): string
     {
         return static::enum_fixed[$key];
+    }
+
+    /**
+     * ループで非表示のカラム型 取得
+     */
+    public static function loopNotShowColumnTypes(): array
+    {
+        $class_name = self::getOptionClass();
+        // オプションクラス有＋メソッド有なら呼ぶ
+        if ($class_name) {
+            if (method_exists($class_name, 'loopNotShowColumnTypes')) {
+                return $class_name::loopNotShowColumnTypes();
+            }
+        }
+
+        return [
+            self::user_name,
+            self::login_id,
+            self::user_email,
+            self::user_password,
+            self::created_at,
+            self::updated_at,
+        ];
     }
 }

--- a/app/Models/Core/UsersColumns.php
+++ b/app/Models/Core/UsersColumns.php
@@ -18,6 +18,8 @@ class UsersColumns extends Model
         'columns_set_id',
         'column_type',
         'column_name',
+        'use_variable',
+        'variable_name',
         'is_fixed_column',
         'is_show_auto_regist',
         'is_show_my_page',
@@ -35,6 +37,19 @@ class UsersColumns extends Model
         'rule_word_count',
         'display_sequence',
     ];
+
+    /**
+     * 選択肢タイプのカラム型か
+     */
+    public static function isSelectColumnType($column_type): bool
+    {
+        if ($column_type == UserColumnType::radio ||
+                $column_type == UserColumnType::checkbox ||
+                $column_type == UserColumnType::select) {
+            return true;
+        }
+        return false;
+    }
 
     /**
      * 選択肢系のカラム型か

--- a/app/Models/Core/UsersColumns.php
+++ b/app/Models/Core/UsersColumns.php
@@ -69,13 +69,7 @@ class UsersColumns extends Model
      */
     public static function isLoopNotShowColumnType($column_type): bool
     {
-        if ($column_type == UserColumnType::user_name ||
-            $column_type == UserColumnType::login_id ||
-            $column_type == UserColumnType::user_email ||
-            $column_type == UserColumnType::user_password ||
-            $column_type == UserColumnType::created_at ||
-            $column_type == UserColumnType::updated_at
-        ) {
+        if (in_array($column_type, UserColumnType::loopNotShowColumnTypes())) {
             return true;
         }
         return false;
@@ -86,14 +80,7 @@ class UsersColumns extends Model
      */
     public static function loopNotShowColumnTypes(): array
     {
-        return [
-            UserColumnType::user_name,
-            UserColumnType::login_id,
-            UserColumnType::user_email,
-            UserColumnType::user_password,
-            UserColumnType::created_at,
-            UserColumnType::updated_at,
-        ];
+        return UserColumnType::loopNotShowColumnTypes();
     }
 
     /**

--- a/app/Models/Core/UsersColumnsSet.php
+++ b/app/Models/Core/UsersColumnsSet.php
@@ -18,6 +18,8 @@ class UsersColumnsSet extends Model
      */
     protected $fillable = [
         'name',
+        'use_variable',
+        'variable_name',
         'display_sequence',
     ];
 }

--- a/app/Plugins/Manage/UserManage/UsersTool.php
+++ b/app/Plugins/Manage/UserManage/UsersTool.php
@@ -80,7 +80,8 @@ class UsersTool
     public static function getUsersInputCols($users_ids)
     {
         // カラムの登録データ
-        $input_cols = UsersInputCols::select(
+        $input_cols = UsersInputCols::
+            select(
                 'users_input_cols.*',
                 'users_columns.column_type',
                 'users_columns.column_name',

--- a/app/Plugins/Manage/UserManage/UsersTool.php
+++ b/app/Plugins/Manage/UserManage/UsersTool.php
@@ -80,7 +80,14 @@ class UsersTool
     public static function getUsersInputCols($users_ids)
     {
         // カラムの登録データ
-        $input_cols = UsersInputCols::select('users_input_cols.*', 'users_columns.column_type', 'users_columns.column_name', 'uploads.client_original_name')
+        $input_cols = UsersInputCols::select(
+                'users_input_cols.*',
+                'users_columns.column_type',
+                'users_columns.column_name',
+                'users_columns.use_variable',
+                'users_columns.variable_name',
+                'uploads.client_original_name'
+            )
             ->leftJoin('users_columns', 'users_columns.id', '=', 'users_input_cols.users_columns_id')
             ->leftJoin('uploads', 'uploads.id', '=', 'users_input_cols.value')
             ->whereIn('users_id', $users_ids)

--- a/database/migrations/2023_08_28_134821_add_use_variable_variable_name_from_users_columns_sets.php
+++ b/database/migrations/2023_08_28_134821_add_use_variable_variable_name_from_users_columns_sets.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUseVariableVariableNameFromUsersColumnsSets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users_columns_sets', function (Blueprint $table) {
+            $table->integer('use_variable')->default(0)->comment('変数名の使用')->after('name');
+            $table->string('variable_name')->nullable()->comment('変数名')->after('use_variable');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users_columns_sets', function (Blueprint $table) {
+            $table->dropColumn('use_variable');
+            $table->dropColumn('variable_name');
+        });
+    }
+}

--- a/database/migrations/2023_08_28_135126_add_use_variable_variable_name_from_users_columns.php
+++ b/database/migrations/2023_08_28_135126_add_use_variable_variable_name_from_users_columns.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUseVariableVariableNameFromUsersColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users_columns', function (Blueprint $table) {
+            $table->integer('use_variable')->default(0)->comment('変数名の使用')->after('column_name');
+            $table->string('variable_name')->nullable()->comment('変数名')->after('use_variable');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users_columns', function (Blueprint $table) {
+            $table->dropColumn('use_variable');
+            $table->dropColumn('variable_name');
+        });
+    }
+}

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -19,8 +19,8 @@ use App\Models\Core\UsersColumns;
 @endphp
 
 <script>
-    /** 会員変更submit */
-    function changeSeminarUserIdAction(columns_set_id) {
+    /** 項目セット変更submit */
+    function changeColumnsSetIdAction(columns_set_id) {
         @if (Auth::user() && Auth::user()->can('admin_user'))
             @if ($is_function_edit)
                 {{-- ユーザ管理-編集 --}}
@@ -73,7 +73,7 @@ use App\Models\Core\UsersColumns;
             <div class="form-group row">
                 <label for="columns_set_id" class="col-md-4 col-form-label text-md-right">項目セット <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-8">
-                    <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif" onchange="changeSeminarUserIdAction(this.value)">
+                    <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif" onchange="changeColumnsSetIdAction(this.value)">
                         <option value=""></option>
                         @foreach ($columns_sets as $columns_set)
                             <option value="{{$columns_set->id}}" @if (old('columns_set_id', $user->columns_set_id) == $columns_set->id) selected="selected" @endif>{{$columns_set->name}}</option>
@@ -88,7 +88,7 @@ use App\Models\Core\UsersColumns;
             <div class="form-group row">
                 <label for="columns_set_id" class="col-md-4 col-form-label text-md-right">{{Configs::getConfigsValue($configs, "user_columns_set_label_name", '項目セット')}} <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-8">
-                    <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif" onchange="changeSeminarUserIdAction()">
+                    <select name="columns_set_id" id="columns_set_id" class="form-control @if ($errors->has('columns_set_id')) border-danger @endif" onchange="changeColumnsSetIdAction()">
                         @foreach ($columns_sets as $columns_set)
                             <option value="{{$columns_set->id}}" @if (old('columns_set_id', $columns_set_id) == $columns_set->id) selected="selected" @endif>{{$columns_set->name}}</option>
                         @endforeach

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -212,7 +212,7 @@ use App\Models\Core\UsersColumns;
             <div class="form-group row">
                 <label class="col-md-4 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$column->column_name}} @if ($column->required)<span class="badge badge-danger">必須</span> @endif</label>
                 <div class="col-md-8">
-                    @include('auth.registe_form_input_' . $column->column_type, ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
+                    @includeFirst(["auth_option.registe_form_input_$column->column_type", "auth.registe_form_input_$column->column_type"], ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
                     <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
                 </div>
             </div>

--- a/resources/views/auth/registe_form_input_affiliation.blade.php
+++ b/resources/views/auth/registe_form_input_affiliation.blade.php
@@ -15,9 +15,5 @@
             @endif
         @endforeach
     </select>
-    @if ($errors && $errors->has("users_columns_value.$user_obj->id"))
-        <div class="d-block text-danger">
-            <i class="fas fa-exclamation-triangle"></i> {{$errors->first("users_columns_value.$user_obj->id")}}
-        </div>
-    @endif
+    @include('plugins.common.errors_inline', ['name' => "users_columns_value.$user_obj->id"])
 @endif

--- a/resources/views/auth/registe_form_input_checkbox.blade.php
+++ b/resources/views/auth/registe_form_input_checkbox.blade.php
@@ -54,9 +54,5 @@
 
         @endforeach
     </div>
-    @if ($errors && $errors->has("users_columns_value.$user_obj->id"))
-        <div class="d-block text-danger">
-            <i class="fas fa-exclamation-triangle"></i> {{$errors->first("users_columns_value.$user_obj->id")}}
-        </div>
-    @endif
+    @include('plugins.common.errors_inline', ['name' => "users_columns_value.$user_obj->id"])
 @endif

--- a/resources/views/auth/registe_form_input_radio.blade.php
+++ b/resources/views/auth/registe_form_input_radio.blade.php
@@ -28,9 +28,5 @@
             </div>
         @endforeach
     </div>
-    @if ($errors && $errors->has("users_columns_value.$user_obj->id"))
-        <div class="d-block text-danger">
-            <i class="fas fa-exclamation-triangle"></i> {{$errors->first("users_columns_value.$user_obj->id")}}
-        </div>
-    @endif
+    @include('plugins.common.errors_inline', ['name' => "users_columns_value.$user_obj->id"])
 @endif

--- a/resources/views/auth/registe_form_input_select.blade.php
+++ b/resources/views/auth/registe_form_input_select.blade.php
@@ -26,9 +26,5 @@
             @endif
         @endforeach
     </select>
-    @if ($errors && $errors->has("users_columns_value.$user_obj->id"))
-        <div class="d-block text-danger">
-            <i class="fas fa-exclamation-triangle"></i> {{$errors->first("users_columns_value.$user_obj->id")}}
-        </div>
-    @endif
+    @include('plugins.common.errors_inline', ['name' => "users_columns_value.$user_obj->id"])
 @endif

--- a/resources/views/plugins/manage/user/column_sets.blade.php
+++ b/resources/views/plugins/manage/user/column_sets.blade.php
@@ -36,7 +36,7 @@
                 <tr>
                     <td class="d-block d-sm-table-cell">
                         <a href="{{url('/')}}/manage/user/editColumnSet/{{$columns_set->id}}"><i class="far fa-edit"></i></a>
-                        <span class="d-sm-none">項目セット名：</span>{{$columns_set->name}}
+                        <span class="d-sm-none">項目セット名：</span>{{$columns_set->name}}@if($columns_set->use_variable) ({{$columns_set->variable_name}}) @endif
                     </td>
                     <td class="d-block d-sm-table-cell"><span class="d-sm-none">表示順：</span>{{$columns_set->display_sequence}}</td>
                     <td class="d-block d-sm-table-cell">

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -94,11 +94,32 @@ use App\Models\Core\UsersColumns;
         return false;
     }
 
-    // ツールチップ
+    /** 変数名の使用の表示・非表示 */
+    function change_use_variable(radio_value) {
+        switch (radio_value) {
+            case '1':
+                $('#variable_name_div').collapse('show');
+                break;
+            case '0':
+                $('#variable_name_div').collapse('hide');
+                break;
+            default:
+                // 空の場合を想定
+                $('#variable_name_div').collapse('hide');
+        }
+    }
+
     $(function () {
-        // 有効化
+        /** ツールチップ有効化 */
         $('[data-toggle="tooltip"]').tooltip()
-    })
+
+        /** 変数名の使用の制御radio.change */
+        $('input[name="use_variable"]').change(function(){
+            // 変数名の使用の表示・非表示
+            change_use_variable($(this).val());
+        });
+
+    });
 </script>
 
 <div class="card">
@@ -652,6 +673,44 @@ use App\Models\Core\UsersColumns;
                 </div>
             </div>
 
+            {{-- 変数名の設定 --}}
+            <div class="card form-group">
+                <h5 class="card-header">変数名の設定</h5>
+                <div class="card-body">
+                    {{-- 変数名の使用 --}}
+                    <div class="form-group row">
+                        <label class="col-md-3 col-form-label text-md-right pt-0">変数名の使用</label>
+                        <div class="col-md-9 align-items-center">
+                            @foreach (UseType::getMembers() as $enum_value => $enum_label)
+                                <div class="custom-control custom-radio custom-control-inline">
+                                    @if (old('use_variable', $column->use_variable) == $enum_value)
+                                        <input type="radio" value="{{$enum_value}}" id="use_variable_{{$enum_value}}" name="use_variable" class="custom-control-input" checked="checked">
+                                    @else
+                                        <input type="radio" value="{{$enum_value}}" id="use_variable_{{$enum_value}}" name="use_variable" class="custom-control-input">
+                                    @endif
+                                    {{-- duskでradioの選択にlabelのid必要 --}}
+                                    <label class="custom-control-label" for="use_variable_{{$enum_value}}" id="label_use_variable_{{$enum_value}}">{{$enum_label}}</label>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+
+                    {{-- 変数名 --}}
+                    <div class="form-group row collapse" id="variable_name_div">
+                        <label class="col-md-3 col-form-label text-md-right">変数名 <span class="badge badge-danger">必須</span></label>
+                        <div class="col-md-9 align-items-center">
+                            <input type="text" name="variable_name" value="{{old('variable_name', $column->variable_name)}}" class="form-control @if ($errors && $errors->has("variable_name")) border-danger @endif" />
+                            @include('plugins.common.errors_inline', ['name' => "variable_name"])
+                        </div>
+                    </div>
+
+                    {{-- ボタンエリア --}}
+                    <div class="form-group text-center">
+                        <button onclick="javascript:submit_update_column_detail();" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
+                    </div>
+                </div>
+            </div>
+
             {{-- ボタンエリア --}}
             <div class="form-group text-center">
                 <a href="{{url('/')}}/manage/user/editColumns/{{$columns_set->id}}" class="btn btn-secondary">
@@ -674,4 +733,8 @@ use App\Models\Core\UsersColumns;
 }
 </style>
 
+<script>
+    {{-- 初期状態で開くもの --}}
+    change_use_variable('{{old('use_variable', $column->use_variable)}}');
+</script>
 @endsection

--- a/resources/views/plugins/manage/user/edit_column_set.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_set.blade.php
@@ -11,6 +11,32 @@
 {{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
 @section('manage_content')
 
+<script type="text/javascript">
+    /** 変数名の使用の表示・非表示 */
+    function change_use_variable(radio_value) {
+        switch (radio_value) {
+            case '1':
+                $('#variable_name_div').collapse('show');
+                break;
+            case '0':
+                $('#variable_name_div').collapse('hide');
+                break;
+            default:
+                // 空の場合を想定
+                $('#variable_name_div').collapse('hide');
+        }
+    }
+
+    $(function () {
+        /** 変数名の使用の制御radio.change */
+        $('input[name="use_variable"]').change(function(){
+            // 変数名の使用の表示・非表示
+            change_use_variable($(this).val());
+        });
+
+    });
+</script>
+
 <div class="card">
     <div class="card-header p-0">
         {{-- 機能選択タブ --}}
@@ -40,6 +66,33 @@
                 <div class="col-md-9">
                     <input type="text" name="name" id="name" value="{{old('name', $columns_set->name)}}" class="form-control @if ($errors->has('name')) border-danger @endif">
                     @include('plugins.common.errors_inline', ['name' => 'name'])
+                </div>
+            </div>
+
+            {{-- 変数名の使用 --}}
+            <div class="form-group form-row">
+                <label class="col-md-3 col-form-label text-md-right pt-0">変数名の使用</label>
+                <div class="col-md-9 align-items-center">
+                    @foreach (UseType::getMembers() as $enum_value => $enum_label)
+                        <div class="custom-control custom-radio custom-control-inline">
+                            @if (old('use_variable', $columns_set->use_variable) == $enum_value)
+                                <input type="radio" value="{{$enum_value}}" id="use_variable_{{$enum_value}}" name="use_variable" class="custom-control-input" checked="checked">
+                            @else
+                                <input type="radio" value="{{$enum_value}}" id="use_variable_{{$enum_value}}" name="use_variable" class="custom-control-input">
+                            @endif
+                            {{-- duskでradioの選択にlabelのid必要 --}}
+                            <label class="custom-control-label" for="use_variable_{{$enum_value}}" id="label_use_variable_{{$enum_value}}">{{$enum_label}}</label>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+
+            {{-- 変数名 --}}
+            <div class="form-group form-row collapse" id="variable_name_div">
+                <label class="col-md-3 col-form-label text-md-right">変数名 <span class="badge badge-danger">必須</span></label>
+                <div class="col-md-9 align-items-center">
+                    <input type="text" name="variable_name" value="{{old('variable_name', $columns_set->variable_name)}}" class="form-control @if ($errors && $errors->has("variable_name")) border-danger @endif" />
+                    @include('plugins.common.errors_inline', ['name' => "variable_name"])
                 </div>
             </div>
 
@@ -99,4 +152,8 @@
     </div>
 </div>
 
+<script>
+    {{-- 初期状態で開くもの --}}
+    change_use_variable('{{old('use_variable', $columns_set->use_variable)}}');
+</script>
 @endsection

--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -5,6 +5,10 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category ユーザ管理
 --}}
+@php
+use App\Models\Core\UsersColumns;
+@endphp
+
 <tr @if ($column->hide_flag) class="table-secondary" @endif>
     {{-- 表示順操作 --}}
     <td class="align-middle text-center" nowrap>
@@ -53,11 +57,7 @@
             type="button"
             class="btn btn-success btn-xs cc-font-90 text-nowrap"
             id="button_user_column_detail_{{ $column->id }}"
-            @if (
-                $column->column_type == UserColumnType::radio ||
-                $column->column_type == UserColumnType::checkbox ||
-                $column->column_type == UserColumnType::select
-                )
+            @if (UsersColumns::isSelectColumnType($column->column_type))
                 {{-- 選択肢の設定がない場合のみツールチップを表示 --}}
                 @if ($column->select_count == 0)
                     id="detail-button-tip" data-toggle="tooltip" title="選択肢がありません。設定してください。" data-trigger="manual" data-placement="bottom"
@@ -92,22 +92,56 @@
         @endif
     </td>
 </tr>
+
 {{-- 選択肢の設定内容の表示行 --}}
-@if (
-    $column->column_type == UserColumnType::radio ||
-    $column->column_type == UserColumnType::checkbox ||
-    $column->column_type == UserColumnType::select
-    )
-    <tr>
-        <td class="pt-0 border border-0"></td>
-        <td class="pt-0 border border-0" colspan="7">
-            @if ($column->select_count > 0)
-                {{-- 選択肢データがある場合、カンマ付で一覧表示する --}}
-                <i class="far fa-list-alt"></i> {{ $column->select_names }}
-            @elseif ($column->select_count == 0)
-                {{-- 選択肢データがない場合はツールチップ分、余白として改行する --}}
-                <br>
+<tr>
+    <td class="pt-0 border border-0"></td>
+    <td class="pt-0 border border-0" colspan="7">
+        <div class="small">
+            @if ($column->is_show_auto_regist)
+                <span class="text-primary mr-3"><i class="fas fa-toggle-on"></i> 自動ユーザ登録時表示：ON</span>
+            @else
+                <span class="text-secondary mr-3"><i class="fas fa-toggle-off"></i> 自動ユーザ登録時表示：OFF</span>
             @endif
-        </td>
-    </tr>
-@endif
+            @if ($column->is_show_my_page)
+                <span class="text-primary mr-3"><i class="fas fa-toggle-on"></i> マイページ表示：ON</span>
+            @else
+                <span class="text-secondary mr-3"><i class="fas fa-toggle-off"></i> マイページ表示：OFF</span>
+            @endif
+            @if ($column->is_edit_my_page)
+                <span class="text-primary"><i class="fas fa-toggle-on"></i> マイページ編集：ON</span>
+            @else
+                <span class="text-secondary"><i class="fas fa-toggle-off"></i> マイページ編集：OFF</span>
+            @endif
+        </div>
+
+        @if ($column->selects->isNotEmpty())
+            {{-- 選択肢データがある場合、カンマ付で一覧表示する --}}
+            <i class="far fa-list-alt" data-toggle="tooltip" title="選択肢"></i> {{ $column->selects->where('users_columns_id', $column->id)->pluck('value')->implode(',') }}
+        @endif
+
+        @if ($column->caption)
+            {{-- キャプションが設定されている場合、キャプションを表示する --}}
+            <div class="small {{ $column->caption_color }}">
+                <i class="fas fa-pen" data-toggle="tooltip" title="キャプション"></i>
+                {!! mb_strimwidth($column->caption, 0, 60, '...', 'UTF-8') !!}
+            </div>
+        @endif
+
+        @if ($column->place_holder)
+            {{-- プレースホルダが設定されている場合、プレースホルダを表示する --}}
+            <div class="small">
+                <i class="fas fa-pen-square" data-toggle="tooltip" title="プレースホルダ"></i>
+                {!! mb_strimwidth($column->place_holder, 0, 60, '...', 'UTF-8') !!}
+            </div>
+        @endif
+
+        @if ($column->use_variable)
+            {{-- 変数名を使用する場合、変数名を表示する --}}
+            <div class="small">
+                <i class="fas fa-box" data-toggle="tooltip" title="変数名"></i>
+                {!! mb_strimwidth($column->variable_name, 0, 60, '...', 'UTF-8') !!}
+            </div>
+        @endif
+    </td>
+</tr>

--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -402,7 +402,6 @@ use App\Models\Core\UsersColumns;
                         @if (UsersColumns::isLoopNotShowColumnType($users_column->column_type))
                             {{-- 表示しない --}}
                         @else
-                            {{-- <td>@include('plugins.manage.user.list_include_value')</td> --}}
                             <td>@includeFirst(['plugins_option.manage.user.list_include_value', 'plugins.manage.user.list_include_value'])</td>
                         @endif
                     @endforeach

--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -145,7 +145,7 @@ use App\Models\Core\UsersColumns;
                                     <div class="form-group row">
                                         <label class="col-md-3 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$column->column_name}}</label>
                                         <div class="col-md-9">
-                                            @include('plugins.manage.user.list_search_' . $column->column_type, ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
+                                            @includeFirst(["plugins_option.manage.user.list_search_$column->column_type", "plugins.manage.user.list_search_$column->column_type"], ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
                                         </div>
                                     </div>
                                 @endif
@@ -402,7 +402,8 @@ use App\Models\Core\UsersColumns;
                         @if (UsersColumns::isLoopNotShowColumnType($users_column->column_type))
                             {{-- 表示しない --}}
                         @else
-                            <td>@include('plugins.manage.user.list_include_value')</td>
+                            {{-- <td>@include('plugins.manage.user.list_include_value')</td> --}}
+                            <td>@includeFirst(['plugins_option.manage.user.list_include_value', 'plugins.manage.user.list_include_value'])</td>
                         @endif
                     @endforeach
                     <td nowrap>

--- a/resources/views/plugins/manage/user/list_search_text.blade.php
+++ b/resources/views/plugins/manage/user/list_search_text.blade.php
@@ -3,5 +3,6 @@
 --}}
 @php
     $value = Session::get('user_search_condition.users_columns_value.' . $user_obj->id);
+    $type = $type ?? $user_obj->column_type;
 @endphp
-<input name="users_columns_value[{{$user_obj->id}}]" class="form-control" type="{{$user_obj->column_type}}" value="{{$value}}" id="{{$label_id}}">
+<input name="users_columns_value[{{$user_obj->id}}]" class="form-control" type="{{$type}}" value="{{$value}}" id="{{$label_id}}">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: ユーザ登録, 任意項目のオプションテンプレート追加対応](https://github.com/opensource-workshop/connect-cms/pull/1801/commits/9240d82cd48aacef4a07b681723e5158d32fbc50)
  * enumsのEnumsOption対応（App\EnumsOption\XxxxOption）
    * 例）ユーザ登録のオプション項目指定（app\EnumsOption\UserColumnTypeOption.php）
  * `UserColumnType::loopNotShowColumnTypes()` のオプションEmuns対応
  * ユーザ登録のオプション項目対応（auth_option.registe_form_input_xxxx）
  * ユーザ管理＞一覧のオプション項目の検索対応（plugins_option.manage.user.list_search_xxxx）
  * ユーザ管理＞一覧表示のオプション項目対応（plugins_option.manage.user.list_include_value）
* [add: [ユーザ管理] ユーザ項目セット, 任意項目に変数名を登録できるように対応](https://github.com/opensource-workshop/connect-cms/pull/1801/commits/72fca0f308b7f938a482ee67f6de9214d0cf94b7)
  * ユーザ管理＞項目セット一覧＞項目設定でキャプションやマイページ表示等の設定値を一覧に表示

## 修正後画面
### ユーザ管理＞項目セットの登録・編集
変数名の登録
![変数名の使用_項目セット](https://github.com/opensource-workshop/connect-cms/assets/2756509/e2a00f1f-86b8-421e-8dc3-49b0f7b4fa52)


### ユーザ管理＞項目セット一覧＞項目設定
キャプションやマイページ表示等の設定値を一覧に表示
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/e217397c-1d4d-4bba-9000-2a95899db820)

### ユーザ管理＞項目セット一覧＞項目設定＞項目詳細設定
変数名の登録
![変数名の使用](https://github.com/opensource-workshop/connect-cms/assets/2756509/a91284b5-3895-4e7d-9861-65d93a4f82ca)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1798

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り / 無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
