### PR TITLE
[フォーム] キャプチャのバリデーションメッセージ修正

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -725,10 +725,11 @@ class FormsPlugin extends UserPluginBase
         ];
 
         // 項目のエラーチェック
-        $validator = Validator::make($request->all(), 
+        $validator = Validator::make(
+            $request->all(),
             [
                 'captcha' => ['required', 'captcha'],
-            ], 
+            ],
             $validation_messages
         );
 

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -719,10 +719,19 @@ class FormsPlugin extends UserPluginBase
      */
     public function publicCaptcha($request, $page_id, $frame_id)
     {
+        // カスタムエラーメッセージの定義
+        $validation_messages = [
+            'captcha.captcha' => '画像上に表示されている正しい文字を入力してください。',
+        ];
+
         // 項目のエラーチェック
-        $validator = Validator::make($request->all(), [
-            'captcha' => ['required', 'captcha'],
-        ]);
+        $validator = Validator::make($request->all(), 
+            [
+                'captcha' => ['required', 'captcha'],
+            ], 
+            $validation_messages
+        );
+
         $validator->setAttributeNames([
             'captcha' => '画像認証',
         ]);


### PR DESCRIPTION
# 概要
 - クライアントから指摘あり。より明示的で次の所作がわかりやすい為、そのまま採用します。
```
画像認証画面で、入力をミスした場合に表示されるエラーメッセージを、

 画像認証には正しい画像の文字を指定してください。
→ 画像上に表示されている正しい文字を入力してください。

のようにご修正いただくことはできますでしょうか。
（※「指定」ではなく「入力」としていただきたい点と、
　　「正しい」がかかる言葉を、近くに置きたい、という主旨でのご依頼です。）
```

# レビュー完了希望日
なし

# 関連Pull requests/Issues
なし

# 参考（対応後イメージ）
![image](https://github.com/opensource-workshop/connect-cms/assets/13323806/06137ae9-b287-4fa8-b06e-9e85a67ccd25)


# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
