### PR TITLE
[ユーザ管理] ユーザ一覧検索で検索条件を開いたまま再表示できるオプション変数を追加, ユーザ一覧検索で検索条件を部分一致か完全一致かカラム型で設定できるオプションメソッドを追加

### DIFF
--- a/app/Enums/UserColumnType.php
+++ b/app/Enums/UserColumnType.php
@@ -79,4 +79,20 @@ class UserColumnType extends EnumsBase
             self::updated_at,
         ];
     }
+
+    /**
+     * 検索で完全一致のカラム型 取得
+     */
+    public static function searchExactMatchColumnTypes(): array
+    {
+        $class_name = self::getOptionClass();
+        // オプションクラス有＋メソッド有なら呼ぶ
+        if ($class_name) {
+            if (method_exists($class_name, 'searchExactMatchColumnTypes')) {
+                return $class_name::searchExactMatchColumnTypes();
+            }
+        }
+
+        return [];
+    }
 }

--- a/app/Models/Core/UsersColumns.php
+++ b/app/Models/Core/UsersColumns.php
@@ -99,6 +99,17 @@ class UsersColumns extends Model
     }
 
     /**
+     * 検索で完全一致のカラム型か
+     */
+    public static function isSearchExactMatchColumnType($column_type): bool
+    {
+        if (in_array($column_type, UserColumnType::searchExactMatchColumnTypes())) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * コレクションからラベル名取得
      */
     private static function getLabelFromCollection(Collection $users_columns, string $column_type, string $default): string

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -623,7 +623,8 @@ class UserManage extends ManagePluginBase
 
         session(["user_search_condition" => $user_search_condition]);
 
-        return redirect("/manage/user");
+        // is_search_collapse_show=1で検索エリアを開いたままにできる（オプションプラグイン等で利用）
+        return redirect("/manage/user")->with('is_search_collapse_show', $request->is_search_collapse_show);
     }
 
     /**

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -323,8 +323,15 @@ class UserManage extends ManagePluginBase
                             ->join('users_columns', 'users_columns.id', '=', 'users_input_cols.users_columns_id')
                             ->where('users_columns.id', $users_column->id)
                             //->whereNotIn('users_columns.id', $hide_columns_ids)
-                            ->where('value', 'like', '%' . $search_keyword . '%')
                             ->groupBy('users_id');
+
+                    if (UsersColumns::isSearchExactMatchColumnType($users_column->column_type)) {
+                        // 完全一致
+                        $query->where('value', $search_keyword);
+                    } else {
+                        // 部分一致（通常）
+                        $query->where('value', 'like', '%' . $search_keyword . '%');
+                    }
                 });
             }
         }

--- a/resources/views/plugins/manage/user/list.blade.php
+++ b/resources/views/plugins/manage/user/list.blade.php
@@ -61,15 +61,12 @@ use App\Models\Core\UsersColumns;
                         絞り込み条件 <i class="fas fa-angle-down"></i>@if (Session::has('user_search_condition'))<span class="badge badge-pill badge-primary ml-2">条件設定中</span>@endif
                     </div>
                 </button>
-                {{-- @if (Session::has('user_search_condition'))
-                <div id="search_collapse" class="collapse show" aria-labelledby="user_search_condition" data-parent="#search_accordion">
-                @else --}}
-                <div id="search_collapse" class="collapse" aria-labelledby="user_search_condition" data-parent="#search_accordion">
-                {{-- @endif --}}
+                <div id="search_collapse" class="collapse @if(Session::get('is_search_collapse_show')) show @endif" aria-labelledby="user_search_condition" data-parent="#search_accordion">
                     <div class="card-body border-bottom">
 
                         <form name="form_search" id="form_search" class="form-horizontal" method="post" action="{{url('/')}}/manage/user/search">
                             {{ csrf_field() }}
+                            <input type="hidden" name="is_search_collapse_show" value="">
 
                             {{-- ログインID --}}
                             <div class="form-group row">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [add: ユーザ管理, ユーザ一覧検索で検索条件を開いたまま再表示できるオプション変数を追加](https://github.com/opensource-workshop/connect-cms/commit/208b5c887d4a0133565d637ce031556c8ba96014)
* [add: ユーザ管理, ユーザ一覧検索で検索条件を部分一致か完全一致かカラム型で設定できるオプションメソッドを追加](https://github.com/opensource-workshop/connect-cms/commit/7a1634e82a3f201b36843125cb7d6bfdac360b7b)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
