### PR TITLE
[GitHub action] Downgrade Chrome browser to v114

### DIFF
--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -137,7 +137,10 @@ jobs:
       # https://readouble.com/laravel/8.x/ja/dusk.html#managing-chromedriver-installations
       - name: Upgrade Chrome Driver
         run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
- 
+
+      - name: Upgrade Chrome Driver2
+        run: php artisan dusk:chrome-driver 116
+  
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -140,6 +140,9 @@ jobs:
 
       - name: Upgrade Chrome Driver2
         run: php artisan dusk:chrome-driver 116
+
+      - name: Upgrade Chrome Driver3
+        run: php artisan dusk:chrome-driver 114
   
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -147,7 +147,7 @@ jobs:
           chrome-version: 1134343 # Last commit number for Chrome v114
       - run: |
            # CHROME_BIN=$(which chrome)
-           ln -nfs `which chrome` /usr/bin/google-chrome
+           sudo ln -nfs `which chrome` /usr/bin/google-chrome
 
       - name: Downgrade Chrome driver to v114
         run: php artisan dusk:chrome-driver 114

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -131,10 +131,12 @@ jobs:
         run: php artisan db:seed --force
 
       # Dusk test
+      - name: Chrome Version
+        run: /opt/google/chrome/chrome --version
+
       # https://readouble.com/laravel/8.x/ja/dusk.html#managing-chromedriver-installations
-      # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver
+        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
  
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -145,9 +145,9 @@ jobs:
         uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: 1134343 # Last commit number for Chrome v114
-      - run: |
-           # CHROME_BIN=$(which chrome)
-           sudo ln -nfs `which chrome` /usr/bin/google-chrome
+
+      - name: Chrome bin-path Override
+        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
 
       - name: Downgrade Chrome driver to v114
         run: php artisan dusk:chrome-driver 114

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -135,13 +135,19 @@ jobs:
         run: /opt/google/chrome/chrome --version
 
       # https://readouble.com/laravel/8.x/ja/dusk.html#managing-chromedriver-installations
-      - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+      #- name: Upgrade Chrome Driver
+      #  run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
 
-      - name: Upgrade Chrome Driver2
-        run: php artisan dusk:chrome-driver 116
+      # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
+      # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
+      - name: Downgrade Chrome browser to v114
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: 1134343 # Last commit number for Chrome v114
+      - run: |
+           CHROME_BIN=$(which chrome)
 
-      - name: Upgrade Chrome Driver3
+      - name: Downgrade Chrome driver to v114
         run: php artisan dusk:chrome-driver 114
   
       - name: Start Chrome Driver

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -140,12 +140,14 @@ jobs:
 
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
+      # https://github.com/browser-actions/setup-chrome (community)
       - name: Downgrade Chrome browser to v114
         uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: 1134343 # Last commit number for Chrome v114
       - run: |
-           CHROME_BIN=$(which chrome)
+           # CHROME_BIN=$(which chrome)
+           ln -nfs `which chrome` /usr/bin/google-chrome
 
       - name: Downgrade Chrome driver to v114
         run: php artisan dusk:chrome-driver 114


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

ChromeDriver 115+になってChromeDriverのダウンロードURLが変更になり、ChromeDriver 115以降でダウンロードできなくなりました。
そのため、Chrome browser を v114にダウングレード＋ChromeDriverもv114にして対応しました。
他のgithub actionでもChromeDriverを使いたい場合は、本修正を横展開すれば対応できる見込みです。

* https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
* https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html

## 余談

Laravel8.xはDusk v6.x系ですが、既にbugfixのサポート期間を過ぎていたため、修正されませんでした。

* https://github.com/laravel/dusk/issues/1055

Dusk v7.x系は https://github.com/laravel/dusk/releases/tag/v7.9.0 で修正されました。
しかし、Dusk v7.x系はphp8.xで実行（https://github.com/laravel/dusk/blob/7.x/composer.json#L13 ）のため、Laravel8.x系では使えませんでした。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

無し

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

無し

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
