### PR TITLE
[セキュリティ管理] ラジオでON・OFF時、左側はOFFで統一する

### DIFF
--- a/app/Plugins/Manage/SecurityManage/SecurityManage.php
+++ b/app/Plugins/Manage/SecurityManage/SecurityManage.php
@@ -2,24 +2,19 @@
 
 namespace App\Plugins\Manage\SecurityManage;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Validator;
-
-use DB;
-
 use App\Models\Core\Configs;
 use App\Models\Core\ConfigsLoginPermits;
-
 use App\Plugins\Manage\ManagePluginBase;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * セキュリティ管理クラス
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category セキュリティ管理
- * @package Contoroller
+ * @package Controller
  * @plugin_title セキュリティ管理
  * @plugin_desc ログイン制限やHTML記述制限など、セキュリティに関する機能が集まった管理機能です。
  */
@@ -33,7 +28,6 @@ class SecurityManage extends ManagePluginBase
         // 権限チェックテーブル
         $role_ckeck_table = array();
         $role_ckeck_table["index"]             = array('admin_site');
-        //$role_ckeck_table["loginPermit"]       = array('admin_site');
         $role_ckeck_table["saveLoginPermit"]   = array('admin_site');
         $role_ckeck_table["deleteLoginPermit"] = array('admin_site');
         $role_ckeck_table["purifier"]          = array('admin_site');
@@ -49,11 +43,8 @@ class SecurityManage extends ManagePluginBase
      * @method_desc ログイン権限を設定できます。
      * @method_detail 権限は適用順に処理されます。全拒否してから特定の権限やIPアドレスを許可するような設定も可能です。
      */
-    public function index($request, $id, $errors = null)
+    public function index($request, $id)
     {
-        // セッション初期化などのLaravel 処理。
-        $request->flash();
-
         // Config データからログイン拒否設定の取得
         $configs_login_reject = Configs::where('name', 'login_reject')->first();
 
@@ -67,8 +58,6 @@ class SecurityManage extends ManagePluginBase
             "plugin_name"          => "security",
             "login_permits"        => $login_permits,
             "configs_login_reject" => $configs_login_reject,
-            "errors"               => $errors,
-            "create_flag"          => true,
         ]);
     }
 
@@ -99,7 +88,7 @@ class SecurityManage extends ManagePluginBase
             ]);
 
             if ($validator->fails()) {
-                return $this->index($request, $id, $validator->errors());
+                return redirect()->back()->withErrors($validator)->withInput();
             }
         }
 
@@ -119,7 +108,7 @@ class SecurityManage extends ManagePluginBase
                 ]);
 
                 if ($validator->fails()) {
-                    return $this->index($request, $id, $validator->errors());
+                    return redirect()->back()->withErrors($validator)->withInput();
                 }
             }
         }

--- a/resources/views/plugins/manage/security/loginpermit.blade.php
+++ b/resources/views/plugins/manage/security/loginpermit.blade.php
@@ -13,221 +13,210 @@
 @section('manage_content')
 
 <div class="card">
