### PR TITLE
[入力エラー] ファイルアップロードで入力エラー時にファイル参照欄を赤線で囲う対応の見直し

### DIFF
--- a/resources/views/plugins/manage/page/page_import.blade.php
+++ b/resources/views/plugins/manage/page/page_import.blade.php
@@ -36,8 +36,8 @@
                 <label for="page_name" class="col-md-3 col-form-label text-md-right">CSVファイル</label>
                 <div class="col-md-9">
                     <div class="custom-file">
-                        <input type="file" class="custom-file-input @if ($errors->has('page_csv')) border-danger @endif" id="page_csv" name="page_csv" accept=".csv">
-                        <label class="custom-file-label @if ($errors->has('page_csv')) border-danger @endif" for="page_csv" data-browse="参照"></label>
+                        <input type="file" class="custom-file-input @if ($errors->has('page_csv')) is-invalid @endif" id="page_csv" name="page_csv" accept=".csv">
+                        <label class="custom-file-label" for="page_csv" data-browse="参照"></label>
                     </div>
                     @if ($errors->has('page_csv'))
                         @foreach ($errors->get('page_csv') as $message)

--- a/resources/views/plugins/manage/page/page_import.blade.php
+++ b/resources/views/plugins/manage/page/page_import.blade.php
@@ -36,8 +36,8 @@
                 <label for="page_name" class="col-md-3 col-form-label text-md-right">CSVファイル</label>
                 <div class="col-md-9">
                     <div class="custom-file">
-                        <input type="file" class="custom-file-input @if ($errors->has('page_csv')) is-invalid @endif" id="page_csv" name="page_csv" accept=".csv">
-                        <label class="custom-file-label" for="page_csv" data-browse="参照"></label>
+                        <input type="file" class="custom-file-input @if ($errors->has('page_csv')) border-danger @endif" id="page_csv" name="page_csv" accept=".csv">
+                        <label class="custom-file-label @if ($errors->has('page_csv')) border-danger @endif" for="page_csv" data-browse="参照"></label>
                     </div>
                     @if ($errors->has('page_csv'))
                         @foreach ($errors->get('page_csv') as $message)

--- a/resources/views/plugins/manage/page/page_import.blade.php
+++ b/resources/views/plugins/manage/page/page_import.blade.php
@@ -36,7 +36,7 @@
                 <label for="page_name" class="col-md-3 col-form-label text-md-right">CSVファイル</label>
                 <div class="col-md-9">
                     <div class="custom-file">
-                        <input type="file" class="custom-file-input @if ($errors->has('page_csv')) border-danger @endif" id="page_csv" name="page_csv" accept=".csv">
+                        <input type="file" class="custom-file-input" id="page_csv" name="page_csv" accept=".csv">
                         <label class="custom-file-label @if ($errors->has('page_csv')) border-danger @endif" for="page_csv" data-browse="参照"></label>
                     </div>
                     @if ($errors->has('page_csv'))

--- a/resources/views/plugins/manage/site/favicon.blade.php
+++ b/resources/views/plugins/manage/site/favicon.blade.php
@@ -41,8 +41,8 @@
                 <label class="col-md-3 col-form-label text-md-right">ファビコン・ファイル</label>
                 <div class="col-md-9">
                     <div class="custom-file">
-                        <input type="file" class="custom-file-input @if ($errors->has('favicon')) border-danger @endif" id="favicon" name="favicon" accept=".ico">
-                        <label class="custom-file-label @if ($errors->has('favicon')) border-danger @endif" for="favicon" data-browse="参照">アイコンファイル(.ico)</label>
+                        <input type="file" class="custom-file-input @if ($errors->has('favicon')) is-invalid @endif" id="favicon" name="favicon" accept=".ico">
+                        <label class="custom-file-label" for="favicon" data-browse="参照">アイコンファイル(.ico)</label>
                     </div>
                     @include('plugins.common.errors_inline', ['name' => 'favicon'])
                 </div>

--- a/resources/views/plugins/manage/site/favicon.blade.php
+++ b/resources/views/plugins/manage/site/favicon.blade.php
@@ -41,8 +41,8 @@
                 <label class="col-md-3 col-form-label text-md-right">ファビコン・ファイル</label>
                 <div class="col-md-9">
                     <div class="custom-file">
