### PR TITLE
[ユーザ管理] 同意型の詳細でチェックボックスの名称等を更新すると500エラーになる不具合修正

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2999,6 +2999,7 @@ class UserManage extends ManagePluginBase
 
         // 項目の更新処理
         $select = UsersColumnsSelects::where('id', $request->select_id)->firstOrNew([]);
+        $select->columns_set_id = $request->columns_set_id;
         $select->users_columns_id = $request->column_id;
         $select->value = $request->value;
         $select->agree_description = $request->agree_description;


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/pull/1792

上記対応時に含まれた不具合です。
その不具合を修正しました。

## エラーログ

```sql
SQLSTATE[HY000]: General error: 1364 Field 'columns_set_id' doesn't have a default value (SQL: insert into `users_columns_selects` (`users_columns_id`, `value`, `agree_description`, `display_sequence`, `created_id`, `created_name`, `updated_at`, `created_at`) values (112, 利用規約, ｄｄｄｄｄｄｄｄｄｄｄｄｄｄｄ, 1, 1, テスト企業, 2023-11-22 16:07:07, 2023-11-22 16:07:07))
```

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
