### PR TITLE
[ページ管理] 外部ページインポートで取り込み済み移行データがあると500エラー（File not found at path: migration/import/pages/1）になる不具合等対応

### DIFF
--- a/resources/views/plugins/manage/page/migration_order.blade.php
+++ b/resources/views/plugins/manage/page/migration_order.blade.php
@@ -2,9 +2,10 @@
  * 外部ページ移行指示画面のテンプレート
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category ページ管理
- --}}
+--}}
 {{-- 管理画面ベース画面 --}}
 @extends('plugins.manage.manage')
 
@@ -21,8 +22,7 @@
     @include('plugins.manage.page.page_edit_tab')
 
     <div class="card-body">
-
-        <div class="alert alert-danger" style="margin-top: 10px;">
+        <div class="alert alert-danger">
             <h1>本機能（Webスクレイピング）を利用するに当たっての注意点</h1>
             <ul>
                 <li>Webスクレイピングは、対象サイトの利用規約に違反する場合があります。必ず対象サイトの利用規約を確認し、遵守してください。</li>
@@ -32,7 +32,7 @@
             </ul>
         </div>
 
-        <div class="alert alert-info" style="margin-top: 10px;">
+        <div class="alert alert-info">
             移行先ページ名：{{$current_page->page_name}}
         </div>
 
@@ -62,8 +62,8 @@
             <div class="form-group row">
                 <label for="page_name" class="col-md-3 col-form-label text-md-right">移行元URL</label>
                 <div class="col-md-9">
-                    <input type="text" name="url" id="page_name" value="{{old('url', '')}}" class="form-control">
-                    @if ($errors && $errors->has('url')) <div class="text-danger">{{$errors->first('url')}}</div> @endif
+                    <input type="text" name="url" id="page_name" value="{{old('url')}}" class="form-control @if ($errors->has('url')) border-danger @endif">
+                    @include('plugins.common.errors_inline', ['name' => 'url'])
                 </div>
             </div>
 
@@ -88,14 +88,11 @@
             </div>
             --}}
 
-            <div class="form-group row mt-3 text-center">
-                <div class="col-sm-3"></div>
-                <div class="col-sm-6">
-                    <button type="submit" class="btn btn-primary">
-                        <i class="fas fa-check"></i> データ取り込み
-                    </button>
-                    @if ($errors && $errors->has('request_interval')) <div class="text-danger">{{$errors->first('request_interval')}}</div> @endif
-                </div>
+            <div class="form-group text-center">
+                <button type="submit" class="btn btn-primary">
+                    <i class="fas fa-check"></i> データ取り込み
+                </button>
+                @include('plugins.common.errors_inline', ['name' => 'request_interval'])
             </div>
         </form>
     </div>
@@ -129,40 +126,32 @@
                 <label for="page_name" class="col-md-3 col-form-label text-md-right pt-0">取り込み済み<br class="d-none d-md-inline" />移行データ<br class="d-none d-md-inline">（取り込み日時）</label>
                 <div class="col-md-9">
                     @foreach($migration_pages as $migration_page)
-                    <div class="custom-control custom-radio custom-control-inline">
+                    <div class="custom-control custom-radio">
                         <input type="radio" value="{{$migration_page->id}}" id="migration_page_{{$migration_page->id}}" name="migration_page_id" class="custom-control-input">
                         {{-- 取り込み済み移行データ名（＝移行先ページ名） --}}
                         <label class="custom-control-label" for="migration_page_{{$migration_page->id}}">{{$migration_page->page_name}}</label>
-                        {{-- ページ毎のディレクトリ更新日時を表示 --}}
-                        <span class="ml-2 mr-2">({{ Carbon::createFromTimestamp(Storage::lastModified('migration/import/pages/' . $migration_page->id))->format('Y/m/d H:i:s') }})</span>
+                        {{-- ページ毎のディレクトリ更新日時 --}}
+                        <span class="ml-2 mr-2">({{ $migration_page->migration_directory_timestamp }})</span>
                         {{-- 削除ボタン --}}
                         <a href="#" onClick="submit_migration_file_delete({{$migration_page->id}});"><i class="fas fa-trash-alt mt-1 ml-1"></i></a>
                     </div>
-                    <br />
                     @endforeach
-                    @if ($errors && $errors->has('migration_page_id')) <div class="text-danger">{{$errors->first('migration_page_id')}}</div> @endif
+                    @include('plugins.common.errors_inline', ['name' => 'migration_page_id'])
                 </div>
             </div>
 
-            <div class="form-group row mt-3 text-center">
-                <div class="col-sm-3"></div>
-                <div class="col-sm-6">
-                    <button type="submit" class="btn btn-primary">
-                        <i class="fas fa-check"></i> インポート
-                    </button>
-                </div>
+            <div class="text-center form-group">
+                <button type="submit" class="btn btn-primary">
+                    <i class="fas fa-check"></i> インポート
+                </button>
             </div>
         </form>
     </div>
 
