### PR TITLE
[データベース]急上昇ワードを表示する機能を追加しました

### DIFF
--- a/app/Enums/DatabaseFrameConfig.php
+++ b/app/Enums/DatabaseFrameConfig.php
@@ -11,9 +11,15 @@ final class DatabaseFrameConfig extends EnumsBase
 {
     // 定数メンバ
     const database_use_select_multiple_flag = 'database_use_select_multiple_flag';
+    const database_show_trend_words = 'database_show_trend_words';
+    const database_trend_words = 'database_trend_words';
+    const database_trend_words_caption = 'database_trend_words_caption';
 
     // key/valueの連想配列
     const enum = [
         self::database_use_select_multiple_flag => '絞り込み機能の表示（複数選択）',
+        self::database_show_trend_words => '急上昇ワードの表示',
+        self::database_trend_words => '急上昇ワード',
+        self::database_trend_words_caption => '急上昇ワード表示項目名',
     ];
 }

--- a/app/Models/User/Databases/DatabasesSearchedWord.php
+++ b/app/Models/User/Databases/DatabasesSearchedWord.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models\User\Databases;
+
+use Illuminate\Database\Eloquent\Model;
+
+use App\UserableNohistory;
+
+class DatabasesSearchedWord extends Model
+{
+    // 保存時のユーザー関連データの保持（履歴なしUserable）
+    use UserableNohistory;
+    // 更新する項目の定義
+    protected $fillable = ['databases_id', 'word'];
+}

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -53,6 +53,7 @@ use App\Enums\DatabaseNoticeEmbeddedTag;
 use App\Enums\StatusType;
 use App\Models\Common\Categories;
 use App\Models\Core\FrameConfig;