-                        <input type="file" class="custom-file-input @if ($errors->has('favicon')) is-invalid @endif" id="favicon" name="favicon" accept=".ico">
-                        <label class="custom-file-label" for="favicon" data-browse="参照">アイコンファイル(.ico)</label>
+                        <input type="file" class="custom-file-input @if ($errors->has('favicon')) border-danger @endif" id="favicon" name="favicon" accept=".ico">
+                        <label class="custom-file-label @if ($errors->has('favicon')) border-danger @endif" for="favicon" data-browse="参照">アイコンファイル(.ico)</label>
                     </div>
                     @include('plugins.common.errors_inline', ['name' => 'favicon'])
                 </div>

--- a/resources/views/plugins/manage/site/favicon.blade.php
+++ b/resources/views/plugins/manage/site/favicon.blade.php
@@ -41,7 +41,7 @@
                 <label class="col-md-3 col-form-label text-md-right">ファビコン・ファイル</label>
                 <div class="col-md-9">
                     <div class="custom-file">
-                        <input type="file" class="custom-file-input @if ($errors->has('favicon')) border-danger @endif" id="favicon" name="favicon" accept=".ico">
+                        <input type="file" class="custom-file-input" id="favicon" name="favicon" accept=".ico">
                         <label class="custom-file-label @if ($errors->has('favicon')) border-danger @endif" for="favicon" data-browse="参照">アイコンファイル(.ico)</label>
                     </div>
                     @include('plugins.common.errors_inline', ['name' => 'favicon'])

--- a/resources/views/plugins/manage/user/import.blade.php
+++ b/resources/views/plugins/manage/user/import.blade.php
@@ -130,8 +130,8 @@
                 <label class="col-md-3 col-form-label text-md-right">CSVファイル <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-9">
                     <div class="custom-file">
-                        <input type="file" class="custom-file-input @if ($errors->has('users_csv')) is-invalid @endif" id="users_csv" name="users_csv" accept=".csv">
-                        <label class="custom-file-label" for="users_csv" data-browse="参照"></label>
+                        <input type="file" class="custom-file-input @if ($errors->has('users_csv')) border-danger @endif" id="users_csv" name="users_csv" accept=".csv">
+                        <label class="custom-file-label @if ($errors->has('users_csv')) border-danger @endif" for="users_csv" data-browse="参照"></label>
                     </div>
                     @if ($errors && $errors->has('users_csv'))
                         @foreach ($errors->get('users_csv') as $message)

--- a/resources/views/plugins/manage/user/import.blade.php
+++ b/resources/views/plugins/manage/user/import.blade.php
@@ -130,7 +130,7 @@
                 <label class="col-md-3 col-form-label text-md-right">CSVファイル <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-9">
                     <div class="custom-file">
-                        <input type="file" class="custom-file-input @if ($errors->has('users_csv')) border-danger @endif" id="users_csv" name="users_csv" accept=".csv">
+                        <input type="file" class="custom-file-input" id="users_csv" name="users_csv" accept=".csv">
                         <label class="custom-file-label @if ($errors->has('users_csv')) border-danger @endif" for="users_csv" data-browse="参照"></label>
                     </div>
                     @if ($errors && $errors->has('users_csv'))

--- a/resources/views/plugins/manage/user/import.blade.php
+++ b/resources/views/plugins/manage/user/import.blade.php
@@ -130,8 +130,8 @@
                 <label class="col-md-3 col-form-label text-md-right">CSVファイル <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-9">
                     <div class="custom-file">
-                        <input type="file" class="custom-file-input @if ($errors->has('users_csv')) border-danger @endif" id="users_csv" name="users_csv" accept=".csv">
-                        <label class="custom-file-label @if ($errors->has('users_csv')) border-danger @endif" for="users_csv" data-browse="参照"></label>
+                        <input type="file" class="custom-file-input @if ($errors->has('users_csv')) is-invalid @endif" id="users_csv" name="users_csv" accept=".csv">
+                        <label class="custom-file-label" for="users_csv" data-browse="参照"></label>
                     </div>
                     @if ($errors && $errors->has('users_csv'))
                         @foreach ($errors->get('users_csv') as $message)

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -144,8 +144,8 @@
         <div class="form-group">
             <div class="custom-file">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
