### PR TITLE
[データベース]閲覧者による表示件数の変更機能を追加しました

### DIFF
--- a/app/Enums/DatabaseFrameConfig.php
+++ b/app/Enums/DatabaseFrameConfig.php
@@ -15,6 +15,8 @@ final class DatabaseFrameConfig extends EnumsBase
     const database_trend_words = 'database_trend_words';
     const database_trend_words_caption = 'database_trend_words_caption';
     const database_destination_frame = 'database_destination_frame';
+    const database_view_count_spectator = 'database_view_count_spectator';
+    const database_page_total_views = 'database_page_total_views';
 
     // key/valueの連想配列
     const enum = [
@@ -23,5 +25,7 @@ final class DatabaseFrameConfig extends EnumsBase
         self::database_trend_words => '急上昇ワード',
         self::database_trend_words_caption => '急上昇ワード表示項目名',
         self::database_destination_frame => '検索後の遷移先',
+        self::database_view_count_spectator => '表示件数リストの表示',
+        self::database_page_total_views => '表示件数の表示',
     ];
 }

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -110,6 +110,7 @@ class DatabasesPlugin extends UserPluginBase
             'cancel',
             'addPref',
             'search',
+            'indexCount',
         ];
         return $functions;
     }
@@ -767,6 +768,7 @@ class DatabasesPlugin extends UserPluginBase
             if ($databases_frames) {
                 $get_count = $databases_frames->view_count;
             }
+            $get_count = session("view_count_spectator_{$frame_id}", $get_count);
             $inputs = $inputs_query->paginate($get_count, ["*"], $this->pageName($frame_id));
 
             // 登録データ行のタイトル取得
@@ -863,6 +865,7 @@ class DatabasesPlugin extends UserPluginBase
             'default_hide_list' => $default_hide_list,
             'frame_configs' => $this->frame_configs,
             'dest_frame' =>$this->getDestinationFrame(),
+            'view_count' => $get_count ?? null,
         // change: 同ページに(a)データベースプラグイン,(b)フォームを配置して(b)フォームで入力エラーが起きても、入力値が復元しないバグ対応。
         // ])->withInput($request->all);
         ]);
@@ -4505,5 +4508,15 @@ AND databases_inputs.posted_at <= NOW()
             $frame = Frame::with('page')->find($this->frame->id);
         }
         return $frame;
+    }
+
+    /**
+     * 件数指定
+     */
+    public function indexCount($request, $page_id, $frame_id)
+    {
+        session(["view_count_spectator_{$frame_id}" => $request->input("view_count_spectator")]);
+
+        // リダイレクト先を指定しないため、画面から渡されたredirect_pathに飛ぶ
     }
 }

--- a/resources/views/plugins/user/databases/default/databases.blade.php
+++ b/resources/views/plugins/user/databases/default/databases.blade.php
@@ -17,6 +17,10 @@
 
     @if ($default_hide_list)
     @else
+        {{-- データベースの表示件数変更セレクトボックス --}}
+        @include('plugins.user.databases.default.databases_include_view_count')
+        {{-- 現在表示している件数テキスト --}}
+        @include('plugins.user.databases.default.databases_include_page_total_views')
         @forelse($inputs as $input)
             <div class="container @if(! $loop->first) mt-4 @endif">
                 {{-- 行グループ ループ --}}

--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -362,6 +362,44 @@
         </div>
     </div>
 
+    {{-- 表示件数リストの表示 --}}
+    @php
+        $view_count_spectator = FrameConfig::getConfigValueAndOld($frame_configs, DatabaseFrameConfig::database_view_count_spectator, ShowType::not_show);
+    @endphp
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">{{DatabaseFrameConfig::getDescription('database_view_count_spectator')}}</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            @foreach (ShowType::getMembers() as $key => $type)
+            <div class="custom-control custom-radio custom-control-inline">
+                <input type="radio" value="{{$key}}" id="view_count_spectator{{$key}}" name="database_view_count_spectator" class="custom-control-input" @if ($view_count_spectator == $key) checked="checked" @endif>
+                <label class="custom-control-label" for="view_count_spectator{{$key}}" id="view_count_spectator{{$key}}">{{$type}}</label>
+            </div>
+            @endforeach
+            <small class="form-text text-muted">
+                表示する場合、閲覧者が表示件数を変更できます。
+            </small>
+        </div>
+    </div>
+
+    {{-- 表示件数の表示 --}}
+    @php
+        $page_total_views = FrameConfig::getConfigValueAndOld($frame_configs, DatabaseFrameConfig::database_page_total_views, ShowType::not_show);
+    @endphp
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">{{DatabaseFrameConfig::getDescription('database_page_total_views')}}</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            @foreach (ShowType::getMembers() as $key => $type)
+            <div class="custom-control custom-radio custom-control-inline">
+                <input type="radio" value="{{$key}}" id="page_total_views{{$key}}" name="database_page_total_views" class="custom-control-input" @if ($page_total_views == $key) checked="checked" @endif>
+                <label class="custom-control-label" for="page_total_views{{$key}}" id="page_total_views{{$key}}">{{$type}}</label>
+            </div>
+            @endforeach
+            <small class="form-text text-muted">
+                表示している一覧の件数と総件数を表示します。
+            </small>
+        </div>
+    </div>
+
     {{-- Submitボタン --}}
     <div class="form-group text-center">
         <div class="row">