+use App\Models\User\Databases\DatabasesSearchedWord;
 
 /**
  * データベース・プラグイン
@@ -97,6 +98,7 @@ class DatabasesPlugin extends UserPluginBase
             'detail',
             'input',
             'search',
+            'trendWords',
         ];
         $functions['post'] = [
             'index',
@@ -130,6 +132,7 @@ class DatabasesPlugin extends UserPluginBase
         $role_check_table["input"]                = array('posts.create', 'posts.update');
         $role_check_table["publicConfirm"]        = array('posts.create', 'posts.update');
         $role_check_table["publicStore"]          = array('posts.create', 'posts.update');
+        $role_check_table["trendWords"] = array('frames.edit');
 
         $role_check_table["addPref"]              = array('buckets.addColumn');
         return $role_check_table;
@@ -497,6 +500,11 @@ class DatabasesPlugin extends UserPluginBase
             // 画面のキーワード指定
             if (!empty(session('search_keyword.'.$frame_id))) {
                 $inputs_query = DatabasesTool::appendSearchKeyword('databases_inputs.id', $inputs_query, $databases_columns_ids, $hide_columns_ids, session('search_keyword.'.$frame_id));
+
+                // 検索キーワードの記録
+                if ($database->save_searched_word) {
+                    DatabasesTool::saveSearchedWord($database->id, session('search_keyword.'.$frame_id));
+                }
             }
 
             // データベースプラグイン単体では $request->search_options をセットしておらず「オプション検索指定」使っていないが、個別の追加テンプレートで利用するため、消さない。
@@ -2115,6 +2123,7 @@ class DatabasesPlugin extends UserPluginBase
         $databases->after_message       = $request->after_message;
         $databases->numbering_use_flag  = (empty($request->numbering_use_flag))  ? 0 : $request->numbering_use_flag;
         $databases->numbering_prefix    = $request->numbering_prefix;
+        $databases->save_searched_word = $request->save_searched_word;
 
         // データ保存
         $databases->save();
@@ -3999,6 +4008,11 @@ class DatabasesPlugin extends UserPluginBase
             ]
         );
 
+        // 急上昇ワード未設定を許容する
+        if (!$request->filled(DatabaseFrameConfig::database_trend_words_caption)) {
+            FrameConfig::where('frame_id', $frame_id)->where('name', DatabaseFrameConfig::database_trend_words_caption)->forceDelete();
+        }
+
         FrameConfig::saveFrameConfigs($request, $frame_id, DatabaseFrameConfig::getMemberKeys());
         // 更新したので、frame_configsを設定しなおす
         $this->refreshFrameConfigs();
@@ -4386,5 +4400,58 @@ AND databases_inputs.posted_at <= NOW()
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+    }
+
+    /**
+     * 急上昇ワードを取得する
+     */
+    public function trendWords($request, $page_id, $frame_id, int $database_id)
+    {
+        if ($database_id === null) {
+            return;
+        }
+
+        // 設定済みの値
+        if ($request->old === 'true') {
+            return $this->trendWordsOld();
+        }
+
+        // 期間指定で最新の内容を取得する
+        $query = DatabasesSearchedWord::select('word')
+            ->where('databases_id', $database_id);
+
+        if ($request->period === 'weekly') {
+            $query->where('created_at', '>', Carbon::now()->subWeek());
+        } elseif ($request->period === 'monthly') {
+            $query->where('created_at', '>', Carbon::now()->subMonth());
+        } else {
+            $query->where('created_at', '>', Carbon::now()->subDay());
+        }
+        $trend_words = $query->groupBy('word')
+            ->orderByRaw('COUNT(*) DESC')
+            ->orderByRaw('MIN(id)')
+            ->limit(20)
+            ->get();
+
+        return json_encode($trend_words, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * 設定済みの急上昇ワードを取得する
+     */
+    private function trendWordsOld()
+    {
+        // 登録済み
+        $trend_words = FrameConfig::getConfigValueAndOld($this->frame_configs, DatabaseFrameConfig::database_trend_words);
+        // old()の場合は配列になっている
+        if (!is_array($trend_words)) {
+            $trend_words = explode('|', $trend_words);
+        }
+
+        $r = [];
+        foreach (array_filter($trend_words) as $word) {
+            $r[] = ['word' => $word];
+        }
+        return json_encode($r, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
     }
 }

--- a/app/Plugins/User/Databases/DatabasesTool.php
+++ b/app/Plugins/User/Databases/DatabasesTool.php
@@ -12,6 +12,7 @@ use App\Traits\ConnectCommonTrait;
 use App\Enums\DatabaseColumnRoleName;
 use App\Enums\DatabaseRoleName;
 use App\Models\User\Databases\DatabasesInputs;
+use App\Models\User\Databases\DatabasesSearchedWord;
 
 /**
  * データベースの便利関数
@@ -470,5 +471,27 @@ class DatabasesTool
         });
 
         return $inputs_query;
+    }
+
+    /**
+     * 検索された語句を保存する
+     *
+     * @param int $databases_id
+     * @param string $keyword
+     */
+    public static function saveSearchedWord(int $databases_id, string $keyword)
+    {
+        $excluded_words = ['AND', '&', 'OR', '|', 'NOT'];
+
+        $keywords = explode(' ', mb_convert_kana($keyword, 's'));
+        foreach ($keywords as $word) {
+            if (in_array(\Str::upper($word), $excluded_words)) {
+                continue;
+            }
+            DatabasesSearchedWord::create([
+                'databases_id' => $databases_id,
+                'word' => $word,
+            ]);
+        }
     }
 }

--- a/database/migrations/2023_09_12_182442_add_save_search_word_to_databases.php
+++ b/database/migrations/2023_09_12_182442_add_save_search_word_to_databases.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSaveSearchWordToDatabases extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases', function (Blueprint $table) {
+            $table->integer('save_searched_word')->default(0)->comment('検索キーワードを記録する')->after('numbering_prefix');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases', function (Blueprint $table) {
+            $table->dropColumn('save_searched_word');
+        });
+    }
+}

