### PR TITLE
[マイページ] マイページトップページとプロフィールページの画面名変更

### DIFF
--- a/resources/views/plugins/mypage/index/index.blade.php
+++ b/resources/views/plugins/mypage/index/index.blade.php
@@ -16,14 +16,14 @@
         {{-- 機能選択タブ --}}
         <div class="frame-setting-menu">
             <nav class="navbar navbar-expand-md navbar-light bg-light py-1">
-                <span class="d-md-none" style="margin: 0.5rem 0;">マイページ</span>
+                <span class="d-md-none" style="margin: 0.5rem 0;">プロフィール</span>
                 <div class="navbar-collapse collapse" id="collapsingNavbarLg">
                     <ul class="navbar-nav">
                         <li role="presentation" class="nav-item">
                         @if ($function == "index")
-                            <span class="nav-link"><span class="active">マイページ</span></span>
+                            <span class="nav-link"><span class="active">プロフィール</span></span>
                         @else
-                            <a href="{{url('/mypage/profile')}}" class="nav-link">マイページ</a></li>
+                            <a href="{{url('/mypage')}}" class="nav-link">プロフィール</a></li>
                         @endif
                         </li>
                     </ul>

--- a/resources/views/plugins/mypage/menus_list.blade.php
+++ b/resources/views/plugins/mypage/menus_list.blade.php
@@ -1,17 +1,20 @@
 {{--
-    マイページメニューリスト
+ * マイページメニューリスト
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category マイページ
 --}}
-
 <div class="list-group">
     @if (isset($plugin_name) && $plugin_name == 'index')
-        <a href="{{url('/')}}/mypage" class="list-group-item active">マイページ</a>
+        <a href="{{url('/')}}/mypage" class="list-group-item active">プロフィール</a>
     @else
-        <a href="{{url('/')}}/mypage" class="list-group-item">マイページ</a>
+        <a href="{{url('/')}}/mypage" class="list-group-item">プロフィール</a>
     @endif
     @if (isset($plugin_name) && $plugin_name == 'profile')
-        <a href="{{url('/')}}/mypage/profile" class="list-group-item active">プロフィール</a>
+        <a href="{{url('/')}}/mypage/profile" class="list-group-item active">プロフィール変更</a>
     @else
-        <a href="{{url('/')}}/mypage/profile" class="list-group-item">プロフィール</a>
+        <a href="{{url('/')}}/mypage/profile" class="list-group-item">プロフィール変更</a>
     @endif
     @if (isset($plugin_name) && $plugin_name == 'loginhistory')
         <a href="{{url('/')}}/mypage/loginHistory" class="list-group-item active">ログイン履歴</a>

--- a/resources/views/plugins/mypage/profile/profile_mypage_tab.blade.php
+++ b/resources/views/plugins/mypage/profile/profile_mypage_tab.blade.php
@@ -1,9 +1,14 @@
 {{--
  * 編集画面tabテンプレート
---}}
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category マイページ
+ --}}
 <div class="frame-setting-menu">
     <nav class="navbar navbar-expand-md navbar-light bg-light py-1">
-        <span class="d-md-none">処理選択 - プロフィール</span>
+        <span class="d-md-none">処理選択 - プロフィール変更</span>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsingNavbarLg">
             <span class="navbar-toggler-icon"></span>
         </button>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

実質と画面名がずれていたため、画面名を修正します。

左側メニュー「マイページ」を「プロフィール」に、「プロフィール」を「プロフィール変更」に変更します。

（修正前：左メニュー）
マイページ：実質プロフィールの確認画面
プロフィール：実質プロフィール変更画面

# 修正後画面
## マイページ：トップページ（PC）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/280c3ebc-e52b-441d-baa9-eeda642b59c3)

## マイページ：トップページ（スマホ）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/f7d89f63-c791-4195-9e7a-a60e82f2e4ab)

## プロフィール変更（PC）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/34e20660-8290-4d77-bb90-be861d25ced7)

## プロフィール変更（スマホ）

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/d5780830-841d-4288-8f9b-caecb388ebe6)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
