### PR TITLE
[コア]フレーム共通ヘッダーbladeの処理を改善しました

### DIFF
--- a/resources/views/core/cms_frame_header.blade.php
+++ b/resources/views/core/cms_frame_header.blade.php
@@ -18,9 +18,15 @@ if ($frame->frame_title) {
     $canFrameHaederDisplayed = true;   // 表示
 }
 
+// 編集権限があるか
+$can_edit_frame = false;
+if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null,null,$frame]])) {
+    $can_edit_frame = true;
+}
+
 // フレームタイトルが無くても、権限あれば、フレームヘッダ表示する。
 //   - Gate::check()は、Auth::user()->can()と同等メソッド。 @see https://readouble.com/laravel/6.x/ja/authorization.html#authorizing-actions-via-gates
-if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null,null,$frame]])) {
+if ($can_edit_frame) {
     $canFrameHaederDisplayed = true;   // 表示
 }
 @endphp
@@ -48,9 +54,9 @@ if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null
     {{-- 認証していてフレームタイトルが空の場合は、パネルヘッダーの中央にアイコンを配置したいので、高さ指定する。 --}}
     @php
         // プラグインが編集可能であることを表すclass
-        $can_edit_plugin = '';
-        if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null,null,$frame]]) && app('request')->input('mode') != 'preview') {
-            $can_edit_plugin = 'can-edit-plugin';
+        $can_edit_frame_class = '';
+        if ($can_edit_frame) {
+            $can_edit_frame_class = 'can-edit-frame';
         }
     @endphp
 
@@ -59,10 +65,10 @@ if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null
         <h1 class="card-header {{$class_header_bg}} border-0" style="padding-top: 0px;padding-bottom: 0px;">
     @elseif (Auth::check() && empty($frame->frame_title))
         @php $class_header_bg = "bg-transparent"; @endphp
-        <h1 class="card-header {{$class_header_bg}} border-0 {{$can_edit_plugin}}" style="padding-top: 0px;padding-bottom: 0px;">
+        <h1 class="card-header {{$class_header_bg}} border-0 {{$can_edit_frame_class}}" style="padding-top: 0px;padding-bottom: 0px;">
     @else
         @php $class_header_bg = "bg-{$frame->frame_design}"; @endphp
-        <h1 class="card-header {{$class_header_bg}} cc-{{$frame->frame_design}}-font-color {{$can_edit_plugin}}">
+        <h1 class="card-header {{$class_header_bg}} cc-{{$frame->frame_design}}-font-color {{$can_edit_frame_class}}">
     @endif
 
     {{-- フレームタイトル --}}
@@ -111,8 +117,7 @@ if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null
         (Auth::user()->can('role_arrangement')) &&
          app('request')->input('mode') != 'preview')
     --}}
-    @if (Gate::check(['role_frame_header', 'frames.move', 'frames.edit'], [[null,null,null,$frame]]) &&
-        app('request')->input('mode') != 'preview')
+    @if ($can_edit_frame && app('request')->input('mode') != 'preview')
 
         {{-- フレームを配置したページのみ、編集できるようにする。 --}}
 {{--


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
- 編集権限があるかの判定を先頭の変数に保持するようにしました
- プラグインが編集可能であることを表すclassを「can-edit-plugin」から「can-edit-frame」に変更しました

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