--- a/database/migrations/2023_09_12_183229_create_databases_searched_words.php
+++ b/database/migrations/2023_09_12_183229_create_databases_searched_words.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateDatabasesSearchedWords extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('databases_searched_words', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('databases_id');
+            $table->string('word');
+
+            $table->integer('created_id')->nullable();
+            $table->string('created_name')->nullable();
+            $table->timestamp('created_at')->nullable();
+            $table->integer('updated_id')->nullable();
+            $table->string('updated_name')->nullable();
+            $table->timestamp('updated_at')->nullable();
+
+            // 外部キー
+            $table->foreign('databases_id')->references('id')->on('databases')->cascadeOnDelete();
+            // インデックス
+            $table->index(['databases_id', 'word', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('databases_searched_words');
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
@@ -120,6 +120,27 @@
         </div>
     </div>
 
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">検索キーワードの記録</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            @foreach (UseType::enum as $key => $value)
+            <div class="custom-control custom-radio custom-control-inline">
+                <input
+                    type="radio"
+                    value="{{ $key }}"
+                    id="{{ "save_searched_word_${key}" }}"
+                    name="save_searched_word"
+                    class="custom-control-input"
+                    {{ old('save_searched_word', $database->save_searched_word) == $key ? 'checked' : '' }}
+                >
+                <label class="custom-control-label" for="{{ "save_searched_word_${key}" }}">
+                    {{ $value }}
+                </label>
+            </div>
+        @endforeach
+        </div>
+    </div>
+
 {{--
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">メール送信先</label>

--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -42,6 +42,7 @@
 
 @if (!$database->id)
 @else
+<div id="app_{{ $frame->id }}">
 <form action="{{url('/')}}/plugin/databases/saveView/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" class="">
     {{ csrf_field() }}
 
@@ -79,6 +80,89 @@
                 ※ 検索テキストボックスに初期表示される補足テキストを設定できます。<br>
                 ※ 未設定時は「検索はキーワードを入力してください。」を表示します。
             </small>
+        </div>
+    </div>
+
+    {{-- 急上昇ワード --}}
+    @php
+        $database_show_trend_words = FrameConfig::getConfigValueAndOld($frame_configs, DatabaseFrameConfig::database_show_trend_words, ShowType::not_show);
+    @endphp
+    <script>
+        function hideTrendWords() {
+            $('#collapse_trend_words_{{$frame_id}}').collapse('hide');
+        }
+
+        function showTrendWords() {
+            $('#collapse_trend_words_{{$frame_id}}').collapse('show');
+        }
+    </script>
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">{{DatabaseFrameConfig::getDescription('database_show_trend_words')}}</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            @foreach (ShowType::getMembers() as $key => $type)
+            <div class="custom-control custom-radio custom-control-inline">
+                <input type="radio" value="{{$key}}" id="database_show_trend_words_{{$key}}" name="database_show_trend_words"
+                     class="custom-control-input" @if ($database_show_trend_words == $key) checked="checked" @endif
+                     @if ($key === ShowType::show)
+                        onclick="showTrendWords();"
+                     @else
+                        onclick="hideTrendWords();"
+                     @endif
+                     >
+                <label class="custom-control-label" for="database_show_trend_words_{{$key}}">{{$type}}</label>
+            </div>
+            @endforeach
+        </div>
+    </div>
+
+    {{-- 急上昇ワードの選択 --}}
+    @php
+        // 急上昇ワード
+        $database_trend_words = [];
+        $registered_trend_words = array_filter(explode('|', FrameConfig::getConfigValue($frame_configs, DatabaseFrameConfig::database_trend_words)));
+        if (old('database_trend_words')) {
+            $database_trend_words = old('database_trend_words');
+        } else {
+            $database_trend_words = $registered_trend_words;
+        }
+
+        // 表示項目名
+        $database_trend_words_caption = FrameConfig::getConfigValue($frame_configs, DatabaseFrameConfig::database_trend_words_caption);
+    @endphp
+
+    <div class="form-group row collapse @if ($database_show_trend_words == ShowType::show) show @endif" id="collapse_trend_words_{{$frame_id}}">
+        <label class="{{$frame->getSettingLabelClass()}}"></label>
+        <div class="{{$frame->getSettingInputClass(false, true)}}">
+            <div class="card mb-1">
+                <div class="card-body">
+                    <h6 class="card-title">設定済みの値</h6>
+                    <div class="mb-2">
+                        @foreach ($registered_trend_words as $trend_word)<span class="badge badge-pill badge-secondary mr-2">{{$trend_word}}</span>@endforeach
+                    </div>
+                </div>
+            </div>
+            <div class="card mb-1">
+                <div class="card-body">
+                    <h6 class="card-title">更新する値</h6>
+                    <div class="mb-2">
+                        <button type="button" class="btn btn-sm btn-primary" v-on:click="fetchTrendWordsDaily">最新化（日間）</button>
+                        <button type="button" class="btn btn-sm btn-primary" v-on:click="fetchTrendWordsWeekly">最新化（週間）</button>
+                        <button type="button" class="btn btn-sm btn-primary" v-on:click="fetchTrendWordsMonthly">最新化（月間）</button>
+                    </div>
+                    <div class="mb-2">
+                        <span class="badge badge-pill badge-info mr-2" v-for="(trend_word, index) in trend_words" v-bind:key="trend_word.word">
+                            @{{trend_word.word}}<a href="javascript:void(0)" class="text-white ml-2" v-on:click="deleteTrendWord(index)"><i class="fas fa-minus-circle"></i></a>
+                            <input type="hidden" name="database_trend_words[]" v-model="trend_word.word">
+                        </span>
+                    </div>
+                </div>
+            </div>
+            <div class="card mb-1">
+                <div class="card-body">
+                    <h6 class="card-title">表示項目名</h6>
+                    <input type="text" name="database_trend_words_caption" value="{{$database_trend_words_caption}}" class="form-control">
+                </div>
+            </div>
         </div>
     </div>
 
@@ -272,6 +356,48 @@
         </div>
     </div>
 </form>
+</div>
+
+<script>
+    const app_{{ $frame->id }} = new Vue({
+        el: "#app_{{ $frame->id }}",
+        data: function() {
+            return {
+                trend_words: [],
+            }
+        },
+        methods: {
+            fetchTrendWords: function (period, old) {
+                let self = this;
+                axios.get("{{url('/')}}/json/databases/trendWords/{{$page->id}}/{{$frame_id}}/{{$database->id}}/?period=" + period + "&old=" + old)
+                    .then(function(res){
+                        self.trend_words = res.data;
+                    })
+                    .catch(function (error) {
+                        console.log(error)
+                    });
+            },
+            fetchTrendWordsDaily: function () {
+                this.fetchTrendWords("daily", false);
+            },
+            fetchTrendWordsWeekly: function () {
+                this.fetchTrendWords("weekly", false);
+            },
+            fetchTrendWordsMonthly: function () {
+                this.fetchTrendWords("monthly", false);
+            },
+            fetchTrendWordsOld: function () {
+                this.fetchTrendWords("", true);
+            },
+            deleteTrendWord: function (index) {
+                this.trend_words.splice(index, 1)
+            },
+        },
+        mounted: function () {
+            this.fetchTrendWordsOld();
+        }
+    });
+</script>
 
 @endif
 @endsection

--- a/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
@@ -23,7 +23,7 @@
 {{-- アクセシビリティ対応。検索OFF & 絞り込み項目なし & ソートOFFの時、検索の空フォームを作らないようにする。 --}}
 @if(($database_frame && $database_frame->use_search_flag == 1) || (($select_columns && count($select_columns) >= 1) || $databases_frames->isBasicUseSortFlag()))
 
-<form action="{{url('/')}}/redirect/plugin/databases/search/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" method="POST" role="search" aria-label="{{$database_frame->databases_name}}">
+<form action="{{url('/')}}/redirect/plugin/databases/search/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}" name="databaseform{{$frame_id}}" method="POST" role="search" aria-label="{{$database_frame->databases_name}}">
     {{ csrf_field() }}
     {{-- 詳細画面でブラウザバックをしたときに、フォーム再送信の確認が表示されないようにリダイレクトする --}}
     <input type="hidden" name="redirect_path" value="{{$page->getLinkUrl()}}?frame_{{$frame_id}}_page=1#frame-{{$frame_id}}">
@@ -44,6 +44,29 @@
                 <i class="fas fa-search" role="presentation"></i>
             </button>
         </div>
+    </div>
+    @endif
+
+    {{-- 急上昇ワード --}}
+    @php
+        $database_show_trend_words = FrameConfig::getConfigValueAndOld($frame_configs, DatabaseFrameConfig::database_show_trend_words, ShowType::not_show);
+        $registered_trend_words = array_filter(explode('|', FrameConfig::getConfigValue($frame_configs, DatabaseFrameConfig::database_trend_words)));
+        $database_trend_words_caption = FrameConfig::getConfigValue($frame_configs, DatabaseFrameConfig::database_trend_words_caption);
+    @endphp
+    @if (($database_frame && $database_frame->use_search_flag == 1 && $database_show_trend_words))
+        <div class="input-group mb-3">
+            <script>
+                function submitSearch(keyword) {
+                    document.databaseform{{$frame_id}}.search_keyword.value = keyword;
+                    document.databaseform{{$frame_id}}.submit();
+                }
+            </script>
+            <span class="trend_word_title">{{$database_trend_words_caption}}</span>
+            @foreach ($registered_trend_words as $word)
+            <a class="mr-2 trend_word" href="javascript:void(0)" onclick="submitSearch('{{$word}}')">
+                {{$word}}
+            </a>
+            @endforeach
     </div>
     @endif
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
急上昇ワード、トレンドといったような情報を表示する機能を追加しました。

## 背景・目的

管理者は、急上昇ワードを表示することで、現在どういったコンテンツが求められているか判断できます。
利用者は、トレンドを理解できます。

## 変更内容

- DB設定画面  「検索キーワードの記録」を追加
- 表示設定画面 「急上昇ワードの表示」を追加
  - 「表示する」を選択することで急上昇ワードを選択できます。
  - 最新化ボタンで現在のデータをもとに表示するワードを選択できます
  - ⊖を押下することで表示したくないワードを消せます
  - 「表示項目名」に任意の文言を設定することでキャプションを変更できます
- 一覧画面 急上昇ワードの表示を追加
  -  リンクを押下すると当該キーワードで検索します

### 表示設定画面

<img width="781" alt="image" src="https://github.com/opensource-workshop/connect-cms/assets/32890286/3c46263e-90c3-4f6e-873f-0faca412399f">

### 一覧画面

<img width="773" alt="image" src="https://github.com/opensource-workshop/connect-cms/assets/32890286/e6f37e3e-4f5f-43c5-b6ce-689bf903d048">


## 特記事項

- 自動で急上昇ワードは変更されません

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