-<div class="card-header p-0">
-
-{{-- 機能選択タブ --}}
-@include('plugins.manage.security.security_manage_tab')
-
-</div>
-<div class="card-body">
-
-    {{-- 削除ボタンのアクション --}}
-    <script type="text/javascript">
-        function form_delete(id) {
-            if (confirm('IP制限設定を削除します。\nよろしいですか？')) {
-                form_delete_loginpermit.action = "{{url('/manage/security/deleteLoginPermit')}}/" + id;
-                form_delete_loginpermit.submit();
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.security.security_manage_tab')
+    </div>
+    <div class="card-body">
+        {{-- 削除ボタンのアクション --}}
+        <script type="text/javascript">
+            function form_delete(id) {
+                if (confirm('IP制限設定を削除します。\nよろしいですか？')) {
+                    form_delete_loginpermit.action = "{{url('/manage/security/deleteLoginPermit')}}/" + id;
+                    form_delete_loginpermit.submit();
+                }
             }
-        }
-    </script>
+        </script>
 
-    <form action="" method="POST" name="form_delete_loginpermit" class="">
-        {{ csrf_field() }}
-    </form>
+        <form action="" method="POST" name="form_delete_loginpermit" class="">
+            {{ csrf_field() }}
+        </form>
 
-    <form action="{{url('/')}}/manage/security/saveLoginPermit" method="POST" class="">
-        {{ csrf_field() }}
+        <form action="{{url('/')}}/manage/security/saveLoginPermit" method="POST" class="">
+            {{ csrf_field() }}
 
-        <div class="card mb-3">
-            <div class="card-body">
-                基本設定：ログインをどこからでも　　
-                <div class="custom-control custom-radio custom-control-inline pl-3">
-                    @if (!empty($configs_login_reject) && $configs_login_reject->value == '1')
-                        <input type="radio" value="1" id="reject_on" name="login_reject" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="reject_on" name="login_reject" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="reject_on">拒否する</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (empty($configs_login_reject) || $configs_login_reject->value == null || $configs_login_reject->value == '0')
-                        <input type="radio" value="0" id="reject_off" name="login_reject" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="0" id="reject_off" name="login_reject" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="reject_off">許可する</label>
-                </div>
-            </div>
-        </div>
-
-        {{-- エラーメッセージ --}}
-        @if ($errors)
-            <div class="card border-danger">
+            <div class="card mb-3">
                 <div class="card-body">
-                    <span class="text-danger">
-                        @foreach($errors->all() as $error)
-                        <i class="fas fa-exclamation-triangle"></i> {{$error}}<br />
-                        @endforeach
-                    </span>
-                    <span class="text-secondary">
-{{--
-                        @if ($errors->has('add_apply_sequence') || $errors->has('add_category') || $errors->has('color') || $errors->has('background_color'))
-                        <i class="fas fa-exclamation-circle"></i> 追加行を入力する場合は、すべての項目を入力してください。
+                    基本設定：ログインをどこからでも　　
+                    <div class="custom-control custom-radio custom-control-inline pl-3">
+                        @if (!empty($configs_login_reject) && $configs_login_reject->value == '1')
+                            <input type="radio" value="1" id="reject_on" name="login_reject" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="reject_on" name="login_reject" class="custom-control-input">
                         @endif
---}}
-                    </span>
+                        <label class="custom-control-label" for="reject_on">拒否する</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (empty($configs_login_reject) || $configs_login_reject->value == null || $configs_login_reject->value == '0')
+                            <input type="radio" value="0" id="reject_off" name="login_reject" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="0" id="reject_off" name="login_reject" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="reject_off">許可する</label>
+                    </div>
                 </div>
             </div>
-        @endif
 
-        <div class="form-group table-responsive">
-            <table class="table table-hover" style="margin-bottom: 0;">
-            <thead>
-                <tr>
-                    <th nowrap style="width:10%;">適用順</th>
-                    <th nowrap>IPアドレス(*でALL)</th>
-                    <th nowrap style="min-width:150px;">権限</th>
-                    <th nowrap>メモ</th>
-                    <th nowrap>許可/拒否</th>
-                    <th nowrap><i class="fas fa-trash-alt"></i></th>
-                </tr>
-            </thead>
-            <tbody>
-            @foreach($login_permits as $login_permit)
-                <tr>
-                    <td nowrap>
-                        <input type="hidden" value="{{$login_permit->id}}" name="login_permits_id[{{$login_permit->id}}]">
-                        <input type="text" value="{{old('apply_sequence.'.$login_permit->id, $login_permit->apply_sequence)}}" name="apply_sequence[{{$login_permit->id}}]" class="form-control">
-                    </td>
-                    <td nowrap>
-                        <input type="text" value="{{old('ip_address.'.$login_permit->id, $login_permit->ip_address)}}" name="ip_address[{{$login_permit->id}}]" class="form-control">
-                    </td>
-                    <td nowrap>
-                        <select name="role[{{$login_permit->id}}]" class="form-control">
-                            <option value="">全権限対象</option>
-                            <optgroup label="コンテンツ権限">
-                            @foreach(Config::get('cc_role.CC_ROLE_LIST') as $cc_role => $cc_role_name)
-                                @if ($cc_role == 'admin_system')
-                                    </optgroup>
-                                    <optgroup label="管理権限">
-                                @endif
-                            <option value="{{$cc_role}}"@if(old('role.'.$login_permit->id, $cc_role)==$login_permit->role) selected  @endif>{{$cc_role_name}}</option>
+            {{-- エラーメッセージ --}}
+            @if ($errors)
+                <div class="card border-danger">
+                    <div class="card-body">
+                        <span class="text-danger">
+                            @foreach($errors->all() as $error)
+                                <i class="fas fa-exclamation-triangle"></i> {{$error}}<br />
                             @endforeach
-                            </optgroup>
-                        </select>
-                    </td>
-                    <td nowrap>
-                        <input type="text" value="{{old('memo.'.$login_permit->id, $login_permit->memo)}}" name="memo[{{$login_permit->id}}]" class="form-control">
-                    </td>
-                    <td nowrap>
-
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if(isset($login_permit["reject"]) && $login_permit["reject"] == 0)
-                            <input type="radio" value="0" id="reject_on[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="0" id="reject_on[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="reject_on[{{$login_permit->id}}]">許可する</label>
+                        </span>
                     </div>
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if(isset($login_permit["reject"]) && $login_permit["reject"] == 1)
-                            <input type="radio" value="1" id="reject_off[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="1" id="reject_off[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="reject_off[{{$login_permit->id}}]">拒否する</label>
-                    </div>
-
-                    </td>
-                    <td nowrap>
-                        <a href="javascript:form_delete('{{$login_permit->id}}');"><span class="btn btn-danger"><i class="fas fa-trash-alt"></i></span></a>
-                    </td>
-                </tr>
-            @endforeach
-            @if ($create_flag)
-                <tr>
-                    <td nowrap>
-                        <input type="text" value="{{old('add_apply_sequence', '')}}" name="add_apply_sequence" class="form-control">
-                    </td>
-                    <td nowrap>
-                        <input type="text" value="{{old('add_ip_address', '')}}" name="add_ip_address" class="form-control">
-                    </td>
-                    <td nowrap>
-                        <select name="add_role" class="form-control">
-                            <option value="">全権限対象</option>
-                            <optgroup label="コンテンツ権限">
-                            @foreach(Config::get('cc_role.CC_ROLE_LIST') as $cc_role => $cc_role_name)
-                                @if ($cc_role == 'admin_system')
-                                    </optgroup>
-                                    <optgroup label="管理権限">
-                                @endif
-                            <option value="{{$cc_role}}"@if(old('add_role')==$cc_role) selected  @endif>{{$cc_role_name}}</option>
-                            @endforeach
-                            </optgroup>
-                        </select>
-                    </td>
-                    <td nowrap>
-                        <input type="text" value="{{old('memo', '')}}" name="add_memo" class="form-control">
-                    </td>
-                    <td nowrap>
-                        <div class="custom-control custom-radio custom-control-inline">
-                            @if(old('reject')=="0")
-                            <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input" checked>
-                            @else
-                            <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input">
-                            @endif
-                            <label class="custom-control-label" for="add_reject_on" id="label_add_reject_on">許可する</label>
-                        </div>
-
-                        <div class="custom-control custom-radio custom-control-inline">
-                            @if(old('add_reject')=="1")
-                            <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input" checked>
-                            @else
-                            <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input">
-                            @endif
-                            <label class="custom-control-label" for="add_reject_off" id="label_add_reject_off">拒否する</label>
-                        </div>
-                    </td>
-                    <td nowrap>
-                    </td>
-                </tr>
-            @else
-                <tr>
-                    <td nowrap>
-                        <input type="text" value="{{old('add_apply_sequence', '')}}" name="add_apply_sequence" class="form-control">
-                    </td>
-                    <td nowrap>
-                        <input type="text" value="{{old('add_ip_address', '')}}" name="add_ip_address" class="form-control">
-                    </td>
-                    <td nowrap>
-                        <input type="text" value="{{old('memo', '')}}" name="add_memo" class="form-control">
-                    </td>
-                    <td nowrap>
-                        <div class="custom-control custom-radio custom-control-inline">
-                            <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input">
-                            <label class="custom-control-label" for="add_reject_on" id="label_add_reject_on">許可する</label>
-                        </div>
-
-                        <div class="custom-control custom-radio custom-control-inline">
-                            <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input">
-                            <label class="custom-control-label" for="add_reject_off" id="label_add_reject_off">拒否する</label>
-                        </div>
-                    </td>
-                    <td nowrap>
-                    </td>
-                </tr>
+                </div>
             @endif
-            </tbody>
-            </table>
-        </div>
 
-        <div class="form-group text-center">
-            <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/security')}}'"><i class="fas fa-times"></i><span class="d-none d-md-inline"> キャンセル</span></button>
-            <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i><span class="d-none d-md-inline"> 変更</span></button>
-        </div>
-    </form>
+            <div class="form-group table-responsive">
+                <table class="table table-hover" style="margin-bottom: 0;">
+                    <thead>
+                        <tr>
+                            <th nowrap style="width:10%;">適用順</th>
+                            <th nowrap>IPアドレス(*でALL)</th>
+                            <th nowrap style="min-width:150px;">権限</th>
+                            <th nowrap>メモ</th>
+                            <th nowrap>許可/拒否</th>
+                            <th nowrap><i class="fas fa-trash-alt"></i></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @foreach($login_permits as $login_permit)
+                        <tr>
+                            <td nowrap>
+                                <input type="hidden" value="{{$login_permit->id}}" name="login_permits_id[{{$login_permit->id}}]">
+                                <input type="text" value="{{old('apply_sequence.'.$login_permit->id, $login_permit->apply_sequence)}}" name="apply_sequence[{{$login_permit->id}}]" class="form-control">
+                            </td>
+                            <td nowrap>
+                                <input type="text" value="{{old('ip_address.'.$login_permit->id, $login_permit->ip_address)}}" name="ip_address[{{$login_permit->id}}]" class="form-control">
+                            </td>
+                            <td nowrap>
+                                <select name="role[{{$login_permit->id}}]" class="form-control">
+                                    <option value="">全権限対象</option>
+                                    <optgroup label="コンテンツ権限">
+                                    @foreach(Config::get('cc_role.CC_ROLE_LIST') as $cc_role => $cc_role_name)
+                                        @if ($cc_role == 'admin_system')
+                                            </optgroup>
+                                            <optgroup label="管理権限">
+                                        @endif
+                                    <option value="{{$cc_role}}"@if(old('role.'.$login_permit->id, $cc_role)==$login_permit->role) selected  @endif>{{$cc_role_name}}</option>
+                                    @endforeach
+                                    </optgroup>
+                                </select>
+                            </td>
+                            <td nowrap>
+                                <input type="text" value="{{old('memo.'.$login_permit->id, $login_permit->memo)}}" name="memo[{{$login_permit->id}}]" class="form-control">
+                            </td>
+                            <td nowrap>
 
-</div>
-</div>
+                            <div class="custom-control custom-radio custom-control-inline">
+                                @if(isset($login_permit["reject"]) && $login_permit["reject"] == 0)
+                                    <input type="radio" value="0" id="reject_on[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input" checked="checked">
+                                @else
+                                    <input type="radio" value="0" id="reject_on[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input">
+                                @endif
+                                <label class="custom-control-label" for="reject_on[{{$login_permit->id}}]">許可する</label>
+                            </div>
+                            <div class="custom-control custom-radio custom-control-inline">
+                                @if(isset($login_permit["reject"]) && $login_permit["reject"] == 1)
+                                    <input type="radio" value="1" id="reject_off[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input" checked="checked">
+                                @else
+                                    <input type="radio" value="1" id="reject_off[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input">
+                                @endif
+                                <label class="custom-control-label" for="reject_off[{{$login_permit->id}}]">拒否する</label>
+                            </div>
+
+                            </td>
+                            <td nowrap>
+                                <a href="javascript:form_delete('{{$login_permit->id}}');"><span class="btn btn-danger"><i class="fas fa-trash-alt"></i></span></a>
+                            </td>
+                        </tr>
+                    @endforeach
+                    @if ($create_flag)
+                        <tr>
+                            <td nowrap>
+                                <input type="text" value="{{old('add_apply_sequence', '')}}" name="add_apply_sequence" class="form-control">
+                            </td>
+                            <td nowrap>
+                                <input type="text" value="{{old('add_ip_address', '')}}" name="add_ip_address" class="form-control">
+                            </td>
+                            <td nowrap>
+                                <select name="add_role" class="form-control">
+                                    <option value="">全権限対象</option>
+                                    <optgroup label="コンテンツ権限">
+                                    @foreach(Config::get('cc_role.CC_ROLE_LIST') as $cc_role => $cc_role_name)
+                                        @if ($cc_role == 'admin_system')
+                                            </optgroup>
+                                            <optgroup label="管理権限">
+                                        @endif
+                                    <option value="{{$cc_role}}"@if(old('add_role')==$cc_role) selected  @endif>{{$cc_role_name}}</option>
+                                    @endforeach
+                                    </optgroup>
+                                </select>
+                            </td>
+                            <td nowrap>
+                                <input type="text" value="{{old('memo', '')}}" name="add_memo" class="form-control">
+                            </td>
+                            <td nowrap>
+                                <div class="custom-control custom-radio custom-control-inline">
+                                    @if(old('reject')=="0")
+                                    <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input" checked>
+                                    @else
+                                    <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input">
+                                    @endif
+                                    <label class="custom-control-label" for="add_reject_on" id="label_add_reject_on">許可する</label>
+                                </div>
+
+                                <div class="custom-control custom-radio custom-control-inline">
+                                    @if(old('add_reject')=="1")
+                                    <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input" checked>
+                                    @else
+                                    <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input">
+                                    @endif
+                                    <label class="custom-control-label" for="add_reject_off" id="label_add_reject_off">拒否する</label>
+                                </div>
+                            </td>
+                            <td nowrap>
+                            </td>
+                        </tr>
+                    @else
+                        <tr>
+                            <td nowrap>
+                                <input type="text" value="{{old('add_apply_sequence', '')}}" name="add_apply_sequence" class="form-control">
+                            </td>
+                            <td nowrap>
+                                <input type="text" value="{{old('add_ip_address', '')}}" name="add_ip_address" class="form-control">
+                            </td>
+                            <td nowrap>
+                                <input type="text" value="{{old('memo', '')}}" name="add_memo" class="form-control">
+                            </td>
+                            <td nowrap>
+                                <div class="custom-control custom-radio custom-control-inline">
+                                    <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input">
+                                    <label class="custom-control-label" for="add_reject_on" id="label_add_reject_on">許可する</label>
+                                </div>
+
+                                <div class="custom-control custom-radio custom-control-inline">
+                                    <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input">
+                                    <label class="custom-control-label" for="add_reject_off" id="label_add_reject_off">拒否する</label>
+                                </div>
+                            </td>
+                            <td nowrap>
+                            </td>
+                        </tr>
+                    @endif
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="form-group text-center">
+                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/security')}}'"><i class="fas fa-times"></i><span class="d-none d-md-inline"> キャンセル</span></button>
+                <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i><span class="d-none d-md-inline"> 変更</span></button>
+            </div>
+        </form>
+    </div><!-- /.card-body -->
+</div><!-- /.card -->
 
 @endsection

--- a/resources/views/plugins/manage/security/loginpermit.blade.php
+++ b/resources/views/plugins/manage/security/loginpermit.blade.php
@@ -2,6 +2,7 @@
  * セキュリティ管理のメインテンプレート
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category セキュリティ管理
  --}}
@@ -40,14 +41,6 @@
         <div class="card mb-3">
             <div class="card-body">
                 基本設定：ログインをどこからでも　　
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (empty($configs_login_reject) || $configs_login_reject->value == null || $configs_login_reject->value == '0')
-                        <input type="radio" value="0" id="reject_off" name="login_reject" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="0" id="reject_off" name="login_reject" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="reject_off">許可する</label>
-                </div>
                 <div class="custom-control custom-radio custom-control-inline pl-3">
                     @if (!empty($configs_login_reject) && $configs_login_reject->value == '1')
                         <input type="radio" value="1" id="reject_on" name="login_reject" class="custom-control-input" checked="checked">
@@ -55,6 +48,14 @@
                         <input type="radio" value="1" id="reject_on" name="login_reject" class="custom-control-input">
                     @endif
                     <label class="custom-control-label" for="reject_on">拒否する</label>
+                </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    @if (empty($configs_login_reject) || $configs_login_reject->value == null || $configs_login_reject->value == '0')
+                        <input type="radio" value="0" id="reject_off" name="login_reject" class="custom-control-input" checked="checked">
+                    @else
+                        <input type="radio" value="0" id="reject_off" name="login_reject" class="custom-control-input">
+                    @endif
+                    <label class="custom-control-label" for="reject_off">許可する</label>
                 </div>
             </div>
         </div>

--- a/resources/views/plugins/manage/security/loginpermit.blade.php
+++ b/resources/views/plugins/manage/security/loginpermit.blade.php
@@ -28,11 +28,11 @@
             }
         </script>
 
