### PR TITLE
[新着情報] card_04_top_thumbnailテンプレート追加

### DIFF
--- a/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
@@ -2,6 +2,7 @@
  * 新着情報表示画面（カード表示）
  *
  * @author 牧野　可也子 <makino@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 新着情報プラグイン
 --}}
@@ -48,6 +49,19 @@
                 @endif
                 <div class="p-2 @if (FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::border))border @endif" style="height: 100%;">
                     <dl>
+                        @if (isset($is_template_top_thumbnail))
+                            {{-- サムネイル --}}
+                            @if ($whatsnew->first_image_path && FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail))
+                                <dd class="text-center whatsnew_thumbnail">
+                                    @if (empty(FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size)))
+                                        <img src="{{$whatsnew->first_image_path}}?size=small" class="pb-1" style="max-width: 200px; max-height: 200px;">
+                                    @else
+                                        <img src="{{$whatsnew->first_image_path}}?size=small" class="pb-1" style="max-width: {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}px; max-height: {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}px;">
+                                    @endif
+                                </dd>
+                            @endif
+                        @endif
+
                         {{-- タイトル --}}
                         @if ($link_pattern[$whatsnew->plugin_name] == 'show_page_frame_post')
                             <dt class="text-center whatsnew_title">
@@ -82,15 +96,17 @@
                             </dd>
                         @endif
 
-                        {{-- サムネイル --}}
-                        @if ($whatsnew->first_image_path && FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail))
-                            <dd class="text-center whatsnew_thumbnail">
-                                @if (empty(FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size)))
-                                    <img src="{{$whatsnew->first_image_path}}?size=small" class="pb-1" style="max-width: 200px; max-height: 200px;">
-                                @else
-                                    <img src="{{$whatsnew->first_image_path}}?size=small" class="pb-1" style="max-width: {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}px; max-height: {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}px;">
-                                @endif
-                            </dd>
+                        @if (!isset($is_template_top_thumbnail))
+                            {{-- サムネイル --}}
+                            @if ($whatsnew->first_image_path && FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail))
+                                <dd class="text-center whatsnew_thumbnail">
+                                    @if (empty(FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size)))
+                                        <img src="{{$whatsnew->first_image_path}}?size=small" class="pb-1" style="max-width: 200px; max-height: 200px;">
+                                    @else
+                                        <img src="{{$whatsnew->first_image_path}}?size=small" class="pb-1" style="max-width: {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}px; max-height: {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}px;">
+                                    @endif
+                                </dd>
+                            @endif
                         @endif
 
                         {{-- 本文 --}}
@@ -136,6 +152,13 @@
                         v-bind:class="{ 'border': border == show }"
                     >
                     <dl>
+                        @if (isset($is_template_top_thumbnail))
+                        {{-- サムネイル --}}
+                        <dd v-if="thumbnail == show && whatsnews.first_image_path" class="text-center whatsnew_thumbnail">
+                            <img v-if="thumbnail_size == 0 || thumbnail_size == ''" v-bind:src="whatsnews.first_image_path" class="pb-1" style="max-width: 200px; max-height: 200px;">
+                            <img v-else v-bind:src="whatsnews.first_image_path" class="pb-1" v-bind:style="thumbnail_style">
+                        </dd>
+                        @endif
 
                         {{-- タイトル＋リンク --}}
                         <dt v-if="link_pattern[whatsnews.plugin_name] == 'show_page_frame_post'" class="text-center whatsnew_title">
@@ -159,11 +182,13 @@
                             @{{ whatsnews.posted_name }}
                         </dd>
 
+                        @if (!isset($is_template_top_thumbnail))
                         {{-- サムネイル --}}
                         <dd v-if="thumbnail == show && whatsnews.first_image_path" class="text-center whatsnew_thumbnail">
                             <img v-if="thumbnail_size == 0 || thumbnail_size == ''" v-bind:src="whatsnews.first_image_path" class="pb-1" style="max-width: 200px; max-height: 200px;">
                             <img v-else v-bind:src="whatsnews.first_image_path" class="pb-1" v-bind:style="thumbnail_style">
                         </dd>
+                        @endif
 
                         {{-- 本文 --}}
                         <dd v-if="post_detail == show" class="whatsnew_post_detail">

--- a/resources/views/plugins/user/whatsnews/card_04_top_thumbnail/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/card_04_top_thumbnail/whatsnews.blade.php
@@ -1,0 +1,10 @@
+{{--
+ * 新着情報表示画面（カード表示, サムネイル一番上表示）
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category 新着情報プラグイン
+--}}
+
+{{-- card_04のblade --}}
+@include('plugins.user.whatsnews.card_04.whatsnews', ['is_template_top_thumbnail' => true])


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

card_04テンプレートはタイトルが上、サムネイルが下です。

サムネイルを上に表示したいため、card_04テンプレートのサムネイルが一番上に表示されるバージョンのテンプレート card_04_top_thumbnail を追加しました。

## card_04_top_thumbnailテンプレート表示

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/1191d864-a38c-4228-8bae-a33fbe72b865)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
