### PR TITLE
[データベース]表示件数型が出力されない問題を対応しました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3097,7 +3097,8 @@ class DatabasesPlugin extends UserPluginBase
                                             'databases_inputs.updated_at as inputs_updated_at',
                                             'databases_inputs.posted_at as inputs_posted_at',
                                             'databases_inputs.expires_at as inputs_expires_at',
-                                            'databases_inputs.display_sequence as inputs_display_sequence'
+                                            'databases_inputs.display_sequence as inputs_display_sequence',
+                                            'databases_inputs.views as inputs_views'
                                         )
                                         ->join('databases_inputs', 'databases_inputs.id', '=', 'databases_input_cols.databases_inputs_id')
                                         ->whereIn('databases_inputs_id', DatabasesInputs::select('id')->where('databases_id', $id))
@@ -3142,6 +3143,9 @@ class DatabasesPlugin extends UserPluginBase
                                 break;
                             case DatabaseColumnType::display:
                                 $csv_array[$input_col->databases_inputs_id][$column->id] = $input_col->inputs_display_sequence;
+                                break;
+                            case DatabaseColumnType::views:
+                                $csv_array[$input_col->databases_inputs_id][$column->id] = $input_col->inputs_views;
                                 break;
                         }
                     }


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
表示件数型の値が出力されない問題を対応しました。
型追加対応で出力処理の追加漏れが原因です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
