### PR TITLE
[サイト管理] エラー設定画面にNo Image画像の設定追加

### DIFF
--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -830,7 +830,7 @@ class SiteManage extends ManagePluginBase
      *  ページエラー設定　表示画面
      *
      * @method_title エラーページ設定
-     * @method_desc 404（該当ページなし）や403（該当ページに権限なし）の際に表示するエラーページを指定できます。
+     * @method_desc 404（該当ページなし）や403（該当ページに権限なし）の際に表示するエラーページを指定できます。また、No Image画像を差し替えられます。
      * @method_detail 指定したエラーページは、通常のページと同じように作成します。また、メニュー表示はOFFにしておきます。
      */
     public function pageError($request, $id)

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -2,15 +2,10 @@
 
 namespace App\Plugins\Manage\SiteManage;
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Lang;
-
-use setasign\Fpdi\Tcpdf\Fpdi;
 
 use App\Models\Core\ApiSecret;
 use App\Models\Core\Configs;
@@ -18,7 +13,6 @@ use App\Models\Core\ConfigsLoginPermits;
 use App\Models\Core\Plugins;
 use App\Models\Core\UsersColumnsSet;
 use App\Models\Common\Categories;
-use App\Models\Common\Frame;
 use App\Models\Common\Group;
 use App\Models\Common\Holiday;
 use App\Models\Common\Page;
@@ -214,6 +208,7 @@ class SiteManage extends ManagePluginBase
         $role_ckeck_table["saveMeta"]         = array('admin_site');
         $role_ckeck_table["pageError"]        = array('admin_site');
         $role_ckeck_table["savePageError"]    = array('admin_site');
+        $role_ckeck_table["deleteNoImage"]    = array('admin_site');
         $role_ckeck_table["analytics"]        = array('admin_site');
         $role_ckeck_table["saveAnalytics"]    = array('admin_site');
         $role_ckeck_table["favicon"]          = array('admin_site');
@@ -838,13 +833,10 @@ class SiteManage extends ManagePluginBase
      * @method_desc 404（該当ページなし）や403（該当ページに権限なし）の際に表示するエラーページを指定できます。
      * @method_detail 指定したエラーページは、通常のページと同じように作成します。また、メニュー表示はOFFにしておきます。
      */
-    public function pageError($request, $id, $errors = null)
+    public function pageError($request, $id)
     {
-        // セッション初期化などのLaravel 処理。
-        $request->flash();
-
-        // 設定されているページエラー設定のリスト取得
-        $configs = Configs::where('category', 'page_error')->get();
+        // ページエラー設定, no-image設定
+        $configs = Configs::where('category', 'page_error')->orWhere('category', 'image_error')->get();
 
         return view('plugins.manage.site.page_error', [
             "function"    => __FUNCTION__,
@@ -857,11 +849,24 @@ class SiteManage extends ManagePluginBase
     /**
      *  ページエラー設定　更新
      */
-    public function savePageError($request, $page_id = null, $errors = array())
+    public function savePageError($request, $id = null)
     {
         // httpメソッド確認
         if (!$request->isMethod('post')) {
             abort(403, '権限がありません。');
+        }
+
+        // 項目のエラーチェック
+        $validator = Validator::make($request->all(), [
+            'no_image' => ['nullable', 'image'],
+        ]);
+        $validator->setAttributeNames([
+            'no_image' => 'No Image画像',
+        ]);
+
+        // エラーがあった場合は入力画面に戻る。
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
         }
 
         // 403
@@ -878,8 +883,62 @@ class SiteManage extends ManagePluginBase
              'value'    => $request->page_permanent_link_404]
         );
 
-        // ページ管理画面に戻る
-        return redirect("/manage/site/pageError");
+        // ファイルがアップロードされた
+        if ($request->hasFile('no_image')) {
+            // ファイル名
+            $filename = $request->file('no_image')->getClientOriginalName();
+
+            // ファイルの保存
+            $request->file('no_image')->storeAs('tmp', $filename);
+
+            // ファイルパス
+            $src_file = storage_path() . '/app/tmp/' . $filename;
+            $dst_dir  = public_path() . '/uploads/no_image';
+            $dst_file = $dst_dir . '/' . $filename;
+
+            // ディレクトリの存在チェック
+            if (!File::isDirectory($dst_dir)) {
+                $result = File::makeDirectory($dst_dir);
+            }
+
+            // ディレクトリへファイルの移動
+            if (!rename($src_file, $dst_file)) {
+                die("Couldn't rename file");
+            }
+
+            // no_image
+            $configs = Configs::updateOrCreate(
+                ['name'     => 'no_image'],
+                ['category' => 'image_error',
+                 'value'    => $filename]
+            );
+        }
+
+        return redirect("/manage/site/pageError")->with('flash_message', '更新しました。');
+    }
+
+    /**
+     * No Image 設定 削除
+     */
+    public function deleteNoImage($request)
+    {
+        // httpメソッド確認
+        if (!$request->isMethod('post')) {
+            abort(403, '権限がありません。');
+        }
+
+        $config = Configs::where('name', 'no_image')->first();
+        if (empty($config)) {
+            abort(404);
+        }
+
+        // ファイル削除
+        $dst_file  = public_path() . '/uploads/no_image/' . $config->value;
+        File::delete($dst_file);
+
+        $config->delete();
+
+        return redirect("/manage/site/pageError")->with('flash_message', 'No Image画像を削除しました。');
     }
 
     /**

--- a/resources/views/plugins/manage/site/page_error.blade.php
+++ b/resources/views/plugins/manage/site/page_error.blade.php
@@ -11,42 +11,98 @@
 {{-- 管理画面メイン部分のコンテンツ section:manage_content で作ること --}}
 @section('manage_content')
 
-<div class="card">
-<div class="card-header p-0">
+<script type="text/javascript">
+    /** NoImageの削除ボタン押下 */
+    function delete_no_image(btn) {
+        if (confirm('No Image画像を削除します。\nよろしいですか？')) {
+            btn.disabled = true;
+            no_image_form.submit();
+        }
+    }
+</script>
 
