### PR TITLE
[ページ管理] ページ変更画面のクラス名の名称変更

### DIFF
--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -204,7 +204,7 @@ class PageManage extends ManagePluginBase
             'header_color'     => 'ヘッダーバーの背景色',
             'ip_address'       => 'IPアドレス制限',
             'othersite_url'    => '外部サイトURL',
-            'class'            => 'クラス名',
+            'class'            => 'メニュークラス名',
         ]);
         return $validator;
     }

--- a/resources/views/plugins/manage/page/page_form.blade.php
+++ b/resources/views/plugins/manage/page/page_form.blade.php
@@ -510,11 +510,11 @@ use App\Models\Common\Page;
         </div>
     </div>
     <div class="form-group row">
-        <label for="class" class="col-md-3 col-form-label text-md-right">クラス名</label>
+        <label for="class" class="col-md-3 col-form-label text-md-right">メニュークラス名</label>
         <div class="col-md-9">
             <input type="text" name="class" id="class" value="{{old('class', $page->class)}}" class="form-control">
             @include('common.errors_inline', ['name' => 'class'])
-            <small class="form-text text-muted">※ デザインで使用するためのclass名</small>
+            <small class="form-text text-muted">※ メニュープラグイン（一部テンプレート）のページに対して、デザインで使用するためのclass名を設定できます。</small>
         </div>
     </div>
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* #734

ページ変更画面の「クラス名」の名称がわかりずらかったため、現状の機能と合わせるために「メニュークラス名」に変更しました。

# 修正後画面
## ページ管理＞ページ変更

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/46a98b35-6105-45b4-afb3-c91a1b674949)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