-        <form action="" method="POST" name="form_delete_loginpermit" class="">
+        <form action="" method="POST" name="form_delete_loginpermit">
             {{ csrf_field() }}
         </form>
 
-        <form action="{{url('/')}}/manage/security/saveLoginPermit" method="POST" class="">
+        <form action="{{url('/')}}/manage/security/saveLoginPermit" method="POST">
             {{ csrf_field() }}
 
             <div class="card mb-3">
@@ -58,155 +58,119 @@
             </div>
 
             {{-- エラーメッセージ --}}
-            @if ($errors)
-                <div class="card border-danger">
-                    <div class="card-body">
-                        <span class="text-danger">
-                            @foreach($errors->all() as $error)
-                                <i class="fas fa-exclamation-triangle"></i> {{$error}}<br />
-                            @endforeach
-                        </span>
-                    </div>
-                </div>
-            @endif
+            @include('plugins.common.errors_all')
 
             <div class="form-group table-responsive">
                 <table class="table table-hover" style="margin-bottom: 0;">
                     <thead>
                         <tr>
-                            <th nowrap style="width:10%;">適用順</th>
-                            <th nowrap>IPアドレス(*でALL)</th>
+                            <th nowrap style="width:10%;">適用順 <label class="badge badge-danger">必須</label></th>
+                            <th nowrap>IPアドレス(*でALL) <label class="badge badge-danger">必須</label></th>
                             <th nowrap style="min-width:150px;">権限</th>
                             <th nowrap>メモ</th>
