### PR TITLE
[プラグイン全般]プラグインの設定アイコンで開く画面をフレーム編集に統一しました。

### DIFF
--- a/app/Plugins/User/Bbses/BbsesPlugin.php
+++ b/app/Plugins/User/Bbses/BbsesPlugin.php
@@ -87,16 +87,6 @@ class BbsesPlugin extends UserPluginBase
     }
 
     /**
-     * 編集画面の最初のタブ（コアから呼び出す）
-     *
-     * スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      * POST取得関数（コアから呼び出す）
      * コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -103,16 +103,6 @@ class BlogsPlugin extends UserPluginBase
     }
 
     /**
-     *  編集画面の最初のタブ（コアから呼び出す）
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      *  POST取得関数（コアから呼び出す）
      *  コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Cabinets/CabinetsPlugin.php
+++ b/app/Plugins/User/Cabinets/CabinetsPlugin.php
@@ -79,16 +79,6 @@ class CabinetsPlugin extends UserPluginBase
     }
 
     /**
-     * 編集画面の最初のタブ（コアから呼び出す）
-     *
-     * スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      * プラグインのバケツ取得関数
      */
     private function getPluginBucket($bucket_id)

--- a/app/Plugins/User/Calendars/CalendarsPlugin.php
+++ b/app/Plugins/User/Calendars/CalendarsPlugin.php
@@ -75,16 +75,6 @@ class CalendarsPlugin extends UserPluginBase
     }
 
     /**
-     * 編集画面の最初のタブ（コアから呼び出す）
-     *
-     * スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      * POST取得関数（コアから呼び出す）
      * コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Contents/ContentsPlugin.php
+++ b/app/Plugins/User/Contents/ContentsPlugin.php
@@ -70,18 +70,6 @@ class ContentsPlugin extends UserPluginBase
     }
 
     /**
-     *  編集画面の最初のタブ
-     *
-     *  スーパークラスをオーバーライド
-     */
-/*
-    public function getFirstFrameEditAction()
-    {
-        return "editBucketsRoles";
-    }
-*/
-
-    /**
      * POST取得関数（コアから呼び出す）
      * コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Conventions/ConventionsPlugin.php
+++ b/app/Plugins/User/Conventions/ConventionsPlugin.php
@@ -64,16 +64,6 @@ class ConventionsPlugin extends UserPluginBase
     }
 
     /**
-     * 編集画面の最初のタブ（コアから呼び出す）
-     *
-     * スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      * POST取得関数（コアから呼び出す）
      * コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Counters/CountersPlugin.php
+++ b/app/Plugins/User/Counters/CountersPlugin.php
@@ -63,16 +63,6 @@ class CountersPlugin extends UserPluginBase
         return $role_check_table;
     }
 
-    /**
-     * 編集画面の最初のタブ（コアから呼び出す）
-     *
-     * スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
     /* private関数 */
 
     /**

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -142,23 +142,6 @@ class DatabasesPlugin extends UserPluginBase
     }
 
     /**
-     *  編集画面の最初のタブ
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        // データベースの設定がまだの場合は、データベースの新規作成に遷移する。
-        $database = $this->getDatabases($this->frame->id);
-        if (empty($database)) {
-            return "createBuckets";
-        }
-
-        // カラムの設定画面
-        return "editColumn";
-    }
-
-    /**
      *  POST取得関数（コアから呼び出す）
      *  コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
+++ b/app/Plugins/User/Databasesearches/DatabasesearchesPlugin.php
@@ -41,16 +41,6 @@ class DatabasesearchesPlugin extends UserPluginBase
     /* コアから呼び出す関数 */
 
     /**
-     *  編集画面の最初のタブ
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      *  関数定義（コアから呼び出す）
      */
     public function getPublicFunctions()

--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -72,16 +72,6 @@ class FaqsPlugin extends UserPluginBase
     }
 
     /**
-     *  編集画面の最初のタブ（コアから呼び出す）
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      *  POST取得関数（コアから呼び出す）
      *  コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -136,23 +136,6 @@ class FormsPlugin extends UserPluginBase
         return $role_check_table;
     }
 
-    /**
-     *  編集画面の最初のタブ
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        // フォームの設定がまだの場合は、フォームの新規作成に遷移する。
-        $form = $this->getForms($this->frame->id);
-        if (empty($form)) {
-            return "createBuckets";
-        }
-
-        // カラムの設定画面
-        return "editColumn";
-    }
-
     /* private関数 */
 
     /**

--- a/app/Plugins/User/Knowledges/KnowledgesPlugin.php
+++ b/app/Plugins/User/Knowledges/KnowledgesPlugin.php
@@ -25,19 +25,6 @@ use App\Plugins\User\UserPluginBase;
  */
 class KnowledgesPlugin extends UserPluginBase
 {
-
-    /**
-     *  編集画面の最初のタブ
-     *
-     *  スーパークラスをオーバーライド
-     */
-/*
-    public function getFirstFrameEditAction()
-    {
-        return "edit";
-    }
-*/
-
     /**
      *  関数定義（コアから呼び出す）
      */

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -173,16 +173,6 @@ class LearningtasksPlugin extends UserPluginBase
     }
 
     /**
-     *  編集画面の最初のタブ（コアから呼び出す）
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      * POST取得関数（コアから呼び出す）
      * コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Linklists/LinklistsPlugin.php
+++ b/app/Plugins/User/Linklists/LinklistsPlugin.php
@@ -66,16 +66,6 @@ class LinklistsPlugin extends UserPluginBase
     }
 
     /**
-     * 編集画面の最初のタブ（コアから呼び出す）
-     *
-     * スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      * POST取得関数（コアから呼び出す）
      * コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Menus/MenusPlugin.php
+++ b/app/Plugins/User/Menus/MenusPlugin.php
@@ -37,16 +37,6 @@ class MenusPlugin extends UserPluginBase
     /* コアから呼び出す関数 */
 
     /**
-     * 編集画面の最初のタブ
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "select";
-    }
-
-    /**
      * 関数定義（コアから呼び出す）
      */
     public function getPublicFunctions()

