### PR TITLE
bugfix: 外部認証, php82の Deprecated: Using ${var} in strings is deprecated 修正

### DIFF
--- a/resources/views/plugins/manage/auth/auth.blade.php
+++ b/resources/views/plugins/manage/auth/auth.blade.php
@@ -72,7 +72,7 @@
                                     type="radio" value="{{ $key }}" class="custom-control-input" id="auth_method_event_{{ $key }}"
                                     name="auth_method_event" {{ $checked }}
                                 >
-                                <label class="custom-control-label" for="{{ "auth_method_event_${key}" }}">
+                                <label class="custom-control-label" for="{{ "auth_method_event_{$key}" }}">
                                     {{ $value }}
                                 </label>
                             </div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1785

上記の修正です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載済み

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
