### PR TITLE
[ユーザ管理] 承認完了メールの埋め込みタグに本登録メールと同じものを実装

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2327,17 +2327,16 @@ class UserManage extends ManagePluginBase
 
         // メール送信
         if ($user_register_user_mail_send_flag && $user->email) {
-            // メール件名の組み立て
+            // メール件名
             $subject = Configs::getConfigsValue($configs, 'user_register_approved_mail_subject');
+            // メール本文
+            $mail_format = Configs::getConfigsValue($configs, 'user_register_approved_mail_format');
 
-            // メール件名内のサイト名文字列を置換
-            $subject = str_replace('[[site_name]]', Configs::getConfigsValue($configs, 'base_site_name'), $subject);
+            // 埋め込みタグ
+            $notice_embedded_tags = UsersTool::getNoticeEmbeddedTags($user);
 
-            // メール本文の組み立て
-            $mail_text = Configs::getConfigsValue($configs, 'user_register_approved_mail_format');
-            // メール本文内のサイト名文字列を置換
-            $mail_text = str_replace('[[site_name]]', Configs::getConfigsValue($configs, 'base_site_name'), $mail_text);
-            $mail_text = str_replace('[[login_id]]', $user->userid, $mail_text);
+            $subject = UserRegisterNoticeEmbeddedTag::replaceEmbeddedTags($subject, $notice_embedded_tags);
+            $mail_text = UserRegisterNoticeEmbeddedTag::replaceEmbeddedTags($mail_format, $notice_embedded_tags);
 
             // メールオプション
             $mail_options = ['subject' => $subject, 'template' => 'mail.send'];

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -72,11 +72,11 @@
                 <label class="col-md-3 col-form-label text-md-right pt-0">管理者の承認</label>
                 <div class="col pt-0">
                     <div class="custom-control custom-radio custom-control-inline">
-                        <input type="radio" value="1" id="require_approval_enable" name="user_registration_require_approval" class="custom-control-input" @if ($require_approval === '1') checked="checked" @endif>
+                        <input type="radio" value="1" id="require_approval_enable" name="user_registration_require_approval" class="custom-control-input" @if ($require_approval === '1') checked="checked" @endif data-toggle="collapse" data-target="#collapse_register_approved" aria-expanded="false" aria-controls="collapse_register_approved">
                         <label class="custom-control-label" for="require_approval_enable" id="label_require_approval_enable">必要</label>
                     </div>
                     <div class="custom-control custom-radio custom-control-inline">
-                        <input type="radio" value="0" id="require_approval_disable" name="user_registration_require_approval" class="custom-control-input" @if ($require_approval === '0') checked="checked" @endif>
+                        <input type="radio" value="0" id="require_approval_disable" name="user_registration_require_approval" class="custom-control-input" @if ($require_approval === '0') checked="checked" @endif data-toggle="collapse" data-target="#collapse_register_approved" aria-expanded="false" aria-controls="collapse_register_approved">
                         <label class="custom-control-label" for="require_approval_disable" id="label_require_approval_disable">不要</label>
                     </div>
                     <small class="form-text text-muted">ユーザ登録に管理者の承認が必要か選択してください。</small>
@@ -221,30 +221,25 @@
                 </div>
             </div>
 
-            {{-- 承認完了メール --}}
-            <div class="form-group row" id="div_user_register_approved_mail_subject">
-                <label class="col-md-3 col-form-label text-md-right pt-0">承認完了メール</label>
-                <div class="col">
-                    <label class="control-label">承認完了メール件名</label>
-                    <input type="text" name="user_register_approved_mail_subject" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_approved_mail_subject')}}" class="form-control">
-                    <small class="text-muted">
-                        ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
-                    </small>
+            <div class="collapse" id="collapse_register_approved">
+                {{-- 承認完了メール --}}
+                <div class="form-group row" id="div_user_register_approved_mail_subject">
+                    <label class="col-md-3 col-form-label text-md-right pt-0">承認完了メール</label>
+                    <div class="col">
+                        <label class="control-label">承認完了メール件名</label>
+                        <input type="text" name="user_register_approved_mail_subject" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_approved_mail_subject')}}" class="form-control">
+                    </div>
+                </div>
+
+                <div class="form-group row">
+                    <label class="col-md-3 col-form-label text-md-right"></label>
+                    <div class="col">
+                        <label class="control-label">承認完了メールフォーマット</label>
+                        <textarea name="user_register_approved_mail_format" class="form-control" rows=5 placeholder="（例）ユーザー登録が承認されました。&#13;&#10;登録したログインID、パスワードでログインしてください。&#13;&#10;----------------------------------&#13;&#10;ログインID：[[login_id]]&#13;&#10;----------------------------------">{{Configs::getConfigsValueAndOld($configs, 'user_register_approved_mail_format')}}</textarea>
+                        @include('plugins.manage.user.description_frame_mails', ['users_columns' => $users_columns])
+                    </div>
                 </div>
             </div>
-
-            <div class="form-group row">
-                <label class="col-md-3 col-form-label text-md-right"></label>
-                <div class="col">
-                    <label class="control-label">承認完了メールフォーマット</label>
-                    <textarea name="user_register_approved_mail_format" class="form-control" rows=5 placeholder="（例）ユーザー登録が承認されました。&#13;&#10;登録したログインID、パスワードでログインしてください。&#13;&#10;----------------------------------&#13;&#10;ログインID：[[login_id]]&#13;&#10;----------------------------------">{{Configs::getConfigsValueAndOld($configs, 'user_register_approved_mail_format')}}</textarea>
-                    <small class="text-muted">
-                        ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
-                        ※ [[login_id]] を記述すると該当部分に登録内容が入ります。<br>
-                    </small>
-                </div>
-            </div>
-
 
             {{-- 自動ユーザ登録時に個人情報保護方針への同意を求めるか --}}
             <div class="form-group row" id="div_user_register_requre_privacy">
@@ -366,11 +361,14 @@
 </div>
 
 {{-- 初期状態で開くもの --}}
-@if(Configs::getConfigsValueAndOld($configs, "user_register_temporary_regist_mail_flag") == "1")
-    <script>
-    $('#collapse_register_temporary').collapse({
-        toggle: true
-    })
-    </script>
-@endif
+<script>
+    @if (Configs::getConfigsValueAndOld($configs, "user_register_temporary_regist_mail_flag") == "1")
+        // 仮登録メール件名・本文
+        $('#collapse_register_temporary').collapse('show')
+    @endif
+    @if ($require_approval == "1")
+        // 承認完了メール件名・本文
+        $('#collapse_register_approved').collapse('show')
+    @endif
+</script>
 @endsection


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* いままで承認完了メールは、サイト名・ログインIDの2種類しか埋め込みタグを対応していませんでした。
本登録メールでは、ユーザー名等の他項目も埋め込みタグが利用できましたので、同等の対応をしました。
* 関連対応
  * 管理者の承認(必要・不要)で、不要であれば、承認完了メール件名・本文を非表示するよう対応しました。


# 修正後画面
## ユーザ管理＞自動ユーザ登録設定

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/91df5e1c-5a64-4110-b641-f9a368999250)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
