### PR TITLE
[データベース]検索窓としての表示設定を可能にしました

### DIFF
--- a/app/Enums/DatabaseFrameConfig.php
+++ b/app/Enums/DatabaseFrameConfig.php
@@ -11,9 +11,11 @@ final class DatabaseFrameConfig extends EnumsBase
 {
     // 定数メンバ
     const database_use_select_multiple_flag = 'database_use_select_multiple_flag';
+    const database_destination_frame = 'database_destination_frame';
 
     // key/valueの連想配列
     const enum = [
         self::database_use_select_multiple_flag => '絞り込み機能の表示（複数選択）',
+        self::database_destination_frame => '検索後の遷移先',
     ];
 }

--- a/app/Models/Common/Frame.php
+++ b/app/Models/Common/Frame.php
@@ -279,4 +279,12 @@ class Frame extends Model
                     ->whereRaw("FALSE = $auth_check");
             });
     }
+
+    /**
+     * フレームに関連しているページの取得
+     */
+    public function page()
+    {
+        return $this->hasOne(Page::class, 'id', 'page_id');
+    }
 }

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -4410,6 +4410,7 @@ AND databases_inputs.posted_at <= NOW()
             ->leftJoin('pages', 'frames.page_id', '=', 'pages.id')
             ->where('databases.id', $database_id)
             ->orderBy('pages._lft', 'asc')
+            ->orderBy('frames.id', 'asc')
             ->get();
         return $frames;
     }

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3,6 +3,7 @@
 namespace App\Plugins\User\Databases;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -4395,9 +4396,9 @@ AND databases_inputs.posted_at <= NOW()
      * データベースのフレームを取得する
      *
      * @param int $database_id
-     * @return EloquentCollection
+     * @return Collection
      */
-    private function getDatabaseFrames(?int $database_id): EloquentCollection
+    private function getDatabaseFrames(?int $database_id): Collection
     {
         if ($database_id === null) {
             return collect([]);

--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -82,6 +82,33 @@
         </div>
     </div>
 
+    {{-- 検索後の遷移先 --}}
+    @php
+        $database_destination_frame = FrameConfig::getConfigValueAndOld($frame_configs, DatabaseFrameConfig::database_destination_frame, $frame->id);
+    @endphp
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">{{DatabaseFrameConfig::getDescription('database_destination_frame')}}<br><small class="text-muted">ページ - フレーム</small></label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            @foreach ($same_database_frames as $database_frame)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="{{$database_frame->id}}" id="database_destination_frame{{$loop->index}}" name="database_destination_frame"
+                        class="custom-control-input" @if(old('database_destination_frame', $database_destination_frame) ==  $database_frame->id) checked="checked" @endif>
+                    <label class="custom-control-label" for="database_destination_frame{{$loop->index}}">
+                        @if ($database_frame->id == $frame->id)
+                            <span class="badge bg-info text-dark">初期設定</span>
+                        @endif
+                        {{$database_frame->page_name}} - {{$database_frame->frame_title}}
+                    </label>
+                </div>
+            @endforeach
+            <div class="text-muted">
+                <small>
+                    ※ トップページなどに検索窓を設けて遷移先は別のページにしたいときに初期設定から変更してください。
+                </small>
+            </div>
+        </div>
+    </div>
+
     {{-- 絞り込み機能の表示 --}}
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass(true)}}">絞り込み機能の表示</label>

--- a/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
@@ -23,10 +23,10 @@
 {{-- アクセシビリティ対応。検索OFF & 絞り込み項目なし & ソートOFFの時、検索の空フォームを作らないようにする。 --}}
 @if(($database_frame && $database_frame->use_search_flag == 1) || (($select_columns && count($select_columns) >= 1) || $databases_frames->isBasicUseSortFlag()))
 
-<form action="{{url('/')}}/redirect/plugin/databases/search/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" role="search" aria-label="{{$database_frame->databases_name}}">
+<form action="{{url('/')}}/redirect/plugin/databases/search/{{$dest_frame->page->id}}/{{$dest_frame->id}}#frame-{{$dest_frame->id}}" method="POST" role="search" aria-label="{{$database_frame->databases_name}}">
     {{ csrf_field() }}
     {{-- 詳細画面でブラウザバックをしたときに、フォーム再送信の確認が表示されないようにリダイレクトする --}}
-    <input type="hidden" name="redirect_path" value="{{$page->getLinkUrl()}}?frame_{{$frame_id}}_page=1#frame-{{$frame_id}}">
+    <input type="hidden" name="redirect_path" value="{{$dest_frame->page->getLinkUrl()}}?frame_{{$dest_frame->id}}_page=1#frame-{{$dest_frame->id}}">
 
     {{-- 検索 --}}
     @if($database_frame && $database_frame->use_search_flag == 1)


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

## 背景や目的

トップページなどにデータベースの検索ボックスを置きたい。
ただ、トップページ内で検索結果を出すと邪魔になるため、別ページへ遷移させたい。

上記を実現する場合、従来だと遷移先に配置した検索ボックスのHTMLをコピーして、トップページの固定記事に張り付けて設定していました。
ただこの手順はHTMLを読めないといけないため、ハードルが高いです。
画面から設定できるよう手順を簡略化する必要があります。

## 変更内容

表示設定画面で検索窓としてのフレームとする設定を追加しました。

- 表示設定画面 検索後の遷移先
  - 同一データベースを設定しているページ・フレームを選択できます。
<img width="843" alt="image" src="https://github.com/opensource-workshop/connect-cms/assets/32890286/68b40586-6229-40e1-b4a4-e0ab17cc9d6f">



# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

 無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
