### PR TITLE
[ユーザ管理] ユーザ一覧表示時にユーザ項目の複数選択肢がnull時のphp8対応

### DIFF
--- a/resources/views/plugins/manage/user/list_include_value.blade.php
+++ b/resources/views/plugins/manage/user/list_include_value.blade.php
@@ -6,7 +6,8 @@
 
     // 複数選択型
     if ($users_column->column_type == UserColumnType::checkbox) {
-        if (empty($obj)) {
+        // php8対応 str_replace(): Passing null to parameter #3 ($subject) of type string is deprecated
+        if (empty($obj) || is_null($obj->value)) {
             $value = '';
         }
         else {


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

php8時のバグ修正です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/1200

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
