### PR TITLE
[スライドショー] アップロード管理等でファイル削除時、スライドショー管理画面でレコードが表示されなくなるのを修正

### DIFF
--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -765,7 +765,7 @@ class SlideshowsPlugin extends UserPluginBase
                 'slideshows_items.*',
                 'uploads.client_original_name'
             )
-            ->join('uploads', 'uploads.id', '=', 'slideshows_items.uploads_id')
+            ->leftjoin('uploads', 'uploads.id', '=', 'slideshows_items.uploads_id')
             ->where('slideshows_items.slideshows_id', $slideshows_id)
             ->orderby('slideshows_items.display_sequence')
             ->get();

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
@@ -57,7 +57,7 @@
             @else
                 {{-- uploadレコードがなければ、no_image画像表示 --}}
                 <img
-                    src="{{ asset("/storage/no_image.png") }}"
+                    src="{{ asset("images/core/no_image/no_image3.png") }}"
                     width="100px"
                 >                       
             @endif

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
@@ -47,11 +47,20 @@
 
         <div class="d-flex align-items-center justify-content-center">
             {{-- 画像プレビュー --}}
-            <a href="#" data-toggle="modal" data-target="#modalPreviewRow{{ $item->id }}">
+            @if ($item->client_original_name)
+                {{-- uploadレコードがあれば、モーダルのリンク表示 --}}
+                <a href="#" data-toggle="modal" data-target="#modalPreviewRow{{ $item->id }}">
+                    <img
+                        :src="image_url_{{ $item->id }}"
+                        width="100px"
+                    >
+            @else
+                {{-- uploadレコードがなければ、no_image画像表示 --}}
                 <img
-                    :src="image_url_{{ $item->id }}"
+                    src="{{ asset("/storage/no_image.png") }}"
                     width="100px"
-                >
+                >                       
+            @endif
             </a>
         </div>
         {{-- 画像プレビューモーダル --}}


### PR DESCRIPTION
# 概要
## クライアントから問い合わせ内容
```
管理画面のアップロードファイルから、スライドショーにアップされた画像を削除すると、
スライドショーデータの方にゴミが残ってしまうが、編集画面から当該データを削除できなくなる。
```

## 原因
項目設定画面用のスライドショーの子テーブル（slideshows_items）抽出時、
アップロードテーブルと内部結合していた為、
アップロード管理等で削除すると表示されなくなっていた

## 対応
 - アップロードテーブルとの結合を外部結合にする
 - アップロードテーブル取得できない場合は明示的にno_image画像を表示するよう画面側も修正
     - ブラウザキャッシュで画像表示されるケースがあり、画像の有無が項目一覧から判別できなくなる為。

# レビュー完了希望日
バグなのでなるはや

# 関連Pull requests/Issues
なし

# 参考（対応後イメージ）
![image](https://github.com/opensource-workshop/connect-cms/assets/13323806/e84833a1-1bfe-4611-be19-3a8b26a4a39b)


# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
