### PR TITLE
[データベース]急上昇ワードを押下しても遷移しない問題を修正しました

### DIFF
--- a/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
@@ -23,7 +23,7 @@
 {{-- アクセシビリティ対応。検索OFF & 絞り込み項目なし & ソートOFFの時、検索の空フォームを作らないようにする。 --}}
 @if(($database_frame && $database_frame->use_search_flag == 1) || (($select_columns && count($select_columns) >= 1) || $databases_frames->isBasicUseSortFlag()))
 
-<form action="{{url('/')}}/redirect/plugin/databases/search/{{$dest_frame->page->id}}/{{$dest_frame->id}}#frame-{{$dest_frame->id}}" method="POST" role="search" aria-label="{{$database_frame->databases_name}}">
+<form action="{{url('/')}}/redirect/plugin/databases/search/{{$dest_frame->page->id}}/{{$dest_frame->id}}#frame-{{$dest_frame->id}}" method="POST" role="search" aria-label="{{$database_frame->databases_name}}" name="databaseform{{$frame_id}}">
     {{ csrf_field() }}
     {{-- 詳細画面でブラウザバックをしたときに、フォーム再送信の確認が表示されないようにリダイレクトする --}}
     <input type="hidden" name="redirect_path" value="{{$dest_frame->page->getLinkUrl()}}?frame_{{$dest_frame->id}}_page=1#frame-{{$dest_frame->id}}">
@@ -56,14 +56,14 @@
     @if (($database_frame && $database_frame->use_search_flag == 1 && $database_show_trend_words))
         <div class="input-group mb-3">
             <script>
-                function submitSearch(keyword) {
+                function submitSearch{{$frame_id}}(keyword) {
                     document.databaseform{{$frame_id}}.search_keyword.value = keyword;
                     document.databaseform{{$frame_id}}.submit();
                 }
             </script>
             <span class="trend_word_title">{{$database_trend_words_caption}}</span>
             @foreach ($registered_trend_words as $word)
-            <a class="mr-2 trend_word" href="javascript:void(0)" onclick="submitSearch('{{$word}}')">
+            <a class="mr-2 trend_word" href="javascript:void(0)" onclick="submitSearch{{$frame_id}}('{{$word}}')">
                 {{$word}}
             </a>
             @endforeach


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
標題の通り。PRの競合を解消した際に発生した不具合です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
#1838

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
