### PR TITLE
[入力チェック] php8.1でWYSIWYG最大バイト数越えチェック時に500エラーになる不具合修正

### DIFF
--- a/app/Rules/CustomValiWysiwygMax.php
+++ b/app/Rules/CustomValiWysiwygMax.php
@@ -29,7 +29,7 @@ class CustomValiWysiwygMax implements Rule
     public function passes($attribute, $value)
     {
         // 65,535 バイトまではOK
-        return (strlen($value) > config('connect.WYSIWYG_MAX_BYTE')) ? false : true;
+        return (strlen((string)$value) > config('connect.WYSIWYG_MAX_BYTE')) ? false : true;
     }
 
     /**

--- a/tests/Browser/Manage/ReservationManageTest.php
+++ b/tests/Browser/Manage/ReservationManageTest.php
@@ -101,7 +101,8 @@ class ReservationManageTest extends DuskTestCase
 
             $browser->scrollIntoView('footer')
                     ->screenshot('manage/reservation/regist/images/regist2')
-                    ->press('登録確定');
+                    ->press('登録確定')
+                    ->assertSee('大会議室');    // 500エラーでも正常終了していたため、チェック追加
         });
 
         // マニュアル用データ出力


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 件名通りです。
* 関連修正
    * [test: 施設管理, 施設登録後に、登録完了メッセージに含まれる文字をチェックして、登録完了しているかチェック追加](https://github.com/opensource-workshop/connect-cms/pull/1829/commits/55558628a4c3f6c7e4101f194d7738f21acad38a)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1752

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
