### PR TITLE
[新着情報] プラグインを配置して新規作成＞登録後は設定変更に画面遷移させる等の対応

### DIFF
--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -772,9 +772,17 @@ class WhatsnewsPlugin extends UserPluginBase
      */
     public function editView($request, $page_id, $frame_id)
     {
+        // 表示中のバケツデータ
+        $whatsnew = $this->getPluginBucket($this->getBucketId());
+
+        if (empty($whatsnew->id)) {
+            // バケツ空テンプレートを呼び出す。
+            return $this->commonView('empty_bucket_setting');
+        }
+
         // 表示テンプレートを呼び出す。
         return $this->view('whatsnews_frame', [
-            'whatsnew' => $this->getPluginBucket($this->getBucketId()),
+            'whatsnew' => $whatsnew,
         ]);
     }
 
@@ -789,7 +797,11 @@ class WhatsnewsPlugin extends UserPluginBase
         // 更新したので、frame_configsを設定しなおす
         $this->refreshFrameConfigs();
 
-        return;
+        // 完了メッセージ
+        $flash_message = '表示設定を変更しました。';
+        session()->flash("flash_message_for_frame{$frame_id}", $flash_message);
+
+        // リダイレクト先を指定しないため、画面から渡されたredirect_pathに飛ぶ
     }
 
     /**

--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -567,15 +567,13 @@ class WhatsnewsPlugin extends UserPluginBase
 
         // データ取得（1ページの表示件数指定）
         $whatsnews = Whatsnews::orderBy('created_at', 'desc')
-                              ->paginate(10, ["*"], "frame_{$frame_id}_page");
+            ->paginate(10, ["*"], "frame_{$frame_id}_page");
 
         // 表示テンプレートを呼び出す。
-        return $this->view(
-            'whatsnews_list_buckets', [
+        return $this->view('whatsnews_list_buckets', [
             'whatsnew_frame' => $whatsnew_frame,
             'whatsnews'      => $whatsnews,
-            ]
-        );
+        ]);
     }
 
     /**
@@ -753,14 +751,15 @@ class WhatsnewsPlugin extends UserPluginBase
     /**
      * データ紐づけ変更関数
      */
