### PR TITLE
[ログ設定] ログ設定でURIを記録する設定をした場合、長いURIで500エラーが出る問題に対応

### DIFF
--- a/database/migrations/2023_10_31_090932_change_uri_length_from_app_logs.php
+++ b/database/migrations/2023_10_31_090932_change_uri_length_from_app_logs.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeUriLengthFromAppLogs extends Migration
+{
+    /**
+     * Run the migrations.
+     * - URL 項目の文字数を255 => 8190 へ変更
+     * - Apache のLimitRequestLine ディレクティブのデフォルト値に合わせた。
+     * - https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestline
+     * @see 2021_10_05_111600_change_url_length.php
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('app_logs', function (Blueprint $table) {
+            $table->text('uri')->nullable()->comment('URI')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('app_logs', function (Blueprint $table) {
+            $table->string('uri')->nullable()->comment('URI')->change();
+        });
+    }
+}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。
（ログ設定OFFの場合、エラーは起こりません）

## 詳細
 * URL 項目の文字数を255 => 8190 へ変更
 * Apache のLimitRequestLine ディレクティブのデフォルト値に合わせた。
 * https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestline

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
