### PR TITLE
[移行] ブログの続きを読む内容のリンクチェックで参照変数が間違っていたため修正

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -1241,7 +1241,7 @@ trait MigrationTrait
                     $blog_post->save();
                 }
             }
-            $links = MigrationUtils::getContentHrefOrSrc($content->post_text2);
+            $links = MigrationUtils::getContentHrefOrSrc($blog_post->post_text2);
             if (is_array($links)) {
                 foreach ($links as $link) {
                     // nc3各プラグインリンク変換

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -2236,6 +2236,8 @@ trait MigrationTrait
                     'source_key'           => $nc2_journal_id,
                     'destination_key'      => $blog->id,
                 ]);
+            } else {
+                $blog = Blogs::find($mapping->destination_key);
             }
 
             // これ以降は追加も更新も同じロジック
@@ -2468,6 +2470,8 @@ trait MigrationTrait
                     'source_key'           => $nc2_faq_id,
                     'destination_key'      => $faq->id,
                 ]);
+            } else {
+                $faq = Faqs::find($mapping->destination_key);
             }
 
             // これ以降は追加も更新も同じロジック
@@ -2618,6 +2622,8 @@ trait MigrationTrait
                     'source_key'           => $nc2_linklist_id,
                     'destination_key'      => $linklist->id,
                 ]);
+            } else {
+                $linklist = Linklist::find($mapping->destination_key);
             }
 
             // これ以降は追加も更新も同じロジック


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

https://connect-cms.jp/plugin/bbses/show/106/233/856#frame-233
掲示板で連絡あり。
移行バグだったため修正しました。


* [bugfix: 移行, ブログの続きを読む内容のリンクチェックで参照変数が間違っていたため修正](https://github.com/opensource-workshop/connect-cms/commit/75c931595cf3ddcf9c1bf2892d69e57750393ac6)
* 関連修正
  * [bugfix: 移行, 再インポート時、マッピングにデータがあるとカテゴリ情報が参照できない不具合修正](https://github.com/opensource-workshop/connect-cms/commit/a64c4599c2de395ab1863d615206dde1df59bb58)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
