### PR TITLE
[ユーザ管理＞ユーザ登録] ユーザ登録時にメールアドレス有りの場合、グループ登録後に500エラーになる不具合修正

### DIFF
--- a/app/Plugins/Manage/UserManage/UsersTool.php
+++ b/app/Plugins/Manage/UserManage/UsersTool.php
@@ -237,6 +237,11 @@ class UsersTool
             });
 
         foreach ($users_columns as $users_column) {
+            if (UsersColumns::isLoopNotShowColumnType($users_column->column_type)) {
+                // 既に取得済みのため、ここでは取得しない
+                continue;
+            }
+
             $value = "";
             if (is_array($users_input_cols[$users_column->id])) {
                 $value = implode(self::CHECKBOX_SEPARATOR, $users_input_cols[$users_column->id]->value);

--- a/resources/views/plugins/manage/user/description_frame_mails.blade.php
+++ b/resources/views/plugins/manage/user/description_frame_mails.blade.php
@@ -9,6 +9,9 @@
  *
  * @param $users_columns   項目設定の埋め込みタグ
 --}}
+@php
+use App\Models\Core\UsersColumns;
+@endphp
 <div class="card bg-light mt-1">
     <div class="card-body px-2 pt-0 pb-0">
         <div class="small">
@@ -28,6 +31,11 @@
                         </tr>
                     @endforeach
                     @foreach($users_columns as $column)
+                        @if (UsersColumns::isLoopNotShowColumnType($column->column_type)) {
+                            {{-- 既に取得済みのため、ここでは取得しない --}}
+                            @continue;
+                        @endif
+
                         <tr>
                             <td><code>[[X-{{$column->column_name}}]]</code></td>
                             <td>{{$column->column_name}}</td>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

## 詳細

* https://github.com/opensource-workshop/connect-cms/pull/1798

固定項目（ログインID等）の名称も変更できる機能を追加した時のバグです。
メール送信画面を表示時に、固定項目（ログインID等）は、任意項目のDBテーブルに値を持たないのに、無い値を参照しようとして500エラーが発生していました。

固定項目（ログインID等）は、任意項目のDBテーブルの値を参照しないように修正しました。


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
