### PR TITLE
[データベース]全文検索機能を追加しました

### DIFF
--- a/app/Models/User/Databases/DatabasesInputs.php
+++ b/app/Models/User/Databases/DatabasesInputs.php
@@ -377,21 +377,21 @@ class DatabasesInputs extends Model
     public function scopeFullText($query, string $keyword)
     {
         $keyword = str_replace(" AND ", "[AND]", $keyword);
-		$keyword = str_replace(" and ", "[AND]", $keyword);
-		$keyword = str_replace(" & ", "[AND]", $keyword);
-		$keyword = str_replace(" OR ", "[OR]", $keyword);
-		$keyword = str_replace(" or ", "[OR]", $keyword);
-		$keyword = str_replace(" | ", "[OR]", $keyword);
-		$keyword = str_replace(" NOT ", "[NOT]", $keyword);
-		$keyword = str_replace(" not ", "[NOT]", $keyword);
+        $keyword = str_replace(" and ", "[AND]", $keyword);
+        $keyword = str_replace(" & ", "[AND]", $keyword);
+        $keyword = str_replace(" OR ", "[OR]", $keyword);
+        $keyword = str_replace(" or ", "[OR]", $keyword);
+        $keyword = str_replace(" | ", "[OR]", $keyword);
+        $keyword = str_replace(" NOT ", "[NOT]", $keyword);
+        $keyword = str_replace(" not ", "[NOT]", $keyword);
 
-		// space replace to AND
-		$keyword = str_replace(" ", "[AND]", $keyword);
+        // space replace to AND
+        $keyword = str_replace(" ", "[AND]", $keyword);
 
-		$keyword = str_replace("[AND]", " +", $keyword);
-		$keyword = str_replace("[OR]", " ", $keyword);
-		$keyword = str_replace("[NOT]", " -", $keyword);
-		$keyword = str_replace("+-", "-", $keyword);
+        $keyword = str_replace("[AND]", " +", $keyword);
+        $keyword = str_replace("[OR]", " ", $keyword);
+        $keyword = str_replace("[NOT]", " -", $keyword);
+        $keyword = str_replace("+-", "-", $keyword);
 
         Log::debug($keyword);
         $query->whereRaw("match(`full_text`) against (? IN BOOLEAN MODE)", [$keyword]);

--- a/app/Models/User/Databases/DatabasesInputs.php
+++ b/app/Models/User/Databases/DatabasesInputs.php
@@ -5,6 +5,7 @@ namespace App\Models\User\Databases;
 use Illuminate\Database\Eloquent\Model;
 
 use App\UserableNohistory;
+use Illuminate\Support\Facades\Log;
 
 class DatabasesInputs extends Model
 {
@@ -368,5 +369,31 @@ class DatabasesInputs extends Model
         }
 
         return $input_col->value;
+    }
+
+    /**
+     * 全文検索を行う
+     */
+    public function scopeFullText($query, string $keyword)
+    {
+        $keyword = str_replace(" AND ", "[AND]", $keyword);
+		$keyword = str_replace(" and ", "[AND]", $keyword);
+		$keyword = str_replace(" & ", "[AND]", $keyword);
+		$keyword = str_replace(" OR ", "[OR]", $keyword);
+		$keyword = str_replace(" or ", "[OR]", $keyword);
+		$keyword = str_replace(" | ", "[OR]", $keyword);
+		$keyword = str_replace(" NOT ", "[NOT]", $keyword);
+		$keyword = str_replace(" not ", "[NOT]", $keyword);
+
+		// space replace to AND
+		$keyword = str_replace(" ", "[AND]", $keyword);
+
+		$keyword = str_replace("[AND]", " +", $keyword);
+		$keyword = str_replace("[OR]", " ", $keyword);
+		$keyword = str_replace("[NOT]", " -", $keyword);
+		$keyword = str_replace("+-", "-", $keyword);
+
+        Log::debug($keyword);
+        $query->whereRaw("match(`full_text`) against (? IN BOOLEAN MODE)", [$keyword]);
     }
 }

