### PR TITLE
[ユーザ管理] 検索時とcolumns_set_idをURL等で指定時には、表示ページ数をクリアする対応

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -491,6 +491,10 @@ class UserManage extends ManagePluginBase
      */
     public function index($request, $id)
     {
+        // 項目セットID
+        // columns_set_idをURL等で指定時、表示ページ数をクリアするため、ページの処理（セッション）より前に処理する
+        $columns_set_id = $this->getColumnsSetIdFromRequestOrSession($request, 'user.columns_set_id');
+
         /* ページの処理（セッション）
         ----------------------------------------------*/
 
@@ -501,9 +505,6 @@ class UserManage extends ManagePluginBase
 
         /* データの取得（検索）
         ----------------------------------------------*/
-
-        // 項目セットID
-        $columns_set_id = $this->getColumnsSetIdFromRequestOrSession($request, 'user.columns_set_id');
 
         // ユーザーのカラム
         $users_columns = UsersTool::getUsersColumns($columns_set_id);
@@ -558,6 +559,9 @@ class UserManage extends ManagePluginBase
 
         if ($request->filled($variable)) {
             session([$session_name => $request->$variable]);
+
+            // columns_set_idをURL等で指定時、表示ページ数をクリア
+            $request->session()->forget('user_page_condition.page');
         }
 
         return $columns_set_id;
@@ -629,6 +633,9 @@ class UserManage extends ManagePluginBase
         }
 
         session(["user_search_condition" => $user_search_condition]);
+
+        // 検索時、表示ページ数をクリア
+        $request->session()->forget('user_page_condition.page');
 
         // is_search_collapse_show=1で検索エリアを開いたままにできる（オプションプラグイン等で利用）
         return redirect("/manage/user")->with('is_search_collapse_show', $request->is_search_collapse_show);


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms-ideas/issues/163

上記の対応です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
