### PR TITLE
[ユーザ登録] 表示のみのカラム型, 自動登録のみ表示するカラム型 判定メソッド等追加

### DIFF
--- a/app/Enums/UserColumnType.php
+++ b/app/Enums/UserColumnType.php
@@ -95,4 +95,39 @@ class UserColumnType extends EnumsBase
 
         return [];
     }
+
+    /**
+     * 表示のみのカラム型 取得
+     */
+    public static function showOnlyColumnTypes(): array
+    {
+        $class_name = self::getOptionClass();
+        // オプションクラス有＋メソッド有なら呼ぶ
+        if ($class_name) {
+            if (method_exists($class_name, 'showOnlyColumnTypes')) {
+                return $class_name::showOnlyColumnTypes();
+            }
+        }
+
+        return [
+            self::created_at,
+            self::updated_at,
+        ];
+    }
+
+    /**
+     * 自動登録のみ表示するカラム型 取得
+     */
+    public static function autoRegistOnlyColumnTypes(): array
+    {
+        $class_name = self::getOptionClass();
+        // オプションクラス有＋メソッド有なら呼ぶ
+        if ($class_name) {
+            if (method_exists($class_name, 'autoRegistOnlyColumnTypes')) {
+                return $class_name::autoRegistOnlyColumnTypes();
+            }
+        }
+
+        return [];
+    }
 }

