### PR TITLE
[フォーム] CAPTCHAの注釈テキストに追記

### DIFF
--- a/resources/views/plugins/user/forms/default/index_captcha.blade.php
+++ b/resources/views/plugins/user/forms/default/index_captcha.blade.php
@@ -37,7 +37,7 @@
             <input type="text" name="captcha" value="{{old('captcha')}}" class="form-control @if ($errors->has('captcha')) border-danger @endif">
             @include('plugins.common.errors_inline', ['name' => 'captcha'])
             <small class="text-muted">
-                画像の文字を入力してください。
+                画像の文字を入力してください。次の画面でフォーム内容を入力することができます。
             </small>
         </div>
     </div>


### PR DESCRIPTION
# 概要
 - クライアントから指摘あり
```
リリースいただきましたCAPTHA機能画面で、
入力ボックスの下部にある以下の文章を修正いただくことはできますでしょうか。

旧：画像の文字を入力してください。
新：画像の文字を入力してください。次の画面でお問合せ内容を入力することができます。
```

 - ページ訪問者は「問い合わせ」や「〇〇申請」等のリンク文字を頼りに画面遷移してくることが多いと思われる為、リンク先開いていきなり「文字入力せよ」は面食らう印象はありそう。故に「これ入力したらその先に目的地があるよ」は分かった方が、変に誤解して離脱する人もいなくなりそうではある為、テキストを微修正します。
 - ただ、「お問合せ」という文言は少し具象的（フォームの種々使い方の一部分に若干寄り気味）な気がするので、「フォーム」という文言にします。
 - 新テキスト案：画像の文字を入力してください。次の画面でフォーム内容を入力することができます。

# レビュー完了希望日
なし
# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
