### PR TITLE
[テスト] GroupManageTest, グループ登録時のテスト修正

### DIFF
--- a/tests/Browser/Manage/GroupManageTest.php
+++ b/tests/Browser/Manage/GroupManageTest.php
@@ -76,7 +76,7 @@ class GroupManageTest extends DuskTestCase
     private function update()
     {
         $this->browse(function (Browser $browser) {
-            $browser->press('グループ変更')
+            $browser->press('グループ登録')
                     ->assertTitleContains('Connect-CMS')
                     ->screenshot('manage/group/update/images/update');
         });


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

開発者向け修正です。
下記修正に含まれていた、グループ登録時のボタン名修正をした影響で、テストでエラーになっていたため、修正しました。

* 下記修正
  * https://github.com/opensource-workshop/connect-cms/pull/2071
* テストでエラー
  * https://github.com/opensource-workshop/connect-cms/actions/runs/11937190694/job/33272584802

# 修正後テスト

https://github.com/opensource-workshop/connect-cms/actions/runs/11944885264

エラー解消を確認しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
