### PR TITLE
[テスト＆マニュアル]WYSIWYSテスト時のタイミング変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ composer-option*
 
 # Dusk
 /tests/tmp/*
+/tests/Browser/screenshots/*
 
 # Docker
 /docker/db

--- a/tests/Browser/Common/WysiwygTest.php
+++ b/tests/Browser/Common/WysiwygTest.php
@@ -319,7 +319,12 @@ class WysiwygTest extends DuskTestCase
                     ->screenshot('common/wysiwyg/table/images/table_cell_detail_detail');
 
             // 一度開きなおす。
-            $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $content->id . '#frame-' . $this->frame->id);
+            $browser->visit('/')
+                    ->pause(500);
+
+            $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $content->id . '#frame-' . $this->frame->id)
+                    ->pause(500)
+                    ->screenshot('common/wysiwyg/table/images/edit_reopen');
 
             // 表のドロップダウン
             $browser->click('#ccMainArea .tox-tinymce .tox-toolbar__group:nth-child(6) button:nth-child(1) div')
@@ -341,7 +346,12 @@ class WysiwygTest extends DuskTestCase
                     ->screenshot('common/wysiwyg/table/images/table_row_detail_detail');
 
             // 一度開きなおす。
-            $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $content->id . '#frame-' . $this->frame->id);
+            $browser->visit('/')
+                    ->pause(500);
+
+            $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $content->id . '#frame-' . $this->frame->id)
+                    ->pause(500)
+                    ->screenshot('common/wysiwyg/table/images/edit_reopen2');
 
             // 表のドロップダウン
             $browser->click('#ccMainArea .tox-tinymce .tox-toolbar__group:nth-child(6) button:nth-child(1) div')
@@ -599,6 +609,11 @@ class WysiwygTest extends DuskTestCase
     {
         // 画面
         $this->browse(function (Browser $browser) {
+
+            // 一度開きなおす。
+            $browser->visit('/')
+                    ->pause(500);
+
             $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $this->content->id . '#frame-' . $this->frame->id)
                     ->click('#ccMainArea .tox-tinymce .tox-toolbar__group:nth-child(12) button:nth-child(1)')
                     ->pause(500)
@@ -631,6 +646,10 @@ class WysiwygTest extends DuskTestCase
     {
         // 画面
         $this->browse(function (Browser $browser) {
+            // 一度開きなおす。
+            $browser->visit('/')
+                    ->pause(500);
+
             $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $this->content->id . '#frame-' . $this->frame->id)
                     ->click('#ccMainArea .tox-tinymce .tox-toolbar__group:nth-child(12) button:nth-child(2)')
                     ->pause(500)
@@ -663,6 +682,10 @@ class WysiwygTest extends DuskTestCase
     {
         // 画面
         $this->browse(function (Browser $browser) {
+            // 一度開きなおす。
+            $browser->visit('/')
+                    ->pause(500);
+
             $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $this->content->id . '#frame-' . $this->frame->id)
                     ->click('#ccMainArea .tox-tinymce .tox-toolbar__group:nth-child(12) button:nth-child(3)')
                     ->pause(500)
@@ -713,6 +736,10 @@ class WysiwygTest extends DuskTestCase
     {
         // 画面
         $this->browse(function (Browser $browser) {
+            // 一度開きなおす。
+            $browser->visit('/')
+                    ->pause(500);
+
             $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $this->content->id . '#frame-' . $this->frame->id)
                     ->click('#ccMainArea .tox-tinymce .tox-toolbar__group:nth-child(13) button')
                     ->pause(500)
@@ -740,6 +767,10 @@ class WysiwygTest extends DuskTestCase
     {
         // 画面
         $this->browse(function (Browser $browser) {
+            // 一度開きなおす。
+            $browser->visit('/')
+                    ->pause(500);
+
             $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $this->content->id . '#frame-' . $this->frame->id)
                     ->click('#ccMainArea .tox-tinymce .tox-toolbar__group:nth-child(14) button')
                     ->pause(500)
@@ -771,6 +802,10 @@ class WysiwygTest extends DuskTestCase
 
         // 画面
         $this->browse(function (Browser $browser) {
+            // 一度開きなおす。
+            $browser->visit('/')
+                    ->pause(500);
+
             // 編集画面を開き、WYSIWYGエディタのセレクタをターゲットにCTRL＋Aキーを押して、全選択させる。その後に翻訳プラグインを起動することで、翻訳するテキストが選択されている状態。
             $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $this->content->id . '#frame-' . $this->frame->id)
                     ->keys('#mce_0_ifr', ['{control}', 'a'])
@@ -826,6 +861,10 @@ class WysiwygTest extends DuskTestCase
 
         // 画面
         $this->browse(function (Browser $browser) {
+            // 一度開きなおす。
+            $browser->visit('/')
+                    ->pause(500);
+
             $browser->visit('/plugin/contents/edit/' . $this->frame->page_id . '/' . $this->frame->id . '/' . $this->content->id . '#frame-' . $this->frame->id)
                     ->click('#ccMainArea .tox-tinymce .tox-toolbar__group:nth-child(15) button:nth-child(2)')
                     ->pause(500)

--- a/tests/Browser/screenshots/.gitignore
+++ b/tests/Browser/screenshots/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
・Chromeドライバが新しくなって、挙動が少し変わったようなので対応しました。
・テスト時の生成される画像フォルダがgitignoreされていなかったので指定しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
特に問題はないと思うので、明日にでもマージします。

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
無し

# チェックリスト
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