--- a/resources/views/plugins/user/databases/default/databases_include_page_total_views.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_page_total_views.blade.php
@@ -1,0 +1,16 @@
+{{--
+ * 現在表示している件数テキスト
+ *
+ * @author 石垣 佑樹 <ishigaki@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category データベース・プラグイン
+--}}
+{{-- 現在表示している件数 --}}
+@php
+    $page_total_views = FrameConfig::getConfigValueAndOld($frame_configs, DatabaseFrameConfig::database_page_total_views, ShowType::not_show);
+@endphp
+@if ($page_total_views == ShowType::show && $inputs->isNotEmpty())
+    <div class="text-right mb-2 database-page-total-views">
+        <span class="database-page-total-views-text">{{$inputs->firstItem()}}～{{$inputs->lastItem()}} 件を表示 ／ 全 {{$inputs->total()}} 件</span>
+    </div>
+@endif

--- a/resources/views/plugins/user/databases/default/databases_include_view_count.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_view_count.blade.php
@@ -1,0 +1,35 @@
+{{--
+ * データベースの表示件数変更セレクトボックス
+ *
+ * @author 石垣 佑樹 <ishigaki@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category データベース・プラグイン
+--}}
+{{-- 件数変更 --}}
+@php
+    $view_count_spectator = FrameConfig::getConfigValueAndOld($frame_configs, DatabaseFrameConfig::database_view_count_spectator, ShowType::not_show);
+@endphp
+@if ($view_count_spectator == ShowType::show && $inputs->isNotEmpty())
+    <div class="float-right mb-2 database-view-count-select">
+        <form action="{{url('/')}}/redirect/plugin/databases/indexCount/{{$dest_frame->page->id}}/{{$dest_frame->id}}#frame-{{$dest_frame->id}}" method="POST" role="indexCount" aria-label="{{$database_frame->databases_name}}" name="view_count_spectator_{{$frame_id}}">
+            {{ csrf_field() }}
+            <input type="hidden" name="redirect_path" value="{{$dest_frame->page->getLinkUrl()}}?frame_{{$dest_frame->id}}_page=1#frame-{{$dest_frame->id}}">
+            {{-- 表示件数リスト --}}
+            @php
+                // 1,5,10,20+表示件数でリストを作成する
+                $view_count_options = [1, 5, 10, 20];
+                if ($databases_frames->view_count) {
+                    $view_count_options[] = $databases_frames->view_count;
+                }
+                $view_count_options = collect($view_count_options)->unique()->sort();
+            @endphp
+
+            <select class="form-control form-control-sm" name="view_count_spectator" onchange="document.forms.view_count_spectator_{{$frame_id}}.submit();">
+                @foreach ($view_count_options as $num)
+                    <option value="{{$num}}"  @if($view_count == $num) selected @endif>{{$num}}件</option>
+                @endforeach
+            </select>
+        </form>
+    </div>
+    <div class="clearfix"></div>
+@endif

--- a/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
@@ -16,6 +16,10 @@
 
     @if ($default_hide_list)
     @else
+        {{-- データベースの表示件数変更セレクトボックス --}}
+        @include('plugins.user.databases.default.databases_include_view_count')
+        {{-- 現在表示している件数テキスト --}}
+        @include('plugins.user.databases.default.databases_include_page_total_views')
         @if($inputs->isNotEmpty())
             {{-- データのループ --}}
             <table class="table table-bordered">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

データベースの表示件数を閲覧者がセレクトボックスで変更できるようにしました。
あわせて、いま何件表示しているかわかりやすくするため、件数表示機能も追加しました。

<img width="207" alt="image" src="https://github.com/opensource-workshop/connect-cms/assets/32890286/90e7d48e-e5e6-4fd0-b200-1086334070c2">

表示設定画面で、表示可否を選択できます。

<img width="500" alt="image" src="https://github.com/opensource-workshop/connect-cms/assets/32890286/de568e0c-e246-461e-89b1-73d6b2ea4d1e">


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
