### PR TITLE
[Utils] setlocale()のwin & linux対応

### DIFF
--- a/app/Models/Common/Uploads.php
+++ b/app/Models/Common/Uploads.php
@@ -34,10 +34,7 @@ class Uploads extends Model
      */
     public function getFilename()
     {
-        // 環境によってはsetlocale しておかないと、ファイル名がうまくpathinfo で取得できなかった。
-        // 2020-12-15 Connect-CMS 公式サイトで、ファイル名が空になったり一部しか取得できないケースがあった。
-        // false を返すことなどもあるようで、ワーニングの抑止の意味も含めて @ 付きでCall
-        @setlocale(LC_ALL, 'ja_JP.UTF-8');
+        FileUtils::setLocale();
         return $path_parts = pathinfo($this->client_original_name, PATHINFO_FILENAME);
     }
 

--- a/app/Plugins/Manage/CodeManage/CodeManage.php
+++ b/app/Plugins/Manage/CodeManage/CodeManage.php
@@ -862,7 +862,6 @@ class CodeManage extends ManagePluginBase
         ]);
 
         if ($validator->fails()) {
-            // Log::debug(var_export($validator->errors(), true));
             // エラーと共に編集画面を呼び出す
             return redirect()->back()->withErrors($validator)->withInput();
         }
@@ -870,14 +869,12 @@ class CodeManage extends ManagePluginBase
 
         // CSVファイル一時保存
         $path = $request->file('codes_csv')->store('tmp');
-        // Log::debug(var_export(storage_path('app/') . $path, true));
         $csv_full_path = storage_path('app/') . $path;
 
         // ファイル拡張子取得
         $file_extension = $request->file('codes_csv')->getClientOriginalExtension();
         // 小文字に変換
         $file_extension = strtolower($file_extension);
-        // Log::debug(var_export($file_extension, true));
 
         // 文字コード
         $character_code = $request->character_code;
@@ -905,15 +902,7 @@ class CodeManage extends ManagePluginBase
             $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
         }
 
-        // ・fgetcsv() は ロケール設定の影響を受け、xampp環境＋日本語文字列で誤動作したため、ロケール設定する。
-        //
-        // [詳細]
-        // ・xampp環境のロケールは、LC_CTYPE=Japanese_Japan.932 でした。
-        //   これだと、「ド」の次のカンマが認識できなくなり 1カラム 'コード,値' で誤認識される。また末尾改行の処理も誤動作おこしました。
-        //   \Log::debug(var_export(setlocale(LC_ALL, "0"), true));
-        //   [2021-05-07 17:26:12] local.DEBUG: 'LC_COLLATE=C;LC_CTYPE=Japanese_Japan.932;LC_MONETARY=C;LC_NUMERIC=C;LC_TIME=C'
-        // ・fgetcsv() https://www.php.net/manual/ja/function.fgetcsv.php
-        setlocale(LC_ALL, 'ja_JP.UTF-8');
+        CsvUtils::setLocale();
 
         // 一行目（ヘッダ）
         $header_columns = fgetcsv($fp, 0, ',');
@@ -922,11 +911,6 @@ class CodeManage extends ManagePluginBase
             // UTF-8のみBOMコードを取り除く
             $header_columns = CsvUtils::removeUtf8Bom($header_columns);
         }
-        // [debug]
-        // fclose($fp);
-        // Storage::delete($path);
-        // \Log::debug('$header_columns:'. var_export($header_columns, true));
-        // dd($csv_full_path);
 
         // カラムの取得
         $code_columns = CodeColumn::getImportColumn();
@@ -967,11 +951,6 @@ class CodeManage extends ManagePluginBase
             return redirect()->back()->withErrors(['codes_csv' => $error_msgs])->withInput();
         }
 
-        // // 一時ファイルの削除
-        // fclose($fp);
-        // Storage::delete($path);
-        // dd('ここまで');
-
         // ファイルポインタの位置を先頭に戻す
         rewind($fp);
 
