### PR TITLE
[メッセージ管理] 初回確認メッセージを更新した場合、以前同意済みでも再度初回メッセージを表示する対応 OW-1965

### DIFF
--- a/app/Http/Controllers/Core/CookieCore.php
+++ b/app/Http/Controllers/Core/CookieCore.php
@@ -59,7 +59,7 @@ class CookieCore
     {
         // メッセージ内容
         // 初回メッセージ確認を「表示する」にした場合、「メッセージ内容」が空でもレコードが作成されるため、基本new Carbon()に到達しない想定。
-        $config = Configs::where('name', 'message_first_content')->firstOrNew([]);
+        $config = Configs::firstOrNew(['name' => 'message_first_content']);
         $updated_at = $config->updated_at ?? new Carbon();
 
         return $updated_at->timestamp;

--- a/app/Http/Controllers/Core/CookieCore.php
+++ b/app/Http/Controllers/Core/CookieCore.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Core;
 
-// use App\Http\Controllers\Core\ConnectController;
 use App\Models\Common\Page;
 use App\Models\Core\Configs;
 use Carbon\Carbon;
@@ -17,7 +16,6 @@ use Carbon\Carbon;
  * @category コア
  * @package Controller
  */
-// class CookieController extends ConnectController
 class CookieCore
 {
     /**
@@ -51,7 +49,6 @@ class CookieCore
         $page = Page::where('id', $page_id)->first();
 
         // cookieをセット（cookie名、値、有効期間（分））して、元ページへリダイレクト
-        // return redirect($page->permanent_link)->cookie('connect_cookie_message_first', 'agreed', 525600);
         return redirect($page->permanent_link)->cookie('connect_cookie_message_first', self::getCookieForMessageTimestamp(), 525600);
     }
 

--- a/app/Http/Controllers/Core/CookieCore.php
+++ b/app/Http/Controllers/Core/CookieCore.php
@@ -2,17 +2,10 @@
 
 namespace App\Http\Controllers\Core;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Facades\View;
-
 // use App\Http\Controllers\Core\ConnectController;
-
 use App\Models\Common\Page;
-
-// use App\Traits\ConnectCommonTrait;
+use App\Models\Core\Configs;
+use Carbon\Carbon;
 
 /**
  * Cookie管理
@@ -27,8 +20,6 @@ use App\Models\Common\Page;
 // class CookieController extends ConnectController
 class CookieCore
 {
-    // use ConnectCommonTrait;
-
     /**
      * コンストラクタ
      *
@@ -60,6 +51,20 @@ class CookieCore
         $page = Page::where('id', $page_id)->first();
 
         // cookieをセット（cookie名、値、有効期間（分））して、元ページへリダイレクト
-        return redirect($page->permanent_link)->cookie('connect_cookie_message_first', 'agreed', 525600);
+        // return redirect($page->permanent_link)->cookie('connect_cookie_message_first', 'agreed', 525600);
+        return redirect($page->permanent_link)->cookie('connect_cookie_message_first', self::getCookieForMessageTimestamp(), 525600);
+    }
+
+    /**
+     * メッセージ内容の更新タイムスタンプ取得
+     */
+    public static function getCookieForMessageTimestamp(): int
+    {
+        // メッセージ内容
+        // 初回メッセージ確認を「表示する」にした場合、「メッセージ内容」が空でもレコードが作成されるため、基本new Carbon()に到達しない想定。
+        $config = Configs::where('name', 'message_first_content')->firstOrNew([]);
+        $updated_at = $config->updated_at ?? new Carbon();
+
+        return $updated_at->timestamp;
     }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -343,8 +343,7 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
         $message_first_exclued_urls = explode(',', Configs::getConfigsValue($cc_configs, 'message_first_exclued_url', ''));
         $message_first_optional_class = Configs::getConfigsValue($cc_configs, 'message_first_optional_class', '');
     @endphp
-    {{-- 管理画面で設定ON、且つ、本ページが初回確認メッセージ表示の除外URL以外、且つ、同意していない（Cookie未セット or Cookieありで初回メッセージの更新日より古い）場合にメッセージ表示 --}}
-    {{-- @if($message_first_show_type == ShowType::show && isset($page) && !in_array($page->permanent_link ,$message_first_exclued_urls) && (!Cookie::has('connect_cookie_message_first') || Cookie::get('connect_cookie_message_first') != 'agreed')) --}}
+    {{-- 管理画面で設定ON、且つ、本ページが初回確認メッセージ表示の除外URL以外、且つ、（Cookie未セット or Cookieありで初回メッセージの更新日より古い）場合にメッセージ表示 --}}
     @if ($message_first_show_type == ShowType::show && isset($page) && !in_array($page->permanent_link ,$message_first_exclued_urls) && (!Cookie::has('connect_cookie_message_first') || Cookie::get('connect_cookie_message_first') < CookieCore::getCookieForMessageTimestamp()))
         <!-- 初回確認メッセージ表示用のモーダルウィンドウ -->
         <div class="modal {{ $message_first_optional_class }}" id="first_message_modal" tabindex="-1" role="dialog" aria-labelledby="first_message_modal_label" aria-hidden="true" data-backdrop="{{ $message_first_permission_type == PermissionType::not_allowed ? 'static' : 'true' }}">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,22 +21,6 @@ use App\Http\Controllers\Core\CookieCore;
         $is_manage_page = true;
     }
 
-/*
-    // トップページの判定
-    if (empty($current_permanent_link)) {
-        $current_permanent_link = "/";
-    }
-
-    // URL パスでPage テーブル検索
-    $current_page = \App\Page::where('permanent_link', '=', $current_permanent_link)->first();
-*/
-/*
-    // ページ一覧の取得
-    $class_name = "App\Page";
-    $page_obj = new $class_name;
-    //$menu_pages = $page_obj::orderBy('display_sequence')->get();
-    $menu_pages = $page_obj::defaultOrderWithDepth();
-*/
 if (! isset($cc_configs)) {
     // cc_configsは app\Http\Middleware\ConnectInit.php で処理しているため、基本ここには入らない。
     // .envのAPP_KEYに"xxxx"とダブルクォートで囲むと`php artisan key:generate`しても変換されない＋APP_DEBUG=falseで、cc_configsなしでここに到達する。
@@ -47,22 +31,12 @@ if (! isset($cc_configs)) {
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
 <head>
-{{--
-@if(isset($configs_array['tracking_code']))
-    {!!$configs_array['tracking_code']->value!!}
-@endif
---}}
 @if (Configs::getConfigsValue($cc_configs, 'tracking_code'))
     {!!Configs::getConfigsValue($cc_configs, 'tracking_code')!!}
 @endif
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-{{--
-@if(isset($configs_array['description']))
-    <meta name="description" content="{{$configs_array['description']->getNobrValue()}}">
-@endif
---}}
 @if (Configs::getConfigsValue($cc_configs, 'description'))
     <meta name="description" content="{{ StringUtils::getNobrValue(Configs::getConfigsValue($cc_configs, 'description')) }}">
 @endif
@@ -91,7 +65,6 @@ if (! isset($cc_configs)) {
 
     <!-- tempusdominus-bootstrap-4 -->
     <link rel="stylesheet" href="{{asset('css/tempusdominus-bootstrap-4/tempusdominus-bootstrap-4.min.css')}}" />
-
 
     <!-- Connect-CMS Global CSS -->
     <link href="{{ asset('css/connect.css') }}?version={{ filemtime(public_path() . "/css/connect.css") }}" rel="stylesheet">
@@ -136,43 +109,23 @@ if (! isset($cc_configs)) {
     </script>
 
     <!-- Favicon -->
-    {{--  @if (isset($configs_array) && isset($configs_array['favicon'])) --}}
     @if (Configs::getConfigsValue($cc_configs, 'favicon'))
         <link href="{{url('/')}}/uploads/favicon/favicon.ico" rel="SHORTCUT ICON" />
     @endif
 </head>
 @php
 // body任意クラスを抽出（カンマ設定時はランダムで１つ設定）
-// $body_optional_class = null;
-// if (isset($configs_array['body_optional_class'])) {
-//     $classes = explode(',', $configs_array['body_optional_class']->value);
-//     $body_optional_class = $classes[array_rand($classes)];
-// }
 $body_optional_class = Configs::getConfigsRandValue($cc_configs, 'body_optional_class');
 
 // ヘッダーバーnavの文字色クラス
 // change: 管理画面ではviewに共通的に変数をセットする仕組みがあったため、管理画面・一般画面どちらも表示するためにここで再度Configsをgetした(苦肉の策)を、共通の$cc_configsを参照するよう見直し
-//$base_header_font_color_class = Configs::getConfigsValue($configs, 'base_header_font_color_class', BaseHeaderFontColorClass::navbar_dark);
-// if (isset($configs) && isset($configs['base_header_font_color_class'])) {
-//     $base_header_font_color_class = $configs['base_header_font_color_class'];
-// } else {
-//     $base_header_font_color_class = BaseHeaderFontColorClass::navbar_dark;
-// }
-// $config_basic_header = Configs::where('category', 'general')->get();
 $base_header_font_color_class = Configs::getConfigsValue($cc_configs, 'base_header_font_color_class', BaseHeaderFontColorClass::navbar_dark);
 
 // ヘッダーバー任意クラスを抽出（カンマ設定時はランダムで１つ設定）
-// $base_header_optional_class = Configs::getConfigsValue($cc_configs, 'base_header_optional_class', null);
-// $base_header_classes = explode(',', $base_header_optional_class);
-// $base_header_optional_class = $base_header_classes[array_rand($base_header_classes)];
 $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_header_optional_class');
 
 @endphp
 <body class="@if(isset($page)){{$page->getPermanentlinkClassname()}}@endif {{ $body_optional_class }}">
-{{--
-@if (Auth::check() || (isset($configs) && isset($configs['base_header_hidden']) && ($configs['base_header_hidden'] != '1')))
-<nav class="navbar navbar-expand-md bg-dark {{$base_header_font_color_class}} @if (isset($configs) && ($configs['base_header_fix'] == '1')) sticky-top @endif {{ $base_header_optional_class }}" aria-label="ヘッダー">
---}}
 @if (Auth::check() || Configs::getConfigsValue($cc_configs, 'base_header_hidden') != '1')
 <nav class="navbar navbar-expand-md bg-dark {{$base_header_font_color_class}} @if (Configs::getConfigsValue($cc_configs, 'base_header_fix') == '1') sticky-top @endif {{ $base_header_optional_class }}" aria-label="ヘッダー">
     <!-- Branding Image -->
@@ -196,17 +149,9 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                 @foreach($page_list as $page_obj)
 
                     {{-- スマホメニューテンプレート(default) --}}
-                    {{--
-                    @if (isset($configs) &&
-                            (!isset($configs['smartphone_menu_template']) ||
-                                (isset($configs['smartphone_menu_template']) && ($configs['smartphone_menu_template'] == ''))
-                            )
-                        )
-                    --}}
                     @if (Configs::getConfigsValue($cc_configs, 'smartphone_menu_template', '') == '')
                         {{-- default メニュー --}}
                         @include('layouts.default_menu')
-                    {{-- @elseif (isset($configs) && isset($configs['smartphone_menu_template']) && ($configs['smartphone_menu_template'] == 'opencurrenttree')) --}}
                     @elseif (Configs::getConfigsValue($cc_configs, 'smartphone_menu_template') == 'opencurrenttree')
                         {{-- opencurrenttree メニュー --}}
                         @include('layouts.opencurrenttree_menu')
@@ -284,7 +229,6 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
             @endif
 
             @guest
-                {{-- @if (isset($configs['base_header_login_link']) && ($configs['base_header_login_link'] == '1')) --}}
                 @if (Configs::getConfigsValue($cc_configs, 'base_header_login_link') == '1')
                     @php
                         // 外部認証設定 取得
@@ -297,8 +241,6 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                         <li><a class="nav-link" href="{{ route('show_login_form') }}">{{config('connect.LOGIN_STR')}}</a></li>
                     @endif
                 @endif
-                {{-- @if (isset($configs['user_register_enable']) && ($configs['user_register_enable'] == '1')) --}}
-                {{-- @if (Configs::getConfigsValue($cc_configs, 'user_register_enable') == '1') --}}
                 @php
                     $user_register_enables = $cc_configs->where('category', 'user_register')
                         ->where('name', 'user_register_enable')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,14 +8,14 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category メニュープラグイン
 --}}
-{{-- ページ名 --}}
 <?php
+use App\Http\Controllers\Core\CookieCore;
+
     // URL から現在のURL パスを判定する。
     $current_url = url()->current();
     $base_url = url('/');
     $current_permanent_link = str_replace( $base_url, '', $current_url);
     $current_permanent_links = explode('/', $current_permanent_link);
-    // print_r($current_permanent_links);
     $is_manage_page = false;
     if (!empty($current_permanent_links) && count($current_permanent_links) > 1 && $current_permanent_links[1] == 'manage') {
         $is_manage_page = true;
@@ -396,26 +396,20 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
     {{-- 初回確認メッセージの表示モーダル --}}
     @php
         // Configsテーブルから設定値を取得
-        // $message_first_show_type = isset($configs_array['message_first_show_type']) ? $configs_array['message_first_show_type']->value : 0;
-        // $message_first_permission_type = isset($configs_array['message_first_permission_type']) ? $configs_array['message_first_permission_type']->value : 0;
-        // $message_first_exclued_urls = isset($configs_array['message_first_exclued_url']) ? explode(',' ,$configs_array['message_first_exclued_url']->value) : array();
-        // $message_first_optional_class = isset($configs_array['message_first_optional_class']) ? $configs_array['message_first_optional_class']->value : '';
         $message_first_show_type = Configs::getConfigsValue($cc_configs, 'message_first_show_type', 0);
         $message_first_permission_type = Configs::getConfigsValue($cc_configs, 'message_first_permission_type', 0);
         $message_first_exclued_urls = explode(',', Configs::getConfigsValue($cc_configs, 'message_first_exclued_url', ''));
         $message_first_optional_class = Configs::getConfigsValue($cc_configs, 'message_first_optional_class', '');
-        // dd($message_first_show_type, $message_first_permission_type, $message_first_exclued_urls, $message_first_optional_class, !in_array($page->permanent_link ,$message_first_exclued_urls), Cookie::get('connect_cookie_message_first'));
     @endphp
-    {{-- 管理画面で設定ON、且つ、本ページが初回確認メッセージ表示の除外URL以外、且つ、同意していない（Cookie未セット）場合にメッセージ表示 --}}
-    @if($message_first_show_type == ShowType::show && isset($page) && !in_array($page->permanent_link ,$message_first_exclued_urls) && Cookie::get('connect_cookie_message_first') != 'agreed')
-
+    {{-- 管理画面で設定ON、且つ、本ページが初回確認メッセージ表示の除外URL以外、且つ、同意していない（Cookie未セット or Cookieありで初回メッセージの更新日より古い）場合にメッセージ表示 --}}
+    {{-- @if($message_first_show_type == ShowType::show && isset($page) && !in_array($page->permanent_link ,$message_first_exclued_urls) && (!Cookie::has('connect_cookie_message_first') || Cookie::get('connect_cookie_message_first') != 'agreed')) --}}
+    @if ($message_first_show_type == ShowType::show && isset($page) && !in_array($page->permanent_link ,$message_first_exclued_urls) && (!Cookie::has('connect_cookie_message_first') || Cookie::get('connect_cookie_message_first') < CookieCore::getCookieForMessageTimestamp()))
         <!-- 初回確認メッセージ表示用のモーダルウィンドウ -->
         <div class="modal {{ $message_first_optional_class }}" id="first_message_modal" tabindex="-1" role="dialog" aria-labelledby="first_message_modal_label" aria-hidden="true" data-backdrop="{{ $message_first_permission_type == PermissionType::not_allowed ? 'static' : 'true' }}">
             <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
                 <div class="modal-content">
                     <div class="modal-body">
                         {{-- メッセージ内容 --}}
-                        {{-- $configs_array['message_first_content']->value --}}
                         {!! Configs::getConfigsValue($cc_configs, 'message_first_content') !!}
                     </div>
                     <div class="modal-footer">
@@ -424,7 +418,6 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
 
                             {{-- ボタン --}}
                             <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submit_form_set_cookie();">
-                                {{-- $configs_array['message_first_button_name']->value --}}
                                 {{ Configs::getConfigsValue($cc_configs, 'message_first_button_name') }}
                             </button>
                         </form>

--- a/resources/views/plugins/manage/message/message.blade.php
+++ b/resources/views/plugins/manage/message/message.blade.php
@@ -71,7 +71,10 @@
             <div class="form-group">
                 <label class="control-label">メッセージ内容</label>
                 <textarea name="message_first_content" class="form-control" rows=5 placeholder="（例）当サイトではトラフィック分析を目的として、クッキー(Cookie)を利用しています。当サイトの閲覧を続けた場合、クッキーの利用に同意いただいたことになります。詳しくはプライバシーポリシーをご覧ください。">{{ Configs::getConfigsValueAndOld($configs, 'message_first_content', null) }}</textarea>
-                <small class="form-text text-muted">※ポップアップに表示するメッセージを設定します。HTML入力が可能です。scriptタグは使用できません。</small>
+                <small class="form-text text-muted">
+                    ※ポップアップに表示するメッセージを設定します。HTML入力が可能です。scriptタグは使用できません。<br />
+                    ※メッセージ内容を変更した場合、すでに同意済みの訪問者にも再度ポップアップメッセージを表示します。
+                </small>
             </div>
 
             {{-- ボタン名 --}}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

初回確認メッセージは、サイト表示時にクッキー情報の利用などの同意を確認するために使える機能です。
メッセージ内容は、変更されることがありますが、変更したら以前同意した人にも再度同意をする必要があるため、当対応をしました。

# 動作

* 「メッセージ内容 `message_first_content`」の更新日のタイムスタンプをクッキーにセット
* 「メッセージ内容」の更新日のタイムスタンプより、クッキーのタイムスタンプが古ければ、再度メッセージ表示
  * クッキーのタイムスタンプが古いチェックは `Cookie::get('connect_cookie_message_first') < CookieCore::getCookieForMessageTimestamp()` でやっていて、同意済みの古いクッキーの値 'agreed' を比較すると `'agreed' < タイムスタンプのint値`  で 文字列はintに暗黙キャストで `0 < タイムスタンプのint値` と比較されてtrueで、再度メッセージが表示されることを確認済み。
    * クッキーのタイムスタンプが古いチェック
    https://github.com/opensource-workshop/connect-cms/pull/1946/files#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7R348
* 備考
  * 初回確認メッセージ画面で、「メッセージ内容」が1文字も変わらなければ、「メッセージ内容」の更新日は変わらない。
  * 「メッセージ内容」が空でも、DBレコードは出来るため、「メッセージ内容」の更新日は取得可能。


# 動作テスト


https://github.com/opensource-workshop/connect-cms/assets/2756509/e426a2e1-8f86-4970-a7f3-ee92a2e0f79b

# (1/23追記)初回確認メッセージ画面

「メッセージ内容」下部にコメント追記しました。
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/0edb6f65-6b37-40b5-b7a4-ed9d79f66e58)



# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

軽微な改修なので急ぎません

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
