### PR TITLE
[ユーザ登録] メール埋め込みタグをカスタマイズできるように対応

### DIFF
--- a/app/Enums/UserColumnType.php
+++ b/app/Enums/UserColumnType.php
@@ -81,6 +81,21 @@ class UserColumnType extends EnumsBase
     }
 
     /**
+     * メール埋め込みタグのループで 既に取得済みのため、表示しないカラム型 取得
+     */
+    public static function loopNotShowEmbeddedTagColumnTypes(): array
+    {
+        return [
+            self::user_name,
+            self::login_id,
+            self::user_email,
+            self::user_password,
+            self::created_at,
+            self::updated_at,
+        ];
+    }
+
+    /**
      * 検索で完全一致のカラム型 取得
      */
     public static function searchExactMatchColumnTypes(): array

--- a/app/Models/Core/UsersColumns.php
+++ b/app/Models/Core/UsersColumns.php
@@ -99,6 +99,17 @@ class UsersColumns extends Model
     }
 
     /**
+     * メール埋め込みタグのループで 既に取得済みのため、表示しないカラム型か
+     */
+    public static function isLoopNotShowEmbeddedTagColumnType($column_type): bool
+    {
+        if (in_array($column_type, UserColumnType::loopNotShowEmbeddedTagColumnTypes())) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * 検索で完全一致のカラム型か
      */
     public static function isSearchExactMatchColumnType($column_type): bool

--- a/app/Plugins/Manage/UserManage/UsersTool.php
+++ b/app/Plugins/Manage/UserManage/UsersTool.php
@@ -305,6 +305,7 @@ class UsersTool
         // オプションクラス有＋メソッド有なら呼ぶ
         if ($class_name) {
             if (method_exists($class_name, 'getNoticeEmbeddedTagsValue')) {
+                // $users_columns は、他項目と連動するカスタム型の値取得に利用
                 return $class_name::getNoticeEmbeddedTagsValue($users_input_cols, $users_column, $users_columns);
             }
         }

--- a/resources/views/plugins/manage/user/description_frame_mails.blade.php
+++ b/resources/views/plugins/manage/user/description_frame_mails.blade.php
@@ -31,7 +31,7 @@ use App\Models\Core\UsersColumns;
                         </tr>
                     @endforeach
                     @foreach($users_columns as $column)
-                        @if (UsersColumns::isLoopNotShowColumnType($column->column_type))
+                        @if (UsersColumns::isLoopNotShowEmbeddedTagColumnType($column->column_type))
                             {{-- 既に取得済みのため、ここでは取得しない --}}
                             @continue;
                         @endif


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

開発者向けの対応です。
ユーザ登録時のメール埋め込みタグの値を、独自に設定できるよう対応しました。

app\PluginsOption\Manage\UserManage\UsersToolOption.php に getNoticeEmbeddedTagsValue() メソッドを作ることで、独自のメール埋め込みタグの値をセットできます。


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
