### PR TITLE
[施設予約] 24h終了予定の繰返し予定で、この日付以降削除するが機能しない不具合修正

### DIFF
--- a/app/Plugins/User/Reservations/ReservationsPlugin.php
+++ b/app/Plugins/User/Reservations/ReservationsPlugin.php
@@ -1865,7 +1865,8 @@ class ReservationsPlugin extends UserPluginBase
                 ReservationsInput::where('inputs_parent_id', $before_inputs_parent_id)
                     ->where('id', '!=', $input->id)
                     ->whereDate('start_datetime', $occurrence->format('Y-m-d'))
-                    ->whereDate('end_datetime', $occurrence->format('Y-m-d'))
+                    // bugfix: 開始日のみで消す。終了日は24h指定時で次の日になるため、end_datetime指定があると機能しない
+                    // ->whereDate('end_datetime', $occurrence->format('Y-m-d'))
                     ->delete();
             }
 

--- a/app/Plugins/User/Reservations/ReservationsPlugin.php
+++ b/app/Plugins/User/Reservations/ReservationsPlugin.php
@@ -1100,7 +1100,7 @@ class ReservationsPlugin extends UserPluginBase
             }
         }
 
-
+        // *** ReservationsInputsColumn更新
         // 項目IDを取得
         $columns_value = $request->columns_value ?? [];
         foreach (array_keys($columns_value) as $key) {
@@ -1121,6 +1121,7 @@ class ReservationsPlugin extends UserPluginBase
             $reservations_inputs_columns->save();
         }
 
+        // *** 登録後メッセージ
         // 利用日時のFrom～To 取得
         $start_end_datetime_str = $reservations_inputs->getStartEndDatetimeStr();
         $flash_message = "{$str_mode}【場所】{$facility->facility_name} 【日時】{$start_end_datetime_str}";
@@ -1136,6 +1137,7 @@ class ReservationsPlugin extends UserPluginBase
 
         session()->flash('flash_message_for_frame' . $frame_id, $flash_message);
 
+        // *** メール送信
         // プラグイン独自の埋め込みタグ
         $overwrite_notice_embedded_tags = [
             NoticeEmbeddedTag::title => $this->getTitle($reservations_inputs, $columns),


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

24h終了予定（例：0:00-24:00等）＋繰返し予定で、削除の「この日付以降を削除する」を指定した時、指定日のみしか削除されず、以降の日付が削除されない不具合を修正しました。

## 詳細

「この日付以降を削除する」を処理時、開始日・終了日を該当日を指定して削除していました（26日以降なら26, 27, 28…と）が、終了時刻が24hの場合、内部データは次の日（26日なら27日、27日なら28日）となっていて、削除できてませんでした。
「この日付以降を削除する」を処理時は、開始日のみ見て、削除するよう見直しました。

* [bugfix: 施設予約, 24h予定の繰返し予定で、この日付以降削除するが機能しない不具合修正](https://github.com/opensource-workshop/connect-cms/pull/1814/commits/369fa766a4b432bd0d08aa83d343c5fe95677649)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
