### PR TITLE
[コア] forbidden画像はキャッシュしない

### DIFF
--- a/app/Http/Controllers/Core/UploadController.php
+++ b/app/Http/Controllers/Core/UploadController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Core;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 use App\Http\Controllers\Core\ConnectController;
@@ -17,7 +16,7 @@ use App\Enums\UseType;
 
 use App\Models\Common\Categories;
 use App\Models\Common\Page;
-use App\Models\Common\PageRole;
+// use App\Models\Common\PageRole;
 use App\Models\Common\Uploads;
 use App\Models\Core\Configs;
 
@@ -104,21 +103,19 @@ class UploadController extends ConnectController
                 return;
             }
 
-            // $page_roles = $this->getPageRoles(array($page->id));
-            $page_roles = PageRole::getPageRoles(array($page->id));
+            // $page_roles = PageRole::getPageRoles(array($page->id));
 
             // 自分のページから親を遡って取得
             $page_tree = Page::reversed()->ancestorsAndSelf($page->id);
 
             // 認証されていなくてパスワードを要求する場合、パスワード要求画面を表示
-            // if ($page->isRequestPassword($request, $this->page_tree)) {
             if ($page->isRequestPassword($request, $page_tree)) {
-                return response()->download(storage_path(config('connect.forbidden_image_path')));
+                return response()->download(storage_path(config('connect.forbidden_image_path')), null, $no_cache_headers);
             }
 
             // ファイルに閲覧権限がない場合
             if (!$page->isVisibleAncestorsAndSelf($page_tree)) {
-                return response()->download(storage_path(config('connect.forbidden_image_path')));
+                return response()->download(storage_path(config('connect.forbidden_image_path')), null, $no_cache_headers);
             }
 
             // 閲覧パスワード設定あるか
@@ -137,9 +134,9 @@ class UploadController extends ConnectController
         if (!empty($uploads->check_method)) {
             list($return_boolean, $return_message) = $this->callCheckMethod($request, $uploads);
             if (!$return_boolean) {
-                //Log::debug($uploads);
-                //Log::debug($return_message);
-                return response()->download(storage_path(config('connect.forbidden_image_path')));
+                // \Log::debug($uploads);
+                // \Log::debug($return_message);
+                return response()->download(storage_path(config('connect.forbidden_image_path')), null, $no_cache_headers);
             }
 
             // キャッシュしない


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

参照権限のない画像を表示すると、forbidden画像が表示されますが、その画像がブラウザキャッシュされていたため、キャッシュしないよう対応しました。

### 例１）
1. これはログイン前に見れなかった画像がforbidden画像とキャッシュされ
1. その後、ログインして、画像の参照権限ありだとしても、ブラウザキャッシュが残っている影響でforbidden画像が表示されていました。
　→ forbidden画像が表示される事自体が稀なため、キャッシュしないよう見直しました。

### 例２）
1. サイト全体を表示パスワードで閲覧制限をつける。
1. スライドショープラグインを配置する。
1. 表示パスワードを入力して、サイトを見る。
1. 次の日、サイトを開くとブラウザキャッシュの影響で、一時的にサイトが見れるけど、表示パスワードの有効時間は切れている。その時にサーバに取りにいった画像（ここではスライドショー）は表示パスワードの時間切れでforbidden画像になる。
1. 再度サイトを開くと、 表示パスワードの入力画面になり、再入力してサイトを開くと、スライドショーの画像はブラウザキャッシュされたforbidden画像が表示される。
（ブラウザキャッシュをクリアすれば解消する）

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
