### PR TITLE
[サイト管理＞サイト設計書] サーバのphp設定で allow_url_fopen=0 の場合＋ファビコンが設定済みの場合、サイト設計書の出力で500エラーになる不具合の修正 OW-2005

### DIFF
--- a/resources/views/plugins/manage/site/pdf/base_favicon.blade.php
+++ b/resources/views/plugins/manage/site/pdf/base_favicon.blade.php
@@ -22,7 +22,8 @@
     <tr nobr="true">
         <td>ファビコン画像</td>
         @if (Configs::getConfigsValue($configs, 'favicon', null))
-            <td><img src="{{url('/')}}/uploads/favicon/{{Configs::getConfigsValue($configs, 'favicon', null)}}" style="width: 50px;" width=50></td>
+            {{-- bugfix: imgタグはフルのURL指定しない。tcpdf内部で getimagesize(): https:// wrapper is disabled in the server configuration by allow_url_fopen=0 エラーになるため --}}
+            <td><img src="uploads/favicon/{{Configs::getConfigsValue($configs, 'favicon', null)}}" style="width: 50px;" width=50></td>
         @else
             <td><br /></td>
         @endif


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/pull/1819

対応時の修正漏れです。
対応しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載済み。

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
