### PR TITLE
個別サポートURL情報の表示機能を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,5 +187,6 @@ REQUIRE_AWS_SDK_PATH=C:\Lib\aws\aws-autoloader.php
 #ADD_THEME_DIR=C:\SitesLaravel\theme\
 
 # support info (If there is a support URL and if a viewing password is required.)
-#INDIVIDUAL_SUPPORT_URL=
-#INDIVIDUAL_SUPPORT_PASSWORD=
+#COMMON_SUPPORT_URL=""
+#INDIVIDUAL_SUPPORT_URL=""
+#INDIVIDUAL_SUPPORT_PASSWORD=""

--- a/.env.example
+++ b/.env.example
@@ -185,3 +185,7 @@ REQUIRE_AWS_SDK_PATH=C:\Lib\aws\aws-autoloader.php
 
 # add theme dir.
 #ADD_THEME_DIR=C:\SitesLaravel\theme\
+
+# support info (If there is a support URL and if a viewing password is required.)
+#INDIVIDUAL_SUPPORT_URL=
+#INDIVIDUAL_SUPPORT_PASSWORD=

--- a/config/connect.php
+++ b/config/connect.php
@@ -187,6 +187,7 @@ return [
     'MANAGE_USERDIR_PUBLIC_TARGET' => env('MANAGE_USERDIR_PUBLIC_TARGET', null),
 
     // 契約ユーザの個別サポート情報
+    'common_support_url' => env('COMMON_SUPPORT_URL', ""),
     'individual_support_url' => env('INDIVIDUAL_SUPPORT_URL', ""),
     'individual_support_password' => env('INDIVIDUAL_SUPPORT_PASSWORD', ""),
 ];

--- a/config/connect.php
+++ b/config/connect.php
@@ -185,4 +185,8 @@ return [
 
     // public配下のディレクトリを指定してファイル管理. null時は機能自体使わない(beta)
     'MANAGE_USERDIR_PUBLIC_TARGET' => env('MANAGE_USERDIR_PUBLIC_TARGET', null),
+
+    // 契約ユーザの個別サポート情報
+    'individual_support_url' => env('INDIVIDUAL_SUPPORT_URL', ""),
+    'individual_support_password' => env('INDIVIDUAL_SUPPORT_PASSWORD', ""),
 ];

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -185,7 +185,7 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                         <a class="nav-link dropdown-toggle" href="#" id="dropdown_support" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">サポート情報</a>
                         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown_auth">
                             <a class="dropdown-item" href="{{config('connect.common_support_url')}}" target="_blank">共通サポートページ <i class="fas fa-external-link-alt"></i></a>
-                            @if (config('connect.individual_support_password'))
+                            @if (config('connect.individual_support_url'))
                                 <div class="dropdown-divider"></div>
                                 <a class="dropdown-item" href="{{config('connect.individual_support_url')}}" target="_blank">個別サポートページ <i class="fas fa-external-link-alt"></i></a>
                             @endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -175,7 +175,7 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
         <ul class="navbar-nav text-nowrap">
             {{-- 管理メニュー表示判定（管理機能 or コンテンツ権限に付与がある場合）--}}
             @if (Auth::check() && Auth::user()->can('role_manage_or_post'))
-                @if (config('connect.individual_support_url'))
+                @if (config('connect.common_support_url'))
                     {{-- .env に個別サポート情報の設定がある場合のみ表示 --}}
                     @if (\Route::currentRouteName() == 'get_mypage' || \Route::currentRouteName() == 'post_mypage')
                         {{-- マイページのトップ（get_allで来る）もしくは、ルートでget_mypage --}}
@@ -184,9 +184,12 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="dropdown_support" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">サポート情報</a>
                         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown_auth">
-                            <a class="dropdown-item" href="{{config('connect.individual_support_url')}}" target="_blank">サポートページ <i class="fas fa-external-link-alt"></i></a>
+                            <a class="dropdown-item" href="{{config('connect.common_support_url')}}" target="_blank">共通サポートページ <i class="fas fa-external-link-alt"></i></a>
                             @if (config('connect.individual_support_password'))
                                 <div class="dropdown-divider"></div>
+                                <a class="dropdown-item" href="{{config('connect.individual_support_url')}}" target="_blank">個別サポートページ <i class="fas fa-external-link-alt"></i></a>
+                            @endif
+                            @if (config('connect.individual_support_password'))
                                 <div class="px-4">ページ閲覧パスワード<br /><input type="text" class="form-control" value="{{config('connect.individual_support_password')}}"></div>
                             @endif
                         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -175,6 +175,24 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
         <ul class="navbar-nav text-nowrap">
             {{-- 管理メニュー表示判定（管理機能 or コンテンツ権限に付与がある場合）--}}
             @if (Auth::check() && Auth::user()->can('role_manage_or_post'))
