### PR TITLE
[自動テスト] ユーザ管理テスト, ブログの表示条件テスト, エラーが出ていたテストケースを修正

### DIFF
--- a/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
@@ -136,6 +136,7 @@
                         @else
                             <input type="radio" value="{{BlogDisplayCreatedName::display}}" id="{{BlogFrameConfig::blog_display_created_name}}_1" name="{{BlogFrameConfig::blog_display_created_name}}" class="custom-control-input">
                         @endif
+                        {{-- duskでradioの選択にlabelのid必要 --}}
                         <label class="custom-control-label text-nowrap" for="{{BlogFrameConfig::blog_display_created_name}}_1" id="label_{{BlogFrameConfig::blog_display_created_name}}_1">{{BlogDisplayCreatedName::getDescription('display')}}</label>
                     </div>
                 </div>
@@ -148,11 +149,12 @@
                     @foreach (ShowType::getMembers() as $enum_value => $enum_label)
                         <div class="custom-control custom-radio custom-control-inline">
                             @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_twitter_button, ShowType::not_show) == $enum_value)
-                                <input type="radio" value="{{$enum_value}}" id="blog_display_twitter_button_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input" checked="checked">
+                                <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::blog_display_twitter_button}}_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input" checked="checked">
                             @else
-                                <input type="radio" value="{{$enum_value}}" id="blog_display_twitter_button_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input">
+                                <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::blog_display_twitter_button}}_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_twitter_button}}" class="custom-control-input">
                             @endif
-                            <label class="custom-control-label text-nowrap" for="blog_display_twitter_button_{{$enum_value}}">{{$enum_label}}</label>
+                            {{-- duskでradioの選択にlabelのid必要 --}}
+                            <label class="custom-control-label text-nowrap" for="{{BlogFrameConfig::blog_display_twitter_button}}_{{$enum_value}}" id="label_{{BlogFrameConfig::blog_display_twitter_button}}_{{$enum_value}}">{{$enum_label}}</label>
                         </div>
                     @endforeach
                 </div>
@@ -165,11 +167,12 @@
                     @foreach (ShowType::getMembers() as $enum_value => $enum_label)
                         <div class="custom-control custom-radio custom-control-inline">
                             @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_facebook_button, ShowType::not_show) == $enum_value)
-                                <input type="radio" value="{{$enum_value}}" id="blog_display_facebook_button_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input" checked="checked">
+                                <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::blog_display_facebook_button}}_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input" checked="checked">
                             @else
-                                <input type="radio" value="{{$enum_value}}" id="blog_display_facebook_button_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input">
+                                <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::blog_display_facebook_button}}_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_facebook_button}}" class="custom-control-input">
                             @endif
-                            <label class="custom-control-label text-nowrap" for="blog_display_facebook_button_{{$enum_value}}">{{$enum_label}}</label>
+                            {{-- duskでradioの選択にlabelのid必要 --}}
+                            <label class="custom-control-label text-nowrap" for="{{BlogFrameConfig::blog_display_facebook_button}}_{{$enum_value}}" id="label_{{BlogFrameConfig::blog_display_facebook_button}}_{{$enum_value}}">{{$enum_label}}</label>
                         </div>
                     @endforeach
                 </div>

--- a/tests/Browser/Manage/UserManageTest.php
+++ b/tests/Browser/Manage/UserManageTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Browser\Manage;
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Artisan;
 use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
 
@@ -52,6 +53,11 @@ class UserManageTest extends DuskTestCase
         // データクリア
         User::where('id', '<>', 1)->forceDelete();
         UsersColumns::truncate();
+
+        // 消してしまった初期の項目の再登録
+        // php artisan db:seed --class=DefaultUsersColumnsTableSeeder --force
+        Artisan::call('db:seed --class=DefaultUsersColumnsTableSeeder --force');
+
         UsersColumnsSelects::truncate();
         UsersInputCols::truncate();
         UsersLoginHistories::truncate();
@@ -152,14 +158,14 @@ class UserManageTest extends DuskTestCase
             // 役割設定を取得して、学生にする。
             $original_role_student = Configs::where('category', 'original_role')->where('name', 'student')->first();
 
-            $browser->visit('/manage/user/editColumns')
+            $browser->visit('/manage/user/editColumns/1')
                     ->assertTitleContains('Connect-CMS')
                     ->type('column_name', '所属')
                     ->press('#button_user_olumn_add')
                     ->screenshot('manage/user/editColumns1/images/editColumns1')
-                    ->click('#column_type_1')
+                    ->click('#column_type_6')
                     ->screenshot('manage/user/editColumns1/images/editColumns2')
-                    ->click('#button_user_column_detail_1')
+                    ->click('#button_user_column_detail_6')
                     ->screenshot('manage/user/editColumns1/images/editColumns3')
                     ->scrollIntoView('footer')
                     ->screenshot('manage/user/editColumns1/images/editColumns4');
@@ -307,7 +313,7 @@ class UserManageTest extends DuskTestCase
     private function autoRegist()
     {
         $this->browse(function (Browser $browser) {
-            $browser->visit('/manage/user/autoRegist')
+            $browser->visit('/manage/user/autoRegist/1')
                 ->assertTitleContains('Connect-CMS')
                 ->screenshot('manage/user/autoRegist/images/autoRegist1')
                 ->scrollIntoView('#user_register_temporary_regist_mail_flag')


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* ユーザ管理テスト, #1798（任意項目にログインID等の固定項目も追加） の修正で動かなくなっていた箇所を修正
* [test: ブログテスト, 表示条件, duskでradioの選択にlabelのid必要なため追加](https://github.com/opensource-workshop/connect-cms/pull/1827/commits/e96daa4320292924f421d75964ee0f4ffff903de)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載済み

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
