### PR TITLE
[コア] トークンの時間切れ（419エラー）時は自動で画面再表示（自動リダイレクト）

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -71,6 +71,8 @@ class Handler extends ExceptionHandler
     {
         if ($exception instanceof TokenMismatchException) {
             // CSRFトークン有効期限切れ(419エラー)
+            session()->flash('flash_message_for_header_class', 'alert-warning');
+            session()->flash('flash_message_for_header', 'トークンの有効期限が切れたため、画面を再表示しました。');
             return redirect()->back();
         }
         return parent::render($request, $exception);

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,9 +2,8 @@
 
 namespace App\Exceptions;
 
-use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Session\TokenMismatchException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -70,6 +69,10 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $exception)
     {
+        if ($exception instanceof TokenMismatchException) {
+            // CSRFトークン有効期限切れ(419エラー)
+            return redirect()->back();
+        }
         return parent::render($request, $exception);
     }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -73,7 +73,12 @@ class Handler extends ExceptionHandler
             // CSRFトークン有効期限切れ(419エラー)
             session()->flash('flash_message_for_header_class', 'alert-warning');
             session()->flash('flash_message_for_header', 'トークンの有効期限が切れたため、画面を再表示しました。');
-            return redirect()->back();
+
+            if ($request->has('redirect_path')) {
+                // 一般プラグイン編集時リダイレクト対応
+                return redirect($request->redirect_path)->withInput();
+            }
+            return redirect()->back()->withInput();
         }
         return parent::render($request, $exception);
     }

--- a/resources/views/common/flash_message_for_header.blade.php
+++ b/resources/views/common/flash_message_for_header.blade.php
@@ -1,0 +1,12 @@
+{{--
+ * フラッシュメッセージ ヘッダー表示
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category views/common
+--}}
+@if (session('flash_message_for_header'))
+    <div class="alert {{ session('flash_message_for_header_class') ?? 'alert-success' }} text-center">
+        {{ session('flash_message_for_header') }}
+    </div>
+@endif

