### PR TITLE
[スライドショー]初期表示の速度を改善しました

### DIFF
--- a/resources/views/plugins/user/slideshows/default/slideshows.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows.blade.php
@@ -37,7 +37,7 @@
                                 <img
                                     src="{{url('/')}}/file/{{ $item->uploads_id }}"
                                     class="d-block w-100"
-                                    loading="lazy"
+                                    @if (!$loop->first) loading="lazy" @endif
                                     @if (!empty($slideshow->height)) style="object-fit: cover; height: {{$slideshow->height}}px;" @endif
                                 >
                             </a>
@@ -46,7 +46,7 @@
                             <img
                                 src="{{url('/')}}/file/{{ $item->uploads_id }}"
                                 class="d-block w-100"
-                                loading="lazy"
+                                @if (!$loop->first) loading="lazy" @endif
                                 @if (!empty($slideshow->height)) style="object-fit: cover; height: {{$slideshow->height}}px;" @endif
                             >
                         @endif


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
ファーストビューに画像の遅延読み込みがあると、描画が遅くなります。
そのため、ファーストビューで使われることが多いスライドショーの一枚目の画像について遅延読み込みをしないようにしました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
