### PR TITLE
[ユーザ管理] 項目設定で選択肢なしの時の「選択肢がありません。」メッセージが表示されない不具合修正、項目設定で設定した選択肢が一覧表示されない不具合修正

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2572,6 +2572,7 @@ class UserManage extends ManagePluginBase
             if (UsersColumns::isSelectColumnType($column->column_type)) {
                 // 選択肢
                 $column->selects = UsersColumnsSelects::where('columns_set_id', $id)
+                    ->where('users_columns_id', $column->id)
                     ->orderBy('users_columns_id', 'asc')
                     ->orderBy('display_sequence', 'asc')
                     ->get();

--- a/resources/views/plugins/manage/user/edit_columns.blade.php
+++ b/resources/views/plugins/manage/user/edit_columns.blade.php
@@ -50,7 +50,7 @@
         // 有効化
         $('[data-toggle="tooltip"]').tooltip()
         // 常時表示 ※表示の判定は項目側で実施
-        $('[id^=detail-button-tip]').tooltip('show');
+        $('.detail-button-tip').tooltip('show');
     })
 </script>
 

--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -55,12 +55,12 @@ use App\Models\Core\UsersColumns;
     <td class="text-center px-2">
         <button
             type="button"
-            class="btn btn-success btn-xs cc-font-90 text-nowrap"
+            class="btn btn-success btn-xs cc-font-90 text-nowrap @if (UsersColumns::isSelectColumnType($column->column_type)) detail-button-tip @endif"
             id="button_user_column_detail_{{ $column->id }}"
             @if (UsersColumns::isSelectColumnType($column->column_type))
                 {{-- 選択肢の設定がない場合のみツールチップを表示 --}}
-                @if ($column->select_count == 0)
-                    id="detail-button-tip" data-toggle="tooltip" title="選択肢がありません。設定してください。" data-trigger="manual" data-placement="bottom"
+                @if ($column->selects->isEmpty())
+                    data-toggle="tooltip" title="選択肢がありません。設定してください。" data-trigger="manual" data-placement="bottom"
                 @endif
             @endif
             onclick="location.href='{{url('/')}}/manage/user/editColumnDetail/{{ $column->id }}'"

--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -46,7 +46,14 @@ use App\Models\Core\UsersColumns;
         @if ($column->is_fixed_column || UsersColumns::isShowOnlyColumnType($column->column_type))
             {{-- 固定項目, 表示のみの型 --}}
             <input type="hidden" name="required_{{ $column->id }}" @if (old('required_'.$column->id, $column->required) == Required::on) value="1" @else value="0" @endif>
-            <input type="checkbox" name="required_{{ $column->id }}" value="1" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif disabled>
+            <input type="checkbox" name="required_{{ $column->id }}" value="1"
+                @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif
+                @if ($column->is_fixed_column)
+                    disabled data-toggle="tooltip" title="ユーザに必ず必要な項目は、必須チェックを変更できません。"
+                @elseif (UsersColumns::isShowOnlyColumnType($column->column_type))
+                    disabled data-toggle="tooltip" title="表示のみの項目のため、必須チェックOFFから変更できません。"
+                @endif
+            >
         @else
             <input type="checkbox" name="required_{{ $column->id }}" value="1" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif>
         @endif
@@ -117,7 +124,7 @@ use App\Models\Core\UsersColumns;
 
         @if ($column->selects->isNotEmpty())
             {{-- 選択肢データがある場合、カンマ付で一覧表示する --}}
-            <i class="far fa-list-alt" data-toggle="tooltip" title="選択肢"></i> {{ $column->selects->where('users_columns_id', $column->id)->pluck('value')->implode(',') }}
+            <i class="far fa-list-alt" data-toggle="tooltip" title="選択肢"></i> {{ $column->selects->pluck('value')->implode(',') }}
         @endif
 
         @if ($column->caption)


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [bugfix: ユーザ管理, 項目設定で選択肢なしの時の「選択肢がありません。」メッセージが表示されない不具合修正](https://github.com/opensource-workshop/connect-cms/commit/10cb6d359bf912c221bb0464dd3f4934055de71e)
* [bugfix: ユーザ管理, 項目設定で設定した選択肢が一覧表示されない不具合修正](https://github.com/opensource-workshop/connect-cms/commit/edb8db9f3baf98cfef815795098be51dc5d31c7d)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
