### PR TITLE
[祝日管理] php8.2で祝日編集時の 500エラー修正

### DIFF
--- a/app/Plugins/Manage/HolidayManage/HolidayManage.php
+++ b/app/Plugins/Manage/HolidayManage/HolidayManage.php
@@ -27,6 +27,12 @@ use App\Plugins\Manage\ManagePluginBase;
 class HolidayManage extends ManagePluginBase
 {
     /**
+     * 独自設定祝日データ
+     * bugfix: php82 - Creation of dynamic property App\Plugins\Manage\HolidayManage\HolidayManage::$post is deprecated 修正
+     */
+    public $post = null;
+
+    /**
      *  権限定義
      */
     public function declareRole()

--- a/tests/Browser/Manage/HolidayManageTest.php
+++ b/tests/Browser/Manage/HolidayManageTest.php
@@ -51,6 +51,7 @@ class HolidayManageTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $browser->visit('/manage/holiday/edit')
                     ->assertTitle('Connect-CMS')
+                    ->assertDontSee('500')        // "500" 文字がない事
                     ->screenshot('manage/holiday/edit/images/edit');
         });
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

## 詳細

* [bugfix: 祝日管理, php82で祝日編集時の Creation of dynamic property App\Plugins\Manage\HolidayManage\HolidayManage::$post is deprecated 修正](https://github.com/opensource-workshop/connect-cms/commit/46ae48d8bc5bb883e596b663835fe349e1a8bbac) 
* [test: 祝日管理テスト, 祝日編集時に500エラーがでてないことをチェック](https://github.com/opensource-workshop/connect-cms/commit/0f1ceebc39cacec125df7feeef6a2acf999a9972)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1831

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