+                @if (config('connect.individual_support_url'))
+                    {{-- .env に個別サポート情報の設定がある場合のみ表示 --}}
+                    @if (\Route::currentRouteName() == 'get_mypage' || \Route::currentRouteName() == 'post_mypage')
+                        {{-- マイページのトップ（get_allで来る）もしくは、ルートでget_mypage --}}
+                        {{-- マイページではサポートメニューは表示しない --}}
+                    @else
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="dropdown_support" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">サポート情報</a>
+                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown_auth">
+                            <a class="dropdown-item" href="{{config('connect.individual_support_url')}}" target="_blank">サポートページ <i class="fas fa-external-link-alt"></i></a>
+                            @if (config('connect.individual_support_password'))
+                                <div class="dropdown-divider"></div>
+                                <div class="px-4">ページ閲覧パスワード<br /><input type="text" class="form-control" value="{{config('connect.individual_support_password')}}"></div>
+                            @endif
+                        </div>
+                    </li>
+                    @endif
+                @endif
                 <li class="nav-item dropdown">
                     {{-- ページリストがある場合は、コンテンツ画面 --}}
                     @if (isset($page_list) && !$is_manage_page)
@@ -230,7 +248,6 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                                             エリア枠
                                         </label>
                                     </div>
-                                    <div class="dropdown-divider"></div>
                                     <script>
                                         // エリアの枠線を付ける
                                         $('#switch-area-border').on('click', function (event) {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -184,7 +184,11 @@ $base_header_optional_class = Configs::getConfigsRandValue($cc_configs, 'base_he
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="dropdown_support" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">サポート情報</a>
                         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown_auth">
-                            <a class="dropdown-item" href="{{config('connect.common_support_url')}}" target="_blank">共通サポートページ <i class="fas fa-external-link-alt"></i></a>
+                            @if (config('connect.individual_support_url'))
+                                <a class="dropdown-item" href="{{config('connect.common_support_url')}}" target="_blank">共通サポートページ <i class="fas fa-external-link-alt"></i></a>
+                            @else
+                                <a class="dropdown-item" href="{{config('connect.common_support_url')}}" target="_blank">サポートページ <i class="fas fa-external-link-alt"></i></a>
+                            @endif
                             @if (config('connect.individual_support_url'))
                                 <div class="dropdown-divider"></div>
                                 <a class="dropdown-item" href="{{config('connect.individual_support_url')}}" target="_blank">個別サポートページ <i class="fas fa-external-link-alt"></i></a>

--- a/resources/views/plugins/manage/index/index.blade.php
+++ b/resources/views/plugins/manage/index/index.blade.php
@@ -27,9 +27,22 @@
 </div>
 @endif
 
+{{-- 個別サポート情報 --}}
+@if (config('connect.individual_support_url'))
+<div class="card mb-2">
+    <div class="card-header bg-success cc-primary-font-color">個別サポート情報</div>
+    <div class="card-body">
+        サポートページ: <a href="{{config('connect.individual_support_url')}}" target="_blank">{{config('connect.individual_support_url')}}</a><br />
+        @if (config('connect.individual_support_password'))
+            ページ閲覧パスワード: {{config('connect.individual_support_password')}}
+        @endif
+    </div>
+</div>
+@endif
+
 @if($rss_xml)
 <div class="card">
-    <div class="card-header">Connect-CMS 更新情報等</div>
+    <div class="card-header bg-primary cc-primary-font-color">Connect-CMS 更新情報等</div>
     <div class="list-group">
     @foreach($rss_xml->channel->item as $rss_item)
         <div class="list-group-item list-group-item-action">
@@ -47,7 +60,7 @@
 </div>
 @else
 <div class="card">
-    <div class="card-header">Connect-CMS 更新情報等</div>
+    <div class="card-header bg-primary cc-primary-font-color">Connect-CMS 更新情報等</div>
     <div class="list-group">
         <div class="list-group-item list-group-item-action">
             <div class="d-flex w-100 justify-content-between">


### PR DESCRIPTION
# 概要
サイトのサポートをするURLがある場合に記述できるようにしました。
このURLは以下の2か所で表示されます。
・管理者メニューのトップ
・ログイン後のヘッダーメニュー
また、サポートページがパスワード付きページに設定されている場合、パスワードも表示するようにしています。

サポートページの設定は.envで行います。

.env.exampleに書き方として以下を追加しました。
＃support info (If there is a support URL and if a viewing password is required.) 
＃INDIVIDUAL_SUPPORT_URL=
＃INDIVIDUAL_SUPPORT_PASSWORD=

# レビュー完了希望日
なるはやを希望

# DB変更の有無
無し

# チェックリスト
<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