-    public function changeBuckets($request, $page_id = null, $frame_id = null, $id = null)
+    public function changeBuckets($request, $page_id, $frame_id, $id = null)
     {
         // FrameのバケツIDの更新
-        Frame::where('id', $frame_id)
-               ->update(['bucket_id' => $request->select_bucket]);
+        Frame::where('id', $frame_id)->update(['bucket_id' => $request->select_bucket]);
 
-        // 新着情報設定選択画面を呼ぶ
-        return $this->listBuckets($request, $page_id, $frame_id, $id);
+        $flash_message = '表示する新着情報を変更しました。';
+        session()->flash("flash_message_for_frame{$frame_id}", $flash_message);
+
+        // リダイレクト先を指定しないため、画面から渡されたredirect_pathに飛ぶ
     }
 
     /**

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
@@ -19,45 +19,30 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
 @endsection
 
 @section("plugin_setting_$frame->id")
-@if ($errors)
-    <div class="alert alert-danger" style="margin-top: 10px;">
-        <i class="fas fa-exclamation-circle"></i>
-        エラーがあります。詳しくは各項目を参照してください。
-    </div>
-@elseif (isset($whatsnew) && !$whatsnew->id)
-    <div class="alert alert-warning" style="margin-top: 10px;">
-        <i class="fas fa-exclamation-circle"></i>
-        設定画面から、使用する新着情報を選択するか、作成してください。
-    </div>
-@else
-    <div class="alert alert-info" style="margin-top: 10px;">
-        <i class="fas fa-exclamation-circle"></i>
 
-        @if ($message)
-            {{$message}}
-        @else
-            @if (empty($whatsnew) || $create_flag)
-                新しい新着情報設定を登録します。
-            @else
-                新着情報設定を変更します。
-            @endif
-        @endif
-    </div>
-@endif
+{{-- 共通エラーメッセージ 呼び出し --}}
+@include('plugins.common.errors_form_line')
+{{-- 登録後メッセージ表示 --}}
+@include('plugins.common.flash_message_for_frame')
 
-@if (isset($whatsnew))
-@if (!$whatsnew->id && !$create_flag)
-@else
-<form action="{{url('/')}}/plugin/whatsnews/saveBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="POST" class="">
-    {{ csrf_field() }}
-    <div id="app_{{ $frame->id }}">
-
-    {{-- create_flag がtrue の場合、新規作成するためにwhatsnews_id を空にする --}}
-    @if ($create_flag)
-        <input type="hidden" name="whatsnews_id" value="">
+<div class="alert alert-info">
+    <i class="fas fa-exclamation-circle"></i>
+    @if (empty($whatsnew->id))
+        新しい新着情報設定を登録します。
     @else
-        <input type="hidden" name="whatsnews_id" value="{{$whatsnew->id}}">
+        新着情報設定を変更します。
     @endif
+</div>
+
+<form action="{{url('/')}}/redirect/plugin/whatsnews/saveBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="post">
+    @if (empty($whatsnew->id))
+        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/whatsnews/createBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
+    @else
+        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/whatsnews/editBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
+    @endif
+    {{ csrf_field() }}
+    <input type="hidden" name="whatsnews_id" value="{{$whatsnew->id}}">
+    <div id="app_{{ $frame->id }}">
 
     {{-- バケツ名 --}}
     <div class="form-group row">
@@ -464,7 +449,7 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
                 </button>
                 <button type="submit" class="btn btn-primary form-horizontal mr-2"><i class="fas fa-check"></i>
                     <span class="{{$frame->getSettingButtonCaptionClass()}}">
-                    @if (empty($whatsnew) || $create_flag)
+                    @if (empty($whatsnew->id))
                         登録
                     @else
                         変更
@@ -473,23 +458,18 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
                 </button>
             </div>
             {{-- 既存新着情報設定の場合は削除処理のボタンも表示 --}}
-            @if ($create_flag)
-            @else
+            @if ($whatsnew->id)
                 <div class="col-3 text-right">
-                    <a data-toggle="collapse" href="#collapse{{$whatsnew_frame->id}}">
+                    <a data-toggle="collapse" href="#collapse{{$frame->id}}">
                         <span class="btn btn-danger"><i class="fas fa-trash-alt"></i><span class="{{$frame->getSettingButtonCaptionClass()}}"> 削除</span></span>
                     </a>
                 </div>
             @endif
         </div>
     </div>
-    </div>
 </form>
-@endif
-@endif
 
-@if (isset($whatsnew))
-<div id="collapse{{$whatsnew_frame->id}}" class="collapse" style="margin-top: 8px;">
+<div id="collapse{{$frame->id}}" class="collapse" style="margin-top: 8px;">
     <div class="card border-danger">
         <div class="card-body">
             <span class="text-danger">新着情報設定を削除します。<br>元に戻すことはできないため、よく確認して実行してください。</span>
@@ -503,7 +483,6 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
         </div>
     </div>
 </div>
-@endif
 
 <script>
     new Vue({

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
@@ -1,5 +1,5 @@
 {{--
- * 新着情報編集画面テンプレート。
+ * 新着情報編集画面テンプレート
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
@@ -24,7 +24,7 @@
     フレームごとの表示設定を変更します。
 </div>
 
-<form action="{{url('/')}}/redirect/plugin/whatsnews/saveView/{{$page->id}}/{{$frame_id}}/{{$whatsnew->id}}#frame-{{$frame->id}}" method="POST" class="">
+<form action="{{url('/')}}/redirect/plugin/whatsnews/saveView/{{$page->id}}/{{$frame_id}}/{{$whatsnew->id}}#frame-{{$frame->id}}" method="post">
     {{ csrf_field() }}
     <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/whatsnews/editView/{{$page->id}}/{{$frame_id}}/{{$whatsnew->bucket_id}}#frame-{{$frame_id}}">
 
@@ -56,8 +56,8 @@
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">本文の表示文字数</label>
         <div class="{{$frame->getSettingInputClass()}}">
-            <input type="text" name="post_detail_length" value="{{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length) }}" class="form-control col-sm-3">
-            @if ($errors && $errors->has('post_detail_length')) <div class="text-danger">{{$errors->first('post_detail_length')}}</div> @endif
+            <input type="text" name="post_detail_length" value="{{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length) }}" class="form-control col-sm-3 @if($errors->has('post_detail_length')) border-danger @endif">
+            @include('plugins.common.errors_inline', ['name' => 'post_detail_length'])
             <small class="text-muted">※ 0の場合、全文が表示されます。</small>
         </div>
     </div>
@@ -90,8 +90,8 @@
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">最大画像サイズ</label>
         <div class="{{$frame->getSettingInputClass()}}">
-            <input type="text" name="thumbnail_size" value="{{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}" class="form-control col-sm-3">
-            @if ($errors && $errors->has('thumbnail_size')) <div class="text-danger">{{$errors->first('thumbnail_size')}}</div> @endif
+            <input type="text" name="thumbnail_size" value="{{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}" class="form-control col-sm-3 @if($errors->has('thumbnail_size')) border-danger @endif">
+            @include('plugins.common.errors_inline', ['name' => 'thumbnail_size'])
             <small class="text-muted">※ 縦横の長い方に適用。0の場合、200が適用されます。</small>
         </div>
     </div>

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
@@ -1,5 +1,9 @@
 {{--
- * フレーム表示設定編集画面テンプレート。
+ * フレーム表示設定編集画面テンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category 新着情報プラグイン
 --}}
 @extends('core.cms_frame_base_setting')
 
@@ -12,150 +16,146 @@
 
 {{-- 共通エラーメッセージ 呼び出し --}}
 @include('plugins.common.errors_form_line')
+{{-- 登録後メッセージ表示 --}}
+@include('plugins.common.flash_message_for_frame')
 
-@if (empty($whatsnew->id) && $action != 'createBuckets')
-    <div class="alert alert-warning">
-        <i class="fas fa-exclamation-circle"></i>
-        選択画面から、使用する新着情報を選択するか、作成してください。
+<div class="alert alert-info">
+    <i class="fas fa-exclamation-circle"></i>
+    フレームごとの表示設定を変更します。
+</div>
+
+<form action="{{url('/')}}/redirect/plugin/whatsnews/saveView/{{$page->id}}/{{$frame_id}}/{{$whatsnew->id}}#frame-{{$frame->id}}" method="POST" class="">
+    {{ csrf_field() }}
+    <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/whatsnews/editView/{{$page->id}}/{{$frame_id}}/{{$whatsnew->bucket_id}}#frame-{{$frame_id}}">
+
+    {{-- 本文 --}}
+    <h5><span class="badge badge-secondary">本文</span></h5>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">本文</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            @foreach (ShowType::enum as $key => $value)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input
+                        type="radio"
+                        value="{{ $key }}"
+                        id="{{ "post_detail_${key}" }}"
+                        name="post_detail"
+                        class="custom-control-input"
+                        {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail, 0) == $key ? 'checked' : '' }}
+                    >
+                    <label class="custom-control-label" for="{{ "post_detail_${key}" }}">
+                        {{ $value }}
+                    </label>
+                </div>
+            @endforeach
+        </div>
     </div>
-@else
-    <div class="alert alert-info">
-        <i class="fas fa-exclamation-circle"></i>
-        フレームごとの表示設定を変更します。
+
+    {{-- 本文の表示文字数 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">本文の表示文字数</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <input type="text" name="post_detail_length" value="{{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length) }}" class="form-control col-sm-3">
+            @if ($errors && $errors->has('post_detail_length')) <div class="text-danger">{{$errors->first('post_detail_length')}}</div> @endif
+            <small class="text-muted">※ 0の場合、全文が表示されます。</small>
+        </div>
     </div>
 
-    <form action="{{url('/')}}/redirect/plugin/whatsnews/saveView/{{$page->id}}/{{$frame_id}}/{{$whatsnew->id}}#frame-{{$frame->id}}" method="POST" class="">
-        {{ csrf_field() }}
-        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/whatsnews/editView/{{$page->id}}/{{$frame_id}}/{{$whatsnew->bucket_id}}#frame-{{$frame_id}}">
+    {{-- サムネイル --}}
+    <h5><span class="badge badge-secondary">サムネイル画像</span></h5>
 
-        {{-- 本文 --}}
-        <h5><span class="badge badge-secondary">本文</span></h5>
-
-        <div class="form-group row">
-            <label class="{{$frame->getSettingLabelClass(true)}}">本文</label>
-            <div class="{{$frame->getSettingInputClass(true)}}">
-                @foreach (ShowType::enum as $key => $value)
-                    <div class="custom-control custom-radio custom-control-inline">
-                        <input
-                            type="radio"
-                            value="{{ $key }}"
-                            id="{{ "post_detail_${key}" }}"
-                            name="post_detail"
-                            class="custom-control-input"
-                            {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail, 0) == $key ? 'checked' : '' }}
-                        >
-                        <label class="custom-control-label" for="{{ "post_detail_${key}" }}">
-                            {{ $value }}
-                        </label>
-                    </div>
-                @endforeach
-            </div>
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">サムネイル画像</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            @foreach (ShowType::enum as $key => $value)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input
+                        type="radio"
+                        value="{{ $key }}"
+                        id="{{ "thumbnail_${key}" }}"
+                        name="thumbnail"
+                        class="custom-control-input"
+                        {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail, 0) == $key ? 'checked' : '' }}
+                    >
+                    <label class="custom-control-label" for="{{ "thumbnail_${key}" }}">
+                        {{ $value }}
+                    </label>
+                </div>
+            @endforeach
         </div>
+    </div>
 
-        {{-- 本文の表示文字数 --}}
-        <div class="form-group row">
-            <label class="{{$frame->getSettingLabelClass()}}">本文の表示文字数</label>
-            <div class="{{$frame->getSettingInputClass()}}">
-                <input type="text" name="post_detail_length" value="{{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length) }}" class="form-control col-sm-3">
-                @if ($errors && $errors->has('post_detail_length')) <div class="text-danger">{{$errors->first('post_detail_length')}}</div> @endif
-                <small class="text-muted">※ 0の場合、全文が表示されます。</small>
-            </div>
+    {{-- サムネイル画像の表示幅 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass()}}">最大画像サイズ</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            <input type="text" name="thumbnail_size" value="{{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}" class="form-control col-sm-3">
+            @if ($errors && $errors->has('thumbnail_size')) <div class="text-danger">{{$errors->first('thumbnail_size')}}</div> @endif
+            <small class="text-muted">※ 縦横の長い方に適用。0の場合、200が適用されます。</small>
         </div>
+    </div>
 
-        {{-- サムネイル --}}
-        <h5><span class="badge badge-secondary">サムネイル画像</span></h5>
+    {{-- 記事間の罫線 --}}
+    <h5><span class="badge badge-secondary">記事間の罫線</span></h5>
 
-        <div class="form-group row">
-            <label class="{{$frame->getSettingLabelClass(true)}}">サムネイル画像</label>
-            <div class="{{$frame->getSettingInputClass(true)}}">
-                @foreach (ShowType::enum as $key => $value)
-                    <div class="custom-control custom-radio custom-control-inline">
-                        <input
-                            type="radio"
-                            value="{{ $key }}"
-                            id="{{ "thumbnail_${key}" }}"
-                            name="thumbnail"
-                            class="custom-control-input"
-                            {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail, 0) == $key ? 'checked' : '' }}
-                        >
-                        <label class="custom-control-label" for="{{ "thumbnail_${key}" }}">
-                            {{ $value }}
-                        </label>
-                    </div>
-                @endforeach
-            </div>
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">記事間の罫線</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            @foreach (ShowType::enum as $key => $value)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input
+                        type="radio"
+                        value="{{ $key }}"
+                        id="{{ "border_${key}" }}"
+                        name="border"
+                        class="custom-control-input"
+                        {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::border, 0) == $key ? 'checked' : '' }}
+                    >
+                    <label class="custom-control-label" for="{{ "border_${key}" }}">
+                        {{ $value }}
+                    </label>
+                </div>
+            @endforeach
         </div>
+    </div>
 
-        {{-- サムネイル画像の表示幅 --}}
-        <div class="form-group row">
-            <label class="{{$frame->getSettingLabelClass()}}">最大画像サイズ</label>
-            <div class="{{$frame->getSettingInputClass()}}">
-                <input type="text" name="thumbnail_size" value="{{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size) }}" class="form-control col-sm-3">
-                @if ($errors && $errors->has('thumbnail_size')) <div class="text-danger">{{$errors->first('thumbnail_size')}}</div> @endif
-                <small class="text-muted">※ 縦横の長い方に適用。0の場合、200が適用されます。</small>
-            </div>
+    {{-- 非同期表示 --}}
+    <h5><span class="badge badge-secondary">非同期表示</span></h5>
+
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">非同期表示</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            @foreach (UseType::enum as $key => $value)
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input
+                        type="radio"
+                        value="{{ $key }}"
+                        id="{{ "async_${key}" }}"
+                        name="async"
+                        class="custom-control-input"
+                        {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::async, 0) == $key ? 'checked' : '' }}
+                    >
+                    <label class="custom-control-label" for="{{ "async_${key}" }}">
+                        {{ $value }}
+                    </label>
+                </div>
+            @endforeach
         </div>
+    </div>
 
-        {{-- 記事間の罫線 --}}
-        <h5><span class="badge badge-secondary">記事間の罫線</span></h5>
+    {{-- Submitボタン --}}
+    <div class="text-center">
+        <a class="btn btn-secondary mr-2" href="{{URL::to($page->permanent_link)}}#frame-{{$frame->id}}">
+            <i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass('md')}}"> キャンセル</span>
+        </a>
+        <button type="submit" class="btn btn-primary form-horizontal">
+            <i class="fas fa-check"></i>
+            <span class="{{$frame->getSettingButtonCaptionClass()}}">
+                変更確定
+            </span>
+        </button>
+    </div>
+</form>
 
-        <div class="form-group row">
-            <label class="{{$frame->getSettingLabelClass(true)}}">記事間の罫線</label>
-            <div class="{{$frame->getSettingInputClass(true)}}">
-                @foreach (ShowType::enum as $key => $value)
-                    <div class="custom-control custom-radio custom-control-inline">
-                        <input
-                            type="radio"
-                            value="{{ $key }}"
-                            id="{{ "border_${key}" }}"
-                            name="border"
-                            class="custom-control-input"
-                            {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::border, 0) == $key ? 'checked' : '' }}
-                        >
-                        <label class="custom-control-label" for="{{ "border_${key}" }}">
-                            {{ $value }}
-                        </label>
-                    </div>
-                @endforeach
-            </div>
-        </div>
-
-        {{-- 非同期表示 --}}
-        <h5><span class="badge badge-secondary">非同期表示</span></h5>
-
-        <div class="form-group row">
-            <label class="{{$frame->getSettingLabelClass(true)}}">非同期表示</label>
-            <div class="{{$frame->getSettingInputClass(true)}}">
-                @foreach (UseType::enum as $key => $value)
-                    <div class="custom-control custom-radio custom-control-inline">
-                        <input
-                            type="radio"
-                            value="{{ $key }}"
-                            id="{{ "async_${key}" }}"
-                            name="async"
-                            class="custom-control-input"
-                            {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::async, 0) == $key ? 'checked' : '' }}
-                        >
-                        <label class="custom-control-label" for="{{ "async_${key}" }}">
-                            {{ $value }}
-                        </label>
-                    </div>
-                @endforeach
-            </div>
-        </div>
-
-        {{-- Submitボタン --}}
-        <div class="text-center">
-            <a class="btn btn-secondary mr-2" href="{{URL::to($page->permanent_link)}}#frame-{{$frame->id}}">
-                <i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass('md')}}"> キャンセル</span>
-            </a>
-            <button type="submit" class="btn btn-primary form-horizontal">
-                <i class="fas fa-check"></i>
-                <span class="{{$frame->getSettingButtonCaptionClass()}}">
-                    変更確定
-                </span>
-            </button>
-        </div>
-    </form>
-@endif
 @endsection

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_list_buckets.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_list_buckets.blade.php
@@ -2,6 +2,7 @@
  * 編集画面(データ選択)テンプレート
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 新着情報プラグイン
  --}}
@@ -13,8 +14,13 @@
 @endsection
 
 @section("plugin_setting_$frame->id")
-<form action="{{url('/')}}/plugin/whatsnews/changeBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="POST" class="">
+
+{{-- 登録後メッセージ表示 --}}
+@include('plugins.common.flash_message_for_frame')
+
+<form action="{{url('/')}}/redirect/plugin/whatsnews/changeBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="POST" class="">
     {{ csrf_field() }}
+    <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/whatsnews/listBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
 
     <div class="form-group {{$frame->getSettingTableClass()}}">
         <table class="table table-hover mb-0">
@@ -46,7 +52,7 @@
 
     <div class="text-center">
         <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}#frame-{{$frame->id}}'"><i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass()}}"> キャンセル</span></button>
-        <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> 変更</button>
+        <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> 表示新着情報変更</button>
     </div>
 </form>
 @endsection

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_list_buckets.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_list_buckets.blade.php
@@ -15,6 +15,13 @@
 
 @section("plugin_setting_$frame->id")
 
+<script>
+    $(function () {
+        // 有効化
+        $('[data-toggle="tooltip"]').tooltip()
+    })
+</script>
+
 {{-- 登録後メッセージ表示 --}}
 @include('plugins.common.flash_message_for_frame')
 
@@ -52,7 +59,7 @@
 
     <div class="text-center">
         <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}#frame-{{$frame->id}}'"><i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass()}}"> キャンセル</span></button>
-        <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> 表示新着情報変更</button>
+        <button type="submit" class="btn btn-primary" data-toggle="tooltip" title="表示新着情報変更"><i class="fas fa-check"></i> 変更</button>
     </div>
 </form>
 @endsection

--- a/resources/views/plugins/user/whatsnews/whatsnews_frame_edit_tab.blade.php
+++ b/resources/views/plugins/user/whatsnews/whatsnews_frame_edit_tab.blade.php
@@ -4,7 +4,14 @@
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 新着情報プラグイン
- --}}
+--}}
+<script>
+    $(function () {
+        // 有効化
+        $('[data-toggle="tooltip"]').tooltip()
+    })
+</script>
+
 @if ($action == 'editBuckets')
     <li role="presentation" class="nav-item">
         <span class="nav-link"><span class="active">設定変更</span></span>
@@ -34,10 +41,10 @@
 @endif
 @if ($action == 'listBuckets')
     <li role="presentation" class="nav-item">
-        <span class="nav-link"><span class="active">選択</span></span>
+        <span class="nav-link"><span class="active" data-toggle="tooltip" title="新着情報選択">選択</span></span>
     </li>
 @else
     <li role="presentation" class="nav-item">
-        <a href="{{url('/')}}/plugin/whatsnews/listBuckets/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">選択</a>
+        <a href="{{url('/')}}/plugin/whatsnews/listBuckets/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link" data-toggle="tooltip" title="新着情報選択">選択</a>
     </li>
 @endif


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms-ideas/issues/166 の対応を行いました。
* 関連対応
  * 表示設定
    * [add: 新着情報, 表示設定変更後にメッセージを表示](https://github.com/opensource-workshop/connect-cms/pull/1911/commits/2b68fe1d4e0ff912764ade4f6fda1f3176088b7b)
  * [change: 新着情報, 表示設定の本文の表示文字数、最大画像サイズは表示する時のみ条件チェックを行うよう修正](https://github.com/opensource-workshop/connect-cms/pull/1911/commits/58310c517dd7ccc72bc4f467b3f0e08c56d4e1b8)
  * バケツ選択
    * [add: 新着情報, 新着情報選択変更後に変更メッセージを表示](https://github.com/opensource-workshop/connect-cms/pull/1911/commits/9f68e596111d6328faa67d6d905df9986a742ff5)
    * [change: 新着情報, バケツ選択の変更ボタンはツールチップ表示](https://github.com/opensource-workshop/connect-cms/pull/1911/commits/3975734932bec76cc274577d5976035e6986f253)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/856

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
