### PR TITLE
[フレーム設定] 公開設定に ログイン後表示 を追加 OW-2077

### DIFF
--- a/app/Enums/ContentOpenType.php
+++ b/app/Enums/ContentOpenType.php
@@ -14,6 +14,7 @@ final class ContentOpenType extends EnumsBase
     const always_close = 2;
     const limited_open = 3;
     const login_close = 4;
+    const login_open = 5;
 
     // key/valueの連想配列
     const enum = [
@@ -21,5 +22,6 @@ final class ContentOpenType extends EnumsBase
         self::always_close => '非公開',
         self::limited_open => '限定公開',
         self::login_close => 'ログイン後非表示',
+        self::login_open => 'ログイン後表示',
     ];
 }

--- a/app/Models/Common/Frame.php
+++ b/app/Models/Common/Frame.php
@@ -233,20 +233,27 @@ class Frame extends Model
      */
     public function isInvisiblePrivateFrame()
     {
-        // 非ログインまたはフレーム編集権限を持たない、且つ、非表示条件（非公開、又は、限定公開、又は、ログイン後非表示）にマッチした場合はフレームを非表示にする
+        // 非ログインまたはフレーム編集権限を持たない、且つ、非表示条件（非公開、又は、限定公開、又は、ログイン後非表示、又は、ログイン後表示（未ログインで非表示））にマッチした場合はフレームを非表示にする
 
         if (Auth::check() && Auth::user()->can('role_arrangement') && app('request')->input('mode') != 'preview') {
             // 表示
             return false;
         }
 
-        if ($this->content_open_type == ContentOpenType::always_close ||
-            (
-                $this->content_open_type == ContentOpenType::limited_open &&
-                !Carbon::now()->between($this->content_open_date_from, $this->content_open_date_to)
-            ) ||
-            (Auth::check() && $this->content_open_type == ContentOpenType::login_close)
-        ) {
+        if ($this->content_open_type == ContentOpenType::always_close) {
+            // 非表示
+            return true;
+
+        } elseif ($this->content_open_type == ContentOpenType::limited_open &&
+            !Carbon::now()->between($this->content_open_date_from, $this->content_open_date_to)) {
+            // 非表示
+            return true;
+
+        } elseif ($this->content_open_type == ContentOpenType::login_close && Auth::check()) {
+            // 非表示
+            return true;
+
+        } elseif ($this->content_open_type == ContentOpenType::login_open && !Auth::check()) {
             // 非表示
             return true;
         }

--- a/resources/views/core/cms_frame_edit.blade.php
+++ b/resources/views/core/cms_frame_edit.blade.php
@@ -195,8 +195,8 @@
         <div id="app_{{ $frame->id }}">
             {{-- コンテンツ公開区分 --}}
             <div class="form-group row">
-                <label class="{{$frame->getSettingLabelClass(true)}}">公開設定</label>
-                <div class="{{$frame->getSettingInputClass(true)}}">
+                <label class="{{$frame->getSettingLabelClass()}} pt-0">公開設定</label>
+                <div class="{{$frame->getSettingInputClass()}}">
                     @foreach (ContentOpenType::enum as $key => $value)
                         <div class="custom-control custom-radio custom-control-inline">
                             <input

--- a/resources/views/core/cms_frame_header.blade.php
+++ b/resources/views/core/cms_frame_header.blade.php
@@ -96,21 +96,24 @@ if ($can_edit_frame) {
         @endif
     @endif
 
-    {{-- 公開以外の場合にステータス表示 ※デフォルト状態の公開もステータス表示すると画面表示が煩雑になる為、意識的な設定（非公開、又は、限定公開）のみステータス表示を行う --}}
-    @if (Auth::check() && $frame->content_open_type != ContentOpenType::always_open)
-        <small>
-            <span class="badge badge-warning">
-                <a href="{{URL::to('/')}}/plugin/{{$frame->plugin_name}}/frame_setting/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}">
-                    <i class="fas fa-cog"></i>
-                </a>
-                {{ ContentOpenType::getDescription($frame->content_open_type) }}
-                @if ($frame->content_open_type == ContentOpenType::limited_open)
-                    {{-- 期限付き公開の場合は日付も表示 --}}
-                    {{ '（' . Carbon::parse($frame->content_open_date_from)->format('Y/n/j H:i:s') . ' - ' . Carbon::parse($frame->content_open_date_to)->format('Y/n/j H:i:s') . '）' }}
-                @endif
-            </span>
-        </small>
-    @endif
+    {{-- 権限あり & 公開以外の場合にステータス表示 ※デフォルト状態の公開もステータス表示すると画面表示が煩雑になる為、意識的な設定（非公開、又は、限定公開）のみステータス表示を行う --}}
+    @can('frames.edit',[[null, null, null, $frame]])
+        @if ($frame->content_open_type != ContentOpenType::always_open)
+            <small>
+                <span class="badge badge-warning">
+                    <a href="{{URL::to('/')}}/plugin/{{$frame->plugin_name}}/frame_setting/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}">
+                        <i class="fas fa-cog"></i>
+                    </a>
+                    {{ ContentOpenType::getDescription($frame->content_open_type) }}
+                    @if ($frame->content_open_type == ContentOpenType::limited_open)
+                        {{-- 期限付き公開の場合は日付も表示 --}}
+                        {{ '（' . Carbon::parse($frame->content_open_date_from)->format('Y/n/j H:i:s') . ' - ' . Carbon::parse($frame->content_open_date_to)->format('Y/n/j H:i:s') . '）' }}
+                    @endif
+                </span>
+            </small>
+        @endif
+    @endcan
+
     {{-- ログインしていて、権限があれば、編集機能を有効にする --}}
     {{--
     @if (Auth::check() &&


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

# 対応後画面
## フレーム編集の公開設定に ログイン後表示 を追加

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/aa3bd609-6590-48a1-9458-d8d18d68ddb8)

## 権限ありでフレームタイトル横に設定が見えます
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/815a4c09-dd42-4b2e-9e7a-3a358f792cb5)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