@@ -986,7 +965,6 @@ class CodeManage extends ManagePluginBase
         // データ
         while (($csv_columns = fgetcsv($fp, 0, ',')) !== false) {
             // --- 入力値変換
-            // Log::debug(var_export($csv_columns, true));
 
             // 入力値をトリム(preg_replace(/u)で置換. /u = UTF-8 として処理)
             $csv_columns = StringUtils::trimInput($csv_columns);
@@ -1001,12 +979,6 @@ class CodeManage extends ManagePluginBase
                 // 空文字をnullに変換
                 $csv_column = StringUtils::convertEmptyStringsToNull($csv_column);
             }
-            // Log::debug('$csv_columns:'. var_export($csv_columns, true));
-
-            // 一時ファイルの削除
-            // fclose($fp);
-            // Storage::delete($path);
-            // dd('ここまで' . $posted_at);
 
             if (empty($codes_id)) {
                 // 登録

--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -27,6 +27,8 @@ use App\Traits\Migration\MigrationExportHtmlPageTrait;
 
 use App\Plugins\Manage\ManagePluginBase;
 
+use App\Utilities\Csv\CsvUtils;
+
 /**
  * ページ管理クラス
  *
@@ -525,7 +527,6 @@ class PageManage extends ManagePluginBase
      */
     public function upload($request, $page_id)
     {
-
         // CSVファイルチェック
         $validator = Validator::make($request->all(), [
             'page_csv' => [
@@ -538,7 +539,6 @@ class PageManage extends ManagePluginBase
             'page_csv' => 'インポートCSV',
         ]);
         if ($validator->fails()) {
-            // return ( $this->import($request, $page_id, $validator->errors()->all()) );
             return redirect()->back()->withErrors($validator)->withInput();
         }
 
@@ -558,7 +558,6 @@ class PageManage extends ManagePluginBase
             fclose($fp);
             Storage::delete($path);
 
-            // return ( $this->import($request, $page_id, $error_msgs) );
             return redirect()->back()->withErrors(['page_csv' => $error_msgs])->withInput();
         }
 
@@ -569,7 +568,6 @@ class PageManage extends ManagePluginBase
             fclose($fp);
             Storage::delete($path);
 
-            // return ( $this->import($request, $page_id, $error_msgs) );
             return redirect()->back()->withErrors(['page_csv' => $error_msgs])->withInput();
         }
 

--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -545,8 +545,7 @@ class PageManage extends ManagePluginBase
         // CSVファイル一時保孫
         $path = $request->file('page_csv')->store('tmp');
 
-        // bugfix: fgetcsv() は ロケール設定の影響を受け、xampp環境＋日本語文字列で誤動作したため、ロケール設定する。
-        setlocale(LC_ALL, 'ja_JP.UTF-8');
+        CsvUtils::setLocale();
 
         // 一行目（ヘッダ）読み込み
         $fp = fopen(storage_path('app/') . $path, 'r');

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1818,8 +1818,7 @@ class UserManage extends ManagePluginBase
             $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
         }
 
-        // bugfix: fgetcsv() は ロケール設定の影響を受け、xampp環境＋日本語文字列で誤動作したため、ロケール設定する。
-        setlocale(LC_ALL, 'ja_JP.UTF-8');
+        CsvUtils::setLocale();
 
         // 一行目（ヘッダ）
         $header_columns = fgetcsv($fp, 0, ',');

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1778,7 +1778,6 @@ class UserManage extends ManagePluginBase
         ]);
 
         if ($validator->fails()) {
-            // Log::debug(var_export($validator->errors(), true));
             // エラーと共に編集画面を呼び出す
             return redirect()->back()->withErrors($validator)->withInput();
         }
@@ -1827,7 +1826,6 @@ class UserManage extends ManagePluginBase
             // UTF-8のみBOMコードを取り除く
             $header_columns = CsvUtils::removeUtf8Bom($header_columns);
         }
-        // \Log::debug('$header_columns:'. var_export($header_columns, true));
 
         // 任意カラムの取得
         $users_columns = UsersTool::getUsersColumns($request->columns_set_id);
