### PR TITLE
[ユーザ管理] .envのUSE_USERS_COLUMNS_SET=true設定時、項目セット登録を行っても固定項目（ログインID等）が初期登録されない不具合修正

### DIFF
--- a/app/Models/Core/UsersColumns.php
+++ b/app/Models/Core/UsersColumns.php
@@ -198,4 +198,68 @@ class UsersColumns extends Model
     {
         return self::getLabelFromCollection($users_columns, UserColumnType::updated_at, '更新日時');
     }
+
+    /**
+     * UsersColumnsSet登録時のUsersColumns初期登録
+     */
+    public static function initInsertForRegistUsersColumnsSet(int $columns_set_id): void
+    {
+        self::insert([
+            [
+                'columns_set_id'        => $columns_set_id,
+                'column_type'           => UserColumnType::user_name,
+                'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_name),
+                'is_fixed_column'       => 1,
+                'is_show_auto_regist'   => 1,
+                'is_show_my_page'       => 1,
+                'is_edit_my_page'       => 0,
+                'required'              => 1,
+                'display_sequence'      => 1,
+            ],
+            [
+                'columns_set_id'        => $columns_set_id,
+                'column_type'           => UserColumnType::login_id,
+                'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::login_id),
+                'is_fixed_column'       => 1,                           // (画面からいじれない項目)
+                'is_show_auto_regist'   => 1,
+                'is_show_my_page'       => 1,
+                'is_edit_my_page'       => 0,
+                'required'              => 1,                           // 設定するけど is_fixed_column=1 はおそらくrequiredは参照しない
+                'display_sequence'      => 2,
+            ],
+            [
+                'columns_set_id'        => $columns_set_id,
+                'column_type'           => UserColumnType::user_email,
+                'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_email),
+                'is_fixed_column'       => 1,
+                'is_show_auto_regist'   => 1,
+                'is_show_my_page'       => 1,
+                'is_edit_my_page'       => 1,
+                'required'              => 1,
+                'display_sequence'      => 3,
+            ],
+            [
+                'columns_set_id'        => $columns_set_id,
+                'column_type'           => UserColumnType::user_password,
+                'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_password),
+                'is_fixed_column'       => 1,
+                'is_show_auto_regist'   => 1,
+                'is_show_my_page'       => 0,
+                'is_edit_my_page'       => 1,
+                'required'              => 1,
+                'display_sequence'      => 4,
+            ],
+            [
+                'columns_set_id'        => $columns_set_id,
+                'column_type'           => UserColumnType::created_at,
+                'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::created_at),
+                'is_fixed_column'       => 0,
+                'is_show_auto_regist'   => 0,
+                'is_show_my_page'       => 1,
+                'is_edit_my_page'       => 0,
+                'required'              => 0,
+                'display_sequence'      => 5,
+            ],
+        ]);
+    }
 }

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2530,6 +2530,9 @@ class UserManage extends ManagePluginBase
             $message = '【 '. $request->name .' 】を変更しました。';
         } else {
             $message = '【 '. $request->name .' 】を登録しました。';
+
+            // UsersColumnsSet登録時のUsersColumns初期登録
+            UsersColumns::initInsertForRegistUsersColumnsSet($columns_set->id);
         }
 
         // 一覧画面に戻る

--- a/database/migrations/2023_08_10_114737_migration_fixed_column_from_users_columns.php
+++ b/database/migrations/2023_08_10_114737_migration_fixed_column_from_users_columns.php
@@ -25,63 +25,8 @@ class MigrationFixedColumnFromUsersColumns extends Migration
 
                 $users_columns = UsersColumns::where('columns_set_id', $columns_set->id)->orderBy('display_sequence')->get();
 
