### PR TITLE
[フォトアルバム] リサイズ設定をしてアップロードしても、アップロードファイル一覧の「サイズ」に原寸サイズが表示されているのを修正しました

### DIFF
--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -552,6 +552,10 @@ class PhotoalbumsPlugin extends UserPluginBase
 //        $image = Uploads::shrinkImage($file, $photoalbum->image_upload_max_px);
         $image = Uploads::shrinkImage($file_params['path'], $photoalbum->image_upload_max_px);
 
+        // リサイズ後のバイナリデータのサイズを取得
+        $extension = strtolower($file_params['extension']);
+        $resized_image_size = strlen((string) $image->encode($extension));
+
         // uploads テーブルに情報追加、ファイルのid を取得する
         $upload = Uploads::create([
 /*
@@ -563,7 +567,7 @@ class PhotoalbumsPlugin extends UserPluginBase
             'client_original_name' => $file_params['client_original_name'],
             'mimetype'             => $file_params['mimetype'],
             'extension'            => $file_params['extension'],
-            'size'                 => $file_params['size'],
+            'size'                 => $resized_image_size,
 
             'plugin_name'          => 'photoalbums',
             'page_id'              => $page_id,

--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -51,6 +51,9 @@ class PhotoalbumsPlugin extends UserPluginBase
     // ファイルダウンロードURL
     private $download_url = '';
 
+    // サポートされている拡張子のリスト
+    private $supported_extensions = ['jpg', 'jpe', 'jpeg', 'png', 'gif'];
+
     /* コアから呼び出す関数 */
 
     /**
@@ -1264,7 +1267,7 @@ class PhotoalbumsPlugin extends UserPluginBase
         // ファイルサイズと形式チェック
         if ($photoalbum->image_upload_max_size !== UploadMaxSize::infinity) {
             $rules['upload_file.*'][] = 'max:' . $photoalbum->image_upload_max_size;
-            $rules['upload_file.*'][] = 'mimes:jpg,jpe,jpeg,png,gif' . $add_mimes;
+            $rules['upload_file.*'][] = 'mimes:' . implode(',', $this->supported_extensions) . $add_mimes;
         }
 
         // 項目名設定


### PR DESCRIPTION
# 概要
## 問題点
 - フォトアルバムにアップロード画像のリサイズ機能がありますが、リサイズ設定（例えば極小）をしても、管理機能－アップロードファイルの一覧に表示される「サイズ」には原寸サイズが表示されていました。
     - ※実体ファイルはリサイズされており、表記のみ誤りがある。
## 対応
 - フォトアルバムからのアップロード時、リサイズ後のサイズをuploadsに登録するよう修正

# レビュー完了希望日
8/28（水）

# 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/issues/2037

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