-                            <th nowrap>許可/拒否</th>
+                            <th nowrap>拒否/許可 <label class="badge badge-danger">必須</label></th>
                             <th nowrap><i class="fas fa-trash-alt"></i></th>
                         </tr>
                     </thead>
                     <tbody>
-                    @foreach($login_permits as $login_permit)
+                        @foreach($login_permits as $login_permit)
+                            <tr>
+                                <td nowrap>
+                                    <input type="hidden" value="{{$login_permit->id}}" name="login_permits_id[{{$login_permit->id}}]">
+                                    <input type="text" value="{{old('apply_sequence.'.$login_permit->id, $login_permit->apply_sequence)}}" name="apply_sequence[{{$login_permit->id}}]" class="form-control">
+                                </td>
+                                <td nowrap>
+                                    <input type="text" value="{{old('ip_address.'.$login_permit->id, $login_permit->ip_address)}}" name="ip_address[{{$login_permit->id}}]" class="form-control">
+                                </td>
+                                <td nowrap>
+                                    <select name="role[{{$login_permit->id}}]" class="form-control">
+                                        <option value="">全権限対象</option>
+                                        <optgroup label="コンテンツ権限">
+                                            @foreach(Config::get('cc_role.CC_ROLE_LIST') as $cc_role => $cc_role_name)
+                                                @if ($cc_role == 'admin_system')
+                                                    </optgroup>
+                                                    <optgroup label="管理権限">
+                                                @endif
+                                            <option value="{{$cc_role}}"@if(old('role.'.$login_permit->id, $cc_role)==$login_permit->role) selected  @endif>{{$cc_role_name}}</option>
+                                            @endforeach
+                                        </optgroup>
+                                    </select>
+                                </td>
+                                <td nowrap>
+                                    <input type="text" value="{{old('memo.'.$login_permit->id, $login_permit->memo)}}" name="memo[{{$login_permit->id}}]" class="form-control">
+                                </td>
+                                <td nowrap>
+
+                                <div class="custom-control custom-radio custom-control-inline">
+                                    @if(isset($login_permit["reject"]) && $login_permit["reject"] == 1)
+                                        <input type="radio" value="1" id="reject_off[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input" checked="checked">
+                                    @else
+                                        <input type="radio" value="1" id="reject_off[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input">
+                                    @endif
+                                    <label class="custom-control-label" for="reject_off[{{$login_permit->id}}]">拒否する</label>
+                                </div>
+                                <div class="custom-control custom-radio custom-control-inline">
+                                    @if(isset($login_permit["reject"]) && $login_permit["reject"] == 0)
+                                        <input type="radio" value="0" id="reject_on[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input" checked="checked">
+                                    @else
+                                        <input type="radio" value="0" id="reject_on[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input">
+                                    @endif
+                                    <label class="custom-control-label" for="reject_on[{{$login_permit->id}}]">許可する</label>
+                                </div>
+
+                                </td>
+                                <td nowrap>
+                                    <a href="javascript:form_delete('{{$login_permit->id}}');"><span class="btn btn-danger"><i class="fas fa-trash-alt"></i></span></a>
+                                </td>
+                            </tr>
+                        @endforeach
+
+                        {{-- 登録 --}}
                         <tr>
                             <td nowrap>
-                                <input type="hidden" value="{{$login_permit->id}}" name="login_permits_id[{{$login_permit->id}}]">
-                                <input type="text" value="{{old('apply_sequence.'.$login_permit->id, $login_permit->apply_sequence)}}" name="apply_sequence[{{$login_permit->id}}]" class="form-control">
+                                <input type="text" value="{{old('add_apply_sequence')}}" name="add_apply_sequence" class="form-control">
                             </td>
                             <td nowrap>
