### PR TITLE
[コア]フレームのヘッダーにプラグインが編集可能であることを表すclassを追加しました

### DIFF
--- a/resources/views/core/cms_frame_header.blade.php
+++ b/resources/views/core/cms_frame_header.blade.php
@@ -46,15 +46,23 @@ if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null
     @endphp
 
     {{-- 認証していてフレームタイトルが空の場合は、パネルヘッダーの中央にアイコンを配置したいので、高さ指定する。 --}}
+    @php
+        // プラグインが編集可能であることを表すclass
+        $can_edit_plugin = '';
+        if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null,null,$frame]]) && app('request')->input('mode') != 'preview') {
+            $can_edit_plugin = 'can-edit-plugin';
+        }
+    @endphp
+
     @if (Auth::check() && empty($frame->frame_title) && app('request')->input('mode') == 'preview')
         @php $class_header_bg = "bg-transparent"; @endphp
         <h1 class="card-header {{$class_header_bg}} border-0" style="padding-top: 0px;padding-bottom: 0px;">
     @elseif (Auth::check() && empty($frame->frame_title))
         @php $class_header_bg = "bg-transparent"; @endphp
-        <h1 class="card-header {{$class_header_bg}} border-0" style="padding-top: 0px;padding-bottom: 0px;">
+        <h1 class="card-header {{$class_header_bg}} border-0 {{$can_edit_plugin}}" style="padding-top: 0px;padding-bottom: 0px;">
     @else
         @php $class_header_bg = "bg-{$frame->frame_design}"; @endphp
-        <h1 class="card-header {{$class_header_bg}} cc-{{$frame->frame_design}}-font-color">
+        <h1 class="card-header {{$class_header_bg}} cc-{{$frame->frame_design}}-font-color {{$can_edit_plugin}}">
     @endif
 
     {{-- フレームタイトル --}}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
フレームのヘッダーのclassに、プラグインが編集可能であることを表すclassを追加しました。

以下のようなデザインを当てるときに利用します。
- タブプラグインを利用する際、一般ユーザにタブ配下のヘッダーを隠す
  - 管理者にはヘッダーを表示させて管理画面を見れるようにする

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