-{{-- 機能選択タブ --}}
-@include('plugins.manage.site.site_manage_tab')
-
-</div>
-<div class="card-body">
-
-    <form action="{{url('/')}}/manage/site/savePageError" method="POST">
+{{-- NoImage削除フォーム --}}
+<form action="{{url('/manage/site/deleteNoImage')}}" method="post" name="no_image_form">
     {{csrf_field()}}
+</form>
 
-        {{-- 403 --}}
-        <div class="form-group">
-            <label class="col-form-label">IPアドレス制限などで権限がない場合の表示ページ</label>
-            <input type="text" name="page_permanent_link_403" value="{{ Configs::getConfigsValueAndOld($configs, 'page_permanent_link_403', null) }}" class="form-control">
-        </div>
+<div class="card">
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.site.site_manage_tab')
+    </div>
+    <div class="card-body">
 
-        {{-- 404 --}}
-        <div class="form-group">
-            <label class="col-form-label">指定ページがない場合の表示ページ</label>
-            <input type="text" name="page_permanent_link_404" value="{{ Configs::getConfigsValueAndOld($configs, 'page_permanent_link_404', null) }}" class="form-control">
-        </div>
+        {{-- 共通エラーメッセージ 呼び出し --}}
+        @include('plugins.common.errors_form_line')
+        {{-- 登録後メッセージ表示 --}}
+        @include('plugins.common.flash_message')
 
-        <div class="card card-body bg-light p-2 mb-3">
-            <ul>
-                <li>エラー設定の対象は一般画面です。管理画面は対象外です。</li>
-            </ul>
-        </div>
+        <form action="{{url('/')}}/manage/site/savePageError" method="post" enctype="multipart/form-data">
+            {{csrf_field()}}
 
-        {{-- Submitボタン --}}
-        <div class="form-group text-center">
-            <button type="submit" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
-        </div>
-    </form>
+            {{-- 403 --}}
+            <div class="form-group">
+                <label class="col-form-label">IPアドレス制限などで権限がない場合の表示ページ</label>
+                <input type="text" name="page_permanent_link_403" value="{{ Configs::getConfigsValueAndOld($configs, 'page_permanent_link_403', null) }}" class="form-control">
+            </div>
+
+            {{-- 404 --}}
+            <div class="form-group">
+                <label class="col-form-label">指定ページがない場合の表示ページ</label>
+                <input type="text" name="page_permanent_link_404" value="{{ Configs::getConfigsValueAndOld($configs, 'page_permanent_link_404', null) }}" class="form-control">
+            </div>
+
+            <div class="card card-body bg-light p-2 mb-3">
+                <ul>
+                    <li>エラー設定の対象は一般画面です。管理画面は対象外です。</li>
+                </ul>
+            </div>
+
+            <div class="form-group">
+                <label class="col-form-label">No Image画像</label>
+                <div>
+                    @php
+                        $no_image = Configs::getConfigsValueAndOld($configs, 'no_image', null);
+                    @endphp
+                    @if ($no_image)
+                        <div class="form-group">
+                            <a href="{{url('/')}}/uploads/no_image/{{$no_image}}" target="_blank">{{$no_image}}</a>
+                            <!-- 削除ボタン -->
+                            <button type="button"
+                                class="btn btn-outline-danger btn-sm"
+                                onclick="javascript:return delete_no_image(this);"
+                            >
+                                <i class="fas fa-trash-alt"></i> 削除
+                            </button>
+                        </div>
+                    @endif
+                    <div class="custom-file">
+                        {{-- laravelでアップできる拡張子と同じにする。see) \Illuminate\Validation\Concerns\ValidatesAttributes::validateImage() --}}
+                        <input type="file" class="custom-file-input" id="id_no_image" name="no_image" accept=".jpeg, .jpg, .png, .gif, .bmp, .svg, .webp">
+                        <label class="custom-file-label @if ($errors->has('no_image')) border-danger @endif" for="id_no_image" data-browse="参照"></label>
+                    </div>
+                    @include('plugins.common.errors_inline', ['name' => 'no_image'])
+                    <small class="form-text text-muted">
+                        設定するとNo Image画像を変更できます。<br />
+                        変更後のNo Image画像を確認するには、ブラウザキャッシュをクリアしてください。<br />
+                    </small>
+                </div>
+            </div>
+
+            {{-- Submitボタン --}}
+            <div class="form-group text-center">
+                <button type="submit" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>
+            </div>
+        </form>
+    </div>
 </div>
-</div>
+
+<script>
+    {{-- custom-file-inputクラスでファイル選択時にファイル名表示 --}}
+    $('.custom-file-input').on('change',function(){
+        $(this).next('.custom-file-label').html($(this)[0].files[0].name);
+    })
+</script>
 
 @endsection


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms-ideas/issues/165

上記の対応です。

# 対応後画面
## サイト管理＞エラー設定

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/f3b90bdc-1e57-4751-815d-ffb63974c5f5)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