-                                <input type="text" value="{{old('ip_address.'.$login_permit->id, $login_permit->ip_address)}}" name="ip_address[{{$login_permit->id}}]" class="form-control">
-                            </td>
-                            <td nowrap>
-                                <select name="role[{{$login_permit->id}}]" class="form-control">
-                                    <option value="">全権限対象</option>
-                                    <optgroup label="コンテンツ権限">
-                                    @foreach(Config::get('cc_role.CC_ROLE_LIST') as $cc_role => $cc_role_name)
-                                        @if ($cc_role == 'admin_system')
-                                            </optgroup>
-                                            <optgroup label="管理権限">
-                                        @endif
-                                    <option value="{{$cc_role}}"@if(old('role.'.$login_permit->id, $cc_role)==$login_permit->role) selected  @endif>{{$cc_role_name}}</option>
-                                    @endforeach
-                                    </optgroup>
-                                </select>
-                            </td>
-                            <td nowrap>
-                                <input type="text" value="{{old('memo.'.$login_permit->id, $login_permit->memo)}}" name="memo[{{$login_permit->id}}]" class="form-control">
-                            </td>
-                            <td nowrap>
-
-                            <div class="custom-control custom-radio custom-control-inline">
-                                @if(isset($login_permit["reject"]) && $login_permit["reject"] == 0)
-                                    <input type="radio" value="0" id="reject_on[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input" checked="checked">
-                                @else
-                                    <input type="radio" value="0" id="reject_on[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input">
-                                @endif
-                                <label class="custom-control-label" for="reject_on[{{$login_permit->id}}]">許可する</label>
-                            </div>
-                            <div class="custom-control custom-radio custom-control-inline">
-                                @if(isset($login_permit["reject"]) && $login_permit["reject"] == 1)
-                                    <input type="radio" value="1" id="reject_off[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input" checked="checked">
-                                @else
-                                    <input type="radio" value="1" id="reject_off[{{$login_permit->id}}]" name="reject[{{$login_permit->id}}]" class="custom-control-input">
-                                @endif
-                                <label class="custom-control-label" for="reject_off[{{$login_permit->id}}]">拒否する</label>
-                            </div>
-
-                            </td>
-                            <td nowrap>
-                                <a href="javascript:form_delete('{{$login_permit->id}}');"><span class="btn btn-danger"><i class="fas fa-trash-alt"></i></span></a>
-                            </td>
-                        </tr>
-                    @endforeach
-                    @if ($create_flag)
-                        <tr>
-                            <td nowrap>
-                                <input type="text" value="{{old('add_apply_sequence', '')}}" name="add_apply_sequence" class="form-control">
-                            </td>
-                            <td nowrap>
-                                <input type="text" value="{{old('add_ip_address', '')}}" name="add_ip_address" class="form-control">
+                                <input type="text" value="{{old('add_ip_address')}}" name="add_ip_address" class="form-control">
                             </td>
                             <td nowrap>
                                 <select name="add_role" class="form-control">
                                     <option value="">全権限対象</option>
                                     <optgroup label="コンテンツ権限">
-                                    @foreach(Config::get('cc_role.CC_ROLE_LIST') as $cc_role => $cc_role_name)
-                                        @if ($cc_role == 'admin_system')
-                                            </optgroup>
-                                            <optgroup label="管理権限">
-                                        @endif
-                                    <option value="{{$cc_role}}"@if(old('add_role')==$cc_role) selected  @endif>{{$cc_role_name}}</option>
-                                    @endforeach
+                                        @foreach(Config::get('cc_role.CC_ROLE_LIST') as $cc_role => $cc_role_name)
+                                            @if ($cc_role == 'admin_system')
+                                                </optgroup>
+                                                <optgroup label="管理権限">
+                                            @endif
+                                            <option value="{{$cc_role}}"@if(old('add_role') == $cc_role) selected  @endif>{{$cc_role_name}}</option>
+                                        @endforeach
                                     </optgroup>
                                 </select>
                             </td>
                             <td nowrap>
-                                <input type="text" value="{{old('memo', '')}}" name="add_memo" class="form-control">
+                                <input type="text" value="{{old('add_memo')}}" name="add_memo" class="form-control">
                             </td>
                             <td nowrap>
                                 <div class="custom-control custom-radio custom-control-inline">
-                                    @if(old('reject')=="0")
-                                    <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input" checked>
+                                    @if(old('add_reject') == "1")
+                                        <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input" checked>
                                     @else
-                                    <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input">
-                                    @endif
-                                    <label class="custom-control-label" for="add_reject_on" id="label_add_reject_on">許可する</label>
-                                </div>
-
-                                <div class="custom-control custom-radio custom-control-inline">
-                                    @if(old('add_reject')=="1")
-                                    <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input" checked>
-                                    @else
-                                    <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input">
+                                        <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input">
                                     @endif
                                     <label class="custom-control-label" for="add_reject_off" id="label_add_reject_off">拒否する</label>
+                                </div>
+                                <div class="custom-control custom-radio custom-control-inline">
+                                    @if(old('add_reject') == "0")
+                                        <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input" checked>
+                                    @else
+                                        <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input">
+                                    @endif
+                                    <label class="custom-control-label" for="add_reject_on" id="label_add_reject_on">許可する</label>
                                 </div>
                             </td>
                             <td nowrap>
                             </td>
                         </tr>
-                    @else
-                        <tr>
-                            <td nowrap>
-                                <input type="text" value="{{old('add_apply_sequence', '')}}" name="add_apply_sequence" class="form-control">
-                            </td>
-                            <td nowrap>
-                                <input type="text" value="{{old('add_ip_address', '')}}" name="add_ip_address" class="form-control">
-                            </td>
-                            <td nowrap>
-                                <input type="text" value="{{old('memo', '')}}" name="add_memo" class="form-control">
-                            </td>
-                            <td nowrap>
-                                <div class="custom-control custom-radio custom-control-inline">
-                                    <input type="radio" value="0" id="add_reject_on" name="add_reject" class="custom-control-input">
-                                    <label class="custom-control-label" for="add_reject_on" id="label_add_reject_on">許可する</label>
-                                </div>
-
-                                <div class="custom-control custom-radio custom-control-inline">
-                                    <input type="radio" value="1" id="add_reject_off" name="add_reject" class="custom-control-input">
-                                    <label class="custom-control-label" for="add_reject_off" id="label_add_reject_off">拒否する</label>
-                                </div>
-                            </td>
-                            <td nowrap>
-                            </td>
-                        </tr>
-                    @endif
                     </tbody>
                 </table>
             </div>

--- a/resources/views/plugins/manage/security/purifier.blade.php
+++ b/resources/views/plugins/manage/security/purifier.blade.php
@@ -13,186 +13,182 @@
 @section('manage_content')
 
 <div class="card">
-<div class="card-header p-0">
-    {{-- 機能選択タブ --}}
-    @include('plugins.manage.security.security_manage_tab')
-</div>
-
-<div class="card-body">
-
-    @include('plugins.common.errors_form_line')
-
-    <div class="alert alert-info" role="alert">
-        XSS対応のJavaScript等の制限を行います。
+    <div class="card-header p-0">
+        {{-- 機能選択タブ --}}
+        @include('plugins.manage.security.security_manage_tab')
     </div>
