### PR TITLE
[データベース]検索をGETメソッドでも実行可能にしました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -994,65 +994,63 @@ class DatabasesPlugin extends UserPluginBase
      */
     public function search($request, $page_id, $frame_id)
     {
-        // POST されたときは、新しい絞り込み条件が設定された。ということになるので、セッションの書き換え
-        if ($request->isMethod('post')) {
-            // 検索ON
-            session(['is_search.'.$frame_id => 1]);
+        // searchが実行されるときは新しい絞り込み条件が設定されたということになるので、セッションの書き換え
+        // 検索ON
+        session(['is_search.'.$frame_id => 1]);
 
-            // キーワード
-            session(['search_keyword.'.$frame_id => $request->search_keyword]);
+        // キーワード
+        session(['search_keyword.'.$frame_id => $request->search_keyword]);
 
-            // 絞り込み
-            session(['search_column.'.$frame_id => $request->search_column]);
+        // 絞り込み
+        session(['search_column.'.$frame_id => $request->search_column]);
 
-            // 絞り込み（複数選択）
-            session(['search_column_multiple.'.$frame_id => $request->search_column_multiple]);
+        // 絞り込み（複数選択）
+        session(['search_column_multiple.'.$frame_id => $request->search_column_multiple]);
 
-            // オプション検索
-            session(['search_options.'.$frame_id => $request->search_options]);
+        // オプション検索
+        session(['search_options.'.$frame_id => $request->search_options]);
 
-            // オプション検索OR
-            session(['search_options_or.'.$frame_id => $request->search_options_or]);
+        // オプション検索OR
+        session(['search_options_or.'.$frame_id => $request->search_options_or]);
 
-            // オプション検索期間
-            session(['search_term.'.$frame_id => $request->search_term]);
+        // オプション検索期間
+        session(['search_term.'.$frame_id => $request->search_term]);
 
-            // ランダム読み込みのための Seed をセッション中に作っておく
-            if (empty(session('sort_seed.'.$frame_id))) {
-                session(['sort_seed.'.$frame_id => rand()]);
-            }
+        // ランダム読み込みのための Seed をセッション中に作っておく
+        if (empty(session('sort_seed.'.$frame_id))) {
+            session(['sort_seed.'.$frame_id => rand()]);
+        }
 
-            // 詳細画面で非表示項目をパラメータのID指定で強制的に表示する機能(beta)
-            if (config('connect.DATABASES_FORCE_SHOW_COLUMN_ON_DETAIL')) {
-                session(['force_show_columns.'.$frame_id => $request->force_show_columns]);
-            }
+        // 詳細画面で非表示項目をパラメータのID指定で強制的に表示する機能(beta)
+        if (config('connect.DATABASES_FORCE_SHOW_COLUMN_ON_DETAIL')) {
+            session(['force_show_columns.'.$frame_id => $request->force_show_columns]);
+        }
 
-            // 並べ替え
-            $sort_column_parts = explode('_', $request->sort_column);
-            if (count($sort_column_parts) == 1) {
-                session(['sort_column_id.'.$frame_id    => $sort_column_parts[0]]);
-                session(['sort_column_order.'.$frame_id => '']);
-                session(['sort_column_option.'.$frame_id => '']);
-            } elseif (count($sort_column_parts) >= 2) {
-                session(['sort_column_id.'.$frame_id    => $sort_column_parts[0]]);
-                session(['sort_column_order.'.$frame_id => $sort_column_parts[1]]);
-                session(['sort_column_option.'.$frame_id => $sort_column_parts[2] ?? '']);
-            } else {
-                session(['sort_column_id.'.$frame_id    => '']);
-                session(['sort_column_order.'.$frame_id => '']);
-                session(['sort_column_option.'.$frame_id => '']);
-            }
-            // var_dump($sort_column_parts);
+        // 並べ替え
+        $sort_column_parts = explode('_', $request->sort_column);
+        if (count($sort_column_parts) == 1) {
+            session(['sort_column_id.'.$frame_id    => $sort_column_parts[0]]);
+            session(['sort_column_order.'.$frame_id => '']);
+            session(['sort_column_option.'.$frame_id => '']);
+        } elseif (count($sort_column_parts) >= 2) {
+            session(['sort_column_id.'.$frame_id    => $sort_column_parts[0]]);
+            session(['sort_column_order.'.$frame_id => $sort_column_parts[1]]);
+            session(['sort_column_option.'.$frame_id => $sort_column_parts[2] ?? '']);
+        } else {
+            session(['sort_column_id.'.$frame_id    => '']);
+            session(['sort_column_order.'.$frame_id => '']);
+            session(['sort_column_option.'.$frame_id => '']);
+        }
+        // var_dump($sort_column_parts);
 
-            // 検索条件を削除
-            if ($request->has('clear')) {
-                session(['is_search.'.$frame_id => '']);
-                session(['search_keyword.'.$frame_id => '']);
-                session(['search_column.'.$frame_id => '']);
-                session(['search_options.'.$frame_id => '']);
-                session(['search_options_or.'.$frame_id => '']);
-                session(['search_term.'.$frame_id => '']);
-            }
+        // 検索条件を削除
+        if ($request->has('clear')) {
+            session(['is_search.'.$frame_id => '']);
+            session(['search_keyword.'.$frame_id => '']);
+            session(['search_column.'.$frame_id => '']);
+            session(['search_options.'.$frame_id => '']);
+            session(['search_options_or.'.$frame_id => '']);
+            session(['search_term.'.$frame_id => '']);
         }
 
         // 詳細画面のブラウザバックでフォーム再送信の確認を表示させないようにするため、リダイレクトする


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

検索結果へのURLを指定できるようにするため、GETでも検索できるようにしました。
例 : /plugin/databases/search/{page_id}/{frame_id}?search_keyword=キーワード

従来は実質POSTのみでsearchアクションが機能していました。
（GETは新たな検索条件を設定できず前回の検索条件で再検索する）

## 特記事項

**検索する画面にURLをコピーする機能があったほうがいいのでは？** by @akagane99 
別issueで積み残します！
検索画面をGETに変えちゃっていい気がします。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
