### PR TITLE
[エラー表示] 同じ項目で2つ以上入力エラーがあった場合に表示できるよう対応

### DIFF
--- a/resources/views/plugins/common/errors_inline.blade.php
+++ b/resources/views/plugins/common/errors_inline.blade.php
@@ -9,5 +9,7 @@
 @endphp
 
 @if ($errors && $errors->has($name))
-    <div class="text-danger {{$class}}"><i class="fas fa-exclamation-triangle"></i> {{$errors->first($name)}}</div>
+    @foreach($errors->get($name) as $error)
+        <div class="text-danger {{$class}}"><i class="fas fa-exclamation-triangle"></i> {{$error}}</div>
+    @endforeach
 @endif


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

・件名通りです。
・通常通り、1項目１入力エラーの表示もいままで通り表示されます。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