-                UsersColumns::insert([
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::user_name,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_name),
-                        'is_fixed_column'       => 1,
-                        'is_show_auto_regist'   => 1,
-                        'is_show_my_page'       => 1,
-                        'is_edit_my_page'       => 0,
-                        'required'              => 1,
-                        'display_sequence'      => 1,
-                    ],
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::login_id,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::login_id),
-                        'is_fixed_column'       => 1,                           // (画面からいじれない項目)
-                        'is_show_auto_regist'   => 1,
-                        'is_show_my_page'       => 1,
-                        'is_edit_my_page'       => 0,
-                        'required'              => 1,                           // 設定するけど is_fixed_column=1 はおそらく参照しない
-                        'display_sequence'      => 2,
-                    ],
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::user_email,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_email),
-                        'is_fixed_column'       => 1,
-                        'is_show_auto_regist'   => 1,
-                        'is_show_my_page'       => 1,
-                        'is_edit_my_page'       => 1,
-                        'required'              => 1,
-                        'display_sequence'      => 3,
-                    ],
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::user_password,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_password),
-                        'is_fixed_column'       => 1,
-                        'is_show_auto_regist'   => 1,
-                        'is_show_my_page'       => 0,
-                        'is_edit_my_page'       => 1,
-                        'required'              => 1,
-                        'display_sequence'      => 4,
-                    ],
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::created_at,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::created_at),
-                        'is_fixed_column'       => 0,
-                        'is_show_auto_regist'   => 0,
-                        'is_show_my_page'       => 1,
-                        'is_edit_my_page'       => 0,
-                        'required'              => 0,
-                        'display_sequence'      => 5,
-                    ],
-                ]);
+                // UsersColumnsSet登録時のUsersColumns初期登録
+                UsersColumns::initInsertForRegistUsersColumnsSet($columns_set->id);
 
                 foreach ($users_columns as $users_column) {
                     $users_column->display_sequence = $users_column->display_sequence + 5;

--- a/database/seeders/DefaultUsersColumnsTableSeeder.php
+++ b/database/seeders/DefaultUsersColumnsTableSeeder.php
@@ -34,63 +34,8 @@ class DefaultUsersColumnsTableSeeder extends Seeder
 
                 $users_columns = UsersColumns::where('columns_set_id', $columns_set->id)->orderBy('display_sequence')->get();
 
-                UsersColumns::insert([
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::user_name,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_name),
-                        'is_fixed_column'       => 1,
-                        'is_show_auto_regist'   => 1,
-                        'is_show_my_page'       => 1,
-                        'is_edit_my_page'       => 0,
-                        'required'              => 1,
-                        'display_sequence'      => 1,
-                    ],
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::login_id,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::login_id),
-                        'is_fixed_column'       => 1,                           // (画面からいじれない項目)
-                        'is_show_auto_regist'   => 1,
-                        'is_show_my_page'       => 1,
-                        'is_edit_my_page'       => 0,
-                        'required'              => 1,                           // 設定するけど is_fixed_column=1 はおそらく参照しない
-                        'display_sequence'      => 2,
-                    ],
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::user_email,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_email),
-                        'is_fixed_column'       => 1,
-                        'is_show_auto_regist'   => 1,
-                        'is_show_my_page'       => 1,
-                        'is_edit_my_page'       => 1,
-                        'required'              => 1,
-                        'display_sequence'      => 3,
-                    ],
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::user_password,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::user_password),
-                        'is_fixed_column'       => 1,
-                        'is_show_auto_regist'   => 1,
-                        'is_show_my_page'       => 0,
-                        'is_edit_my_page'       => 1,
-                        'required'              => 1,
-                        'display_sequence'      => 4,
-                    ],
-                    [
-                        'columns_set_id'        => $columns_set->id,
-                        'column_type'           => UserColumnType::created_at,
-                        'column_name'           => UserColumnType::getDescriptionFixed(UserColumnType::created_at),
-                        'is_fixed_column'       => 0,
-                        'is_show_auto_regist'   => 0,
-                        'is_show_my_page'       => 1,
-                        'is_edit_my_page'       => 0,
-                        'required'              => 0,
-                        'display_sequence'      => 5,
-                    ],
-                ]);
+                // UsersColumnsSet登録時のUsersColumns初期登録
+                UsersColumns::initInsertForRegistUsersColumnsSet($columns_set->id);
 
                 foreach ($users_columns as $users_column) {
                     $users_column->display_sequence = $users_column->display_sequence + 5;


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/pull/1792 の不具合修正です。

.envのUSE_USERS_COLUMNS_SET=false、または設定なしであれば、不具合の影響ありません。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載済み

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
