### PR TITLE
[自動テスト] 掲示板, 登録時の確認ダイアログ追加に伴う自動テストの修正

### DIFF
--- a/tests/Browser/User/BbsesPluginTest.php
+++ b/tests/Browser/User/BbsesPluginTest.php
@@ -114,7 +114,8 @@ class BbsesPluginTest extends DuskTestCase
             $browser->pause(500)
                     ->screenshot('user/bbses/edit/images/create')
                     ->press('登録確定')
-                    ->acceptDialog();
+                    ->acceptDialog()
+                    ->pause(500);
 
             // 最新の記事を取得
             $post = BbsPost::orderBy('id', 'desc')->first();

--- a/tests/Browser/User/BbsesPluginTest.php
+++ b/tests/Browser/User/BbsesPluginTest.php
@@ -180,8 +180,7 @@ class BbsesPluginTest extends DuskTestCase
                     // ->type('like_button_name', '👍')
                     ->type('like_button_name', 'イイネ！')
                     ->screenshot('user/bbses/createBuckets/images/createBuckets')
-                    ->press('登録確定')
-                    ->acceptDialog();
+                    ->press('登録確定');
 
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'bbses')->first();

--- a/tests/Browser/User/BbsesPluginTest.php
+++ b/tests/Browser/User/BbsesPluginTest.php
@@ -113,7 +113,8 @@ class BbsesPluginTest extends DuskTestCase
 
             $browser->pause(500)
                     ->screenshot('user/bbses/edit/images/create')
-                    ->press('登録確定');
+                    ->press('登録確定')
+                    ->acceptDialog();
 
             // 最新の記事を取得
             $post = BbsPost::orderBy('id', 'desc')->first();
@@ -179,7 +180,8 @@ class BbsesPluginTest extends DuskTestCase
                     // ->type('like_button_name', '👍')
                     ->type('like_button_name', 'イイネ！')
                     ->screenshot('user/bbses/createBuckets/images/createBuckets')
-                    ->press('登録確定');
+                    ->press('登録確定')
+                    ->acceptDialog();
 
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'bbses')->first();


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1876

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
