### PR TITLE
[ページ管理] 外部ページインポートの取り込み済み移行データが削除できない不具合の変数名見直し

### DIFF
--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -731,7 +731,7 @@ class PageManage extends ManagePluginBase
         foreach ($migration_pages as $page) {
             // ページ毎のディレクトリ更新日時
             $page->migration_directory_timestamp = Carbon::createFromTimestamp(Storage::lastModified($migration_directories_page_ids[$page_id]['migration_directory']))->format('Y/m/d H:i:s');
-            $page->page_id_dir = $migration_directories_page_ids[$page_id]['page_id_dir'];
+            $page->delete_file_page_id_dir = $migration_directories_page_ids[$page_id]['page_id_dir'];
         }
 
         // 画面呼び出し

--- a/resources/views/plugins/manage/page/migration_order.blade.php
+++ b/resources/views/plugins/manage/page/migration_order.blade.php
@@ -133,7 +133,7 @@
                         {{-- ページ毎のディレクトリ更新日時 --}}
                         <span class="ml-2 mr-2">({{ $migration_page->migration_directory_timestamp }})</span>
                         {{-- 削除ボタン --}}
-                        <button type="button" class="btn btn-link p-0" onClick="submit_migration_file_delete('{{$migration_page->page_id_dir}}');">
+                        <button type="button" class="btn btn-link p-0" onClick="submit_migration_file_delete('{{$migration_page->delete_file_page_id_dir}}');">
                             <i class="fas fa-trash-alt"></i>
                         </button>
                     </div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/pull/1916

上記の変数名の修正のみのため、リリースに含めない対応としてマージします。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
