### PR TITLE
[マイページ] 管理機能 or コンテンツ権限なしでマイページ表示すると、コンテンツ画面へが表示されないバグ修正

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -272,6 +272,15 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                     @endif
                 </li>
             {{-- /管理メニュー表示判定（管理機能 or コンテンツ権限に付与がある場合）--}}
+            @else
+                {{-- マイページのコンテンツ画面へ対応（管理機能 or コンテンツ権限 なしもあり） --}}
+                <li class="nav-item dropdown">
+                    {{-- ページリストがある場合は、コンテンツ画面 --}}
+                    @if (isset($page_list) && !$is_manage_page)
+                    @else
+                        <a class="nav-link" href="{{ url('/') }}">コンテンツ画面へ</a>
+                    @endif
+                </li>
             @endif
 
             @guest


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

件名通りです。

参考：マイページのコンテンツ画面へ
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/0f25a11d-135c-4799-beaf-c19e69f0c1ff)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
