### PR TITLE
[ユーザ管理] 項目セットのソート順を選択肢等に反映

### DIFF
--- a/app/Http/Controllers/Auth/RegistersUsers.php
+++ b/app/Http/Controllers/Auth/RegistersUsers.php
@@ -43,9 +43,14 @@ trait RegistersUsers
     public function showRegistrationForm(Request $request)
     {
         // ユーザー登録の許可
-        $user_register_enables = Configs::where('category', 'user_register')
-            ->where('name', 'user_register_enable')
-            ->where('value', '1')
+        $user_register_enables = Configs::
+            leftJoin('users_columns_sets', function ($join) {
+                $join->on('users_columns_sets.id', 'configs.additional1');
+            })
+            ->where('configs.category', 'user_register')
+            ->where('configs.name', 'user_register_enable')
+            ->where('configs.value', '1')
+            ->orderBy('users_columns_sets.display_sequence')
             ->get();
 
         $user_register_enable = $user_register_enables->first();
@@ -77,7 +82,7 @@ trait RegistersUsers
         }
 
         // ユーザ登録が有効な項目セット
-        $columns_sets = UsersColumnsSet::whereIn('id', $user_register_enables->pluck('additional1'))->get();
+        $columns_sets = UsersColumnsSet::whereIn('id', $user_register_enables->pluck('additional1'))->orderBy('display_sequence')->get();
 
         // *** ユーザの追加項目
         // ユーザーのカラム

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -530,7 +530,7 @@ class UserManage extends ManagePluginBase
             "plugin_name" => "user",
             "users" => $users,
             'columns_set_id' => $columns_set_id,
-            'columns_sets' => UsersColumnsSet::get(),
+            'columns_sets' => UsersColumnsSet::orderBy('display_sequence')->get(),
             "users_columns" => $users_columns,
             "users_columns_id_select" => $users_columns_id_select,
             "input_cols" => $input_cols,
@@ -699,7 +699,7 @@ class UserManage extends ManagePluginBase
             "user" => $user,
             "original_role_configs" => $original_role_configs,
             'columns_set_id' => $columns_set_id,
-            'columns_sets' => UsersColumnsSet::get(),
+            'columns_sets' => UsersColumnsSet::orderBy('display_sequence')->get(),
             'users_columns' => $users_columns,
             'users_columns_id_select' => $users_columns_id_select,
             'input_cols' => $input_cols,
@@ -794,7 +794,7 @@ class UserManage extends ManagePluginBase
             "users_roles" => $users_roles,
             "original_role_configs" => $original_role_configs,
             'columns_set_id' => $columns_set_id,
-            'columns_sets' => UsersColumnsSet::get(),
+            'columns_sets' => UsersColumnsSet::orderBy('display_sequence')->get(),
             'users_columns' => $users_columns,
             'users_columns_id_select' => $users_columns_id_select,
             'input_cols' => $input_cols,
@@ -1319,7 +1319,7 @@ class UserManage extends ManagePluginBase
             "plugin_name" => "user",
             "configs" => $configs,
             'columns_set_id' => $id,
-            'columns_sets' => UsersColumnsSet::get(),
+            'columns_sets' => UsersColumnsSet::orderBy('display_sequence')->get(),
             "users_columns" => UsersTool::getUsersColumns($id),
         ]);
     }
@@ -1751,7 +1751,7 @@ class UserManage extends ManagePluginBase
             "function"       => __FUNCTION__,
             "plugin_name"    => "user",
             'columns_set_id' => $this->getColumnsSetIdManageDefault(),
-            'columns_sets'   => UsersColumnsSet::get(),
+            'columns_sets' => UsersColumnsSet::orderBy('display_sequence')->get(),
         ]);
     }
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

ユーザー管理の項目セットは並び順を持っていますが、選択肢等の並び順に反映されていなかったため、対応しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1792

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