@@ -1862,11 +1860,6 @@ class UserManage extends ManagePluginBase
             return redirect()->back()->withErrors(['users_csv' => $error_msgs])->withInput();
         }
 
-        // [debug]
-        // fclose($fp);
-        // Storage::delete($path); // 一時ファイルの削除
-        // dd('ここまで');
-
         // ファイルポインタの位置を先頭に戻す
         rewind($fp);
 
@@ -1881,7 +1874,6 @@ class UserManage extends ManagePluginBase
         // データ
         while (($csv_columns = fgetcsv($fp, 0, ',')) !== false) {
             // --- 入力値変換
-            // Log::debug(var_export($csv_columns, true));
 
             // 入力値をトリム(preg_replace(/u)で置換. /u = UTF-8 として処理)
             $csv_columns = StringUtils::trimInput($csv_columns);
@@ -1897,13 +1889,6 @@ class UserManage extends ManagePluginBase
                 // 空文字をnullに変換
                 $csv_column = StringUtils::convertEmptyStringsToNull($csv_column);
             }
-            // Log::debug('$csv_columns:'. var_export($csv_columns, true));
-
-            // [debug]
-            //// 一時ファイルの削除
-            // fclose($fp);
-            // Storage::delete($path);
-            // dd('ここまで' . $posted_at);
 
             // --- User
             if (empty($users_id)) {

--- a/app/Plugins/User/Calendars/CalendarsPlugin.php
+++ b/app/Plugins/User/Calendars/CalendarsPlugin.php
@@ -23,6 +23,8 @@ use App\Plugins\User\UserPluginBase;
 
 use App\Rules\CustomValiWysiwygMax;
 
+use App\Utilities\File\FileUtils;
+
 /**
  * カレンダー・プラグイン
  *
@@ -272,7 +274,7 @@ class CalendarsPlugin extends UserPluginBase
     public function index($request, $page_id, $frame_id)
     {
         // 曜日表示のために日本語設定にする。
-        setlocale(LC_ALL, 'ja_JP.UTF-8');
+        FileUtils::setLocale();
 
         // プラグインのフレームデータ
         $plugin_frame = $this->getPluginFrame($frame_id);

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -3331,8 +3331,7 @@ class DatabasesPlugin extends UserPluginBase
             $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
         }
 
-        // bugfix: fgetcsv() は ロケール設定の影響を受け、xampp環境＋日本語文字列で誤動作したため、ロケール設定する。
-        setlocale(LC_ALL, 'ja_JP.UTF-8');
+        CsvUtils::setLocale();
 
         // 一行目（ヘッダ）
         $header_columns = fgetcsv($fp, 0, ',');

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -2632,21 +2632,18 @@ class LearningtasksPlugin extends UserPluginBase
         ]);
 
         if ($validator->fails()) {
-            // Log::debug(var_export($validator->errors(), true));
             // エラーと共に編集画面を呼び出す
             return redirect()->back()->withErrors($validator)->withInput();
         }
 
         // CSVファイル一時保存
         $path = $request->file('examinations_csv')->store('tmp');
-        // Log::debug(var_export(storage_path('app/') . $path, true));
         $csv_full_path = storage_path('app/') . $path;
 
         // ファイル拡張子取得
         $file_extension = $request->file('examinations_csv')->getClientOriginalExtension();
         // 小文字に変換
         $file_extension = strtolower($file_extension);
-        // Log::debug(var_export($file_extension, true));
 
         // 文字コード
         $character_code = $request->character_code;
@@ -2683,8 +2680,6 @@ class LearningtasksPlugin extends UserPluginBase
             // UTF-8のみBOMコードを取り除く
             $header_columns = CsvUtils::removeUtf8Bom($header_columns);
         }
-        // dd($csv_full_path);
-        // \Log::debug('$header_columns:'. var_export($header_columns, true));
 
         // カラムの取得
         $examination_columns = LearningtasksExaminationColumn::getImportColumn();
@@ -2695,8 +2690,7 @@ class LearningtasksPlugin extends UserPluginBase
             // 一時ファイルの削除
             fclose($fp);
             Storage::delete($path);
-
-            return redirect()->back()->withErrors(['learningtasks_examinations_id' => $error_msgs])->withInput();
+            return redirect()->back()->withErrors(['examinations_csv' => $error_msgs])->withInput();
         }
 
         $cvs_rules = [
@@ -2724,12 +2718,6 @@ class LearningtasksPlugin extends UserPluginBase
             return redirect()->back()->withErrors(['examinations_csv' => $error_msgs])->withInput();
         }
 
-        // [debug]
-        // // 一時ファイルの削除
-        // fclose($fp);
-        // Storage::delete($path);
-        // dd('ここまで');
-
         // ファイルポインタの位置を先頭に戻す
         rewind($fp);
 
@@ -2744,7 +2732,6 @@ class LearningtasksPlugin extends UserPluginBase
         // データ
         while (($csv_columns = fgetcsv($fp, 0, ',')) !== false) {
             // --- 入力値変換
-            // Log::debug(var_export($csv_columns, true));
 
             // 入力値をトリム(preg_replace(/u)で置換. /u = UTF-8 として処理)
             $csv_columns = StringUtils::trimInput($csv_columns);
@@ -2759,13 +2746,6 @@ class LearningtasksPlugin extends UserPluginBase
                 // 空文字をnullに変換
                 $csv_column = StringUtils::convertEmptyStringsToNull($csv_column);
             }
-            // Log::debug('$csv_columns:'. var_export($csv_columns, true));
-
-            // [debug]
-            //// 一時ファイルの削除
-            // fclose($fp);
-            // Storage::delete($path);
-            // dd('ここまで' . $posted_at);
 
             if (empty($learningtasks_examinations_id)) {
                 // 登録
@@ -2778,11 +2758,6 @@ class LearningtasksPlugin extends UserPluginBase
 
             $learningtasks_examinations->post_id = $post_id;
 
-            // $learningtasks_examinations->start_at = $csv_columns[0] . ':00';
-            // $learningtasks_examinations->end_at = $csv_columns[1] . ':00';
-            // if ($csv_columns[2]) {
-            //     $learningtasks_examinations->entry_end_at = $csv_columns[2] . ':00';
-            // }
             $learningtasks_examinations->start_at = new Carbon($csv_columns[0]);
             $learningtasks_examinations->end_at = new Carbon($csv_columns[1]);
             if ($csv_columns[2]) {

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -2674,8 +2674,7 @@ class LearningtasksPlugin extends UserPluginBase
             $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
         }
 
-        // bugfix: fgetcsv() は ロケール設定の影響を受け、xampp環境＋日本語文字列で誤動作したため、ロケール設定する。
-        setlocale(LC_ALL, 'ja_JP.UTF-8');
+        CsvUtils::setLocale();
 
         // 一行目（ヘッダ）
         $header_columns = fgetcsv($fp, 0, ',');

--- a/app/Utilities/Csv/CsvUtils.php
+++ b/app/Utilities/Csv/CsvUtils.php
@@ -2,12 +2,11 @@
 
 namespace App\Utilities\Csv;
 
-use Illuminate\Support\Facades\Validator;
-
+use App\Enums\CsvCharacterCode;
 use App\Utilities\Csv\SjisToUtf8EncodingFilter;
 use App\Utilities\String\StringUtils;
-
-use App\Enums\CsvCharacterCode;
+use App\Utilities\File\FileUtils;
+use Illuminate\Support\Facades\Validator;
 
 class CsvUtils
 {
@@ -167,5 +166,14 @@ class CsvUtils
         }
 
         return $csv_data;
+    }
+
+    /**
+     * localeをセット
+     * fgetcsv()処理前に利用
+     */
+    public static function setLocale(): void
+    {
+        FileUtils::setLocale();
     }
 }

