### PR TITLE
[ブログ] 投稿者絞込機能追加2 OW-2072

### DIFF
--- a/app/Enums/BlogFrameConfig.php
+++ b/app/Enums/BlogFrameConfig.php
@@ -14,7 +14,6 @@ final class BlogFrameConfig extends EnumsBase
     const blog_display_twitter_button = 'blog_display_twitter_button';
     const blog_display_facebook_button = 'blog_display_facebook_button';
     const blog_view_count = 'blog_view_count';
-    const narrowing_down_type_for_created_id = 'narrowing_down_type_for_created_id';
 
     // key/valueの連想配列
     const enum = [
@@ -22,6 +21,5 @@ final class BlogFrameConfig extends EnumsBase
         self::blog_display_twitter_button => 'Twitterアイコン表示',
         self::blog_display_facebook_button => 'Facebookアイコン表示',
         self::blog_view_count => '表示件数',
-        self::narrowing_down_type_for_created_id => '投稿者の絞り込み機能表示',
     ];
 }

--- a/app/Enums/BlogNarrowingDownTypeForCreatedId.php
+++ b/app/Enums/BlogNarrowingDownTypeForCreatedId.php
@@ -15,7 +15,7 @@ use App\Enums\EnumsBase;
 final class BlogNarrowingDownTypeForCreatedId extends EnumsBase
 {
     // 定数メンバ
-    const none = 'none';
+    const none = '';
     const dropdown = 'dropdown';
 
     // key/valueの連想配列

--- a/app/Models/User/Blogs/Blogs.php
+++ b/app/Models/User/Blogs/Blogs.php
@@ -18,6 +18,7 @@ class Blogs extends Model
         'use_like',
         'use_view_count_spectator',
         'narrowing_down_type',
+        'narrowing_down_type_for_created_id',
     ];
 
     /**
@@ -37,6 +38,7 @@ class Blogs extends Model
                 'blogs.like_button_name',
                 'blogs.use_view_count_spectator',
                 'blogs.narrowing_down_type',
+                'blogs.narrowing_down_type_for_created_id',
                 'blogs_frames.scope',
                 'blogs_frames.scope_value',
                 'blogs_frames.important_view',

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -641,7 +641,7 @@ WHERE status = 0
             $categories_id = (int)$request->categories_id;
             if ($categories_id) {
                 // 絞り込み条件あり
-                session(['categories_id_'. $frame_id => (int)$request->categories_id]);
+                session(['categories_id_'. $frame_id => $categories_id]);
             } else {
                 // 絞り込み条件で空を選択
                 session()->forget('categories_id_'. $this->frame->id);

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -592,7 +592,7 @@ WHERE status = 0
         $created_id = null;
         $created_users = collect();
 
-        if (FrameConfig::getConfigValue($this->frame_configs, BlogFrameConfig::narrowing_down_type_for_created_id, BlogNarrowingDownTypeForCreatedId::getDefault()) == BlogNarrowingDownTypeForCreatedId::dropdown) {
+        if ($blog_frame->narrowing_down_type_for_created_id == BlogNarrowingDownTypeForCreatedId::dropdown) {
             // 投稿者の絞り込み機能ありなら、投稿者検索. sessionなしなら投稿者検索しない(null)
             $created_id = session('created_id_'. $this->frame->id);
 
@@ -1268,6 +1268,7 @@ WHERE status = 0
         $blogs->like_button_name = $request->like_button_name;
         $blogs->use_view_count_spectator = $request->use_view_count_spectator;
         $blogs->narrowing_down_type = $request->narrowing_down_type;
+        $blogs->narrowing_down_type_for_created_id = $request->narrowing_down_type_for_created_id;
         //$blogs->approval_flag = $request->approval_flag;
 
         // データ保存

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1273,16 +1273,6 @@ WHERE status = 0
         // データ保存
         $blogs->save();
 
-        // ブログ名で、Buckets名も更新する
-        Buckets::where('id', $blogs->bucket_id)->update(['bucket_name' => $request->blog_name]);
-
-        // ブログ名で、Buckets名も更新する
-        //Log::debug($blogs->bucket_id);
-        //Log::debug($request->blog_name);
-
-        // 新規作成フラグを付けてブログ設定変更画面を呼ぶ.
-        // $create_flag = false;
-        // return $this->editBuckets($request, $page_id, $frame_id, $blogs_id, $create_flag, $message);
         return collect(['redirect_path' => url('/') . '/plugin/blogs/editBuckets/' . $page_id . '/' . $frame_id . '/' . $blogs->id . '#frame-' . $frame_id]);
     }
 

--- a/database/migrations/2023_11_15_175748_add_narrowing_down_type_for_created_id_from_blogs.php
+++ b/database/migrations/2023_11_15_175748_add_narrowing_down_type_for_created_id_from_blogs.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNarrowingDownTypeForCreatedIdFromBlogs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('blogs', function (Blueprint $table) {
+            $table->string('narrowing_down_type')->nullable()->comment('カテゴリ絞り込み機能')->change();
+            $table->string('narrowing_down_type_for_created_id')->nullable()->comment('投稿者絞り込み機能')->after('narrowing_down_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('blogs', function (Blueprint $table) {
+            $table->string('narrowing_down_type')->nullable()->comment('絞り込み機能')->change();
+            $table->dropColumn('narrowing_down_type_for_created_id');
+        });
+    }
+}

--- a/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
@@ -138,7 +138,7 @@
         </div>
     </div>
 
-    <div class="row">
+    <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass(true)}}">カテゴリの絞り込み機能表示</label>
         <div class="{{$frame->getSettingInputClass(true)}}">
             @foreach (BlogNarrowingDownType::getMembers() as $enum_value => $enum_label)
@@ -150,6 +150,23 @@
                         <input type="radio" value="{{$enum_value}}" id="narrowing_down_type_{{$enum_value}}" name="narrowing_down_type" class="custom-control-input">
                     @endif
                     <label class="custom-control-label" for="narrowing_down_type_{{$enum_value}}">{{$enum_label}}</label>
+                </div>
+            @endforeach
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">投稿者の絞り込み機能表示</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            @foreach (BlogNarrowingDownTypeForCreatedId::getMembers() as $enum_value => $enum_label)
+                <div class="custom-control custom-radio custom-control-inline">
+                    @php $narrowing_down_type_for_created_id = $blog->narrowing_down_type_for_created_id ?? BlogNarrowingDownTypeForCreatedId::getDefault(); @endphp
+                    @if (old('narrowing_down_type_for_created_id', $narrowing_down_type_for_created_id) == $enum_value)
+                        <input type="radio" value="{{$enum_value}}" id="narrowing_down_type_for_created_id_{{$enum_value}}" name="narrowing_down_type_for_created_id" class="custom-control-input" checked="checked">
+                    @else
+                        <input type="radio" value="{{$enum_value}}" id="narrowing_down_type_for_created_id_{{$enum_value}}" name="narrowing_down_type_for_created_id" class="custom-control-input">
+                    @endif
+                    <label class="custom-control-label" for="narrowing_down_type_for_created_id_{{$enum_value}}">{{$enum_label}}</label>
                 </div>
             @endforeach
         </div>

--- a/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
@@ -178,24 +178,6 @@
                 </div>
             </div>
 
-            {{-- 投稿者の絞り込み機能表示 --}}
-            <div class="form-group row">
-                <label class="{{$frame->getSettingLabelClass()}}">{{BlogFrameConfig::getDescription(BlogFrameConfig::narrowing_down_type_for_created_id)}}</label>
-                <div class="{{$frame->getSettingInputClass(true)}}">
-                    @foreach (BlogNarrowingDownTypeForCreatedId::getMembers() as $enum_value => $enum_label)
-                        <div class="custom-control custom-radio custom-control-inline">
-                            @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::narrowing_down_type_for_created_id, BlogNarrowingDownTypeForCreatedId::getDefault()) == $enum_value)
-                                <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::narrowing_down_type_for_created_id}}_{{$enum_value}}" name="{{BlogFrameConfig::narrowing_down_type_for_created_id}}" class="custom-control-input" checked="checked">
-                            @else
-                                <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::narrowing_down_type_for_created_id}}_{{$enum_value}}" name="{{BlogFrameConfig::narrowing_down_type_for_created_id}}" class="custom-control-input">
-                            @endif
-                            {{-- duskでradioの選択にlabelのid必要 --}}
-                            <label class="custom-control-label text-nowrap" for="{{BlogFrameConfig::narrowing_down_type_for_created_id}}_{{$enum_value}}" id="label_{{BlogFrameConfig::narrowing_down_type_for_created_id}}_{{$enum_value}}">{{$enum_label}}</label>
-                        </div>
-                    @endforeach
-                </div>
-            </div>
-
             {{-- Submitボタン --}}
             <div class="form-group text-center mt-3">
                 <div class="row">

--- a/resources/views/plugins/user/blogs/default/include_narrowing_down_for_created_id.blade.php
+++ b/resources/views/plugins/user/blogs/default/include_narrowing_down_for_created_id.blade.php
@@ -5,7 +5,7 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category ブログプラグイン
 --}}
-@if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::narrowing_down_type_for_created_id) == BlogNarrowingDownTypeForCreatedId::dropdown)
+@if ($blog_frame->narrowing_down_type_for_created_id === BlogNarrowingDownTypeForCreatedId::dropdown)
     <form action="{{url('/')}}/plugin/blogs/search/{{$page->id}}/{{$frame_id}}/#frame-{{$frame_id}}" method="GET" name="narrowing_down_type_for_created_id{{$frame_id}}">
         <select class="form-control form-control-sm" name="created_id" class="form-control" id="created_id_{{$frame_id}}" onchange="document.forms.narrowing_down_type_for_created_id{{$frame_id}}.submit();">
             <option value="">投稿者</option>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/pull/1882

の修正です。

投稿者の絞り込み機能はフレーム設定から、ブログ設定に移動して表示件数絞込・カテゴリ絞込と同じにしました。

# 対応後画面
## 設定 に投稿者絞込機能を追加

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/f7cdc0a3-7fb7-42c0-8eb1-f617fbe41bb1)

## 投稿者絞込=ON時

投稿者毎に絞り込めます。

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/8d9b6de3-f12d-4059-81bc-1f9f3cb507c0)



# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載済み

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

あり

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
