### PR TITLE
[カテゴリ設定]クラス名の登録時にチェック処理を追加（必須＆ユニーク）

### DIFF
--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Lang;
+use Illuminate\Validation\Rule;
 
 use setasign\Fpdi\Tcpdf\Fpdi;
 
@@ -509,29 +510,44 @@ class SiteManage extends ManagePluginBase
         if (!empty($request->add_display_sequence) || !empty($request->add_classname)  || !empty($request->add_category) || !empty($request->add_color) || !empty($request->add_background_color)) {
             // 項目のエラーチェック
             $rules['add_display_sequence'] = ['required'];
+            $rules['add_classname'] = ['required', 'unique:categories,classname'];
             $rules['add_category'] = ['required'];
             $rules['add_color'] = ['required'];
             $rules['add_background_color'] = ['required'];
 
             $setAttributeNames['add_display_sequence'] = '追加行の表示順';
+            $setAttributeNames['add_classname'] = 'クラス名';
             $setAttributeNames['add_category'] = '追加行のカテゴリ';
             $setAttributeNames['add_color'] = '追加行の文字色';
             $setAttributeNames['add_background_color'] = '追加行の背景色';
         }
 
         // 既存項目のidに値が入っていたら、行の他の項目も必須
+        $is_not_unique = false;
         if (!empty($request->categories_id)) {
             foreach ($request->categories_id as $category_id) {
                 // 項目のエラーチェック
                 $rules['display_sequence.'.$category_id] = ['required'];
+                $rules['classname.'.$category_id] = ['required'];
                 $rules['category.'.$category_id] = ['required'];
                 $rules['color.'.$category_id] = ['required'];
                 $rules['background_color.'.$category_id] = ['required'];
 
                 $setAttributeNames['display_sequence.'.$category_id] = '表示順';
+                $setAttributeNames['classname.'.$category_id] = 'クラス名';
                 $setAttributeNames['category.'.$category_id] = 'カテゴリ';
                 $setAttributeNames['color.'.$category_id] = '文字色';
                 $setAttributeNames['background_color.'.$category_id] = '背景色';
+                /**
+                 * （classname重複チェック）categoriesを検索、classnameに同じものが1件でもあれば$is_not_uniqueにtrueをセット
+                 */
+                $is_exists = Categories::query()
+                    ->where('classname', $request->classname[$category_id])
+                    ->where('id', '!=', $category_id)
+                    ->exists();
+                if($is_exists){
+                    $is_not_unique = true;
+                }
             }
         }
 
@@ -541,6 +557,11 @@ class SiteManage extends ManagePluginBase
 
         if ($validator->fails()) {
             // return $this->categories($request, $id, $validator->errors());
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+        // classname重複チェック
+        if($is_not_unique){
+            $validator->errors()->add("duplicate_class_name_violation", 'そのクラス名は既に使用されています。');
             return redirect()->back()->withErrors($validator)->withInput();
         }
 

--- a/resources/views/plugins/manage/site/categories.blade.php
+++ b/resources/views/plugins/manage/site/categories.blade.php
@@ -49,7 +49,7 @@
                         --}}
                         <tr>
                             <th nowrap>表示順 <span class="badge badge-danger">必須</span></th>
-                            <th nowrap>クラス名</th>
+                            <th nowrap>クラス名 <span class="badge badge-danger">必須</span></th>
                             <th nowrap>カテゴリ <span class="badge badge-danger">必須</span></th>
                             <th nowrap>文字色 <span class="badge badge-danger">必須</span></th>
                             <th nowrap>背景色 <span class="badge badge-danger">必須</span></th>
@@ -126,7 +126,7 @@
                     <li>カテゴリ設定後は、各プラグインのカテゴリ設定で表示設定が必要です。</li>
                     <li>各プラグインのカテゴリ設定から、コンテンツ単位で独自カテゴリを設定することも可能です。</li>
                     <li>「文字色」「背景色」にはHTMLで指定できる色キーワード（例：<code>red</code>, <code>blue</code>）やRGB色（例：<code>#000000</code>, <code>#111</code>）等を設定できます。</li>
-                    <li>「クラス名」はCSSのクラス名を設定できます。<code>cc_category_クラス名</code> で使用できます。</li>
+                    <li>「クラス名」はCSSのクラス名を設定できます。<code>cc_category_クラス名</code> で使用できます。「クラス名」は重複しないように設定してください。</li>
                 </ul>
             </div>
 


### PR DESCRIPTION
# 概要
 - （背景）登録時、及び、更新時に「クラス名」は何もバリデーションされていなかった。
 - とあるクライアントがカテゴリ設定を利用していたが、クラス名をすべて空で登録していた為、新着等のbladeでCSSのclass展開された際にすべて同値のクラス（cc_category_）となってしまい、意図した反映が出来ずにいた。
 - 上記のような運用事故をなくす為、カテゴリ設定のクラス名の登録時＆更新時に下記チェックを追加しました。
     - 必須チェック
     - ユニークチェック
 - 更新時の配列へのunique制約の記法が四苦八苦しまして、時間がなかったこともあり、少し妥協した実装になってます。記法がわかったらリファクタリングしたいですが、とりあえず今は機能優先でPR出しちゃいます。
### 新規登録時（必須）
![image](https://github.com/opensource-workshop/connect-cms/assets/13323806/4a083883-7f55-45b0-876b-fa1ac2862730)
### 新規登録時（重複）
![image](https://github.com/opensource-workshop/connect-cms/assets/13323806/5068d5b9-aada-4bfc-81b5-194808809c7a)
### 更新時（必須）
![image](https://github.com/opensource-workshop/connect-cms/assets/13323806/427d26e7-b135-414c-b206-7fa816e1c58f)
### 更新時（重複）
![image](https://github.com/opensource-workshop/connect-cms/assets/13323806/acf2aa2c-d05c-4a16-a53d-22c48773ed3e)


# レビュー完了希望日
バグという程のものではないですが、

# 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/pull/1886
※本件、対応時に牟田さんと話題に挙がり、追加の運びとなりました。

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