+    <div class="card-body">
+        @include('plugins.common.errors_form_line')
 
-    <form action="{{url('/manage/security/savePurifier')}}" method="POST" class="form-horizontal">
-        {{csrf_field()}}
-        <div class="form-group row mb-0">
-            <label for="permanent_link" class="col-md-3 col-form-label text-md-right">コンテンツ管理者</label>
-            <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_article_admin', $purifiers['role_article_admin']) == '0')
-                        <input type="radio" value="0" id="role_article_admin_0" name="role_article_admin" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="0" id="role_article_admin_0" name="role_article_admin" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_article_admin_0" id="label_role_article_admin_0">制限しない</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_article_admin', $purifiers['role_article_admin']) == '1')
-                        <input type="radio" value="1" id="role_article_admin_1" name="role_article_admin" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_article_admin_1" name="role_article_admin" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_article_admin_1" id="label_role_article_admin_1">制限する</label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row mb-0">
-            <label for="permanent_link" class="col-md-3 col-form-label text-md-right">プラグイン管理者</label>
-            <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_arrangement', $purifiers['role_arrangement']) == 0)
-                        <input type="radio" value="0" id="role_arrangement_0" name="role_arrangement" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="0" id="role_arrangement_0" name="role_arrangement" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_arrangement_0" id="label_role_arrangement_0">制限しない</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_arrangement', $purifiers['role_arrangement']) == 1)
-                        <input type="radio" value="1" id="role_arrangement_1" name="role_arrangement" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_arrangement_1" name="role_arrangement" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_arrangement_1" id="label_role_arrangement_1">制限する</label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row mb-0">
-            <label for="permanent_link" class="col-md-3 col-form-label text-md-right">モデレータ</label>
-            <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_article', $purifiers['role_article']) == 0)
-                        <input type="radio" value="0" id="role_article_0" name="role_article" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="0" id="role_article_0" name="role_article" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_article_0" id="label_role_article_0">制限しない</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_article', $purifiers['role_article']) == 1)
-                        <input type="radio" value="1" id="role_article_1" name="role_article" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_article_1" name="role_article" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_article_1" id="label_role_article_1">制限する</label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row mb-0">
-            <label for="permanent_link" class="col-md-3 col-form-label text-md-right">承認者</label>
-            <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_approval', $purifiers['role_approval']) == 0)
-                        <input type="radio" value="0" id="role_approval_0" name="role_approval" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="0" id="role_approval_0" name="role_approval" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_approval_0" id="label_role_approval_0">制限しない</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_approval', $purifiers['role_approval']) == 1)
-                        <input type="radio" value="1" id="role_approval_1" name="role_approval" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_approval_1" name="role_approval" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_approval_1" id="label_role_approval_1">制限する</label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row mb-0">
-            <label for="permanent_link" class="col-md-3 col-form-label text-md-right">編集者</label>
-            <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_reporter', $purifiers['role_reporter']) == 0)
-                        <input type="radio" value="0" id="role_reporter_0" name="role_reporter" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="0" id="role_reporter_0" name="role_reporter" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_reporter_0" id="label_role_reporter_0">制限しない</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_reporter', $purifiers['role_reporter']) == 1)
-                        <input type="radio" value="1" id="role_reporter_1" name="role_reporter" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_reporter_1" name="role_reporter" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_reporter_1" id="label_role_reporter_1">制限する</label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group row">
-            <label for="permanent_link" class="col-md-3 col-form-label text-md-right">ゲスト</label>
-            <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_guest', $purifiers['role_guest']) == 0)
-                        <input type="radio" value="0" id="role_guest_0" name="role_guest" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="0" id="role_guest_0" name="role_guest" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_guest_0" id="label_role_guest_0">制限しない</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_guest', $purifiers['role_guest']) == 1)
-                        <input type="radio" value="1" id="role_guest_1" name="role_guest" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_guest_1" name="role_guest" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_guest_1" id="label_role_guest_1">制限する</label>
-                </div>
-            </div>
+        <div class="alert alert-info" role="alert">
+            XSS対応のJavaScript等の制限を行います。
         </div>
 
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right">注意 <label class="badge badge-danger">必須</label></div>
-            <div class="col-md-9">
-                <div class="form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" name="confirm_purifier" value="1">以下のXSSに対する注意点を理解して実行します。
-                    </label>
-                </div>
-                @if ($errors->has('confirm_purifier'))
-                    <div class="alert alert-danger mb-0">
-                        <i class="fas fa-exclamation-triangle"></i> XSSに対する注意点の確認を行ってください。
+        <form action="{{url('/manage/security/savePurifier')}}" method="POST" class="form-horizontal">
+            {{csrf_field()}}
+            <div class="form-group row mb-0">
+                <label for="permanent_link" class="col-md-3 col-form-label text-md-right">コンテンツ管理者</label>
+                <div class="col-md-9 d-sm-flex align-items-center">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_article_admin', $purifiers['role_article_admin']) == '0')
+                            <input type="radio" value="0" id="role_article_admin_0" name="role_article_admin" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="0" id="role_article_admin_0" name="role_article_admin" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_article_admin_0" id="label_role_article_admin_0">制限しない</label>
                     </div>
-                @endif
-            </div>
-        </div>
-
-        <div class="form-group row">
-            <div class="col-md-3 text-md-right"></div>
-            <div class="col-md-9">
-                <div class="alert alert-warning">
-                    JavaScript等を「制限しない」ことで、XSSの危険性が発生します。<br />
-                    「制限しない」に設定する場合は、該当権限のユーザが悪意のあるJavaScriptを埋め込む可能性が発生することを理解し、リスクを許容し実行してください。
-                </div>
-                <div class="alert alert-primary">
-                    設定値の初期値はモデレータ以上のみ「制限しない」です。<br />
-                    これは、モデレータ以上の権限はサイトの運営を行っている管理者であるという視点によるものです。
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_article_admin', $purifiers['role_article_admin']) == '1')
+                            <input type="radio" value="1" id="role_article_admin_1" name="role_article_admin" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="role_article_admin_1" name="role_article_admin" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_article_admin_1" id="label_role_article_admin_1">制限する</label>
+                    </div>
                 </div>
             </div>