-                <label class="custom-file-label" for="upload_file" data-browse="参照">ファイル選択...</label>
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input" id="upload_file{{$frame_id}}">
+                <label class="custom-file-label @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" for="upload_file" data-browse="参照">ファイル選択...</label>
             </div>
             @if ($errors && $errors->has("upload_file.$frame_id"))
                 <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("upload_file.*")}}</div>

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -144,7 +144,7 @@
         <div class="form-group">
             <div class="custom-file">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) is-invalid @endif" id="upload_file{{$frame_id}}">
                 <label class="custom-file-label" for="upload_file" data-browse="参照">ファイル選択...</label>
             </div>
             @if ($errors && $errors->has("upload_file.$frame_id"))

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -144,7 +144,7 @@
         <div class="form-group">
             <div class="custom-file">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) is-invalid @endif" id="upload_file{{$frame_id}}">
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
                 <label class="custom-file-label" for="upload_file" data-browse="参照">ファイル選択...</label>
             </div>
             @if ($errors && $errors->has("upload_file.$frame_id"))

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_input.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_input.blade.php
@@ -54,8 +54,8 @@
         <label class="col-md-2" for="add_task_file">課題ファイル</label>
         <div class="col-md-10">
             <div class="custom-file">
-                <input type="file" class="custom-file-input @if ($errors->has('add_task_file')) border-danger @endif" id="add_task_file" name="add_task_file" accept=".pdf, .doc, .docx">
-                <label class="custom-file-label @if ($errors->has('add_task_file')) border-danger @endif" for="add_task_file" data-browse="参照">PDF もしくは ワード形式。</label>
+                <input type="file" class="custom-file-input @if ($errors->has('add_task_file')) is-invalid @endif" id="add_task_file" name="add_task_file" accept=".pdf, .doc, .docx">
+                <label class="custom-file-label" for="add_task_file" data-browse="参照">PDF もしくは ワード形式。</label>
                 @include('plugins.common.errors_inline', ['name' => 'add_task_file'])
                 <small class="text-muted">※ アップロードできる１ファイルの最大サイズ: {{ini_get('upload_max_filesize')}}</small><br />
             </div>

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_input.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_input.blade.php
@@ -54,7 +54,7 @@
         <label class="col-md-2" for="add_task_file">課題ファイル</label>
         <div class="col-md-10">
             <div class="custom-file">
-                <input type="file" class="custom-file-input @if ($errors->has('add_task_file')) border-danger @endif" id="add_task_file" name="add_task_file" accept=".pdf, .doc, .docx">
+                <input type="file" class="custom-file-input" id="add_task_file" name="add_task_file" accept=".pdf, .doc, .docx">
                 <label class="custom-file-label @if ($errors->has('add_task_file')) border-danger @endif" for="add_task_file" data-browse="参照">PDF もしくは ワード形式。</label>
                 @include('plugins.common.errors_inline', ['name' => 'add_task_file'])
                 <small class="text-muted">※ アップロードできる１ファイルの最大サイズ: {{ini_get('upload_max_filesize')}}</small><br />

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_input.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_input.blade.php
@@ -54,8 +54,8 @@
         <label class="col-md-2" for="add_task_file">課題ファイル</label>
         <div class="col-md-10">
             <div class="custom-file">
-                <input type="file" class="custom-file-input @if ($errors->has('add_task_file')) is-invalid @endif" id="add_task_file" name="add_task_file" accept=".pdf, .doc, .docx">
-                <label class="custom-file-label" for="add_task_file" data-browse="参照">PDF もしくは ワード形式。</label>
+                <input type="file" class="custom-file-input @if ($errors->has('add_task_file')) border-danger @endif" id="add_task_file" name="add_task_file" accept=".pdf, .doc, .docx">
+                <label class="custom-file-label @if ($errors->has('add_task_file')) border-danger @endif" for="add_task_file" data-browse="参照">PDF もしくは ワード形式。</label>
                 @include('plugins.common.errors_inline', ['name' => 'add_task_file'])
                 <small class="text-muted">※ アップロードできる１ファイルの最大サイズ: {{ini_get('upload_max_filesize')}}</small><br />
             </div>

