### PR TITLE
[カレンダー]開始日時・終了日時の初期値を利用しやすい時刻にしました

### DIFF
--- a/app/Plugins/User/Calendars/CalendarsPlugin.php
+++ b/app/Plugins/User/Calendars/CalendarsPlugin.php
@@ -694,7 +694,6 @@ class CalendarsPlugin extends UserPluginBase
         if ($init_date->isToday()) {
             // 当日は現在時刻から近い時刻を設定する
             $init_date = CarbonImmutable::now();
-            $init_date = CarbonImmutable::parse('2024-04-30 22:11:00');
             $start_date = $init_date->addHour(1);
             $end_date = $init_date->addHour(2);
             $post->start_date = $start_date->format('Y-m-d');

--- a/resources/views/plugins/user/calendars/default/edit.blade.php
+++ b/resources/views/plugins/user/calendars/default/edit.blade.php
@@ -146,7 +146,8 @@
                 $(function () {
                     $('#start_time').datetimepicker({
                         locale: 'ja',
-                        format: 'HH:mm'
+                        format: 'HH:mm',
+                        defaultDate: moment().add(1, "hours").format('YYYY-MM-DD HH:00'),
                     });
                 });
             </script>
@@ -191,7 +192,8 @@
                 $(function () {
                     $('#end_time').datetimepicker({
                         locale: 'ja',
-                        format: 'HH:mm'
+                        format: 'HH:mm',
+                        defaultDate: moment().add(2, "hours").format('YYYY-MM-DD HH:00'),
                     });
                 });
             </script>

--- a/resources/views/plugins/user/calendars/default/edit.blade.php
+++ b/resources/views/plugins/user/calendars/default/edit.blade.php
@@ -147,7 +147,6 @@
                     $('#start_time').datetimepicker({
                         locale: 'ja',
                         format: 'HH:mm',
-                        defaultDate: moment().add(1, "hours").format('YYYY-MM-DD HH:00'),
                     });
                 });
             </script>
@@ -193,7 +192,6 @@
                     $('#end_time').datetimepicker({
                         locale: 'ja',
                         format: 'HH:mm',
-                        defaultDate: moment().add(2, "hours").format('YYYY-MM-DD HH:00'),
                     });
                 });
             </script>

--- a/resources/views/plugins/user/calendars/default/edit.blade.php
+++ b/resources/views/plugins/user/calendars/default/edit.blade.php
@@ -146,7 +146,7 @@
                 $(function () {
                     $('#start_time').datetimepicker({
                         locale: 'ja',
-                        format: 'HH:mm',
+                        format: 'HH:mm'
                     });
                 });
             </script>
@@ -191,7 +191,7 @@
                 $(function () {
                     $('#end_time').datetimepicker({
                         locale: 'ja',
-                        format: 'HH:mm',
+                        format: 'HH:mm'
                     });
                 });
             </script>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

## 変更内容

予定を新規で登録する際、開始日時・終了日時の初期値を以下のように変更します。

**変更前**
- 開始日時：空白（テキストボックスを選択すると現在時刻が選ばれる）
- 終了日時：空白（テキストボックスを選択すると現在時刻が選ばれる）

**変更後**
- 当日の予定
  - 開始日時：現在時刻から1時間後の00分
  - 終了日時：現在時刻から2時間後の00分

- 当日以外の予定
  - 開始日時：09:00
  - 終了日時：10:00

例えば、現在時刻が18:15の場合、以下のようになります。
開始日時 ⇒ 19:00
終了日時 ⇒ 20:00

## 背景や目的

- カレンダーの予定には00分以外の分（12分など1分単位の値）を入力することが少ない
- 現在時刻の予定を入力することは少ない

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
