### PR TITLE
[新着情報] card03, 04テンプレートでもっと見る時、サムネイル画像のsmaill指定抜け対応

### DIFF
--- a/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
@@ -155,8 +155,8 @@
                         @if (isset($is_template_top_thumbnail))
                         {{-- サムネイル --}}
                         <dd v-if="thumbnail == show && whatsnews.first_image_path" class="text-center whatsnew_thumbnail">
-                            <img v-if="thumbnail_size == 0 || thumbnail_size == ''" v-bind:src="whatsnews.first_image_path" class="pb-1" style="max-width: 200px; max-height: 200px;">
-                            <img v-else v-bind:src="whatsnews.first_image_path" class="pb-1" v-bind:style="thumbnail_style">
+                            <img v-if="thumbnail_size == 0 || thumbnail_size == ''" v-bind:src="whatsnews.first_image_path + '?size=small'" class="pb-1" style="max-width: 200px; max-height: 200px;">
+                            <img v-else v-bind:src="whatsnews.first_image_path + '?size=small'" class="pb-1" v-bind:style="thumbnail_style">
                         </dd>
                         @endif
 
@@ -185,8 +185,8 @@
                         @if (!isset($is_template_top_thumbnail))
                         {{-- サムネイル --}}
                         <dd v-if="thumbnail == show && whatsnews.first_image_path" class="text-center whatsnew_thumbnail">
-                            <img v-if="thumbnail_size == 0 || thumbnail_size == ''" v-bind:src="whatsnews.first_image_path" class="pb-1" style="max-width: 200px; max-height: 200px;">
-                            <img v-else v-bind:src="whatsnews.first_image_path" class="pb-1" v-bind:style="thumbnail_style">
+                            <img v-if="thumbnail_size == 0 || thumbnail_size == ''" v-bind:src="whatsnews.first_image_path + '?size=small'" class="pb-1" style="max-width: 200px; max-height: 200px;">
+                            <img v-else v-bind:src="whatsnews.first_image_path + '?size=small'" class="pb-1" v-bind:style="thumbnail_style">
                         </dd>
                         @endif
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

新着情報＞card03, 04テンプレートを利用時、もっと見るボタンを押下時のサムネイル画像に、smaill指定が抜けていたため、追加しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
