### PR TITLE
[マイグレーション] MariaDBは5.6以上でFULLTEXT対応

### DIFF
--- a/database/migrations/2023_09_04_153112_add_full_text_search_to_databases.php
+++ b/database/migrations/2023_09_04_153112_add_full_text_search_to_databases.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class AddFullTextSearchToDatabases extends Migration
@@ -25,7 +26,13 @@ class AddFullTextSearchToDatabases extends Migration
         $version =  $result[0]->version;
         // MariaDBはNGRAMが使えない
         if (strpos($version, 'Maria') !== false) {
-            DB::statement('ALTER TABLE databases_inputs ADD FULLTEXT INDEX ft_idx_databases_inputs_full_text (full_text);');
+            // MariaDB
+            $version = str_replace('-MariaDB', '', $version);
+            $version_arr = explode('.', $version);
+            // MariaDBは5.6以上でFULLTEXT対応
+            if ($version_arr[0] >= 5 && $version_arr[1] >= 6) {
+                DB::statement('ALTER TABLE databases_inputs ADD FULLTEXT INDEX ft_idx_databases_inputs_full_text (full_text);');
+            }
         } else {
             DB::statement('ALTER TABLE databases_inputs ADD FULLTEXT INDEX ft_idx_databases_inputs_full_text (full_text) WITH PARSER ngram;');
         }


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

MariaDBは5.6以上でFULLTEXT対応のため、DBマイグレーションを見直しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り（MariaDB 5.5以下）

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
