### PR TITLE
[wysiwyg] インストール時「初期に選択させる画像サイズ」を小に変更

### DIFF
--- a/app/Enums/ResizedImageSize.php
+++ b/app/Enums/ResizedImageSize.php
@@ -44,7 +44,7 @@ final class ResizedImageSize extends EnumsBase
      */
     public static function getDefault()
     {
-        return self::asis;
+        return self::small;
     }
 
     /**

--- a/resources/views/plugins/manage/site/pdf/base_wysiwyg.blade.php
+++ b/resources/views/plugins/manage/site/pdf/base_wysiwyg.blade.php
@@ -21,11 +21,9 @@
     </tr>
     <tr nobr="true">
         <td>初期に選択させる画像サイズ</td>
-        @if (Configs::getConfigsValue($configs, 'resized_image_size_initial', null) == '1200') <td>大(1200px)</td>
-        @elseif (Configs::getConfigsValue($configs, 'resized_image_size_initial', null) == '800') <td>中(800px)</td>
-        @elseif (Configs::getConfigsValue($configs, 'resized_image_size_initial', null) == '400') <td>小(400px)</td>
-        @elseif (Configs::getConfigsValue($configs, 'resized_image_size_initial', null) == '200') <td>極小(200px)</td>
-        @else <td>原寸(以下の幅、高さ)</td>
-        @endif
+        @php
+            $resized_image_size_initial = Configs::getConfigsValue($configs, "resized_image_size_initial", ResizedImageSize::getDefault());
+        @endphp
+        <td>{{ ResizedImageSize::getDescription($resized_image_size_initial) }}</td>
     </tr>
 </table>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

今まで、Connect-CMSをインストール時にSeederで設定している、wysiwygの初期画像サイズは「原寸大」でした。
wysiwygは、固定記事やブログ、掲示板等、多岐にわたり利用されるワープロ機能ですが、意識せず画像を「原寸大」のままアップロードし続けると、サーバーのディスク容量を圧迫します。

そのため、学校ブログでアップロードされる画像サイズを考慮して、初期画像サイズを「小」に変更しました。

※ インストール時にDB設定される値（Seeder）の変更ですので、すでにインストール済みConnect-CMSには影響ありません。
※ インストール後は、管理者メニューから初期画像サイズを変更できます。https://manual.connect-cms.jp/manage/site/wysiwyg/index.html

## 画像サイズ参考

原寸 1.83MB jpg
大  214KB
中  112KB
小   38KB
極小 13KB

### 原寸 1.83MB jpg
![写真 2015-08-09 9 24 07](https://github.com/opensource-workshop/connect-cms/assets/2756509/0cfe6f99-7df4-4bce-931c-69f531510471)

### 大  214KB
![大](https://github.com/opensource-workshop/connect-cms/assets/2756509/5fdc8013-0d69-4af6-838e-95e761e8002b)

### 中  112KB
![中](https://github.com/opensource-workshop/connect-cms/assets/2756509/04c9a37b-dbd2-4873-91ce-8a78b6c55f1a)

###  小   38KB
![小](https://github.com/opensource-workshop/connect-cms/assets/2756509/917d7a6c-6b0a-4734-bd96-ccfaf26ca04d)

###  極小 13KB
![極小](https://github.com/opensource-workshop/connect-cms/assets/2756509/984ea704-8a5b-4789-980b-25a4aabdc18b)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