--- a/app/Plugins/User/Databases/DatabasesTool.php
+++ b/app/Plugins/User/Databases/DatabasesTool.php
@@ -11,6 +11,8 @@ use App\Traits\ConnectCommonTrait;
 
 use App\Enums\DatabaseColumnRoleName;
 use App\Enums\DatabaseRoleName;
+use App\Enums\UseType;
+use App\Models\User\Databases\Databases;
 use App\Models\User\Databases\DatabasesInputs;
 
 /**
@@ -260,7 +262,7 @@ class DatabasesTool
      * データベース検索プラグイン例）$where_in_colum_name = 'databases_inputs_id'
      * 新着例）                    $where_in_colum_name = 'databases_inputs.id'
      */
-    public static function appendSearchKeyword($where_in_colum_name, $inputs_query, $databases_columns_ids, $hide_columns_ids, $search_keyword)
+    public static function appendSearchKeyword($where_in_colum_name, $inputs_query, $databases_columns_ids, $hide_columns_ids, $search_keyword, $full_text_search = false)
     {
         /**
          * キーワードでスペース連結してAND検索
@@ -269,6 +271,11 @@ class DatabasesTool
          * s:全角スペース→半角スペース
          */
         $search_keywords = explode(' ', mb_convert_kana($search_keyword, 's'));
+
+        // 全文検索
+        if ($full_text_search) {
+            return $inputs_query->fullText(mb_convert_kana($search_keyword, 's'));
+        }
 
         $target_databases_inputs_ids = collect();
 
@@ -470,5 +477,76 @@ class DatabasesTool
         });
 
         return $inputs_query;
+    }
+
+    /**
+     * 全文検索項目を洗い替える
+     *
+     * @param int $database_id 洗い替え対象のdatabase_id
+     * @param int $dadatabase_input_idtabase_id 洗い替え対象のdatabase_input_id
+     */
+    public function updateFullText(int $database_id = null, int $database_input_id = null)
+    {
+        // 全文検索対象のデータベースを取得する
+        $query = Databases::where('full_text_search', UseType::use);
+        if ($database_id) {
+            $query = $query->where('id', $database_id);
+        }
+        $databases = $query->get();
+
+        foreach ($databases as $database) {
+            $this->updateFullTextValues($database->id, $database_input_id);
+        }
+    }
+
+    /**
+     * 全文検索項目更新処理
+     *
+     * @param int $database_id 洗い替え対象のdatabase_id
+     * @param int $dadatabase_input_idtabase_id 洗い替え対象のdatabase_input_id
+     */
+    private function updateFullTextValues(int $database_id, $database_input_id = null)
+    {
+        // カラムの取得
+        $columns = DatabasesColumns::where('databases_id', $database_id)->where('search_flag', 1)->get();
+        // ゲストが見られる項目のみ検索対象のカラムとする
+        $hide_columns_ids = $this->getHideColumnsIds($columns, 'list_detail_display_flag');
+        // 検索対象となるカラム
+        $search_column_ids = $columns->WhereNotIn('id', $hide_columns_ids)->pluck('id');
+
+        $query = DatabasesInputs::where('databases_id', $database_id);
+        if ($database_input_id) {
+            $query = $query->where('id', $database_input_id);
+        }
+        $database_inputs = $query->get();
+
+        foreach ($database_inputs as $input) {
+            // 洗い替える
+            // GROUP_CONCATで取得するとGROUP_CONCATの上限桁数（MySQL設定値）があって全部を取得できないことがある
+            // なので、PHPで結合する
+            $input_value = DatabasesInputCols::where('databases_inputs_id', $input->id)
+                ->whereIn('databases_columns_id', $search_column_ids)
+                ->get()
+                ->implode('value');
+
+            // カテゴリも検索対象
+            $category = DatabasesInputs::leftJoin('categories', 'databases_inputs.categories_id', '=', 'categories.id')
+                ->where('databases_inputs.id', $input->id)
+                ->get()
+                ->implode('category');
+
+            $input->full_text = $input_value . $category;
+            $input->save();
+        }
+    }
+
+    /**
+     * 全文検索項目を消す
+     *
+     * @param int $database_id 洗い替え対象のdatabase_id
+     */
+    public function flushFullText(int $database_id)
+    {
+        DatabasesInputs::where('databases_id', $database_id)->update(['full_text' => null]);
     }
 }

