### PR TITLE
[フォーム] 登録一覧の編集画面で項目名と値が被って表示される不具合修正

### DIFF
--- a/resources/views/plugins/user/forms/default/forms_edit_input.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_input.blade.php
@@ -22,15 +22,15 @@
         {{-- ラベル --}}
         @if (isset($is_template_label_sm_4))
             {{-- label-sm-4テンプレート --}}
-            <label class="col-sm-4 control-label text-nowrap" for="status{{$frame_id}}">状態</label>
+            <label class="col-sm-4 control-label" for="status{{$frame_id}}">状態</label>
 
         @elseif (isset($is_template_label_sm_6))
             {{-- label-sm-6テンプレート --}}
-            <label class="col-sm-6 control-label text-nowrap" for="status{{$frame_id}}">状態</label>
+            <label class="col-sm-6 control-label" for="status{{$frame_id}}">状態</label>
 
         @else
             {{-- defaultテンプレート --}}
-            <label class="col-sm-2 control-label text-nowrap" for="status{{$frame_id}}">状態</label>
+            <label class="col-sm-2 control-label" for="status{{$frame_id}}">状態</label>
         @endif
 
         {{-- 項目 --}}
@@ -51,15 +51,15 @@
         {{-- ラベル --}}
         @if (isset($is_template_label_sm_4))
             {{-- label-sm-4テンプレート --}}
-            <label class="col-sm-4 control-label text-nowrap">{{$form_column->column_name}}</label>
+            <label class="col-sm-4 control-label">{{$form_column->column_name}}</label>
 
         @elseif (isset($is_template_label_sm_6))
             {{-- label-sm-6テンプレート --}}
-            <label class="col-sm-6 control-label text-nowrap">{{$form_column->column_name}}</label>
+            <label class="col-sm-6 control-label">{{$form_column->column_name}}</label>
 
         @else
             {{-- defaultテンプレート --}}
-            <label class="col-sm-2 control-label text-nowrap">{{$form_column->column_name}}</label>
+            <label class="col-sm-2 control-label">{{$form_column->column_name}}</label>
         @endif
 
         {{-- 項目 --}}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
