### PR TITLE
[サイト管理＞サイト設計書] 自動ユーザ登録設定の「個人情報保護方針の表示内容」「ユーザ登録について」のHTMLが壊れていた場合、500エラーになる不具合修正 OW-2005

### DIFF
--- a/app/Models/Core/ApiSecret.php
+++ b/app/Models/Core/ApiSecret.php
@@ -25,7 +25,7 @@ class ApiSecret extends Model
      */
     public function getApiCheckbpoxs($api_inis, $check_off = false)
     {
-        $apis = explode(',', $this->apis);
+        $apis = explode(',', (string)$this->apis);
         $ret_apis = array();
         foreach ($api_inis as $api_name => $api_ini) {
             $check = false;

--- a/app/Models/Core/Configs.php
+++ b/app/Models/Core/Configs.php
@@ -2,9 +2,9 @@
 
 namespace App\Models\Core;
 
+use App\Utilities\Html\HtmlUtils;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 
 class Configs extends Model
 {
@@ -74,6 +74,20 @@ class Configs extends Model
         $config = $configs->firstWhere('name', $key);
         // firstWhere()で取得空の場合null が返ってくる。$config->value としても Null 合体演算子?? でundfind indexエラーでないので問題なし。nullなら default値 を返す。
         $value = $config->value ?? $default;
+
+        return $value;
+    }
+
+    /**
+     * 設定値（HTML）を修復して取得
+     */
+    public static function getConfigsValueWithHtmlRepair($configs, $key, $default = false)
+    {
+        $value = self::getConfigsValue($configs, $key, $default);
+
+        // 閉じタグしかない等、壊れたHTMLを整形（＝修復）して出力するために HtmlPurifier を利用
+        $purifier = HtmlUtils::getHtmlPurifier();
+        $value = $purifier->purify($value);
 
         return $value;
     }

--- a/app/Models/Core/Configs.php
+++ b/app/Models/Core/Configs.php
@@ -84,6 +84,8 @@ class Configs extends Model
     public static function getConfigsValueWithHtmlRepair($configs, $key, $default = false)
     {
         $value = self::getConfigsValue($configs, $key, $default);
+        // php8.x対応: nullだと HtmlPurifier::purify()内部で preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated エラー起こすため
+        $value = is_null($value) ? '' : $value;
 
         // 閉じタグしかない等、壊れたHTMLを整形（＝修復）して出力するために HtmlPurifier を利用
         $purifier = HtmlUtils::getHtmlPurifier();

--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 
 use Monolog\Logger;
@@ -19,8 +18,6 @@ use Monolog\Handler\RotatingFileHandler;
 use Symfony\Component\Process\PhpExecutableFinder;
 // use Symfony\Component\Process\Process;
 
-use HTMLPurifier;
-use HTMLPurifier_Config;
 use Request;
 
 use Carbon\Carbon;
@@ -50,6 +47,8 @@ use App\Rules\CustomValiRequiredWithoutAllSupportsArrayInput;
 
 use App\Traits\ConnectCommonTrait;
 use App\Traits\ConnectRoleTrait;
+
+use App\Utilities\Html\HtmlUtils;
 
 /**
  * ユーザープラグイン
@@ -1324,25 +1323,7 @@ class UserPluginBase extends PluginBase
     {
         if ($this->isHtmlPurifier()) {
             if (empty($this->purifier)) {
-                // HTMLPurifierを設定するためのクラスを生成する
-                $config = HTMLPurifier_Config::createDefault();
-
-                if (!Storage::exists('tmp/htmlpurifier')) {
-                    Storage::makeDirectory('tmp/htmlpurifier');
-                }
-                $config->set('Cache.SerializerPath', storage_path('app/tmp/htmlpurifier'));
-
-                // bugfix: class指定を許可は、デフォルト null ですべてのクラスが許可されている http://htmlpurifier.org/live/configdoc/plain.html#Attr.AllowedClasses
-                // $config->set('Attr.AllowedClasses', array()); // class指定を許可する
-                $config->set('Attr.AllowedClasses', null); // class指定を許可する
-                $config->set('Attr.EnableID', true);          // id属性を許可する
-                $config->set('Filter.YouTube', true);         // Youtube埋め込みを許可する
-                $config->set('HTML.TargetBlank', true);       // target="_blank" が使えるようにする
-                $config->set('Attr.AllowedFrameTargets', ['_blank']);
-                $config->set('HTML.SafeIframe', true);
-                $config->set('URI.SafeIframeRegexp', '%^(https?:)?//(www\.youtube(?:-nocookie)?\.com/embed/|player\.vimeo\.com/video/)%'); //allow YouTube and Vimeo
-
-                $this->purifier = new HTMLPurifier($config);
+                $this->purifier = HtmlUtils::getHtmlPurifier();
             }
 
             return $this->purifier->purify($text);

--- a/app/Utilities/Html/HtmlUtils.php
+++ b/app/Utilities/Html/HtmlUtils.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Utilities\Html;
+
+use HTMLPurifier;
+use HTMLPurifier_Config;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * HtmlUtils
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @package Utilities
+ */
+class HtmlUtils
+{
+    /**
+     * HTMLPurifierのクラスインスタンスを取得
+     */
+    public static function getHtmlPurifier()
+    {
+        // HTMLPurifierを設定するためのクラスを生成する
+        $config = HTMLPurifier_Config::createDefault();
+
+        if (!Storage::exists('tmp/htmlpurifier')) {
+            Storage::makeDirectory('tmp/htmlpurifier');
+        }
+        $config->set('Cache.SerializerPath', storage_path('app/tmp/htmlpurifier'));
+
+        // bugfix: class指定を許可は、デフォルト null ですべてのクラスが許可されている http://htmlpurifier.org/live/configdoc/plain.html#Attr.AllowedClasses
+        // $config->set('Attr.AllowedClasses', array()); // class指定を許可する
+        $config->set('Attr.AllowedClasses', null); // class指定を許可する
+        $config->set('Attr.EnableID', true);          // id属性を許可する
+        $config->set('Filter.YouTube', true);         // Youtube埋め込みを許可する
+        $config->set('HTML.TargetBlank', true);       // target="_blank" が使えるようにする
+        $config->set('Attr.AllowedFrameTargets', ['_blank']);
+        $config->set('HTML.SafeIframe', true);
+        $config->set('URI.SafeIframeRegexp', '%^(https?:)?//(www\.youtube(?:-nocookie)?\.com/embed/|player\.vimeo\.com/video/)%'); //allow YouTube and Vimeo
+
+        $purifier = new HTMLPurifier($config);
+        return $purifier;
+    }
+
+}

--- a/resources/views/plugins/manage/site/pdf/api_list.blade.php
+++ b/resources/views/plugins/manage/site/pdf/api_list.blade.php
@@ -29,7 +29,7 @@
             <td>{{$api_secret->secret_code}}</td>
         @endif
         <td>{{$api_secret->ip_address}}</td>
-        <td>{!!nl2br($api_secret->apis)!!}</td>
+        <td>{!!nl2br((string)$api_secret->apis)!!}</td>
     </tr>
     @endforeach
     @if($api_secrets->isEmpty())

--- a/resources/views/plugins/manage/site/pdf/base_analytics.blade.php
+++ b/resources/views/plugins/manage/site/pdf/base_analytics.blade.php
@@ -17,6 +17,6 @@
     </tr>
     <tr nobr="true">
         <td>トラッキングコード</td>
-        <td>{!!nl2br(htmlspecialchars(Configs::getConfigsValue($configs, 'tracking_code', null)), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401)!!}</td>
+        <td>{!!nl2br(htmlspecialchars(Configs::getConfigsValue($configs, 'tracking_code', '')), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401)!!}</td>
     </tr>
 </table>

--- a/resources/views/plugins/manage/site/pdf/contact.blade.php
+++ b/resources/views/plugins/manage/site/pdf/contact.blade.php
@@ -15,14 +15,14 @@
 <h3><u>{{Configs::getConfigsValue($configs, 'document_support_org_title', null)}}</u></h3>
 <br />
 <br />
-{!!nl2br(Configs::getConfigsValue($configs, 'document_support_org_txt', null))!!}<br />
+{!!nl2br(Configs::getConfigsValue($configs, 'document_support_org_txt', ''))!!}<br />
 
 <h3><u>{{Configs::getConfigsValue($configs, 'document_support_contact_title', null)}}</u></h3>
 <br />
 <br />
-{!!nl2br(Configs::getConfigsValue($configs, 'document_support_contact_txt', null))!!}<br />
+{!!nl2br(Configs::getConfigsValue($configs, 'document_support_contact_txt', ''))!!}<br />
 
 <h3><u>{{Configs::getConfigsValue($configs, 'document_support_other_title', null)}}</u></h3>
 <br />
 <br />
-{!!nl2br(Configs::getConfigsValue($configs, 'document_support_other_txt', null))!!}<br />
+{!!nl2br(Configs::getConfigsValue($configs, 'document_support_other_txt', ''))!!}<br />

--- a/resources/views/plugins/manage/site/pdf/user_regist.blade.php
+++ b/resources/views/plugins/manage/site/pdf/user_regist.blade.php
@@ -118,7 +118,7 @@
             <td>次行を参照</td>
         </tr>
         <tr nobr="true">
-            <td colspan="2">{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_privacy_description', null))!!}</td>
+            <td colspan="2">{!!nl2br(Configs::getConfigsValueWithHtmlRepair($configs_user_register, 'user_register_privacy_description', null))!!}</td>
         </tr>
     </table>
 
@@ -134,7 +134,7 @@
             <td>次行を参照</td>
         </tr>
         <tr nobr="true">
-            <td colspan="2">{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_description', null))!!}</td>
+            <td colspan="2">{!!nl2br(Configs::getConfigsValueWithHtmlRepair($configs_user_register, 'user_register_description', null))!!}</td>
         </tr>
     </table>
 @endforeach

--- a/resources/views/plugins/manage/site/pdf/user_regist.blade.php
+++ b/resources/views/plugins/manage/site/pdf/user_regist.blade.php
@@ -69,7 +69,7 @@
         </tr>
         <tr nobr="true">
             <td>仮登録メールフォーマット</td>
-            <td>{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_temporary_regist_mail_format', null))!!}</td>
+            <td>{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_temporary_regist_mail_format', ''))!!}</td>
         </tr>
         <tr nobr="true">
             <td>仮登録後のメッセージ</td>
@@ -90,7 +90,7 @@
         </tr>
         <tr nobr="true">
             <td>本登録メールフォーマット</td>
-            <td>{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_mail_format', null))!!}</td>
+            <td>{!!nl2br(Configs::getConfigsValue($configs_user_register, 'user_register_mail_format', ''))!!}</td>
         </tr>
         <tr nobr="true">
             <td>本登録後のメッセージ</td>
@@ -118,7 +118,7 @@
             <td>次行を参照</td>
         </tr>
         <tr nobr="true">
-            <td colspan="2">{!!nl2br(Configs::getConfigsValueWithHtmlRepair($configs_user_register, 'user_register_privacy_description', null))!!}</td>
+            <td colspan="2">{!!nl2br(Configs::getConfigsValueWithHtmlRepair($configs_user_register, 'user_register_privacy_description', ''))!!}</td>
         </tr>
     </table>
 
@@ -134,7 +134,7 @@
             <td>次行を参照</td>
         </tr>
         <tr nobr="true">
-            <td colspan="2">{!!nl2br(Configs::getConfigsValueWithHtmlRepair($configs_user_register, 'user_register_description', null))!!}</td>
+            <td colspan="2">{!!nl2br(Configs::getConfigsValueWithHtmlRepair($configs_user_register, 'user_register_description', ''))!!}</td>
         </tr>
     </table>
 @endforeach


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [bugfix: サイト管理＞サイト設計書, 自動ユーザ登録設定の「個人情報保護方針の表示内容」「ユーザ登録について」のHTMLが壊れていた場合、500エラーになる不具合修正](https://github.com/opensource-workshop/connect-cms/commit/8f6024da9a7f17c245b38115d9a95d106e2fa61d) 
* [bugfix: サイト管理＞サイト設計書, php8.x対応](https://github.com/opensource-workshop/connect-cms/commit/d63750a8b34002fdf5f83866b2c98f978571dc5b)
* [bugfix: API管理, php8.x対応](https://github.com/opensource-workshop/connect-cms/commit/6c21ac380de097675ffa356ec7aea4ed4cb3e31b)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り / 無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

