### PR TITLE
[wysiwyg] page_id = nullだとDBに登録できないため見直し

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -9,7 +9,7 @@
     // php8.0 Warning対応
     $frame_id = $frame_id ?? null;
     $frame = $frame ?? new \App\Models\Common\Frame();
-    $page_id = $page_id ?? null;
+    $page_id = $page_id ?? 0;
     $theme_group_default = $theme_group_default ?? null;
     $theme = $theme ?? null;
 

--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -100,7 +100,7 @@ use App\Models\Core\UsersColumns;
     </td>
 </tr>
 
-{{-- 選択肢の設定内容の表示行 --}}
+{{-- 設定内容の表示行 --}}
 <tr>
     <td class="pt-0 border border-0"></td>
     <td class="pt-0 border border-0" colspan="7">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。
（現状 page_id = null にならないため、エラーおきません。
　今はありませんが、今後 wysiwygを管理画面に使う場合に page_id = null になることが予想されます。）

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