--- a/app/Utilities/File/FileUtils.php
+++ b/app/Utilities/File/FileUtils.php
@@ -57,4 +57,33 @@ class FileUtils
         }
         return $list;
     }
+
+    /**
+     * localeをセット
+     * fgetcsv(), pathinfo()等の処理前に実行する
+     */
+    public static function setLocale(): void
+    {
+        if (0 === strpos(PHP_OS, 'WIN')) {
+            // *** win
+            // fgetcsv() は ロケール設定の影響を受け、xampp環境＋日本語文字列で誤動作したため、ロケール設定する。
+            //
+            // [詳細]
+            // ・xampp環境のロケールは、LC_CTYPE=Japanese_Japan.932 でした。
+            //   これだと、「ド」の次のカンマが認識できなくなり 1カラム 'コード,値' で誤認識される。また末尾改行の処理も誤動作おこしました。
+            //   \Log::debug(var_export(setlocale(LC_ALL, "0"), true));
+            //   [2021-05-07 17:26:12] local.DEBUG: 'LC_COLLATE=C;LC_CTYPE=Japanese_Japan.932;LC_MONETARY=C;LC_NUMERIC=C;LC_TIME=C'
+            // ・fgetcsv() https://www.php.net/manual/ja/function.fgetcsv.php
+            //
+            // [windowsのlocale]
+            // ・https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c
+            //   > (表列)Language tag ＞ ja-JP
+            setlocale(LC_ALL, 'ja-JP.UTF-8');
+        } else {
+            // *** linux
+            // 環境によってはsetlocale しておかないと、ファイル名がうまくpathinfo で取得できなかった。
+            // 2020-12-15 Connect-CMS 公式サイトで、ファイル名が空になったり一部しか取得できないケースがあった。
+            setlocale(LC_ALL, 'ja_JP.UTF-8');
+        }
+    }
 }

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_import_examinations.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_import_examinations.blade.php
@@ -70,11 +70,7 @@
                 <input type="file" class="custom-file-input" id="examinations_csv" name="examinations_csv" accept=".csv">
                 <label class="custom-file-label" for="examinations_csv" data-browse="参照"></label>
             </div>
