### PR TITLE
[wysiwygエディタ]画像編集時の詳細設定タブを追加しました

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -646,6 +646,9 @@
         // 画像プラグイン＞アップロード（タブ）非表示. アップロード（タブ）で画像アップロードすると即時アップロードされ、一般（タブ）のリサイズのパラメータが拾えず全て原寸でアップロードされるため、使わない。
         image_uploadtab: false,
 
+        // 画像の詳細設定タブ機能
+        image_advtab: true,
+
         image_class_list: [
             {title: 'Responsive', value: 'img-fluid'},
             {title: '枠線＋Responsive', value: 'img-fluid img-thumbnail'},


### PR DESCRIPTION
# 概要
- クライアント要望です。
- wisiwygエディタ－画像編集ボタン押下時ウィンドウに左ペイン、及び、詳細設定が追加されます。
    - 詳細設定では余白や枠線の設定が可能になり、従来CSSで対応するしかなかったものが画面から対応可能になります。
## 対応前ウィンドウ
![image](https://github.com/opensource-workshop/connect-cms/assets/13323806/64f399f2-a686-4ea3-8721-bbe29a373ea0)
## 対応後ウィンドウ
![image](https://github.com/opensource-workshop/connect-cms/assets/13323806/25c0cf6f-9ac5-424e-8c9d-bbfa9906d3c5)

# レビュー完了希望日
10/3（火）一杯

# 関連Pull requests/Issues
なし

# 参考
https://www.tiny.cloud/docs/plugins/opensource/image/#image_advtab

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
