### PR TITLE
[コア] ページ管理等で共通変数のtop_pageがセットされず毎回再取得していた不具合修正

### DIFF
--- a/app/Http/Controllers/Core/ClassController.php
+++ b/app/Http/Controllers/Core/ClassController.php
@@ -32,8 +32,7 @@ class ClassController extends ConnectController
      */
     public function __construct()
     {
-        // ClassController::invokeGetCore, invokePostCore のみ指定（only）
-        $this->middleware('connect.page')->only(['invokeGetCore', 'invokePostCore']);
+        $this->middleware('connect.page');
     }
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -72,7 +72,7 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
 
-        // Connect-CMS ページ処理（一般プラグインページ用）
+        // Connect-CMS ページ処理（一般プラグインページ, ページ管理等で利用）
         'connect.page' => \App\Http\Middleware\ConnectPage::class,
 
         // Connect-CMS 閲覧パスワードページ処理（一般プラグインページ用）


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

共通変数のtop_pageは、middlewareのconnect.pageでセットされますが、管理画面系は不要と考え除外していました。
しかしページ管理の一覧画面で、継承関係の表示をするために、1ページ1ページで自身を遡ってページツリーを取得する際、共通変数のtop_pageがなく、毎回DBに再取得しに行っていた事が調査でわかったため、修正しました。

また、権限チェックのGate処理時にも、ページを遡る処理があり、同様の状態でした。

対応後は毎回DBに再取得がなくなるため、大量ページのサイトでページ管理の表示が若干早くなります。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
