### PR TITLE
[WYSIWYG]画像ダイアログの詳細タブで保存すると画像がリサイズされない問題を修正しました

### DIFF
--- a/public/js/tinymce/plugins/image/plugin.min.js
+++ b/public/js/tinymce/plugins/image/plugin.min.js
@@ -1240,7 +1240,8 @@
         vspace: data.vspace,
         border: data.border,
         borderStyle: data.borderstyle,
-        isDecorative: data.isDecorative
+        isDecorative: data.isDecorative,
+        resize: data.resize
       };
     };
     var addPrependUrl2 = function (info, srcURL) {

--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -274,7 +274,7 @@
             selector : 'textarea',
         @endif
 
-        cache_suffix: '?v=5.8.0.11',
+        cache_suffix: '?v=5.8.0.12',
 
         // change: app.blade.phpと同様にlocaleを見て切替
         // language : 'ja',

--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -823,7 +823,7 @@
                     //        エラーが出ないように要素が無い場合、処理しない事を検討したが、その場合、リサイズされなくなるため、対応を見送った。
 
                     // リサイズ画像サイズをinput type=textに保持
-                    document.getElementById('cc-resized-image-size-' + frame_id).value = jQuery('.tox-listbox--select')[0].dataset.value
+                    document.getElementById('cc-resized-image-size-' + frame_id).value = event.value.resize;
                 }
             });
 


### PR DESCRIPTION
# 概要

詳細設定タブで保存ボタンを押すと、パラメータに画像サイズが設定されないのが原因でした。
下記コードで値を設定していましたが、詳細設定タブを開くと一般タブの要素はすべて入れ替わるため、値を設定できていませんでした。

`document.getElementById('cc-resized-image-size-' + frame_id).value = jQuery('.tox-listbox--select')[0].dataset.value`

そこで、以下のように修正しました。

`document.getElementById('cc-resized-image-size-' + frame_id).value = event.value.resize;`

併せて、TinyMCEのコードも修正し、event.valueに画像サイズのデータを追加しました。
この修正により詳細設定タブでも画像サイズがサーバーに送信されます。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues

#1961 

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
