### PR TITLE
[ブログ] 表示条件設定に 自身の投稿のみ を追加 OW-2076

### DIFF
--- a/app/Enums/BlogFrameScope.php
+++ b/app/Enums/BlogFrameScope.php
@@ -13,11 +13,13 @@ final class BlogFrameScope extends EnumsBase
     const all = '';
     const year = 'year';
     const fiscal = 'fiscal';
+    const created_id = 'created_id';
 
     // key/valueの連想配列
     const enum = [
         self::all => '全て',
         self::year => '年',
         self::fiscal => '年度',
+        self::created_id => '自身の投稿のみ',
     ];
 }

--- a/app/Models/User/Blogs/BlogsPosts.php
+++ b/app/Models/User/Blogs/BlogsPosts.php
@@ -6,6 +6,7 @@ use App\Enums\BlogFrameScope;
 use App\Userable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Auth;
 
 class BlogsPosts extends Model
 {
@@ -49,13 +50,21 @@ class BlogsPosts extends Model
             // 全件取得のため、追加条件なしで戻る。
         } elseif ($blog_frame->scope == BlogFrameScope::year) {
             // 年
-            $query->Where('posted_at', '>=', $blog_frame->scope_value . '-01-01')
-                  ->Where('posted_at', '<=', $blog_frame->scope_value . '-12-31 23:59:59');
+            $query->where('posted_at', '>=', $blog_frame->scope_value . '-01-01')
+                  ->where('posted_at', '<=', $blog_frame->scope_value . '-12-31 23:59:59');
         } elseif ($blog_frame->scope == BlogFrameScope::fiscal) {
             // 年度
             $fiscal_next = intval($blog_frame->scope_value) + 1;
-            $query->Where('posted_at', '>=', $blog_frame->scope_value . '-04-01')
-                  ->Where('posted_at', '<=', $fiscal_next . '-03-31 23:59:59');
+            $query->where('posted_at', '>=', $blog_frame->scope_value . '-04-01')
+                  ->where('posted_at', '<=', $fiscal_next . '-03-31 23:59:59');
+        } elseif ($blog_frame->scope == BlogFrameScope::created_id) {
+            // 自身の投稿のみ
+            $users_id = null;
+            if (Auth::check()) {
+                $users_id = Auth::user()->id;
+            }
+
+            $query->where('blogs_posts.created_id', $users_id);
         }
 
         return $query;

--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -67,7 +67,7 @@
     <div class="sidetitleindex">
     @endif
 
-    @foreach($blogs_posts as $post)
+    @forelse($blogs_posts as $post)
 
         @if ($loop->last)
         <article>
@@ -244,7 +244,9 @@
                 </div>
             </footer>
         </article>
-    @endforeach
+    @empty
+        <div class="alert alert-info mt-2">記事はありません。</div>
+    @endforelse
 
     {{-- sidetitleindexテンプレートはページング表示しない --}}
     @if (isset($is_template_sidetitleindex))

--- a/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
@@ -215,6 +215,8 @@
                     target_range_text = this.v_scope_value + '年1月1日 00:00:00 ~ ' + this.v_scope_value + '年12月31日 23:59:59';
                 }else if(this.v_scope_radio == "fiscal" && this.isNumber(this.v_scope_value) && this.v_scope_value.length == 4){
                     target_range_text = this.v_scope_value + '年4月1日 00:00:00 ~ ' + (Number(this.v_scope_value) + 1) + '年3月31日 23:59:59';
+                }else if(this.v_scope_radio == "created_id"){
+                    target_range_text = '自身の投稿のみ';
                 }
               return target_range_text;
             }

--- a/resources/views/plugins/user/blogs/default/include_scope.blade.php
+++ b/resources/views/plugins/user/blogs/default/include_scope.blade.php
@@ -10,6 +10,10 @@
         <a href="{{url('/')}}/plugin/blogs/settingBlogFrame/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}">
             <i class="fas fa-cog"></i>
         </a>
-        表示条件{{ '（' . $blog_frame_setting->scope_value . BlogFrameScope::getDescription($blog_frame_setting->scope) . '）' }}
+        @if ($blog_frame_setting->scope == BlogFrameScope::created_id)
+            表示条件{{ '（' . BlogFrameScope::getDescription($blog_frame_setting->scope) . '）' }}
+        @else
+            表示条件{{ '（' . $blog_frame_setting->scope_value . BlogFrameScope::getDescription($blog_frame_setting->scope) . '）' }}
+        @endif
     </span>
 @endif

--- a/resources/views/plugins/user/blogs/designbase/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs.blade.php
@@ -58,7 +58,7 @@
 <div class="clearfix"></div>
 <div>
     <dl>
-    @foreach($blogs_posts as $post)
+    @forelse($blogs_posts as $post)
         {{-- 投稿日時 --}}
         <dt>
             {{$post->posted_at->format('Y/m/d')}}
@@ -78,7 +78,9 @@
                 <span class="badge badge-pill badge-danger">重要記事に設定</span>
             @endif
         </dd>
-    @endforeach
+    @empty
+        <div class="alert alert-info mt-2">記事はありません。</div>
+    @endforelse
 
         {{-- ページング処理 --}}
         @include('plugins.common.user_paginate', ['posts' => $blogs_posts, 'frame' => $frame, 'aria_label_name' => $blog_frame->blog_name])


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# 対応後画面
## 表示条件 に 自身の投稿のみ を追加
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/287a02ab-835e-4d36-ad8f-810085875ca0)

## 表示例（フレーム編集権限があれば、表示条件見える）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/d90fafde-7a1e-4cfa-8d33-09a34e643109)

## 関連対応：０件表示時にメッセージ表示を追加

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/6fedbe2a-2b1e-4307-94af-182dbc4baf52)




# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
