### PR TITLE
[フォーム] まとめ行の必須チェックは一旦させない

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -769,9 +769,10 @@ class FormsPlugin extends UserPluginBase
                     // まとめ行で指定している項目について、バリデータールールをセット
                     $validator_array = $this->getValidatorRule($validator_array, $group_item, $request);
                 }
+            } else {
+                // まとめ行以外の項目について、バリデータールールをセット
+                $validator_array = $this->getValidatorRule($validator_array, $forms_column, $request);
             }
-            // まとめ行以外の項目について、バリデータールールをセット
-            $validator_array = $this->getValidatorRule($validator_array, $forms_column, $request);
         }
 
         // 入力値をトリム


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

まとめ行に必須チェックを設定できるが、まとめ行自体に入力項目がない＋入力時にエラーチェックにひっかかりフォームが登録できない状態でした。
そのため、いったんまとめ行の必須チェックはさせないよう対応しました。
（プログラム内コメントに「まとめ行以外の項目について、バリデータールールをセット」とありましたので、本来はまとめ行の入力チェックをしない事を想定していたと思われます。）

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1037

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