-    <div class="card-body">
-        <div class="form-group row text-center">
-            <div class="col">
-                <a href="{{url('/manage/page/edit')}}/{{$page->id}}" class="btn btn-secondary mr-2">
-                    <i class="fas fa-chevron-left"></i> ページ変更へ
-                </a>
-            </div>
-        </div>
+    <div class="text-center form-group">
+        <a href="{{url('/manage/page/edit')}}/{{$page->id}}" class="btn btn-secondary mr-2">
+            <i class="fas fa-chevron-left"></i> ページ変更へ
+        </a>
     </div>
 </div>
 @endsection

--- a/resources/views/plugins/manage/page/migration_order.blade.php
+++ b/resources/views/plugins/manage/page/migration_order.blade.php
@@ -22,6 +22,12 @@
     @include('plugins.manage.page.page_edit_tab')
 
     <div class="card-body">
+
+        {{-- 共通エラーメッセージ 呼び出し --}}
+        @include('plugins.common.errors_form_line')
+        {{-- 登録後メッセージ表示 --}}
+        @include('plugins.common.flash_message')
+
         <div class="alert alert-danger">
             <h1>本機能（Webスクレイピング）を利用するに当たっての注意点</h1>
             <ul>
@@ -98,42 +104,38 @@
     </div>
 
     <script type="text/javascript">
-        {{-- 移行データ削除用のsubmit JavaScript --}}
-        function submit_migration_file_delete(delete_file_page_id) {
-
+        /** 取り込み済みデータ削除 */
+        function submit_migration_file_delete(delete_file_page_id_dir) {
             if (confirm("取り込み済みデータを削除します。\nよろしいですか？")) {
-                // 続き
+                form_migration_file_delete.delete_file_page_id_dir.value = delete_file_page_id_dir;
+                form_migration_file_delete.submit();
             }
-            else {
-                return false;
-            }
-
-            form_migration_file_delete.delete_file_page_id.value = delete_file_page_id;
-            form_migration_file_delete.submit();
         }
     </script>
-    <form action="{{url('/manage/page/migrationFileDelete')}}/{{$current_page->id}}" method="POST" name="form_migration_file_delete">
+    <form action="{{url('/manage/page/migrationFileDelete')}}/{{$current_page->id}}" method="post" name="form_migration_file_delete">
         {{ csrf_field() }}
-        <input type="hidden" name="delete_file_page_id" value="">
+        <input type="hidden" name="delete_file_page_id_dir" value="">
     </form>
 
-
     <div class="card-body">
-        <form action="{{url('/manage/page/migrationImort')}}/{{$current_page->id}}" method="POST" class="form-horizontal">
+        <form action="{{url('/manage/page/migrationImort')}}/{{$current_page->id}}" method="post" class="form-horizontal">
             {{ csrf_field() }}
 
             <div class="form-group row">
                 <label for="page_name" class="col-md-3 col-form-label text-md-right pt-0">取り込み済み<br class="d-none d-md-inline" />移行データ<br class="d-none d-md-inline">（取り込み日時）</label>
                 <div class="col-md-9">
                     @foreach($migration_pages as $migration_page)
-                    <div class="custom-control custom-radio">
+                    <div class="custom-control custom-radio ">
                         <input type="radio" value="{{$migration_page->id}}" id="migration_page_{{$migration_page->id}}" name="migration_page_id" class="custom-control-input">
                         {{-- 取り込み済み移行データ名（＝移行先ページ名） --}}
                         <label class="custom-control-label" for="migration_page_{{$migration_page->id}}">{{$migration_page->page_name}}</label>
+                        <br class="d-sm-none">
                         {{-- ページ毎のディレクトリ更新日時 --}}
                         <span class="ml-2 mr-2">({{ $migration_page->migration_directory_timestamp }})</span>
                         {{-- 削除ボタン --}}
-                        <a href="#" onClick="submit_migration_file_delete({{$migration_page->id}});"><i class="fas fa-trash-alt mt-1 ml-1"></i></a>
+                        <button type="button" class="btn btn-link p-0" onClick="submit_migration_file_delete('{{$migration_page->page_id_dir}}');">
+                            <i class="fas fa-trash-alt"></i>
+                        </button>
                     </div>
                     @endforeach
                     @include('plugins.common.errors_inline', ['name' => 'migration_page_id'])


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [bugfix: ページ管理, 外部ページインポートで取り込み済み移行データがあると500エラー（File not found at path: migration/import/pages/1）になる不具合修正](https://github.com/opensource-workshop/connect-cms/pull/1916/commits/98ecee5dcef1c4e26b9123143b72e03a0a29f3a4) 
* 関連対応
  * [buffix: ページ管理, 外部ページインポートの取り込み済み移行データが削除できない不具合修正](https://github.com/opensource-workshop/connect-cms/pull/1916/commits/1e560aa7bc1f7c6b99bfa393091fc5e167a4abfd)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