--- a/resources/views/core/cms.blade.php
+++ b/resources/views/core/cms.blade.php
@@ -49,12 +49,8 @@ $(function(){
         </div>
     @endif
 
-    {{-- フラッシュメッセージ表示 --}}
-    @if (session('flash_message_for_header'))
-        <div class="alert {{ session('flash_message_for_header_class') ?? 'alert-success' }} text-center">
-            {{ session('flash_message_for_header') }}
-        </div>
-    @endif
+    {{-- フラッシュメッセージ ヘッダー表示 --}}
+    @include('common.flash_message_for_header')
 
     {{-- ヘッダーエリア --}}
     @if ($layouts_info[0]['exists'])

--- a/resources/views/core/cms.blade.php
+++ b/resources/views/core/cms.blade.php
@@ -10,38 +10,15 @@
 {{-- 大元のレイアウトの継承とページコンテンツは大元のレイアウトに埋め込むために @section で定義する --}}
 @extends('layouts.app')
 @section('content')
-<div class="container-fluid p-0">
-
-
-{{-- *********************************************************** --}}
-
-{{-- <a href="#" data-href="/test_dir/load.html" data-toggle="modal" data-target="#modalDetails">リンク</a> --}}
-{{-- <a href="#" data-href="{{URL::to('/')}}/test/1" data-toggle="modal" data-target="#modalDetails">リンク</a> --}}
-
-<!-- Modal -->
-<div class="modal fade" id="modalDetails" tabindex="-1" role="dialog" data-backdrop="static">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-        </div>
-    </div>
-</div>
 
 <script>
-$(function () {
-    //任意のリンクをモーダル内に読み込む
-    $("#modalDetails").on("show.bs.modal", function(e) {
-        var link = $(e.relatedTarget); //クリックしたセルのオブジェクトデータ
-        $(this).find(".modal-content").load(link.attr("data-href"));
+    $(function () {
+        // フラッシュメッセージのfadeout
+        $('.connect-flash').fadeOut(10000);
     });
-});
-
-// フラッシュメッセージのfadeout
-$(function(){
-    $('.connect-flash').fadeOut(10000);
-});
 </script>
 
-{{-- *********************************************************** --}}
+<div class="container-fluid p-0">
     {{-- フラッシュメッセージ表示(fadeout あり) --}}
     @if (session('flash_message_for_add_plugin'))
         <div class="connect-flash alert alert-success text-center">

--- a/resources/views/core/cms.blade.php
+++ b/resources/views/core/cms.blade.php
@@ -3,7 +3,9 @@
  *
  * @param obj $frames 表示すべきフレームの配列
  * @param obj $page 現在表示中のページ
+ *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category コア
 --}}
@@ -31,7 +33,6 @@
 
     {{-- ヘッダーエリア --}}
     @if ($layouts_info[0]['exists'])
-        {{-- @if (isset($configs_array['browser_width_header']) && $configs_array['browser_width_header']->value == '100%') --}}
         @if (Configs::getConfigsValue($cc_configs, 'browser_width_header') == '100%')
     <header id="ccHeaderArea" class="ccHeaderArea row p-0 mx-auto">
         @else
@@ -53,14 +54,8 @@
     {{-- 中央エリア --}}
     @php
         // センターエリア任意クラスを抽出（カンマ設定時はランダムで１つ設定）
-        // $center_area_optional_class = null;
-        // if(isset($configs_array['center_area_optional_class'])){
-        //     $classes = explode(',', $configs_array['center_area_optional_class']->value);
-        //     $center_area_optional_class = $classes[array_rand($classes)];
-        // }
         $center_area_optional_class = Configs::getConfigsRandValue($cc_configs, 'center_area_optional_class');
     @endphp
-        {{-- @if (isset($configs_array['browser_width_center']) && $configs_array['browser_width_center']->value == '100%') --}}
         @if (Configs::getConfigsValue($cc_configs, 'browser_width_center') == '100%')
     <div id="ccCenterArea" class="ccCenterArea row mx-auto p-0 d-flex align-items-start {{ $center_area_optional_class }}">
         @else
@@ -114,11 +109,6 @@
     {{-- フッターエリア --}}
     @php
         // フッターエリア任意クラスを抽出（カンマ設定時はランダムで１つ設定）
-        // $footer_area_optional_class = null;
-        // if(isset($configs_array['footer_area_optional_class'])){
-        //     $classes = explode(',', $configs_array['footer_area_optional_class']->value);
-        //     $footer_area_optional_class = $classes[array_rand($classes)];
-        // }
         $footer_area_optional_class = Configs::getConfigsRandValue($cc_configs, 'footer_area_optional_class');
     @endphp
     @if ($layouts_info[4]['exists'])
@@ -152,6 +142,6 @@
     </footer>
     @endif
 
-</div>{{-- /container --}}
+</div>{{-- /container-fluid --}}
 
 @endsection

--- a/resources/views/core/cms_frame_header.blade.php
+++ b/resources/views/core/cms_frame_header.blade.php
@@ -166,14 +166,6 @@ if ($can_edit_frame) {
 
             {{-- 変更画面へのリンク --}}
             <a href="{{url('/')}}/plugin/{{$plugin_instances[$frame->frame_id]->frame->plugin_name}}/{{$plugin_instances[$frame->frame_id]->getFirstFrameEditAction()}}/{{$page->id}}/{{$frame->frame_id}}#frame-{{$frame->frame_id}}" title="{{$plugin_name_full}}設定"><small><i class="fas fa-cog {{$class_header_bg}} cc-font-color"></i></small></a>
-
-{{-- モーダル実装 --}}
-            {{-- 変更画面へのリンク --}}
-{{--
-            <a href="#" data-href="{{URL::to('/')}}/core/frame/edit/{{$page->id}}/{{ $frame->frame_id }}" data-toggle="modal" data-target="#modalDetails"><span class="glyphicon glyphicon-edit {{$class_header_bg}}"></a>
---}}
-
-            {{-- 削除。POSTのためのフォーム --}}
         </div>
 {{--
         @else

--- a/resources/views/plugins/manage/manage.blade.php
+++ b/resources/views/plugins/manage/manage.blade.php
@@ -1,5 +1,7 @@
 {{--
-    管理画面のメインテンプレート
+ * 管理画面のメインテンプレート
+ *
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
 --}}
 {{-- ベース画面 --}}
 @extends('layouts.app')
@@ -7,35 +9,22 @@
 {{-- 管理画面メイン部分への挿入 --}}
 @section('content')
 
+{{-- フラッシュメッセージ ヘッダー表示 --}}
+@include('common.flash_message_for_header')
+
 <div class="container-fluid">
     <div class="row mt-3">
-
         {{-- 管理メニュー --}}
         <aside class="col-lg-2 order-1">
             @include('plugins.manage.menus')
         </aside>
 
         <main class="col-lg-10 order-2" role="main">
-
-<?php
-//    PHPでクラスを呼ぶ際のサンプル
-//    $class_name = "App\ManagePlugins\PageManager\PageManager";
-
-
-//    $class_name = "App\ManagePlugins\\" . $manage_class . "\\" . $manage_class;
-//    $PageManager = new $class_name;
-//    $method = "init";
-//    echo $PageManager->$method(app('request'));
-
-?>
-
             {{-- 管理画面各プラグインの画面内容 --}}
             @yield('manage_content')
-
         </main>
-
     </div>{{-- /row --}}
-</div>{{-- /container --}}
+</div>{{-- /container-fluid --}}
 
 <footer class="container">
     <div class="card border-0 mt-2">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

419エラー時は、自動リダイレクト（NC2と同様の動き）＋入力保持＋画面上部にエラーメッセージ表示で対応します。

### 画面上部にエラーメッセージ表示
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/c9387013-0a24-4804-a218-c8cb901eb2e9)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

要件等

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* セッション切断時にPOST通信をし419エラーになるのを防ぐ方法
https://zenn.dev/yuzuyuzu0830/articles/3952e36dc91705

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