--- a/resources/views/plugins/user/photoalbums/default/edit_contents.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/edit_contents.blade.php
@@ -67,7 +67,7 @@
             </div>
             <div class="custom-file">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) is-invalid @endif" id="upload_file{{$frame_id}}">
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
                 <label class="custom-file-label" for="upload_file" data-browse="参照">画像ファイル選択...</label>
                 <small class="form-text text-muted">ファイルを入れ替える際は指定します。</small>
                 @if ($errors && $errors->has("upload_file.$frame_id"))

--- a/resources/views/plugins/user/photoalbums/default/edit_contents.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/edit_contents.blade.php
@@ -67,8 +67,8 @@
             </div>
             <div class="custom-file">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
-                <label class="custom-file-label" for="upload_file" data-browse="参照">画像ファイル選択...</label>
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input" id="upload_file{{$frame_id}}">
+                <label class="custom-file-label @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" for="upload_file" data-browse="参照">画像ファイル選択...</label>
                 <small class="form-text text-muted">ファイルを入れ替える際は指定します。</small>
                 @if ($errors && $errors->has("upload_file.$frame_id"))
                     <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("upload_file.*")}}</div>

--- a/resources/views/plugins/user/photoalbums/default/edit_contents.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/edit_contents.blade.php
@@ -67,7 +67,7 @@
             </div>
             <div class="custom-file">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) is-invalid @endif" id="upload_file{{$frame_id}}">
                 <label class="custom-file-label" for="upload_file" data-browse="参照">画像ファイル選択...</label>
                 <small class="form-text text-muted">ファイルを入れ替える際は指定します。</small>
                 @if ($errors && $errors->has("upload_file.$frame_id"))

--- a/resources/views/plugins/user/photoalbums/default/edit_video.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/edit_video.blade.php
@@ -59,10 +59,10 @@
             </div>
             <div class="custom-file">
                 <input type="hidden" name="upload_video[{{$frame_id}}]" value="">
-                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) border-danger @endif" id="upload_video{{$frame_id}}">
-                <label class="custom-file-label" for="upload_video" data-browse="参照">動画ファイル選択...</label>
+                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input" id="upload_video{{$frame_id}}">
+                <label class="custom-file-label @if ($errors && $errors->has("upload_video.$frame_id")) border-danger @endif" for="upload_video" data-browse="参照">動画ファイル選択...</label>
                 <small class="form-text text-muted">ファイルを入れ替える際は指定します。</small>
-                @if ($errors && $errors->has("upload_video.$frame_id")) 
+                @if ($errors && $errors->has("upload_video.$frame_id"))
                     <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("upload_video.*")}}</div>
                 @endif
             </div>
@@ -83,8 +83,8 @@
             @endif
             <div class="custom-file">
                 <input type="hidden" name="upload_poster[{{$frame_id}}]" value="">
-                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) border-danger @endif" id="upload_poster{{$frame_id}}">
-                <label class="custom-file-label" for="upload_poster" data-browse="参照">ポスター画像選択...</label>
+                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input" id="upload_poster{{$frame_id}}">
+                <label class="custom-file-label @if ($errors && $errors->has("upload_poster.$frame_id")) border-danger @endif" for="upload_poster" data-browse="参照">ポスター画像選択...</label>
             </div>
         </div>
     </div>
@@ -94,7 +94,7 @@
         <div class="col-md-10">
             <input type="text" name="title[{{$frame_id}}]" value="{{old("title.$frame_id", $photoalbum_content->name)}}" class="form-control @if ($errors->has("title.$frame_id")) border-danger @endif" id="title{{$frame_id}}">
             <small class="form-text text-muted">空の場合、ファイル名をタイトルとして登録します。</small>
-            @if ($errors && $errors->has("title.$frame_id")) 
+            @if ($errors && $errors->has("title.$frame_id"))
                 <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("title.*")}}</div>
             @endif
         </div>
@@ -104,7 +104,7 @@
         <label class="col-md-2 control-label text-md-right">説明</label>
         <div class="col-md-10">
             <textarea name="description[{{$frame_id}}]" class="form-control @if ($errors->has("description.$frame_id")) border-danger @endif" id="description{{$frame_id}}" rows=2>{!!old("description.$frame_id", $photoalbum_content->description)!!}</textarea>
-            @if ($errors && $errors->has("description.$frame_id")) 
+            @if ($errors && $errors->has("description.$frame_id"))
                 <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("description.*")}}</div>
             @endif
         </div>

