### PR TITLE
[フォーム] まとめ行を入れ子にするとエラーになる不具合対応

### DIFF
--- a/resources/views/plugins/user/forms/default/forms.blade.php
+++ b/resources/views/plugins/user/forms/default/forms.blade.php
@@ -32,7 +32,7 @@
             <div class="form-group row">
 
                 @switch($form_column->column_type)
-                    @case("group")
+                    @case(FormColumnType::group)
                         @if (isset($is_template_label_sm_4))
                             {{-- label-sm-4テンプレート --}}
                             <label class="col-sm-4 control-label">{{$form_column->column_name}} @if ($form_column->required)<strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger lead' }}">{{__('messages.required')}}</strong> @endif</label>
@@ -54,6 +54,11 @@
                         <div class="col-sm pr-0">
                             <div class="container-fluid row p-0">
                                 @foreach($form_column->group as $group_row)
+                                    @if ($form_column->column_type == FormColumnType::group)
+                                        {{-- まとめ行2重設定エラー --}}
+                                        @include('plugins.user.forms.default.include_error_multiple_group')
+                                        @continue
+                                    @endif
 
                                     {{-- 項目名。ラジオとチェックボックスは選択肢にラベルを使っているため、項目名のラベルにforを付けない。
                                         時間FromToは入力項目のtitleで項目説明しているため、項目名のラベルにforを付けない。--}}

--- a/resources/views/plugins/user/forms/default/forms_confirm.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm.blade.php
@@ -2,6 +2,7 @@
  * 確認画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>, 井上 雅人 <inoue@opensource-workshop.jp / masamasamasato0216@gmail.com>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category フォーム・プラグイン
 --}}
@@ -58,6 +59,12 @@
         @case(FormColumnType::group)
             <div class="form-inline">
                 @foreach($form_column->group as $group_row)
+                    @if ($group_row->column_type == FormColumnType::group)
+                        {{-- まとめ行2重設定エラー --}}
+                        @include('plugins.user.forms.default.include_error_multiple_group')
+                        @continue
+                    @endif
+
                     <label class="control-label" style="vertical-align: top; margin-right: 10px;@if (!$loop->first) margin-left: 30px;@endif">{{$group_row->column_name}}</label>
                     {{-- bugfix: グループ行が各カラムタイプを考慮してなかったため対応 --}}
                     @include('plugins.user.forms.default.forms_confirm_column_' . $group_row->column_type, ['form_obj' => $group_row])

--- a/resources/views/plugins/user/forms/default/include_error_multiple_group.blade.php
+++ b/resources/views/plugins/user/forms/default/include_error_multiple_group.blade.php
@@ -1,0 +1,13 @@
+{{--
+ * まとめ行多重設定エラー表示インクルードテンプレート
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォームプラグイン
+--}}
+{{-- 項目設定権限ありならエラーメッセージ表示 --}}
+@can('buckets.editColumn',[[null, null, null, $frame]])
+    <div class="alert alert-danger">
+        まとめ行が多重に設定されていおり、表示できません。[ <a href="{{url('/')}}/plugin/forms/editColumn/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}">項目設定</a> ]を見直してください。
+    </div>
+@endcan


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1039
上記の不具合対応です。500エラーを出さないようにする＋エラーメッセージ表示をするようにしました。

# 対応後画面
## フォーム入力画面＋項目設定権限あり（まとめ行入れ子エラー）

※ ２つエラーメッセージ表示されるのはご愛敬。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/99390924-8c54-42f0-98bb-0907aaac4020)

※ 権限なしだとエラーメッセージ表示しない。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/99aacd90-1a0c-4372-9045-29f68cc9cec0)

## フォーム確認画面＋項目設定権限あり（まとめ行入れ子エラー）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/cbfb5ff7-48d9-4411-b1d5-6d2d96c04dfc)

## 参考：項目設定（まとめ行入れ子状態）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/463abf35-27e0-48a5-bc0f-4a41d4da36f8)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
