### PR TITLE
[サイト管理] 使用容量 画面追加

### DIFF
--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -27,6 +27,7 @@ use App\Plugins\Manage\ManagePluginBase;
 use App\Plugins\Manage\SiteManage\CCPDF;
 use App\Enums\BaseLoginRedirectPage;
 use App\Enums\StatusType;
+use App\Utilities\File\FileUtils;
 
 /* 移行データ用 */
 use App\Models\User\Contents\Contents;
@@ -177,6 +178,7 @@ use App\Models\Migration\Nc3\Nc3Video;
  * サイト管理クラス
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category サイト管理
  * @package Controller
@@ -222,6 +224,7 @@ class SiteManage extends ManagePluginBase
         $role_ckeck_table["document"]         = array('admin_site');
         $role_ckeck_table["saveDocument"]     = array('admin_site');
         $role_ckeck_table["downloadDocument"] = array('admin_site');
+        $role_ckeck_table["total"]            = ['admin_site'];
 
         return $role_ckeck_table;
     }
@@ -1969,5 +1972,31 @@ class SiteManage extends ManagePluginBase
         $size_str = sprintf("%'.02d", $size);
 
         return sprintf("%'." . $size_str . "d", $id);
+    }
+
+    /**
+     * 使用容量
+     *
+     * @return view
+     * @method_title 使用容量
+     * @method_desc ファイルの使用量を確認できます。
+     * @method_detail Connect-CMSで使用しているファイル容量を確認できます。
+     */
+    public function total($request, $id = null)
+    {
+        $total = 0;
+        // ディレクトリの全ファイル一覧
+        $files = FileUtils::getFileList(base_path());
+        foreach ($files as $file) {
+            $total += filesize($file);
+        }
+        // 単位付与
+        $total = FileUtils::getFormatSizeDecimalPoint($total);
+
+        return view('plugins.manage.site.total', [
+            "function"    => __FUNCTION__,
+            "plugin_name" => "site",
+            "total"       => $total,
+        ]);
     }
 }

--- a/app/Utilities/File/FileUtils.php
+++ b/app/Utilities/File/FileUtils.php
@@ -23,7 +23,7 @@ class FileUtils
     /**
      * サイズのフォーマット(小数点)
      */
-    public static function getFormatSizeDecimalPoint($size)
+    public static function getFormatSizeDecimalPoint(int $size): string
     {
         $units = array("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB");
         for ($i = 0; $size >= 1024 && $i < 4; $i++) {
@@ -45,7 +45,8 @@ class FileUtils
     /**
      * 指定ディレクトリ配下のサブディレクトリを含めたファイル一覧取得
      */
-    public static function getFileList($dir) {
+    public static function getFileList(string $dir): array
+    {
         $iterator = new RecursiveDirectoryIterator($dir);
         $iterator = new RecursiveIteratorIterator($iterator);
         $list = array();

--- a/app/Utilities/File/FileUtils.php
+++ b/app/Utilities/File/FileUtils.php
@@ -3,11 +3,13 @@
 namespace App\Utilities\File;
 
 use App\Enums\ImageMimetype;
+use \RecursiveDirectoryIterator;
+use \RecursiveIteratorIterator;
 
 class FileUtils
 {
     /**
-     * サイズのフォーマット
+     * サイズのフォーマット(round)
      */
     public static function getFormatSize($size, $r = 0)
     {
@@ -19,6 +21,18 @@ class FileUtils
     }
 
     /**
+     * サイズのフォーマット(小数点)
+     */
+    public static function getFormatSizeDecimalPoint($size)
+    {
+        $units = array("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB");
+        for ($i = 0; $size >= 1024 && $i < 4; $i++) {
+            $size /= 1024;
+        }
+        return sprintf('%1.2f', $size).$units[$i];
+    }
+
+    /**
      * 画像ファイルならtrueを返す
      *
      * @return boolean
@@ -26,5 +40,20 @@ class FileUtils
     public static function isImage($mimetype) : bool
     {
         return in_array($mimetype, ImageMimetype::getMemberKeys()) ? true : false;
+    }
+
+    /**
+     * 指定ディレクトリ配下のサブディレクトリを含めたファイル一覧取得
+     */
+    public static function getFileList($dir) {
+        $iterator = new RecursiveDirectoryIterator($dir);
+        $iterator = new RecursiveIteratorIterator($iterator);
+        $list = array();
+        foreach ($iterator as $fileinfo) { // $fileinfoはSplFiIeInfoオブジェクト
+            if ($fileinfo->isFile()) {
+                $list[] = $fileinfo->getPathname();
+            }
+        }
+        return $list;
     }
 }

--- a/resources/views/plugins/manage/site/site_manage_tab.blade.php
+++ b/resources/views/plugins/manage/site/site_manage_tab.blade.php
@@ -53,6 +53,14 @@
                 @endif
                 </li>
 
+                <li role="presentation" class="nav-item">
+                    @if ($function == "total")
+                        <span class="nav-link"><span class="active">使用容量</span></span>
+                    @else
+                        <a href="{{url('/manage/site/total')}}" class="nav-link">使用容量</a>
+                    @endif
+                </li>
+
                 <li class="nav-item dropdown">
                     <a href="#" class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         その他設定

--- a/resources/views/plugins/manage/site/total.blade.php
+++ b/resources/views/plugins/manage/site/total.blade.php
@@ -1,0 +1,24 @@
+{{--
+ * 使用容量 テンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category サイト管理
+--}}
+{{-- 管理画面ベース画面 --}}
+@extends('plugins.manage.manage')
+
+{{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
+@section('manage_content')
+
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.site.site_manage_tab')
+    </div>
+    <div class="card-body">
+        ファイル使用容量: {{ $total }}
+    </div>
+</div>
+
+@endsection


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

ファイル使用容量を確認できる画面を追加しました。

# 追加画面
## サイト管理＞使用容量

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/604176a3-32eb-4c93-aa08-a4e1cc3225f7)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* （PHPで）指定ディレクトリ以下を全部チェックしてファイル一覧を取得する方法
https://blog.asial.co.jp/1250/

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