--- a/resources/views/plugins/user/photoalbums/default/edit_video.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/edit_video.blade.php
@@ -59,10 +59,10 @@
             </div>
             <div class="custom-file">
                 <input type="hidden" name="upload_video[{{$frame_id}}]" value="">
-                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) is-invalid @endif" id="upload_video{{$frame_id}}">
+                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) border-danger @endif" id="upload_video{{$frame_id}}">
                 <label class="custom-file-label" for="upload_video" data-browse="参照">動画ファイル選択...</label>
                 <small class="form-text text-muted">ファイルを入れ替える際は指定します。</small>
-                @if ($errors && $errors->has("upload_video.$frame_id"))
+                @if ($errors && $errors->has("upload_video.$frame_id")) 
                     <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("upload_video.*")}}</div>
                 @endif
             </div>
@@ -83,7 +83,7 @@
             @endif
             <div class="custom-file">
                 <input type="hidden" name="upload_poster[{{$frame_id}}]" value="">
-                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) is-invalid @endif" id="upload_poster{{$frame_id}}">
+                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) border-danger @endif" id="upload_poster{{$frame_id}}">
                 <label class="custom-file-label" for="upload_poster" data-browse="参照">ポスター画像選択...</label>
             </div>
         </div>
@@ -94,7 +94,7 @@
         <div class="col-md-10">
             <input type="text" name="title[{{$frame_id}}]" value="{{old("title.$frame_id", $photoalbum_content->name)}}" class="form-control @if ($errors->has("title.$frame_id")) border-danger @endif" id="title{{$frame_id}}">
             <small class="form-text text-muted">空の場合、ファイル名をタイトルとして登録します。</small>
-            @if ($errors && $errors->has("title.$frame_id"))
+            @if ($errors && $errors->has("title.$frame_id")) 
                 <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("title.*")}}</div>
             @endif
         </div>
@@ -104,7 +104,7 @@
         <label class="col-md-2 control-label text-md-right">説明</label>
         <div class="col-md-10">
             <textarea name="description[{{$frame_id}}]" class="form-control @if ($errors->has("description.$frame_id")) border-danger @endif" id="description{{$frame_id}}" rows=2>{!!old("description.$frame_id", $photoalbum_content->description)!!}</textarea>
-            @if ($errors && $errors->has("description.$frame_id"))
+            @if ($errors && $errors->has("description.$frame_id")) 
                 <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("description.*")}}</div>
             @endif
         </div>

--- a/resources/views/plugins/user/photoalbums/default/edit_video.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/edit_video.blade.php
@@ -59,10 +59,10 @@
             </div>
             <div class="custom-file">
                 <input type="hidden" name="upload_video[{{$frame_id}}]" value="">
-                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) border-danger @endif" id="upload_video{{$frame_id}}">
+                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) is-invalid @endif" id="upload_video{{$frame_id}}">
                 <label class="custom-file-label" for="upload_video" data-browse="参照">動画ファイル選択...</label>
                 <small class="form-text text-muted">ファイルを入れ替える際は指定します。</small>
-                @if ($errors && $errors->has("upload_video.$frame_id")) 
+                @if ($errors && $errors->has("upload_video.$frame_id"))
                     <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("upload_video.*")}}</div>
                 @endif
             </div>
@@ -83,7 +83,7 @@
             @endif
             <div class="custom-file">
                 <input type="hidden" name="upload_poster[{{$frame_id}}]" value="">
-                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) border-danger @endif" id="upload_poster{{$frame_id}}">
+                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) is-invalid @endif" id="upload_poster{{$frame_id}}">
                 <label class="custom-file-label" for="upload_poster" data-browse="参照">ポスター画像選択...</label>
             </div>
         </div>
@@ -94,7 +94,7 @@
         <div class="col-md-10">
             <input type="text" name="title[{{$frame_id}}]" value="{{old("title.$frame_id", $photoalbum_content->name)}}" class="form-control @if ($errors->has("title.$frame_id")) border-danger @endif" id="title{{$frame_id}}">
             <small class="form-text text-muted">空の場合、ファイル名をタイトルとして登録します。</small>
-            @if ($errors && $errors->has("title.$frame_id")) 
+            @if ($errors && $errors->has("title.$frame_id"))
                 <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("title.*")}}</div>
             @endif
         </div>
