### PR TITLE
[ユーザ登録] 登録後の自動ログイン

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1398,6 +1398,15 @@ class UserManage extends ManagePluginBase
             ]
         );
 
+        // 自動ユーザ登録後の自動ログイン
+        $configs = Configs::updateOrCreate(
+            ['name' => 'user_register_auto_login_flag', 'additional1' => $id],
+            [
+                'category' => 'user_register',
+                'value' => $request->user_register_auto_login_flag
+            ]
+        );
+
         // 以下のアドレスにメール送信する
         $configs = Configs::updateOrCreate(
             ['name' => 'user_register_mail_send_flag', 'additional1' => $id],

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -83,6 +83,22 @@
                 </div>
             </div>
 
+            <!-- 自動ユーザ登録後の自動ログイン -->
+            <div class="form-group row">
+                <label class="col-md-3 col-form-label text-md-right pt-0">自動ユーザ登録後の自動ログイン</label>
+                <div class="col pt-0">
+                    @foreach (PermissionType::getMembers() as $enum_value => $enum_label)
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="{{$enum_value}}" id="user_register_auto_login_flag{{$loop->iteration}}" name="user_register_auto_login_flag" class="custom-control-input" @if(Configs::getConfigsValueAndOld($configs, 'user_register_auto_login_flag', '0') == $enum_value) checked @endif>
+                            <label class="custom-control-label" for="user_register_auto_login_flag{{$loop->iteration}}">{{$enum_label}}</label>
+                        </div>
+                    @endforeach
+                    <small class="form-text text-muted">
+                        ※ 許可した場合、自動ユーザ登録を行ったユーザは、登録後に自動ログインします。<br />
+                    </small>
+                </div>
+            </div>
+
             {{-- 自動ユーザ登録時に以下のアドレスにメール送信する --}}
             <div class="form-group row">
                 <label class="col-md-3 col-form-label text-md-right pt-0">メール送信先</label>

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -122,7 +122,7 @@
                     <label class="col-form-label">送信するメールアドレス（複数ある場合はカンマで区切る）</label>
                     <input type="text" name="user_register_mail_send_address" value="{{Configs::getConfigsValueAndOld($configs, 'user_register_mail_send_address')}}" class="form-control">
                     <small class="form-text text-muted">自動ユーザ登録時に管理者や担当者等に通知するメールアドレスを設定</small>
-                    @if ($errors && $errors->has('user_register_mail_send_address')) <div class="text-danger">{{$errors->first('user_register_mail_send_address')}}</div> @endif
+                    @include('plugins.common.errors_inline', ['name' => 'user_register_mail_send_address'])
                 </div>
             </div>
 
@@ -139,10 +139,9 @@
                         @endif
                         <label class="custom-control-label" for="user_register_user_mail_send_flag">登録者にメール送信する</label>
                     </div>
-                    @if ($errors && $errors->has('user_register_user_mail_send_flag')) <div class="text-danger">{{$errors->first('user_register_user_mail_send_flag')}}</div> @endif
+                    @include('plugins.common.errors_inline', ['name' => 'user_register_user_mail_send_flag'])
                 </div>
             </div>
-
 
             <div class="form-group row">
                 <label class="col-md-3 col-form-label text-md-right pt-0">仮登録メール</label>
@@ -187,7 +186,7 @@
                             ※ [[site_name]] を記述すると該当部分にサイト名が入ります。<br>
                             ※ [[body]] を記述すると該当部分に登録内容が入ります。
                         </small>
-                        @if ($errors && $errors->has('user_register_temporary_regist_mail_format')) <div class="text-danger">{{$errors->first('user_register_temporary_regist_mail_format')}}</div> @endif
+                        @include('plugins.common.errors_inline', ['name' => 'user_register_temporary_regist_mail_format'])
                     </div>
                 </div>
 

--- a/resources/views/plugins/manage/user/auto_regist.blade.php
+++ b/resources/views/plugins/manage/user/auto_regist.blade.php
@@ -41,22 +41,12 @@
             <div class="form-group row">
                 <label class="col-md-3 col-form-label text-md-right pt-0">自動ユーザ登録の使用</label>
                 <div class="col pt-0">
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if(Configs::getConfigsValueAndOld($configs, "user_register_enable") == "1")
-                            <input type="radio" value="1" id="user_register_enable_on" name="user_register_enable" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="1" id="user_register_enable_on" name="user_register_enable" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="user_register_enable_on" id="label_user_register_enable_on">許可する</label>
-                    </div>
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if(Configs::getConfigsValueAndOld($configs, "user_register_enable") == "0")
-                            <input type="radio" value="0" id="user_register_enable_off" name="user_register_enable" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="0" id="user_register_enable_off" name="user_register_enable" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="user_register_enable_off" id="label_user_register_enable_off">許可しない</label>
-                    </div>
+                    @foreach (PermissionType::getMembers() as $enum_value => $enum_label)
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="{{$enum_value}}" id="user_register_enable{{$loop->iteration}}" name="user_register_enable" class="custom-control-input" @if(Configs::getConfigsValueAndOld($configs, 'user_register_enable', '0') == $enum_value) checked @endif>
+                            <label class="custom-control-label" for="user_register_enable{{$loop->iteration}}">{{$enum_label}}</label>
+                        </div>
+                    @endforeach
                     <small class="form-text text-muted">
                         ※ 自動ユーザ登録を使用するかどうかを選択<br />
                         ※ 自動ユーザ登録時に登録させる項目は [ <a href="{{ url('/manage/user/editColumns/'. $columns_set_id) }}">項目設定</a> ] の「詳細」からそれぞれ設定してください。<br />
@@ -72,12 +62,12 @@
                 <label class="col-md-3 col-form-label text-md-right pt-0">管理者の承認</label>
                 <div class="col pt-0">
                     <div class="custom-control custom-radio custom-control-inline">
-                        <input type="radio" value="1" id="require_approval_enable" name="user_registration_require_approval" class="custom-control-input" @if ($require_approval === '1') checked="checked" @endif data-toggle="collapse" data-target="#collapse_register_approved" aria-expanded="false" aria-controls="collapse_register_approved">
-                        <label class="custom-control-label" for="require_approval_enable" id="label_require_approval_enable">必要</label>
-                    </div>
-                    <div class="custom-control custom-radio custom-control-inline">
                         <input type="radio" value="0" id="require_approval_disable" name="user_registration_require_approval" class="custom-control-input" @if ($require_approval === '0') checked="checked" @endif data-toggle="collapse" data-target="#collapse_register_approved" aria-expanded="false" aria-controls="collapse_register_approved">
                         <label class="custom-control-label" for="require_approval_disable" id="label_require_approval_disable">不要</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        <input type="radio" value="1" id="require_approval_enable" name="user_registration_require_approval" class="custom-control-input" @if ($require_approval === '1') checked="checked" @endif data-toggle="collapse" data-target="#collapse_register_approved" aria-expanded="false" aria-controls="collapse_register_approved">
+                        <label class="custom-control-label" for="require_approval_enable" id="label_require_approval_enable">必要</label>
                     </div>
                     <small class="form-text text-muted">ユーザ登録に管理者の承認が必要か選択してください。</small>
                 </div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

下記対応です。
* https://github.com/opensource-workshop/connect-cms-ideas/issues/167
* 関連対応
  * [change: 自動ユーザ登録設定, 項目の入力エラー表示で共通部品を使う](https://github.com/opensource-workshop/connect-cms/pull/1952/commits/9b5814debf7f8738a881b5c511d5eb4dbada39db)
  * [change: 自動ユーザ登録設定, ラジオでON・OFF時、左側はOFFで統一する](https://github.com/opensource-workshop/connect-cms/pull/1952/commits/299475815762991e2fdf42457db0198fcfeb1ffa) 
  https://github.com/opensource-workshop/connect-cms/issues/737

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
