### PR TITLE
[移行ツール] インポートコマンド実行時、redoオプション未設定でもtargetのデータが消える不具合修正

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -887,7 +887,7 @@ trait MigrationTrait
         $this->putMonitor(3, "importSite() Start.");
 
         // 移行の初期処理
-        if ($added == false) {
+        if ($added == false && $redo === true) {
             $this->clearData($target, true);
         }
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

移行ツールのインポートコマンドにはredo（やり直し）オプションがありますが、未設定でもtargetとなるccデータが全削除されていました。
そのため、redo=trueの時のみクリアするよう修正しました。

## 修正後動作例

```
php artisan command:ImportSite all           ← クリアしないように変更。
php artisan command:ImportSite all redo   ←今までと動作変わらず、クリアされる。
```

## インポートコマンド例
```
$ php artisan command:ImportSite all {redo}  
$ php artisan command:ImportSite uploads {redo}  
$ php artisan command:ImportSite categories {redo}  
$ php artisan command:ImportSite users {redo}  
```

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/wiki/Migration-from-NC2

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
