### PR TITLE
[データベース検索]並べ替え条件にランダムを追加しました

### DIFF
--- a/app/Enums/DatabaseSearcherSortType.php
+++ b/app/Enums/DatabaseSearcherSortType.php
@@ -15,9 +15,12 @@ final class DatabaseSearcherSortType extends EnumsBase
     const views = 'views';
     const posted  = 'posted';
     const display = 'display';
+    const random  = 'random';
 
     const order_asc     = 'asc';
     const order_desc    = 'desc';
+    const order_session = 'session';
+    const order_every   = 'every';
 
     // 定数メンバ
     const created_asc    = self::created . '_' . self::order_asc;
@@ -30,6 +33,8 @@ final class DatabaseSearcherSortType extends EnumsBase
     const posted_desc    = self::posted . '_' . self::order_desc;
     const display_asc    = self::display . '_' . self::order_asc;
     const display_desc   = self::display . '_' . self::order_desc;
+    const random_session = self::random . '_' . self::order_session;
+    const random_every   = self::random . '_' . self::order_every;
 
     // key/valueの連想配列
     const enum = [
@@ -43,5 +48,7 @@ final class DatabaseSearcherSortType extends EnumsBase
         self::posted_desc    => '公開日（新しい順）',
         self::display_asc    => '表示順（昇順）',
         self::display_desc   => '表示順（降順）',
+        self::random_session => 'ランダム（セッション）',
+        self::random_every   => 'ランダム（毎回）',
     ];
 }

--- a/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
+++ b/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
@@ -312,6 +312,16 @@ class DatabasesearchesPlugin extends UserPluginBase
             case DatabaseSearcherSortType::display_desc:
                 $inputs_ids->orderBy('databases_inputs.display_sequence', 'desc');
                 break;
+            case DatabaseSearcherSortType::random_session:
+                // ランダム読み込みのための Seed をセッション中に作っておく
+                if (empty(session('database_searches_sort_seed.'.$frame_id))) {
+                    session(['database_searches_sort_seed.'.$frame_id => rand()]);
+                }
+                $inputs_ids->inRandomOrder(session('database_searches_sort_seed.'.$frame_id));
+                break;
+            case DatabaseSearcherSortType::random_every:
+                $inputs_ids->inRandomOrder();
+                break;
             default:
                 $inputs_ids->orderBy('databases_inputs.created_at', 'asc');
                 break;


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

並べ替え条件をデータベースプラグインと合わせました。
ランダム（セッション）、ランダム（毎回）を追加しました。
データベース検索プラグインでもランダム表示を利用できます。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
