### PR TITLE
[単体テスト] Bucktes, FrameにFactory追加

### DIFF
--- a/app/Models/Common/Buckets.php
+++ b/app/Models/Common/Buckets.php
@@ -2,16 +2,17 @@
 
 namespace App\Models\Common;
 
+use App\Models\Common\BucketsRoles;
+use App\Traits\ConnectRoleTrait;
+use Database\Factories\Common\BucketsFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
-
-use App\Models\Common\BucketsRoles;
-
-use App\Traits\ConnectRoleTrait;
 
 class Buckets extends Model
 {
     use ConnectRoleTrait;
+    use HasFactory;
 
     /**
      * create()やupdate()で入力を受け付ける ホワイトリスト
@@ -206,5 +207,10 @@ class Buckets extends Model
             }
         }
         return true;
+    }
+
+    protected static function newFactory()
+    {
+        return BucketsFactory::new();
     }
 }

--- a/app/Models/Common/Frame.php
+++ b/app/Models/Common/Frame.php
@@ -2,17 +2,17 @@
 
 namespace App\Models\Common;
 
-use Illuminate\Database\Eloquent\Model;
-
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
-
 use App\Enums\ContentOpenType;
-
 use Carbon\Carbon;
+use Database\Factories\Common\FrameFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Frame extends Model
 {
+    use HasFactory;
+
     // 日付型
     protected $dates = [
         'content_open_date_from',
@@ -30,8 +30,10 @@ class Frame extends Model
         'plugin_name',
         'frame_col',
         'template',
+        'plug_name',
         'browser_width',
         'disable_whatsnews',
+        'disable_searchs',
         'page_only',
         'default_hidden',
         'classname',
@@ -294,5 +296,10 @@ class Frame extends Model
     public function page()
     {
         return $this->hasOne(Page::class, 'id', 'page_id');
+    }
+
+    protected static function newFactory()
+    {
+        return FrameFactory::new();
     }
 }

--- a/database/factories/Common/BucketsFactory.php
+++ b/database/factories/Common/BucketsFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories\Common;
+
+use App\Enums\PluginName;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class BucketsFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'bucket_name' => $this->faker->title(),
+            'plugin_name' => PluginName::getPluginName(array_rand(PluginName::enum)),
+            'container_page_id' => null,
+        ];
+    }
+}

--- a/database/factories/Common/FrameFactory.php
+++ b/database/factories/Common/FrameFactory.php
@@ -24,12 +24,14 @@ class FrameFactory extends Factory
         $frame_design = [null, 'none', 'default', 'primary', 'secondary', 'success', 'info', 'warning', 'danger'];
         $frame_col = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
+        $plugin_name = PluginName::getPluginName(array_rand(PluginName::enum));
+
         return [
             'page_id' => Page::factory(),
             'area_id' => $area_ids[array_rand($area_ids)],
             'frame_title' => $this->faker->title(),
             'frame_design' => $frame_design[array_rand($frame_design)],
-            'plugin_name' => PluginName::getPluginName(array_rand(PluginName::enum)),
+            'plugin_name' => $plugin_name,
             'frame_col' => $frame_col[array_rand($frame_col)],
             'template' => 'default',
             'plug_name' => null,
@@ -41,7 +43,9 @@ class FrameFactory extends Factory
             'classname' => $this->faker->word(),
             'classname_body' => $this->faker->word(),
             'none_hidden' => 0,
-            'bucket_id' => Buckets::factory(),
+            'bucket_id' => Buckets::factory()->create([
+                'plugin_name' => $plugin_name,
+            ]),
             'display_sequence' => $this->faker->unique()->randomNumber(),
             'content_open_type' => array_rand(ContentOpenType::enum),
             'content_open_date_from' => $this->faker->dateTimeBetween('now', '+1 week'),

--- a/database/factories/Common/FrameFactory.php
+++ b/database/factories/Common/FrameFactory.php
@@ -43,7 +43,7 @@ class FrameFactory extends Factory
             'none_hidden' => 0,
             'bucket_id' => Buckets::factory(),
             'display_sequence' => $this->faker->unique()->randomNumber(),
-            'content_open_type' => ContentOpenType::always_open,
+            'content_open_type' => array_rand(ContentOpenType::enum),
             'content_open_date_from' => $this->faker->dateTimeBetween('now', '+1 week'),
             'content_open_date_to' =>  $this->faker->dateTimeBetween('+1 week', '+2 week'),
         ];

--- a/database/factories/Common/FrameFactory.php
+++ b/database/factories/Common/FrameFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Factories\Common;
+
+use App\Enums\ContentOpenType;
+use App\Enums\PluginName;
+use App\Models\Common\Page;
+use App\Models\Common\Buckets;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class FrameFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        // app/Plugins/Manage/SiteManage/SiteManage.php よりコピー
+        $area_ids = [0, 1, 3, 4, 2];
+
+        // resources\views\core\cms_frame_edit.blade.php よりコピー
+        $frame_design = [null, 'none', 'default', 'primary', 'secondary', 'success', 'info', 'warning', 'danger'];
+        $frame_col = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+        return [
+            'page_id' => Page::factory(),
+            'area_id' => $area_ids[array_rand($area_ids)],
+            'frame_title' => $this->faker->title(),
+            'frame_design' => $frame_design[array_rand($frame_design)],
+            'plugin_name' => PluginName::getPluginName(array_rand(PluginName::enum)),
+            'frame_col' => $frame_col[array_rand($frame_col)],
+            'template' => 'default',
+            'plug_name' => null,
+            'browser_width' => null,
+            'disable_whatsnews' => 0,
+            'disable_searchs' => 0,
+            'page_only' => 0,
+            'default_hidden' => 0,
+            'classname' => $this->faker->word(),
+            'classname_body' => $this->faker->word(),
+            'none_hidden' => 0,
+            'bucket_id' => Buckets::factory(),
+            'display_sequence' => $this->faker->unique()->randomNumber(),
+            'content_open_type' => ContentOpenType::always_open,
+            'content_open_date_from' => $this->faker->dateTimeBetween('now', '+1 week'),
+            'content_open_date_to' =>  $this->faker->dateTimeBetween('+1 week', '+2 week'),
+        ];
+    }
+}

--- a/database/factories/Common/FrameFactory.php
+++ b/database/factories/Common/FrameFactory.php
@@ -18,7 +18,7 @@ class FrameFactory extends Factory
     public function definition()
     {
         // app/Plugins/Manage/SiteManage/SiteManage.php よりコピー
-        $area_ids = [0, 1, 3, 4, 2];
+        $area_ids = [0, 1, 2, 3, 4];
 
         // resources\views\core\cms_frame_edit.blade.php よりコピー
         $frame_design = [null, 'none', 'default', 'primary', 'secondary', 'success', 'info', 'warning', 'danger'];


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

開発者用アップデートです。
Bucktes, Frameモデルにテストデータを自動生成するFactoryクラスを追加しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
