### PR TITLE
[データベース検索]ウィジウィグ型にaタグが含まれるとHTMLが崩れる問題を修正しました

### DIFF
--- a/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
+++ b/resources/views/plugins/user/databasesearches/card_04/databasesearches.blade.php
@@ -38,7 +38,11 @@
                                 <div class="dbsearch_col_{{$view_col->databases_columns_id}}" >
                                         @if ($view_col->column_type == DatabaseColumnType::wysiwyg)
                                             {{-- wysiwygエディタ項目の場合 --}}
-                                            <span class="column_title">{{$view_column}}：</span><span class="column_value">{!! $view_col->value !!}</span>
+                                            @php
+                                                // aタグの中にaタグがあるとリンクが崩れるのでaタグを除去する
+                                                $contents = preg_replace('/<a .*?>(.*?)<\/a>/', "$1", $view_col->value);
+                                            @endphp
+                                            <span class="column_title">{{$view_column}}：</span><span class="column_value">{!! $contents !!}</span>
                                         @elseif ($view_col->column_type == DatabaseColumnType::image)
                                             {{-- 画像項目の場合 --}}
                                             <img class="img-fluid" src="{{url('/')}}/file/{{$view_col->value}}">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

カード型のテンプレートを利用する場合、aタグが含まれるウィジウィグ型の項目を出力するとHTMLが崩れます。
これはは、一つのカードがaタグでくくられているためです。
aタグの中にaタグはHTMLとして許容されません。

以上より、ウィジウィグ型を出力する際にaタグを除去する処理を追加しました。

対象のテンプレート：card03, card04

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

バグのためなるはやでお願いします。

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
