### PR TITLE
[メニュー] ディレクトリ展開式デザイン用テンプレートにページ詳細のクラス名をliタグに適用

### DIFF
--- a/resources/views/plugins/user/menus/opencurrenttree_for_design/menus.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree_for_design/menus.blade.php
@@ -21,7 +21,7 @@
                     {{-- 非表示のページは対象外(非表示の判断はこのページのみで、子のページはそのページでの判断を行う) --}}
                     @if ($page->isView(Auth::user(), false, true, $page_roles))
 
-                        <li>
+                        <li @if($page->getClass()) class="{{$page->getClass()}}"@endif>
                             {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
                             @if ($page->id == $page_id)
                             <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item {{ 'depth-' . $page->depth }} active" aria-current="page">
@@ -57,7 +57,7 @@
 
                     {{-- 非表示のページは対象外 --}}
                     @if ($page->isView(Auth::user(), false, true, $page_roles))
-                        <li>
+                        <li @if($page->getClass()) class="{{$page->getClass()}}"@endif>
                             {{-- リンク生成。メニュー項目全体をリンクにして階層はその中でインデント表記したいため、a タグから記載 --}}
                             @if ($page->id == $page_id)
                             <a href="{{$page->getUrl()}}" {!!$page->getUrlTargetTag()!!} class="list-group-item active" aria-current="page">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

他テンプレートと同様に、ディレクトリ展開式デザイン用テンプレートのliタグに、ページ詳細のクラス名を反映させる対応をしました。
https://github.com/opensource-workshop/connect-cms/wiki/Menu#ページ管理ページ詳細クラス名

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

概要に記載

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