-        </div>
+            <div class="form-group row mb-0">
+                <label for="permanent_link" class="col-md-3 col-form-label text-md-right">プラグイン管理者</label>
+                <div class="col-md-9 d-sm-flex align-items-center">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_arrangement', $purifiers['role_arrangement']) == 0)
+                            <input type="radio" value="0" id="role_arrangement_0" name="role_arrangement" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="0" id="role_arrangement_0" name="role_arrangement" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_arrangement_0" id="label_role_arrangement_0">制限しない</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_arrangement', $purifiers['role_arrangement']) == 1)
+                            <input type="radio" value="1" id="role_arrangement_1" name="role_arrangement" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="role_arrangement_1" name="role_arrangement" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_arrangement_1" id="label_role_arrangement_1">制限する</label>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row mb-0">
+                <label for="permanent_link" class="col-md-3 col-form-label text-md-right">モデレータ</label>
+                <div class="col-md-9 d-sm-flex align-items-center">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_article', $purifiers['role_article']) == 0)
+                            <input type="radio" value="0" id="role_article_0" name="role_article" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="0" id="role_article_0" name="role_article" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_article_0" id="label_role_article_0">制限しない</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_article', $purifiers['role_article']) == 1)
+                            <input type="radio" value="1" id="role_article_1" name="role_article" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="role_article_1" name="role_article" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_article_1" id="label_role_article_1">制限する</label>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row mb-0">
+                <label for="permanent_link" class="col-md-3 col-form-label text-md-right">承認者</label>
+                <div class="col-md-9 d-sm-flex align-items-center">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_approval', $purifiers['role_approval']) == 0)
+                            <input type="radio" value="0" id="role_approval_0" name="role_approval" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="0" id="role_approval_0" name="role_approval" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_approval_0" id="label_role_approval_0">制限しない</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_approval', $purifiers['role_approval']) == 1)
+                            <input type="radio" value="1" id="role_approval_1" name="role_approval" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="role_approval_1" name="role_approval" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_approval_1" id="label_role_approval_1">制限する</label>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row mb-0">
+                <label for="permanent_link" class="col-md-3 col-form-label text-md-right">編集者</label>
+                <div class="col-md-9 d-sm-flex align-items-center">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_reporter', $purifiers['role_reporter']) == 0)
+                            <input type="radio" value="0" id="role_reporter_0" name="role_reporter" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="0" id="role_reporter_0" name="role_reporter" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_reporter_0" id="label_role_reporter_0">制限しない</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_reporter', $purifiers['role_reporter']) == 1)
+                            <input type="radio" value="1" id="role_reporter_1" name="role_reporter" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="role_reporter_1" name="role_reporter" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_reporter_1" id="label_role_reporter_1">制限する</label>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="permanent_link" class="col-md-3 col-form-label text-md-right">ゲスト</label>
+                <div class="col-md-9 d-sm-flex align-items-center">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_guest', $purifiers['role_guest']) == 0)
+                            <input type="radio" value="0" id="role_guest_0" name="role_guest" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="0" id="role_guest_0" name="role_guest" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_guest_0" id="label_role_guest_0">制限しない</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if (old('role_guest', $purifiers['role_guest']) == 1)
+                            <input type="radio" value="1" id="role_guest_1" name="role_guest" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="role_guest_1" name="role_guest" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="role_guest_1" id="label_role_guest_1">制限する</label>
+                    </div>
+                </div>
+            </div>
 
-        <div class="form-group text-center">
-            <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/security')}}'"><i class="fas fa-times"></i><span class="d-none d-md-inline"> キャンセル</span></button>
-            <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i><span class="d-none d-md-inline"> 登録</span></button>
-        </div>
+            <div class="form-group row">
+                <div class="col-md-3 text-md-right">注意 <label class="badge badge-danger">必須</label></div>
+                <div class="col-md-9">
+                    <div class="form-check">
+                        <label class="form-check-label">
+                            <input class="form-check-input" type="checkbox" name="confirm_purifier" value="1">以下のXSSに対する注意点を理解して実行します。
+                        </label>
+                    </div>
+                    @if ($errors->has('confirm_purifier'))
+                        <div class="alert alert-danger mb-0">
+                            <i class="fas fa-exclamation-triangle"></i> XSSに対する注意点の確認を行ってください。
+                        </div>
+                    @endif
+                </div>
+            </div>
 
-    </form>
+            <div class="form-group row">
+                <div class="col-md-3 text-md-right"></div>
+                <div class="col-md-9">
+                    <div class="alert alert-warning">
+                        JavaScript等を「制限しない」ことで、XSSの危険性が発生します。<br />
+                        「制限しない」に設定する場合は、該当権限のユーザが悪意のあるJavaScriptを埋め込む可能性が発生することを理解し、リスクを許容し実行してください。
+                    </div>
+                    <div class="alert alert-primary">
+                        設定値の初期値はモデレータ以上のみ「制限しない」です。<br />
+                        これは、モデレータ以上の権限はサイトの運営を行っている管理者であるという視点によるものです。
+                    </div>
+                </div>
+            </div>
 
-</div>
-</div>
+            <div class="form-group text-center">
+                <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/security')}}'"><i class="fas fa-times"></i><span class="d-none d-md-inline"> キャンセル</span></button>
+                <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i><span class="d-none d-md-inline"> 登録</span></button>
+            </div>
+        </form>
+    </div><!-- /.card-body -->
+</div><!-- /.card -->
 
 @endsection

--- a/resources/views/plugins/manage/security/purifier.blade.php
+++ b/resources/views/plugins/manage/security/purifier.blade.php
@@ -2,6 +2,7 @@
  * セキュリティ管理のHTML記述制限テンプレート
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category セキュリティ管理
 --}}
@@ -31,14 +32,6 @@
             <label for="permanent_link" class="col-md-3 col-form-label text-md-right">コンテンツ管理者</label>
             <div class="col-md-9 d-sm-flex align-items-center">
                 <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_article_admin', $purifiers['role_article_admin']) == '1')
-                        <input type="radio" value="1" id="role_article_admin_1" name="role_article_admin" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_article_admin_1" name="role_article_admin" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_article_admin_1" id="label_role_article_admin_1">制限する</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
                     @if (old('role_article_admin', $purifiers['role_article_admin']) == '0')
                         <input type="radio" value="0" id="role_article_admin_0" name="role_article_admin" class="custom-control-input" checked="checked">
                     @else
@@ -46,19 +39,19 @@
                     @endif
                     <label class="custom-control-label" for="role_article_admin_0" id="label_role_article_admin_0">制限しない</label>
                 </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    @if (old('role_article_admin', $purifiers['role_article_admin']) == '1')
+                        <input type="radio" value="1" id="role_article_admin_1" name="role_article_admin" class="custom-control-input" checked="checked">
+                    @else
+                        <input type="radio" value="1" id="role_article_admin_1" name="role_article_admin" class="custom-control-input">
+                    @endif
+                    <label class="custom-control-label" for="role_article_admin_1" id="label_role_article_admin_1">制限する</label>
+                </div>
             </div>
         </div>
         <div class="form-group row mb-0">
             <label for="permanent_link" class="col-md-3 col-form-label text-md-right">プラグイン管理者</label>
             <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_arrangement', $purifiers['role_arrangement']) == 1)
