### PR TITLE
[サイト内検索] 多言語モード採用時、対象言語ページの絞り込みが効かないバグを修正

### DIFF
--- a/app/Plugins/User/Bbses/BbsesPlugin.php
+++ b/app/Plugins/User/Bbses/BbsesPlugin.php
@@ -278,7 +278,7 @@ class BbsesPlugin extends UserPluginBase
     /**
      * 検索用メソッド
      */
-    public static function getSearchArgs($search_keyword)
+    public static function getSearchArgs($search_keyword, $page_ids = null)
     {
         $return[] = BbsPost::
             select(
@@ -303,6 +303,7 @@ class BbsesPlugin extends UserPluginBase
             })
             ->join('frames', 'frames.bucket_id', '=', 'bbses.bucket_id')
             ->leftjoin('pages', 'pages.id', '=', 'frames.page_id')
+            ->whereIn('pages.id', $page_ids)
             ->where(function ($plugin_query) use ($search_keyword) {
                 $plugin_query->where('bbs_posts.title', 'like', '%' . $search_keyword . '%')
                     ->orWhere('bbs_posts.body', 'like', '%' . $search_keyword . '%');

--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -363,7 +363,7 @@ class FaqsPlugin extends UserPluginBase
     /**
      *  検索用メソッド
      */
-    public static function getSearchArgs($search_keyword)
+    public static function getSearchArgs($search_keyword, $page_ids = null)
     {
         $return[] = DB::table('faqs_posts')
                       ->select(
@@ -385,6 +385,7 @@ class FaqsPlugin extends UserPluginBase
                       ->join('frames', 'frames.bucket_id', '=', 'faqs.bucket_id')
                       ->leftJoin('categories', 'categories.id', '=', 'faqs_posts.categories_id')
                       ->leftjoin('pages', 'pages.id', '=', 'frames.page_id')
+                      ->whereIn('pages.id', $page_ids)
                       ->where('status', '?')
                       ->where(function ($plugin_query) use ($search_keyword) {
                           $plugin_query->where('faqs_posts.post_title', 'like', "%$search_keyword%")

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -698,7 +698,7 @@ class LearningtasksPlugin extends UserPluginBase
     /**
      *  検索用メソッド
      */
-    public static function getSearchArgs($search_keyword)
+    public static function getSearchArgs($search_keyword, $page_ids = null)
     {
         $return[] = DB::table('learningtasks_posts')
                       ->select(
@@ -719,6 +719,7 @@ class LearningtasksPlugin extends UserPluginBase
                       ->join('frames', 'frames.bucket_id', '=', 'learningtasks.bucket_id')
                       ->leftJoin('categories', 'categories.id', '=', 'learningtasks_posts.categories_id')
                       ->leftjoin('pages', 'pages.id', '=', 'frames.page_id')
+                      ->whereIn('pages.id', $page_ids)
                       ->where('status', '?')
                       ->where(function ($plugin_query) use ($search_keyword) {
                           $plugin_query->where('learningtasks_posts.post_title', 'like', '?')


### PR DESCRIPTION
# 概要
 - （掲示板）（FAQ）動確済み
 - （課題管理）サイト内検索の対象外なので動確未
https://github.com/opensource-workshop/connect-cms/issues/2067

# レビュー完了希望日
11/22（金）

# 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/issues/2067

# 参考
なし

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
