### PR TITLE
[ユーザ管理＞ユーザ登録＞メール送信] php8.1で埋込タグの値がnullの場合、500エラーになる不具合修正

### DIFF
--- a/app/Enums/NoticeEmbeddedTag.php
+++ b/app/Enums/NoticeEmbeddedTag.php
@@ -74,7 +74,7 @@ class NoticeEmbeddedTag extends EnumsBase
     public static function replaceEmbeddedTags($body, array $notice_embedded_tags)
     {
         foreach ($notice_embedded_tags as $tag => $value) {
-            $body = str_ireplace("[[{$tag}]]", $value, $body);
+            $body = str_ireplace("[[{$tag}]]", (string)$value, $body);
         }
         return $body;
     }

--- a/tests/Browser/Manage/UserManageTest.php
+++ b/tests/Browser/Manage/UserManageTest.php
@@ -221,7 +221,8 @@ class UserManageTest extends DuskTestCase
                     ->pause(500)
                     ->screenshot('manage/user/regist/images/regist3')
                     ->press('変更')
-                    ->screenshot('manage/user/regist/images/regist4');
+                    ->screenshot('manage/user/regist/images/regist4')
+                    ->assertSee('件名');    // 500エラーでも正常終了していたため、チェック追加
         });
 
         // マニュアル用データ出力


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 件名通りです。
* 関連修正
  * [test: ユーザ管理＞ユーザ登録＞メール送信, メール送信画面をしているかチェック追加](https://github.com/opensource-workshop/connect-cms/commit/ec7e0682c067da0891ccdcb5cd66e28b2fecb5e2)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1752

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
