### PR TITLE
[新着情報]非同期で表示する機能を追加しました

### DIFF
--- a/app/Enums/WhatsnewFrameConfig.php
+++ b/app/Enums/WhatsnewFrameConfig.php
@@ -15,6 +15,7 @@ final class WhatsnewFrameConfig extends EnumsBase
     const border = 'border';
     const post_detail = 'post_detail';
     const post_detail_length = 'post_detail_length';
+    const async = 'async';
 
     // key/valueの連想配列
     const enum = [
@@ -23,5 +24,6 @@ final class WhatsnewFrameConfig extends EnumsBase
         self::border => '記事間の罫線',
         self::post_detail => '記事本文',
         self::post_detail_length => '記事本文の文字数',
+        self::async => '非同期表示',
     ];
 }

--- a/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
@@ -23,17 +23,18 @@
 @endif
 
 @if ($whatsnews)
-
-@if (isset($whatsnews_frame->rss) && $whatsnews_frame->rss == UseType::use)
-<p class="text-left">
-    <a href="{{url('/')}}/redirect/plugin/whatsnews/rss/{{$page->id}}/{{$frame_id}}/" title="{{$whatsnews_frame->whatsnew_name}}のRSS2.0"><span class="badge badge-info">RSS2.0</span></a>
-</p>
+    @if (isset($whatsnews_frame->rss) && $whatsnews_frame->rss == UseType::use)
+    <p class="text-left">
+        <a href="{{url('/')}}/redirect/plugin/whatsnews/rss/{{$page->id}}/{{$frame_id}}/" title="{{$whatsnews_frame->whatsnew_name}}のRSS2.0"><span class="badge badge-info">RSS2.0</span></a>
+    </p>
+    @endif
 @endif
 
-<div class="container" id="{{ $whatsnews_frame->read_more_use_flag == UseType::use ? 'app_' . $frame->id : '' }}">
+<div class="container" id="{{ 'app_' . $frame->id}}">
 
     <article class="clearfix">
         <div class="row">
+            @if ($whatsnews)
             @foreach($whatsnews as $whatsnew)
             @if (isset($is_template_col_3))
             {{-- カードタイプ３の場合 --}}
@@ -110,10 +111,12 @@
                 @endif
             </div>
             @endforeach
+            @endif
         </div>
     </article>
 
-    @if ($whatsnews_frame->read_more_use_flag == UseType::use)
+    @if ($whatsnews_frame->read_more_use_flag == UseType::use
+        || FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::async) == UseType::use)
         {{-- 「もっと見る」ボタン押下時、非同期で新着一覧をレンダリング --}}
         <article class="clearfix">
             <div class="row">
@@ -125,9 +128,9 @@
                 <div v-for="whatsnews in whatsnewses" class="col-12 col-sm-6 col-lg-3 whatsnew_card mb-2">
                 @endif
 
-                    @if ($link_pattern[$whatsnew->plugin_name] == 'show_page_frame_post')
-                    <a :href="url + link_base[whatsnews.plugin_name] + '/' + whatsnews.page_id + '/' + whatsnews.frame_id + '/' + whatsnews.post_id + '#frame-' + whatsnews.frame_id" style="text-decoration: none; color: initial;">
-                    @endif
+                    {{-- 本当はaタグだけ消して子要素は残したいが、、、 現在show_page_frame_postのパターンがないので一旦このv-ifで回避--}}
+                    <a v-if="link_pattern[whatsnews.plugin_name] == 'show_page_frame_post'"
+                        :href="url + link_base[whatsnews.plugin_name] + '/' + whatsnews.page_id + '/' + whatsnews.frame_id + '/' + whatsnews.post_id + '#frame-' + whatsnews.frame_id" style="text-decoration: none; color: initial;">
 
                     <div  class="p-2" style="height: 100%;"
                         v-bind:class="{ 'border': border == show }"
@@ -139,7 +142,6 @@
                             @{{ whatsnews.post_title_strip_tags }}
                         </dt>
 
-                        
                         {{-- カテゴリ --}}
                         <dd v-if="whatsnews.category != null && whatsnews.category != ''" class="text-center whatsnew_category">
                             <div>
@@ -170,9 +172,7 @@
 
                     </dl>
                 </div>
-                @if ($link_pattern[$whatsnew->plugin_name] == 'show_page_frame_post')
                 </a>
-                @endif
                 </div>
             </div>
         </article>
@@ -193,8 +193,8 @@
     @endif
 </div>
 
-    @if ($whatsnews_frame->read_more_use_flag == UseType::use)
+    @if ($whatsnews_frame->read_more_use_flag == UseType::use
+        || FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::async) == UseType::use)
         @include('plugins.user.whatsnews.whatsnews_script')
     @endif
-@endif
 @endsection

--- a/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
@@ -23,14 +23,16 @@
 @endif
 
 @if ($whatsnews)
-<p class="text-left">
-    @if (isset($whatsnews_frame->rss) && $whatsnews_frame->rss == 1)
-    <a href="{{url('/')}}/redirect/plugin/whatsnews/rss/{{$page->id}}/{{$frame_id}}/" title="{{$whatsnews_frame->whatsnew_name}}のRSS2.0"><span class="badge badge-info">RSS2.0</span></a>
-    @endif
-</p>
+    <p class="text-left">
+        @if (isset($whatsnews_frame->rss) && $whatsnews_frame->rss == 1)
+        <a href="{{url('/')}}/redirect/plugin/whatsnews/rss/{{$page->id}}/{{$frame_id}}/" title="{{$whatsnews_frame->whatsnew_name}}のRSS2.0"><span class="badge badge-info">RSS2.0</span></a>
+        @endif
+    </p>
+@endif
 
