### PR TITLE
[コア]オプションプラグインのCSSファイル読み込みを追加しました

### DIFF
--- a/public/css/option/.gitignore
+++ b/public/css/option/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -72,10 +72,11 @@ if (! isset($cc_configs)) {
     <!-- Connect-CMS Option Plugin's CSS -->
     @php
         $option_css_path = public_path('css/option');
-        $option_csses = \File::files($option_css_path);
+        $option_csses = glob($option_css_path . '/*.css');
     @endphp
     @foreach ($option_csses as $css)
-        <link href="{{ asset('css/option/' . $css->getFilename()) }}?version={{ $css->getMTime() }}" rel="stylesheet">
+        @php $file = new SplFileInfo($css);@endphp
+        <link href="{{ asset('css/option/' . $file->getFilename()) }}?version={{ $file->getMTime() }}" rel="stylesheet">
     @endforeach
 
     <!-- Themes CSS（基本） -->

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -69,6 +69,15 @@ if (! isset($cc_configs)) {
     <!-- Connect-CMS Global CSS -->
     <link href="{{ asset('css/connect.css') }}?version={{ filemtime(public_path() . "/css/connect.css") }}" rel="stylesheet">
 
+    <!-- Connect-CMS Option Plugin's CSS -->
+    @php
+        $option_css_path = public_path('css/option');
+        $option_csses = \File::files($option_css_path);
+    @endphp
+    @foreach ($option_csses as $css)
+        <link href="{{ asset('css/option/' . $css->getFilename()) }}?version={{ $css->getMTime() }}" rel="stylesheet">
+    @endforeach
+
     <!-- Themes CSS（基本） -->
 @if (isset($themes['css']) && $themes['css'] != '' && file_exists(public_path() . "/themes/{$themes['css']}/themes.css"))
     <link href="{{url('/')}}/themes/{{$themes['css']}}/themes.css?version={{ filemtime(public_path() . "/themes/{$themes['css']}/themes.css") }}" rel="stylesheet">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
オプションプラグインのCSSファイル読み込みを追加しました。
public/css/option配下にあるcssファイルを対象にします。
オプションプラグインのCSSよりテーマのCSSを優先したいため、読み込み順をテーマより先にしています。


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
2/29

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