@@ -104,7 +104,7 @@
         <label class="col-md-2 control-label text-md-right">説明</label>
         <div class="col-md-10">
             <textarea name="description[{{$frame_id}}]" class="form-control @if ($errors->has("description.$frame_id")) border-danger @endif" id="description{{$frame_id}}" rows=2>{!!old("description.$frame_id", $photoalbum_content->description)!!}</textarea>
-            @if ($errors && $errors->has("description.$frame_id")) 
+            @if ($errors && $errors->has("description.$frame_id"))
                 <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$errors->first("description.*")}}</div>
             @endif
         </div>

--- a/resources/views/plugins/user/photoalbums/default/index_head.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_head.blade.php
@@ -162,8 +162,8 @@
             <label class="{{$frame->getSettingLabelClass()}} pr-3 pb-0" for="upload_file">画像ファイル <label class="badge badge-danger">必須</label></label>
             <div class="custom-file {{$frame->getSettingInputClass()}}">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
-                <label class="custom-file-label ml-md-2" for="upload_file" data-browse="参照">画像ファイル選択...</label>
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input" id="upload_file{{$frame_id}}">
+                <label class="custom-file-label ml-md-2 @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" for="upload_file" data-browse="参照">画像ファイル選択...</label>
             </div>
         </div>
         {{-- カスタムインプットで、ファイル行のマージン等が制御できないので、項目注釈やエラーを別の行で作成 --}}
@@ -232,8 +232,8 @@
             <label class="{{$frame->getSettingLabelClass()}} pr-3" for="upload_video">動画ファイル <label class="badge badge-danger">必須</label></label>
             <div class="custom-file {{$frame->getSettingInputClass()}}">
                 <input type="hidden" name="upload_video[{{$frame_id}}]" value="">
-                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) border-danger @endif" id="upload_video{{$frame_id}}">
-                <label class="custom-file-label ml-md-2" for="upload_video" data-browse="参照">動画ファイル選択...</label>
+                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input" id="upload_video{{$frame_id}}">
+                <label class="custom-file-label ml-md-2 @if ($errors && $errors->has("upload_video.$frame_id")) border-danger @endif" for="upload_video" data-browse="参照">動画ファイル選択...</label>
             </div>
         </div>
         {{-- カスタムインプットで、ファイル行のマージン等が制御できないので、項目注釈やエラーを別の行で作成 --}}
@@ -257,8 +257,8 @@
             <label class="{{$frame->getSettingLabelClass()}} pr-3" for="upload_poster">ポスター画像</label>
             <div class="custom-file {{$frame->getSettingInputClass()}}">
                 <input type="hidden" name="upload_poster[{{$frame_id}}]" value="">
-                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) border-danger @endif" id="upload_poster{{$frame_id}}">
-                <label class="custom-file-label ml-md-2" for="upload_poster" data-browse="参照">ポスター画像選択...</label>
+                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input" id="upload_poster{{$frame_id}}">
+                <label class="custom-file-label ml-md-2 @if ($errors && $errors->has("upload_poster.$frame_id")) border-danger @endif" for="upload_poster" data-browse="参照">ポスター画像選択...</label>
             </div>
         </div>
         {{-- カスタムインプットで、ファイル行のマージン等が制御できないので、項目注釈やエラーを別の行で作成 --}}

--- a/resources/views/plugins/user/photoalbums/default/index_head.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_head.blade.php
@@ -162,7 +162,7 @@
             <label class="{{$frame->getSettingLabelClass()}} pr-3 pb-0" for="upload_file">画像ファイル <label class="badge badge-danger">必須</label></label>
             <div class="custom-file {{$frame->getSettingInputClass()}}">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) is-invalid @endif" id="upload_file{{$frame_id}}">
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
                 <label class="custom-file-label ml-md-2" for="upload_file" data-browse="参照">画像ファイル選択...</label>
             </div>
         </div>
@@ -232,7 +232,7 @@
             <label class="{{$frame->getSettingLabelClass()}} pr-3" for="upload_video">動画ファイル <label class="badge badge-danger">必須</label></label>
             <div class="custom-file {{$frame->getSettingInputClass()}}">
                 <input type="hidden" name="upload_video[{{$frame_id}}]" value="">