-                        <input type="radio" value="1" id="role_arrangement_1" name="role_arrangement" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_arrangement_1" name="role_arrangement" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_arrangement_1" id="label_role_arrangement_1">制限する</label>
-                </div>
                 <div class="custom-control custom-radio custom-control-inline">
                     @if (old('role_arrangement', $purifiers['role_arrangement']) == 0)
                         <input type="radio" value="0" id="role_arrangement_0" name="role_arrangement" class="custom-control-input" checked="checked">
@@ -67,19 +60,19 @@
                     @endif
                     <label class="custom-control-label" for="role_arrangement_0" id="label_role_arrangement_0">制限しない</label>
                 </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    @if (old('role_arrangement', $purifiers['role_arrangement']) == 1)
+                        <input type="radio" value="1" id="role_arrangement_1" name="role_arrangement" class="custom-control-input" checked="checked">
+                    @else
+                        <input type="radio" value="1" id="role_arrangement_1" name="role_arrangement" class="custom-control-input">
+                    @endif
+                    <label class="custom-control-label" for="role_arrangement_1" id="label_role_arrangement_1">制限する</label>
+                </div>
             </div>
         </div>
         <div class="form-group row mb-0">
             <label for="permanent_link" class="col-md-3 col-form-label text-md-right">モデレータ</label>
             <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_article', $purifiers['role_article']) == 1)
-                        <input type="radio" value="1" id="role_article_1" name="role_article" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_article_1" name="role_article" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_article_1" id="label_role_article_1">制限する</label>
-                </div>
                 <div class="custom-control custom-radio custom-control-inline">
                     @if (old('role_article', $purifiers['role_article']) == 0)
                         <input type="radio" value="0" id="role_article_0" name="role_article" class="custom-control-input" checked="checked">
@@ -88,19 +81,19 @@
                     @endif
                     <label class="custom-control-label" for="role_article_0" id="label_role_article_0">制限しない</label>
                 </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    @if (old('role_article', $purifiers['role_article']) == 1)
+                        <input type="radio" value="1" id="role_article_1" name="role_article" class="custom-control-input" checked="checked">
+                    @else
+                        <input type="radio" value="1" id="role_article_1" name="role_article" class="custom-control-input">
+                    @endif
+                    <label class="custom-control-label" for="role_article_1" id="label_role_article_1">制限する</label>
+                </div>
             </div>
         </div>
         <div class="form-group row mb-0">
             <label for="permanent_link" class="col-md-3 col-form-label text-md-right">承認者</label>
             <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_approval', $purifiers['role_approval']) == 1)
-                        <input type="radio" value="1" id="role_approval_1" name="role_approval" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_approval_1" name="role_approval" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_approval_1" id="label_role_approval_1">制限する</label>
-                </div>
                 <div class="custom-control custom-radio custom-control-inline">
                     @if (old('role_approval', $purifiers['role_approval']) == 0)
                         <input type="radio" value="0" id="role_approval_0" name="role_approval" class="custom-control-input" checked="checked">
@@ -109,19 +102,19 @@
                     @endif
                     <label class="custom-control-label" for="role_approval_0" id="label_role_approval_0">制限しない</label>
                 </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    @if (old('role_approval', $purifiers['role_approval']) == 1)
+                        <input type="radio" value="1" id="role_approval_1" name="role_approval" class="custom-control-input" checked="checked">
+                    @else
+                        <input type="radio" value="1" id="role_approval_1" name="role_approval" class="custom-control-input">
+                    @endif
+                    <label class="custom-control-label" for="role_approval_1" id="label_role_approval_1">制限する</label>
+                </div>
             </div>
         </div>
         <div class="form-group row mb-0">
             <label for="permanent_link" class="col-md-3 col-form-label text-md-right">編集者</label>
             <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_reporter', $purifiers['role_reporter']) == 1)
-                        <input type="radio" value="1" id="role_reporter_1" name="role_reporter" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_reporter_1" name="role_reporter" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_reporter_1" id="label_role_reporter_1">制限する</label>
-                </div>
                 <div class="custom-control custom-radio custom-control-inline">
                     @if (old('role_reporter', $purifiers['role_reporter']) == 0)
                         <input type="radio" value="0" id="role_reporter_0" name="role_reporter" class="custom-control-input" checked="checked">
@@ -130,19 +123,19 @@
                     @endif
                     <label class="custom-control-label" for="role_reporter_0" id="label_role_reporter_0">制限しない</label>
                 </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    @if (old('role_reporter', $purifiers['role_reporter']) == 1)
+                        <input type="radio" value="1" id="role_reporter_1" name="role_reporter" class="custom-control-input" checked="checked">
+                    @else
+                        <input type="radio" value="1" id="role_reporter_1" name="role_reporter" class="custom-control-input">
+                    @endif
+                    <label class="custom-control-label" for="role_reporter_1" id="label_role_reporter_1">制限する</label>
+                </div>
             </div>
         </div>
         <div class="form-group row">
             <label for="permanent_link" class="col-md-3 col-form-label text-md-right">ゲスト</label>
             <div class="col-md-9 d-sm-flex align-items-center">
-                <div class="custom-control custom-radio custom-control-inline">
-                    @if (old('role_guest', $purifiers['role_guest']) == 1)
-                        <input type="radio" value="1" id="role_guest_1" name="role_guest" class="custom-control-input" checked="checked">
-                    @else
-                        <input type="radio" value="1" id="role_guest_1" name="role_guest" class="custom-control-input">
-                    @endif
-                    <label class="custom-control-label" for="role_guest_1" id="label_role_guest_1">制限する</label>
-                </div>
                 <div class="custom-control custom-radio custom-control-inline">
                     @if (old('role_guest', $purifiers['role_guest']) == 0)
                         <input type="radio" value="0" id="role_guest_0" name="role_guest" class="custom-control-input" checked="checked">
@@ -150,6 +143,14 @@
                         <input type="radio" value="0" id="role_guest_0" name="role_guest" class="custom-control-input">
                     @endif
                     <label class="custom-control-label" for="role_guest_0" id="label_role_guest_0">制限しない</label>
+                </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    @if (old('role_guest', $purifiers['role_guest']) == 1)
+                        <input type="radio" value="1" id="role_guest_1" name="role_guest" class="custom-control-input" checked="checked">
+                    @else
+                        <input type="radio" value="1" id="role_guest_1" name="role_guest" class="custom-control-input">
+                    @endif
+                    <label class="custom-control-label" for="role_guest_1" id="label_role_guest_1">制限する</label>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/737
上記対応です。

# 変更後画面
## セキュリティ管理＞ログイン制限

![image](https://github.com/user-attachments/assets/0f2e6833-3a14-42a9-a6ca-c66ad4c730cc)

## セキュリティ管理＞HTML記述制限

![image](https://github.com/user-attachments/assets/abfcdff1-d5e8-4d06-b198-7c646fc1cec7)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