-<div id="{{ $whatsnews_frame->read_more_use_flag == UseType::use ? 'app_' . $frame->id : '' }}">
+<div id="{{ 'app_' . $frame->id }}">
     <dl>
+    @if ($whatsnews)
     @foreach($whatsnews as $whatsnew)
         {{-- 登録日時、カテゴリ --}}
         @if ($whatsnews_frame->view_posted_at)
@@ -86,6 +88,7 @@
         </dd>
         @endif
     @endforeach
+    @endif
     {{-- 「もっと見る」ボタン押下時、非同期で新着一覧をレンダリング ※templateタグはタグとして出力されないタグです。 --}}
     <template v-for="whatsnews in whatsnewses">
         {{-- 登録日時、カテゴリ --}}
@@ -139,8 +142,8 @@
         {{-- offset<input type="text" name="offset" value="" v-model="offset"> --}}
 </div>
 
-    @if ($whatsnews_frame->read_more_use_flag == UseType::use)
+    @if ($whatsnews_frame->read_more_use_flag == UseType::use
+        || FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::async) == UseType::use)
         @include('plugins.user.whatsnews.whatsnews_script')
     @endif
-@endif
 @endsection

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
@@ -120,6 +120,30 @@
             </div>
         </div>
 
+        {{-- 非同期表示 --}}
+        <h5><span class="badge badge-secondary">非同期表示</span></h5>
+
+        <div class="form-group row">
+            <label class="{{$frame->getSettingLabelClass(true)}}">非同期表示</label>
+            <div class="{{$frame->getSettingInputClass(true)}}">
+                @foreach (UseType::enum as $key => $value)
+                    <div class="custom-control custom-radio custom-control-inline">
+                        <input
+                            type="radio"
+                            value="{{ $key }}"
+                            id="{{ "async_${key}" }}"
+                            name="async"
+                            class="custom-control-input"
+                            {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::async, 0) == $key ? 'checked' : '' }}
+                        >
+                        <label class="custom-control-label" for="{{ "async_${key}" }}">
+                            {{ $value }}
+                        </label>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+
         {{-- Submitボタン --}}
         <div class="text-center">
             <a class="btn btn-secondary mr-2" href="{{URL::to($page->permanent_link)}}#frame-{{$frame->id}}">

--- a/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
@@ -23,15 +23,15 @@
 @endif
 
 @if ($whatsnews)
-
-@if (isset($whatsnews_frame->rss) && $whatsnews_frame->rss == 1)
-<p class="text-left">
-    <a href="{{url('/')}}/redirect/plugin/whatsnews/rss/{{$page->id}}/{{$frame_id}}/" title="{{$whatsnews_frame->whatsnew_name}}のRSS2.0"><span class="badge badge-info">RSS2.0</span></a>
-</p>
+    @if (isset($whatsnews_frame->rss) && $whatsnews_frame->rss == 1)
+    <p class="text-left">
+        <a href="{{url('/')}}/redirect/plugin/whatsnews/rss/{{$page->id}}/{{$frame_id}}/" title="{{$whatsnews_frame->whatsnew_name}}のRSS2.0"><span class="badge badge-info">RSS2.0</span></a>
+    </p>
+    @endif
 @endif
 
-<div class="container" id="{{ $whatsnews_frame->read_more_use_flag == UseType::use ? 'app_' . $frame->id : '' }}">
-
+<div class="container" id="{{'app_' . $frame->id}}">
+@if ($whatsnews)
 @foreach($whatsnews as $whatsnew)
     <article class="clearfix">
         <div class="row @if (!$loop->first && FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::border))border-top @endif pt-1">
@@ -100,7 +100,9 @@
         @endif
     </article>
 @endforeach
-    @if ($whatsnews_frame->read_more_use_flag == UseType::use)
+@endif
+    @if ($whatsnews_frame->read_more_use_flag == UseType::use
+        || FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::async) == UseType::use)
         {{-- 「もっと見る」ボタン押下時、非同期で新着一覧をレンダリング --}}
         <article v-for="whatsnews in whatsnewses" class="clearfix">
             <div class="row pt-1"
@@ -164,8 +166,8 @@
     @endif
 </div>
 
-    @if ($whatsnews_frame->read_more_use_flag == UseType::use)
+    @if ($whatsnews_frame->read_more_use_flag == UseType::use
+    || FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::async) == UseType::use)
         @include('plugins.user.whatsnews.whatsnews_script')
     @endif
-@endif
 @endsection


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

## 目的

1ページに新着情報をたくさん並べると、表示に時間がかかります。
表示を早くするために、非同期でコンテンツを取得するようにしました。

## 変更内容

- 表示設定画面 - 非同期表示の項目を追加しました
- 各テンプレート - 非同期表示ONの場合、非同期でデータを取得するように変更しました

### 表示設定画面
<img width="669" alt="image" src="https://github.com/opensource-workshop/connect-cms/assets/32890286/775dde8c-96d4-49ec-9b3e-88080f57767a">

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
