### PR TITLE
[パスワード付ページ] 末尾のページIDを消して表示すると500エラー対応

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -107,7 +107,7 @@ Route::get('/file/{id?}', 'Core\UploadController@getFile')->name('get_file');
 Route::get('/language/{language_or_1stdir?}/{link_or_after2nd?}', 'Core\DefaultController@changeLanguage')->where('link_or_after2nd', '.*')->name('get_language');
 
 // パスワード付きページのアクション
-Route::match(['get', 'post'], '/password/{action}/{page_id?}', 'Core\PasswordController@invoke')->name('password_input');
+Route::match(['get', 'post'], '/password/{action}/{page_id}', 'Core\PasswordController@invoke')->name('password_input');
 
 // 基本のアクション
 // コアの画面処理や各プラグインの処理はここから呼び出す。


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/2019

上記不具合対応です。
パスワード付ページではURLの末尾ページIDが必須だったため、処理を見直しました。

# 修正後画面
##  パスワード付ページ表示（URLの末尾ページIDなし）
http://localhost/password/input

![image](https://github.com/opensource-workshop/connect-cms/assets/2756509/e002d3ad-0e9e-4118-a8bb-77da6cb59676)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし
# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
