### PR TITLE
[パスワードリセット] 新しいパスワードの項目名をプロフィール変更と同じに見直し

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,9 +1,17 @@
+{{--
+ * パスワードリセット
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category パスワードリセット
+--}}
 @extends('layouts.app')
 
 @section('content')
 <main class="container" role="main">
     <div class="row mt-3">
-        <div class="col-8 mx-auto">
+        <div class="col-12 mx-auto">
             <div class="card">
                 <div class="card-header">{{-- Reset Password --}}パスワード リセット</div>
 
@@ -20,17 +28,13 @@
                         <div class="form-group row">
                             <label for="userid" class="col-md-3 col-form-label text-md-right">eメール</label>
                             <div class="col-md-7">
-                                <input id="email" type="text" class="form-control" name="email" value="{{ old('email') }}" required>
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
+                                <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email') }}" required>
+                                @include('plugins.common.errors_inline', ['name' => 'email'])
                             </div>
                         </div>
 
                         <div class="form-group row">
-                            <div class="col-md-8 offset-md-3">
+                            <div class="col-md-9 offset-md-3">
                                 <button type="submit" class="btn btn-primary">
                                     <i class="fas fa-check"></i> パスワードのリセットリンクを送信する。
                                 </button>

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,61 +1,51 @@
+{{--
+ * リセットパスワード
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category パスワードリセット
+--}}
 @extends('layouts.app')
 
 @section('content')
 <main class="container" role="main">
     <div class="row mt-3">
-        <div class="col-8 mx-auto">
+        <div class="col-12 mx-auto">
             <div class="card">
                 <div class="card-header">{{-- Reset Password --}}リセット パスワード</div>
 
                 <div class="card-body">
                     <form class="form-horizontal" method="POST" action="{{ route('password.request') }}">
                         {{ csrf_field() }}
-
                         <input type="hidden" name="token" value="{{ $token }}">
 
-                        <div class="row form-group{{ $errors->has('email') ? ' has-error' : '' }}">
+                        <div class="row form-group">
                             <label for="email" class="col-md-3 col-form-label text-md-right">{{-- E-Mail Address --}}eメール</label>
-
                             <div class="col-md-7">
-                                <input id="email" type="text" class="form-control" name="email" value="{{ $email or old('email') }}" required autofocus>
-
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="row form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label for="password" class="col-md-3 col-form-label text-md-right">{{-- Password --}}パスワード</label>
-
-                            <div class="col-md-7">
-                                <input id="password" type="password" class="form-control" name="password" required>
-
-                                @if ($errors->has('password'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="row form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
-                            <label for="password-confirm" class="col-md-3 col-form-label text-md-right">{{-- Confirm Password --}}確認用パスワード</label>
-                            <div class="col-md-7">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
-
-                                @if ($errors->has('password_confirmation'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
-                                    </span>
-                                @endif
+                                <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ $email or old('email') }}" required autofocus>
+                                @include('plugins.common.errors_inline', ['name' => 'email'])
                             </div>
                         </div>
 
                         <div class="row form-group">
-                            <div class="col-md-7 offset-md-3">
+                            <label for="password" class="col-md-3 col-form-label text-md-right">{{-- Password --}}新しいパスワード</label>
+                            <div class="col-md-7">
+                                <input id="password" type="password" class="form-control @if ($errors->has('password')) border-danger @endif" name="password" required>
+                                @include('plugins.common.errors_inline', ['name' => 'password'])
+                            </div>
+                        </div>
+
+                        <div class="row form-group">
+                            <label for="password-confirm" class="col-md-3 col-form-label text-md-right">{{-- Confirm Password --}}新しいパスワードの確認</label>
+                            <div class="col-md-7">
+                                <input id="password-confirm" type="password" class="form-control @if ($errors->has('password_confirmation')) border-danger @endif" name="password_confirmation" required>
+                                @include('plugins.common.errors_inline', ['name' => 'password_confirmation'])
+                            </div>
+                        </div>
+
+                        <div class="row form-group">
+                            <div class="col-md-9 offset-md-3">
                                 <button type="submit" class="btn btn-primary">
                                     <i class="fas fa-check"></i> {{-- Reset Password --}}パスワードリセット
                                 </button>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 件名通りです。
* 関連修正
  * 入力エラー時の表示を共通部品を使う

# 変更後画面
## リセットパスワード

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/eecad0f3-d9d7-49dc-aac4-75fc1ae2b962)

## パスワードリセット
![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/d6a3da54-3fb2-42a3-ba5a-ea22bd93ba91)


## (参考) マイページ＞プロフィール変更

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/f5c44371-d986-4289-9f7e-ca3c32c7b6a4)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
