### PR TITLE
[データベース]ウィジウィグ型を含むCSVをExcelで閲覧すると崩れる問題を対応しました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3162,6 +3162,7 @@ class DatabasesPlugin extends UserPluginBase
         $csv_data = '';
         foreach ($csv_array as $csv_line) {
             foreach ($csv_line as $csv_col) {
+                $csv_col = str_replace('"', '""', $csv_col);
                 $csv_data .= '"' . $csv_col . '",';
             }
             // 末尾カンマを削除


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
ウィジウィグ型を含むデータベースでCSVをエクスポートし、そのCSVをExcelで開くと項目が列からはみ出て崩れていました。
これは、ウィジウィグ型に含まれる"（ダブルクォート）が原因でした。
ダブルクォートがエスケープされていないかったため、Excelが項目の区切りを正しく認識できなくなっていました。

以上より、ダブルクォートをエスケープする処理を追加しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
