### PR TITLE
[コア] Kernelに毎分実行用のオプションバッチスケジュール処理を追加

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -17,6 +17,9 @@ class Kernel extends ConsoleKernel
     {
         // $schedule->command('inspire')
         //          ->hourly();
+        /**
+         * 指定日時でバッチスケジュールを設定
+         */
         if(env('OPTION_BATCH_SCHEDULE')){
             // カンマ連結されたバッチスケジュールセットを分割
             $defs = explode(',', env('OPTION_BATCH_SCHEDULE'));
@@ -28,6 +31,21 @@ class Kernel extends ConsoleKernel
 
                 // バッチスケジュールを定義
                 $schedule->command($cmd)->at($time);
+            }
+        }
+
+        /**
+         * 毎分実行のスケジュール設定
+         */
+        if(env('OPTION_BATCH_SCHEDULE_MINUTELY')){
+            // カンマ連結されたバッチスケジュールセットを分割
+            $defs = explode(',', env('OPTION_BATCH_SCHEDULE_MINUTELY'));
+            foreach($defs as $def){
+                // コマンドを取得
+                $cmd = 'command:' . $def;
+
+                // 毎分バッチスケジュールを定義
+                $schedule->command($cmd)->everyMinute();
             }
         }
     }


### PR DESCRIPTION
# 概要
 - Kernelに毎分実行用のスケジュール読込処理がなかった為、これを追加しました。

# レビュー完了希望日
7/5（金）

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