--- a/database/migrations/2023_09_04_153112_add_full_text_search_to_databases.php
+++ b/database/migrations/2023_09_04_153112_add_full_text_search_to_databases.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFullTextSearchToDatabases extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases', function (Blueprint $table) {
+            $table->integer('full_text_search')->default(0)->comment('全文検索を使用する')->after('numbering_prefix');
+        });
+
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->mediumText('full_text')->nullable()->comment('全文検索用項目')->after('categories_id');
+        });
+
+        $result = DB::select( DB::raw("select version() as version"));
+        $version =  $result[0]->version;
+        // MariaDBはNGRAMが使えない
+        if (strpos($version, 'Maria') !== false) {
+            DB::statement('ALTER TABLE databases_inputs ADD FULLTEXT INDEX ft_idx_databases_inputs_full_text (full_text);');
+        } else {
+            DB::statement('ALTER TABLE databases_inputs ADD FULLTEXT INDEX ft_idx_databases_inputs_full_text (full_text) WITH PARSER ngram;');
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases', function (Blueprint $table) {
+            $table->dropColumn('full_text_search');
+        });
+
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->dropIndex('ft_idx_databases_inputs_full_text');
+            $table->dropColumn('full_text');
+        });
+
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
@@ -120,6 +120,27 @@
         </div>
     </div>
 
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">全文検索</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            @foreach (UseType::enum as $key => $value)
+            <div class="custom-control custom-radio custom-control-inline">
+                <input
+                    type="radio"
+                    value="{{ $key }}"
+                    id="{{ "full_text_search_${key}" }}"
+                    name="full_text_search"
+                    class="custom-control-input"
+                    {{ old('full_text_search', $database->full_text_search) == $key ? 'checked' : '' }}
+                >
+                <label class="custom-control-label" for="{{ "full_text_search_${key}" }}">
+                    {{ $value }}
+                </label>
+            </div>
+        @endforeach
+        </div>
+    </div>
+
 {{--
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">メール送信先</label>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

## 目的

- データベースのキーワード検索を高速化する
- OR検索、除外検索（-）を可能にする

## 変更内容

- DB設定画面 全文検索の設定項目を追加
  - 全文検索を有効にする場合、「使用する」を選択します
  - 項目を検索対象にすれば、検索されます
- キーワード検索
  - 「OR もしくは | 」キーワードいずれかを含むデータを検索します
  - 「AND もしくは &」キーワードすべてを含むデータを検索します
  - 「NOT または –」キーワードを除外したデータを検索します

## 特記事項

### 仕組み

databases_inputs に full_text を追加し、databases_inputs.full_text に検索対象の値をすべて結合して格納します。
全文検索を有効時には、databases_inputs.full_text をキーワード検索します。

databases_inputs.full_textは以下のタイミングで更新されます。

- 値の追加
- 値の更新
- 列の削除　検索対象ON
- 列の更新　検索対象ON
- 列の更新　検索対象OFF
- DB設定変更　全文検索を使用する
- CSVインポート

また、databases_inputs.full_textは以下のタイミングでクリアされます。

- DB設定変更　全文検索を使用しない

### 検討したがやらなかったこと

**バッチでのdatabases_inputs.full_textを一括更新**
スケジューラの設定が一般ユーザーにはハードルが高いため、画面から都度更新するようにしました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
