### PR TITLE
[フォーム] 登録時のリダイレクト対応

### DIFF
--- a/resources/views/plugins/user/forms/default/forms.blade.php
+++ b/resources/views/plugins/user/forms/default/forms.blade.php
@@ -12,6 +12,17 @@
 
 @include('plugins.common.errors_form_line')
 
+{{-- エラーメッセージ：publicStoreToken()リダイレクト時 --}}
+@if (session('error_messages' . $frame_id))
+    <div class="card border-danger form-group">
+        <div class="card-body">
+            <span class="text-danger">
+                <i class="fas fa-exclamation-triangle"></i> {{ session('error_messages' . $frame_id) }}
+            </span>
+        </div>
+    </div>
+@endif
+
 @if ($form->can_view_inputs_moderator)
     @can('role_article')
         <div class="row">

--- a/resources/views/plugins/user/forms/default/forms_confirm.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm.blade.php
@@ -12,12 +12,13 @@
 <script type="text/javascript">
     {{-- 保存のsubmit JavaScript --}}
     function submit_forms_store() {
-        forms_store{{$frame_id}}.action = "{{URL::to('/')}}/plugin/forms/publicStore/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+        forms_store{{$frame_id}}.action = "{{url('/')}}/redirect/plugin/forms/publicStore/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+        forms_store{{$frame_id}}.redirect_path.value = "{{url('/')}}/plugin/forms/publicConfirm/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
         forms_store{{$frame_id}}.submit();
     }
     {{-- 保存のキャンセル JavaScript --}}
     function submit_forms_cancel() {
-        forms_store{{$frame_id}}.action = "{{URL::to('/')}}/plugin/forms/index/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+        forms_store{{$frame_id}}.action = "{{url('/')}}/plugin/forms/index/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
         forms_store{{$frame_id}}.submit();
     }
     {{-- 二重クリック防止 JavaScript --}}
@@ -34,6 +35,8 @@
 
 <form action="" name="forms_store{{$frame_id}}" method="POST">
     {{ csrf_field() }}
+    <input type="hidden" name="redirect_path" value="">
+
     @foreach($forms_columns as $form_column)
     <div class="form-group container-fluid row">
 

--- a/resources/views/plugins/user/forms/default/forms_confirm_tandem.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm_tandem.blade.php
@@ -11,12 +11,13 @@
 <script type="text/javascript">
     {{-- 保存のsubmit JavaScript --}}
     function submit_forms_store() {
-        forms_store{{$frame_id}}.action = "{{URL::to('/')}}/plugin/forms/publicStore/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+        forms_store{{$frame_id}}.action = "{{url('/')}}/redirect/plugin/forms/publicStore/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+        forms_store{{$frame_id}}.redirect_path.value = "{{url('/')}}/plugin/forms/publicConfirm/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
         forms_store{{$frame_id}}.submit();
     }
     {{-- 保存のキャンセル JavaScript --}}
     function submit_forms_cancel() {
-        forms_store{{$frame_id}}.action = "{{URL::to('/')}}/plugin/forms/index/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+        forms_store{{$frame_id}}.action = "{{url('/')}}/plugin/forms/index/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
         forms_store{{$frame_id}}.submit();
     }
     {{-- 二重クリック防止 JavaScript --}}
@@ -33,6 +34,8 @@
 
 <form action="" name="forms_store{{$frame_id}}" method="POST">
     {{ csrf_field() }}
+    <input type="hidden" name="redirect_path" value="">
+
     @php $no = 1; @endphp
     @foreach($forms_columns as $form_column)
     <div class="form-group container-fluid row">

--- a/resources/views/plugins/user/forms/default/forms_confirm_token.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm_token.blade.php
@@ -4,25 +4,22 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
-<form action="{{url('/')}}/plugin/forms/publicStoreToken/{{$page->id}}/{{$frame_id}}/{{$id}}?token={{$token}}#frame-{{$frame_id}}" name="form_add_column{{$frame_id}}" method="POST" class="form-horizontal">
+<form action="{{url('/')}}/redirect/plugin/forms/publicStoreToken/{{$page->id}}/{{$frame_id}}/{{$id}}?token={{$token}}#frame-{{$frame_id}}" name="form_add_column{{$frame_id}}" method="POST" class="form-horizontal">
     {{ csrf_field() }}
+    <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/forms/publicConfirmToken/{{$page->id}}/{{$frame_id}}/{{$id}}#frame-{{$frame_id}}">
 
     <div class="alert alert-info">
-        <i class="fas fa-exclamation-circle"></i> 本登録ボタンを押して登録を確定してください。
-        <br>
-        <i class="fas fa-exclamation-circle"></i> 本登録ボタンは１度だけ押してください。
-        <br>
-        <i class="fas fa-exclamation-circle"></i> 本登録処理が完了するまでには時間を要する場合があります。
-        <br>
-        <i class="fas fa-exclamation-circle"></i> 本登録完了メールが到着するまでには時間を要する場合があります。
-        <br>
+        <i class="fas fa-exclamation-circle"></i> 本登録ボタンを押して登録を確定してください。<br>
+        <i class="fas fa-exclamation-circle"></i> 本登録ボタンは１度だけ押してください。<br>
+        <i class="fas fa-exclamation-circle"></i> 本登録処理が完了するまでには時間を要する場合があります。<br>
+        <i class="fas fa-exclamation-circle"></i> 本登録完了メールが到着するまでには時間を要する場合があります。<br>
         <i class="fas fa-exclamation-circle"></i> 本登録完了後に再度、仮登録メールより本登録は行わないでください。
     </div>
 
     {{-- ボタンエリア --}}
     <div class="form-group text-center">
         <button type="submit" class="btn btn-primary" onclick="javascript:return confirm('本登録します。よろしいですか？')">
-        <i class="fas fa-check"></i> {{__('messages.main_regist')}}
+            <i class="fas fa-check"></i> {{__('messages.main_regist')}}
         </button>
     </div>
 </form>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

フォームには登録後画面を再表示すると、重複してデータが登録される事がありました。
今回の対応は、登録後画面を再表示しても、重複したデータが登録されないようにするための対応です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/856

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
