### PR TITLE
[コア] オプション管理プラグインの管理者メニュー自動対応

### DIFF
--- a/resources/views/plugins/manage/menus.blade.php
+++ b/resources/views/plugins/manage/menus.blade.php
@@ -11,12 +11,12 @@
     <div class="collapse navbar-collapse mt-2" id="Navber">
         @include('plugins.manage.menus_list')
         {{-- オプションプラグインの管理者メニュー --}}
-        @includeIf('plugins_option.manage.menus_list')
+        @includeFirst(['plugins_option.manage.menus_list', 'plugins.manage.menus_list_option'])
     </div>
 </nav>
 
 <nav class="list-group d-none d-lg-block">
     @include('plugins.manage.menus_list')
     {{-- オプションプラグインの管理者メニュー --}}
-    @includeIf('plugins_option.manage.menus_list')
+    @includeFirst(['plugins_option.manage.menus_list', 'plugins.manage.menus_list_option'])
 </nav>

--- a/resources/views/plugins/manage/menus_list_option.blade.php
+++ b/resources/views/plugins/manage/menus_list_option.blade.php
@@ -1,0 +1,45 @@
+{{--
+ * オプション管理メニューリスト
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category オプション管理
+--}}
+@if (Auth::user()->can('admin_system'))
+    @php
+        $option_plugins = [];
+        $option_directories = [];
+
+        // オプション管理プラグインのディレクトリの取得
+        if (File::exists(app_path() . '/PluginsOption/Manage')) {
+            $option_directories = File::directories(app_path() . '/PluginsOption/Manage');
+        }
+
+        // プラグインのini ファイルの取得
+        foreach ($option_directories as $dirkey => $directorie) {
+            // オプション管理プラグインとして存在するか確認
+            $plugin_manage = basename($directorie);
+            $class_name = "App\PluginsOption\Manage\\" . ucfirst($plugin_manage) . "\\" . ucfirst($plugin_manage);
+            if (class_exists($class_name)) {
+                $option_plugins[] = [
+                    // 'class_name'       => $class_name,
+                    'plugin_name'      => defined("$class_name::plugin_name") ? $class_name::plugin_name : null,
+                    'plugin_name_full' => defined("$class_name::plugin_name_full") ? $class_name::plugin_name_full : null,
+                ];
+            }
+        }
+    @endphp
+    @if ($option_plugins)
+        <div class="list-group mt-2">
+            <div class="list-group-item bg-light">オプション管理系</div>
+
+            @foreach ($option_plugins as $option_plugin)
+                @if (isset($plugin_name) && $plugin_name == $option_plugin['plugin_name'])
+                    <a href="{{url('/')}}/manage/{{$option_plugin['plugin_name']}}" class="list-group-item active">{{$option_plugin['plugin_name_full']}}</a>
+                @else
+                    <a href="{{url('/')}}/manage/{{$option_plugin['plugin_name']}}" class="list-group-item">{{$option_plugin['plugin_name_full']}}</a>
+                @endif
+            @endforeach
+        </div>
+    @endif
+@endif


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

今までオプション管理プラグインを管理者メニューに表示するには、plugins_option.manage.menus_list bladeの追加が必須でした。
修正後はオプション管理プラグインに所定のconstを設定すれば、管理者メニューに自動表示されます。
また、いままでのオプション管理者メニューも有効です。

### オプション管理プラグインの所定のconst例
```php
class TotalizationManage extends ManagePluginOptionBase
{
    /**
     * プラグイン名
     * 管理者メニュー表示に必要
     *
     * @var string
     */
    const plugin_name = 'totalization';

    /**
     * プラグイン名（和名）
     * 管理者メニュー表示に必要
     *
     * @var string
     */
    const plugin_name_full = '集計機能';

(略)
}
```

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