-                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) is-invalid @endif" id="upload_video{{$frame_id}}">
+                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) border-danger @endif" id="upload_video{{$frame_id}}">
                 <label class="custom-file-label ml-md-2" for="upload_video" data-browse="参照">動画ファイル選択...</label>
             </div>
         </div>
@@ -257,7 +257,7 @@
             <label class="{{$frame->getSettingLabelClass()}} pr-3" for="upload_poster">ポスター画像</label>
             <div class="custom-file {{$frame->getSettingInputClass()}}">
                 <input type="hidden" name="upload_poster[{{$frame_id}}]" value="">
-                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) is-invalid @endif" id="upload_poster{{$frame_id}}">
+                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) border-danger @endif" id="upload_poster{{$frame_id}}">
                 <label class="custom-file-label ml-md-2" for="upload_poster" data-browse="参照">ポスター画像選択...</label>
             </div>
         </div>

--- a/resources/views/plugins/user/photoalbums/default/index_head.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_head.blade.php
@@ -162,7 +162,7 @@
             <label class="{{$frame->getSettingLabelClass()}} pr-3 pb-0" for="upload_file">画像ファイル <label class="badge badge-danger">必須</label></label>
             <div class="custom-file {{$frame->getSettingInputClass()}}">
                 <input type="hidden" name="upload_file[{{$frame_id}}]" value="">
-                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
+                <input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) is-invalid @endif" id="upload_file{{$frame_id}}">
                 <label class="custom-file-label ml-md-2" for="upload_file" data-browse="参照">画像ファイル選択...</label>
             </div>
         </div>
@@ -232,7 +232,7 @@
             <label class="{{$frame->getSettingLabelClass()}} pr-3" for="upload_video">動画ファイル <label class="badge badge-danger">必須</label></label>
             <div class="custom-file {{$frame->getSettingInputClass()}}">
                 <input type="hidden" name="upload_video[{{$frame_id}}]" value="">
-                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) border-danger @endif" id="upload_video{{$frame_id}}">
+                <input type="file" name="upload_video[{{$frame_id}}]" value="{{old("upload_video.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_video.$frame_id")) is-invalid @endif" id="upload_video{{$frame_id}}">
                 <label class="custom-file-label ml-md-2" for="upload_video" data-browse="参照">動画ファイル選択...</label>
             </div>
         </div>
@@ -257,7 +257,7 @@
             <label class="{{$frame->getSettingLabelClass()}} pr-3" for="upload_poster">ポスター画像</label>
             <div class="custom-file {{$frame->getSettingInputClass()}}">
                 <input type="hidden" name="upload_poster[{{$frame_id}}]" value="">
-                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) border-danger @endif" id="upload_poster{{$frame_id}}">
+                <input type="file" name="upload_poster[{{$frame_id}}]" value="{{old("upload_poster.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_poster.$frame_id")) is-invalid @endif" id="upload_poster{{$frame_id}}">
                 <label class="custom-file-label ml-md-2" for="upload_poster" data-browse="参照">ポスター画像選択...</label>
             </div>
         </div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

ファイルアップロードで入力エラー時にファイル参照欄を赤線で囲おうとしていましたが、赤線が表示されていない画面がありましたので対応しました。

# 詳細

エラー時 `<input type="file">` に border-danger クラスを追加しても赤線枠が表示されない
↓
エラー時 `<label class="custom-file-label">` に border-danger クラスを追加すると赤線枠が表示される

※ `<input type="file">`、`<label class="custom-file-label">`  両方に  border-danger クラスを追加している画面もありましたので、`<label class="custom-file-label">` にだけ追加するよう見直しました。

```html
<input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" id="upload_file{{$frame_id}}">
<label class="custom-file-label" for="upload_file" data-browse="参照">ファイル選択...</label>
↓
<input type="file" name="upload_file[{{$frame_id}}]" value="{{old("upload_file.$frame_id")}}" class="custom-file-input" id="upload_file{{$frame_id}}">
<label class="custom-file-label @if ($errors && $errors->has("upload_file.$frame_id")) border-danger @endif" for="upload_file" data-browse="参照">ファイル選択...</label>
```

# 修正後画面

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/a6b60a98-4483-46ed-9cd0-1add5e145f64)

## （参考）修正前画面

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/28da2a8c-1760-4514-99ed-db4786057f9f)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