--- a/app/Models/Core/UsersColumns.php
+++ b/app/Models/Core/UsersColumns.php
@@ -110,6 +110,39 @@ class UsersColumns extends Model
     }
 
     /**
+     * 表示のみのカラム型か
+     */
+    public static function isShowOnlyColumnType($column_type): bool
+    {
+        if (in_array($column_type, UserColumnType::showOnlyColumnTypes())) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 自動登録で表示のみのカラム型か
+     */
+    public static function isShowOnlyAutoRegistColumnType($column_type): bool
+    {
+        if ($column_type == UserColumnType::created_at || $column_type == UserColumnType::updated_at) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 自動登録のみ表示するカラム型か
+     */
+    public static function isAutoRegistOnlyColumnTypes($column_type): bool
+    {
+        if (in_array($column_type, UserColumnType::autoRegistOnlyColumnTypes())) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * コレクションからラベル名取得
      */
     private static function getLabelFromCollection(Collection $users_columns, string $column_type, string $default): string

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2623,10 +2623,21 @@ class UserManage extends ManagePluginBase
         $column->columns_set_id = $request->columns_set_id;
         $column->column_name = $request->column_name;
         $column->column_type = $request->column_type;
-        $column->required = $request->required ? Required::on : Required::off;
+        $message = '項目【 '. $request->column_name .' 】を追加しました。';
+
+        if (UsersColumns::isShowOnlyColumnType($column->column_type)) {
+            $column->required = Required::off;
+            $message = '項目【 '.$column->column_name.' 】を追加し、表示のみの型のため、必須入力を【 off 】に設定しました。';
+        } else {
+            // 通常
+            $column->required = $request->required ? Required::on : Required::off;
+        }
+
+        $column->is_show_auto_regist = ShowType::show;
+        $column->is_show_my_page = ShowType::show;
+        $column->is_edit_my_page = EditType::ng;
         $column->display_sequence = $max_display_sequence;
         $column->save();
-        $message = '項目【 '. $request->column_name .' 】を追加しました。';
 
         // 編集画面を呼び出す
         return redirect("/manage/user/editColumns/$request->columns_set_id")->with('flash_message', $message);
@@ -2660,8 +2671,15 @@ class UserManage extends ManagePluginBase
         $column = UsersColumns::where('id', $request->column_id)->where('columns_set_id', $request->columns_set_id)->first();
         $column->column_name = $request->$str_column_name;
         $column->column_type = $request->$str_column_type;
-        $column->required = $request->$str_required ? Required::on : Required::off;
         $message = '項目【 '. $column->column_name .' 】を更新しました。';
+
+        if (UsersColumns::isShowOnlyColumnType($column->column_type)) {
+            $column->required = Required::off;
+            $message = '項目【 '.$column->column_name.' 】を更新し、表示のみの型のため、必須入力を【 off 】に設定しました。';
+        } else {
+            // 通常
+            $column->required = $request->$str_required ? Required::on : Required::off;
+        }
 
         // 固定項目以外
         if (!UsersColumns::isFixedColumnType($column->column_type)) {

--- a/app/Plugins/Mypage/ProfileMypage/ProfileMypage.php
+++ b/app/Plugins/Mypage/ProfileMypage/ProfileMypage.php
@@ -42,6 +42,13 @@ class ProfileMypage extends MypagePluginBase
      */
     public function index($request, $id = null)
     {
+        // post ＆ URLのなかに'/mypage/profile/index'が含まれている場合、oldに値をセット。(optionテンプレート等で使用)
+        // 入力エラー時はリダイレクトでget通信がくるので、その時は通さない
+        if ($request->isMethod('post') && strpos($request->url(), '/mypage/profile/index') !== false) {
+            // old()に全inputをセット
+            $request->flash();
+        }
+
         // ログインしているユーザー情報を取得
         $user = Auth::user();
         // ユーザーのカラム

--- a/resources/views/auth/registe_form.blade.php
+++ b/resources/views/auth/registe_form.blade.php
@@ -193,10 +193,24 @@ use App\Models\Core\UsersColumns;
                 </div>
             </div>
 
-        @elseif ($column->column_type == UserColumnType::created_at)
+        @elseif (UsersColumns::isShowOnlyAutoRegistColumnType($column->column_type))
             {{-- 表示しない --}}
-        @elseif ($column->column_type == UserColumnType::updated_at)
-            {{-- 表示しない --}}
+        @elseif (UsersColumns::isAutoRegistOnlyColumnTypes($column->column_type))
+            {{-- 未ログイン（自動登録）時のみ表示 --}}
+            @if (!Auth::user())
+                @php
+                    $label_for = 'for=user-column-' . $column->id;
+                    $label_class = '';
+                @endphp
+                <div class="form-group row">
+                    <label class="col-md-4 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$column->column_name}} @if ($column->required)<span class="badge badge-danger">必須</span> @endif</label>
+                    <div class="col-md-8">
+                        @includeFirst(["auth_option.registe_form_input_$column->column_type", "auth.registe_form_input_$column->column_type"], ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
+                        <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
+                    </div>
+                </div>
+            @endif
+
         @else
             @php
                 // ラジオとチェックボックスは選択肢にラベルを使っているため、項目名のラベルにforを付けない

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -498,7 +498,7 @@ use App\Models\Core\UsersColumns;
                 </div>
             @endif
 
-            @if ($column->column_type == UserColumnType::created_at || $column->column_type == UserColumnType::updated_at)
+            @if (UsersColumns::isShowOnlyColumnType($column->column_type))
                 {{-- 表示しない --}}
             @else
                 {{-- キャプション設定 --}}
@@ -579,8 +579,9 @@ use App\Models\Core\UsersColumns;
                 <h5 class="card-header">表示・編集設定</h5>
                 <div class="card-body">
 
-                    @if ($column->column_type == UserColumnType::created_at || $column->column_type == UserColumnType::updated_at)
+                    @if (UsersColumns::isShowOnlyColumnType($column->column_type))
                         {{-- 表示しない --}}
+                        <input type="hidden" name="is_show_auto_regist" value="{{$column->is_show_auto_regist}}">
                     @else
                         {{-- 自動ユーザ登録時の表示指定 --}}
                         <div class="form-group row">
@@ -640,8 +641,9 @@ use App\Models\Core\UsersColumns;
                         </div>
                     @endif
 
-                    @if ($column->column_type == UserColumnType::created_at || $column->column_type == UserColumnType::updated_at)
+                    @if (UsersColumns::isShowOnlyColumnType($column->column_type))
                         {{-- 表示しない --}}
+                        <input type="hidden" name="is_edit_my_page" value="{{$column->is_edit_my_page}}">
                     @else
                         {{-- マイページの編集指定 --}}
                         <div class="form-group row">

--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -43,8 +43,8 @@ use App\Models\Core\UsersColumns;
     </td>
     {{-- 必須 --}}
     <td class="align-middle text-center">
-        @if ($column->is_fixed_column || $column->column_type == UserColumnType::created_at || $column->column_type == UserColumnType::updated_at)
-            {{-- 固定項目, 登録日時, 更新日時 --}}
+        @if ($column->is_fixed_column || UsersColumns::isShowOnlyColumnType($column->column_type))
+            {{-- 固定項目, 表示のみの型 --}}
             <input type="hidden" name="required_{{ $column->id }}" @if (old('required_'.$column->id, $column->required) == Required::on) value="1" @else value="0" @endif>
             <input type="checkbox" name="required_{{ $column->id }}" value="1" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif disabled>
         @else

--- a/resources/views/plugins/mypage/index/include_index_column_value.blade.php
+++ b/resources/views/plugins/mypage/index/include_index_column_value.blade.php
@@ -1,0 +1,15 @@
+{{--
+ * マイページトップのデータ表示テンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category マイページ
+ --}}
+@php
+    $input_col = $input_cols->firstWhere('users_columns_id', $column->id);
+    $value = $input_col->value ?? ''
+@endphp
+<tr class="input-cols">
+    <th>{{$column->column_name}}</th>
+    <td>{{$value}}</td>
+</tr>

--- a/resources/views/plugins/mypage/index/index.blade.php
+++ b/resources/views/plugins/mypage/index/index.blade.php
@@ -1,5 +1,9 @@
 {{--
-    マイページ画面のトップのメインテンプレート
+ * マイページ画面のトップのメインテンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category マイページ
 --}}
 {{-- マイページ画面ベース画面 --}}
 @extends('plugins.mypage.mypage')
@@ -71,13 +75,7 @@
                                     <td nowrap="nowrap">{{ $user->updated_at->format('Y/m/d H:i') }}</td>
                                 </tr>
                             @else
-                                @php
-                                    $input_col = $input_cols->firstWhere('users_columns_id', $column->id);
-                                @endphp
-                                <tr class="input-cols">
-                                    <th>{{$column->column_name}}</th>
-                                    <td>{{$input_col->value ?? ''}}</td>
-                                </tr>
+                                @includeFirst(['plugins_option.mypage.index.include_index_column_value', 'plugins.mypage.index.include_index_column_value'])
                             @endif
                         @endforeach
                     </tbody>

--- a/resources/views/plugins/mypage/profile/edit_form.blade.php
+++ b/resources/views/plugins/mypage/profile/edit_form.blade.php
@@ -1,5 +1,10 @@
 {{--
+ * プロフィール変更のテンプレート
  * copy by resources\views\auth\registe_form.blade.php
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category プロフィール
 --}}
 @php
 use App\Models\Core\UsersColumns;
@@ -11,7 +16,7 @@ use App\Models\Core\UsersColumns;
 {{-- 登録後メッセージ表示 --}}
 @include('plugins.common.flash_message')
 
-<form action="{{url('/')}}/mypage/profile/update/{{$id}}" class="form-horizontal" method="POST">
+<form action="{{url('/')}}/mypage/profile/update/{{$id}}" class="form-horizontal" method="POST" name="form_profile">
     {{ csrf_field() }}
 
     @foreach($users_columns as $column)
@@ -79,9 +84,7 @@ use App\Models\Core\UsersColumns;
                 </div>
             </div>
 
-        @elseif ($column->column_type == UserColumnType::created_at)
-            {{-- 表示しない --}}
-        @elseif ($column->column_type == UserColumnType::updated_at)
+        @elseif (UsersColumns::isShowOnlyColumnType($column->column_type))
             {{-- 表示しない --}}
         @else
             @php
@@ -98,7 +101,7 @@ use App\Models\Core\UsersColumns;
             <div class="form-group row">
                 <label class="col-md-4 col-form-label text-md-right {{$label_class}}" {{$label_for}}>{{$column->column_name}} @if ($column->required)<span class="badge badge-danger">必須</span> @endif</label>
                 <div class="col-md-8">
-                    @include('auth.registe_form_input_' . $column->column_type, ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
+                    @includeFirst(["auth_option.registe_form_input_$column->column_type", "auth.registe_form_input_$column->column_type"], ['user_obj' => $column, 'label_id' => 'user-column-'.$column->id])
                     <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
                 </div>
             </div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [[ユーザ登録] 表示のみのカラム型, 自動登録のみ表示するカラム型 判定メソッド追加](https://github.com/opensource-workshop/connect-cms/commit/e453e064b83994dbf65ccd31319a0c0fc70da1ca)
* [change: マイページ, 任意項目表示のオプションテンプレート対応](https://github.com/opensource-workshop/connect-cms/commit/cc7c9bbdb1ced6c327f196ac0000db109ecb3c73)
* [change: プロフィール変更, 任意項目表示のオプションテンプレート対応](https://github.com/opensource-workshop/connect-cms/commit/a1833f192367ddfe58dbfaf5f88c4d9f4cac1b3b)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