--- a/app/Plugins/User/Opacs/OpacsPlugin.php
+++ b/app/Plugins/User/Opacs/OpacsPlugin.php
@@ -126,16 +126,6 @@ class OpacsPlugin extends UserPluginBase
     }
 
     /**
-     *  編集画面の最初のタブ
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      * POST取得関数（コアから呼び出す）
      * コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Openingcalendars/OpeningcalendarsPlugin.php
+++ b/app/Plugins/User/Openingcalendars/OpeningcalendarsPlugin.php
@@ -80,16 +80,6 @@ class OpeningcalendarsPlugin extends UserPluginBase
         return $role_check_table;
     }
 
-    /**
-     *  編集画面の最初のタブ（コアから呼び出す）
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
     /* private関数 */
 
     /**

--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -87,17 +87,6 @@ class PhotoalbumsPlugin extends UserPluginBase
     }
 
     /**
-     * 編集画面の最初のタブ（コアから呼び出す）
-     * スーパークラスをオーバーライド
-     *
-     * @return string 関数名
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      * プラグインのバケツ取得関数
      *
      * @param int $bucket_id バケツID

--- a/app/Plugins/User/Reservations/ReservationsPlugin.php
+++ b/app/Plugins/User/Reservations/ReservationsPlugin.php
@@ -126,16 +126,6 @@ class ReservationsPlugin extends UserPluginBase
     }
 
     /**
-     *  編集画面の最初のタブ（コアから呼び出す）
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
-    /**
      * POST取得関数（コアから呼び出す）
      * コアがPOSTチェックの際に呼び出す関数
      */

--- a/app/Plugins/User/Rsses/RssesPlugin.php
+++ b/app/Plugins/User/Rsses/RssesPlugin.php
@@ -76,16 +76,6 @@ class RssesPlugin extends UserPluginBase
         return $role_check_table;
     }
 
-    /**
-     *  編集画面の最初のタブ ※スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        // RSS未作成の場合、RSSの新規作成に遷移
-        $rss = $this->getRsses($this->frame->id);
-        return $rss ? 'editBuckets' : 'createBuckets';
-    }
-
     /* private関数 */
 
     /**

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -66,16 +66,6 @@ class SearchsPlugin extends UserPluginBase
         return $role_check_table;
     }
 
-    /**
-     * 編集画面の最初のタブ（コアから呼び出す）
-     *
-     * スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
     /* private関数 */
 
     /**

--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -82,16 +82,6 @@ class SlideshowsPlugin extends UserPluginBase
         return $role_check_table;
     }
 
-    /**
-     *  編集画面の最初のタブ ※スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        // スライドショー未作成の場合、スライドショーの新規作成に遷移
-        $slideshow = $this->getSlideshows($this->frame->id);
-        return $slideshow ? 'editBuckets' : 'createBuckets';
-    }
-
     /* private関数 */
 
     /**

--- a/app/Plugins/User/Tabs/TabsPlugin.php
+++ b/app/Plugins/User/Tabs/TabsPlugin.php
@@ -34,16 +34,6 @@ class TabsPlugin extends UserPluginBase
     /* コアから呼び出す関数 */
 
     /**
-     *  編集画面の最初のタブ
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "select";
-    }
-
-    /**
      *  関数定義（コアから呼び出す）
      */
     public function getPublicFunctions()

--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -94,16 +94,6 @@ class WhatsnewsPlugin extends UserPluginBase
         return $role_check_table;
     }
 
-    /**
-     *  編集画面の最初のタブ（コアから呼び出す）
-     *
-     *  スーパークラスをオーバーライド
-     */
-    public function getFirstFrameEditAction()
-    {
-        return "editBuckets";
-    }
-
     /* private関数 */
 
     /**


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
プラグインの設定アイコンをクリックした際、バケツの編集画面が開くケースとフレームの設定画面が開くケースがりました。
必要な操作を素早く実行できるように。という意図をもって、プラグイン毎にプラグインの設定アイコンをクリックした際に開く画面を変えられるようにしていました。
しかし、この動きが原因となり、意図せずにバケツを削除し、ブログやカレンダーなどのデータを消してしまうという誤操作が複数あったため、画面の動きを見直しました。
プラグインの設定アイコンをクリックした際はフレームの編集画面が開くことにより、そのまま勢いでの削除を押すという誤操作は防げるようになることを期待しています。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
無し

# チェックリスト
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