-            @if ($errors && $errors->has('examinations_csv'))
-                @foreach ($errors->get('examinations_csv') as $message)
-                    <div class="text-danger">{{$message}}</div>
-                @endforeach
-            @endif
+            @include('plugins.common.errors_inline', ['name' => 'examinations_csv'])
             <small class="text-muted">※ アップロードできる１ファイルの最大サイズ: {{ini_get('upload_max_filesize')}}</small><br />
         </div>
     </div>
@@ -90,7 +86,7 @@
             <small class="text-muted">
                 ※ UTF-8はBOM付・BOMなしどちらにも対応しています。
             </small>
-            @if ($errors && $errors->has('character_code')) <div class="text-danger">{{$errors->first('character_code')}}</div> @endif
+            @include('plugins.common.errors_inline', ['name' => 'character_code'])
         </div>
     </div>
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

開発者向けアップデートで、共通メソッド setlocale の追加です。
setlocale()はxampp(win)とLinuxとで、対応が若干異なっていて、xamppのみでfgetcsv()使用時にエラーが出る場合がありましたので、共通メソッドで対応するようにしました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

・Japanese Moodle: ユーザの一括登録に関して | Moodle.org
https://moodle.org/mod/forum/discuss.php?d=383085
> XAMPP 7.1.26で確認したのですが、下記ブログ記事にあるとおり fgetcsv() で日本語などが含まれると正常にカンマなどの区切り文字を認識できないためカラム数がおかしくなりエラーとなっています。
> http://iamapen.hatenablog.com/entry/2017/08/10/134224

・PHP: setlocale - Manual
https://www.php.net/manual/ja/function.setlocale.php

・locale
// win
[MS-LCID]: Appendix A: Product Behavior | Microsoft Learn
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c
> (表列)Language tag ＞ ja-JP

// CentOS7
ja_JP.UTF-8


# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
