### PR TITLE
[新着情報] もっと見るボタン押下時に不要なリダイレクトの発生をなくす

### DIFF
--- a/resources/views/plugins/user/whatsnews/whatsnews_script.blade.php
+++ b/resources/views/plugins/user/whatsnews/whatsnews_script.blade.php
@@ -61,7 +61,7 @@
             searchWhatsnewses: function () {
                 let self = this;
                 // 非同期通信で追加の一覧を取得
-                axios.get("{{url('/')}}/json/whatsnews/indexJson/{{$page->id}}/{{$frame_id}}/?limit=" + this.limit + "&offset=" + this.offset + "&post_detail_length=" + this.post_detail_length)
+                axios.get("{{url('/')}}/json/whatsnews/indexJson/{{$page->id}}/{{$frame_id}}?limit=" + this.limit + "&offset=" + this.offset + "&post_detail_length=" + this.post_detail_length)
                     .then(function(res){
                         // foreach内ではthisでvueインスタンスのwhatsnewsesが参照できない為、tmp_arrに一時的に代入
                         tmp_arr = self.whatsnewses;


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 公式掲示板の報告より https://connect-cms.jp/plugin/bbses/show/106/233/866#frame-233
* おそらく上記の原因を対応しました。
  * 新着情報のもっと見るボタンのURLに、不要な末尾/がついていましたので、削除しました。
  * 末尾/ があると、.htaccess の mod_rewrite 設定に引っ掛かり、getへ自動リダイレクトされます。
  * 自動リダイレクト後、http → httpsへの自動リダイレクト設定がない場合、mixed content（混在コンテンツ）となり、もっと見るの記事がブラウザによって表示されませんでした。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* laravelでトレイリングスラッシュを有効にする方法 #Laravel - Qiita
https://qiita.com/naoqoo2/items/cdbd84220e97eb160ea8
  * > トレイリングスラッシュ（URL末尾のスラッシュ）
* 混在コンテンツ - ウェブセキュリティ | MDN
https://developer.mozilla.org/ja/docs/Web/Security/Mixed_content


# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
