### PR TITLE
[掲示板][サイト内検索] 歯車＞新規作成, ラジオでON・OFF時、左側はOFFで統一する

### DIFF
--- a/resources/views/plugins/user/bbses/default/bucket.blade.php
+++ b/resources/views/plugins/user/bbses/default/bucket.blade.php
@@ -52,12 +52,12 @@
             <label class="{{$frame->getSettingLabelClass(true)}}">いいねボタンの表示</label>
             <div class="{{$frame->getSettingInputClass(true)}}">
                 <div class="custom-control custom-radio custom-control-inline">
-                    <input type="radio" value="1" id="use_like_on" name="use_like" class="custom-control-input" data-toggle="collapse" data-target="#collapse_like_button_name:not(.show)" aria-expanded="false" aria-controls="collapse_like_button_name" @if (old('use_like', $bbs->use_like) == 1) checked="checked" @endif>
-                    <label class="custom-control-label" for="use_like_on" id="label_use_like_on">表示する</label>
-                </div>
-                <div class="custom-control custom-radio custom-control-inline">
                     <input type="radio" value="0" id="use_like_off" name="use_like" class="custom-control-input" data-toggle="collapse" data-target="#collapse_like_button_name.show" aria-expanded="false" aria-controls="collapse_like_button_name"  @if (old('use_like', $bbs->use_like) == 0) checked="checked" @endif>
                     <label class="custom-control-label" for="use_like_off">表示しない</label>
+                </div>
+                <div class="custom-control custom-radio custom-control-inline">
+                    <input type="radio" value="1" id="use_like_on" name="use_like" class="custom-control-input" data-toggle="collapse" data-target="#collapse_like_button_name:not(.show)" aria-expanded="false" aria-controls="collapse_like_button_name" @if (old('use_like', $bbs->use_like) == 1) checked="checked" @endif>
+                    <label class="custom-control-label" for="use_like_on" id="label_use_like_on">表示する</label>
                 </div>
             </div>
         </div>

--- a/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
@@ -72,20 +72,20 @@
                 <label class="{{$frame->getSettingLabelClass()}}">登録者の表示</label>
                 <div class="{{$frame->getSettingInputClass(true)}}">
                     <div class="custom-control custom-radio custom-control-inline">
-                        @if(old('view_posted_name', $searchs->view_posted_name) == 1)
-                            <input type="radio" value="1" id="view_posted_name_1" name="view_posted_name" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="1" id="view_posted_name_1" name="view_posted_name" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="view_posted_name_1">表示する</label>
-                    </div>
-                    <div class="custom-control custom-radio custom-control-inline">
                         @if(old('view_posted_name', $searchs->view_posted_name) == 0)
                             <input type="radio" value="0" id="view_posted_name_0" name="view_posted_name" class="custom-control-input" checked="checked">
                         @else
                             <input type="radio" value="0" id="view_posted_name_0" name="view_posted_name" class="custom-control-input">
                         @endif
                         <label class="custom-control-label" for="view_posted_name_0">表示しない</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if(old('view_posted_name', $searchs->view_posted_name) == 1)
+                            <input type="radio" value="1" id="view_posted_name_1" name="view_posted_name" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="view_posted_name_1" name="view_posted_name" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="view_posted_name_1">表示する</label>
                     </div>
                 </div>
             </div>
@@ -94,20 +94,20 @@
                 <label class="{{$frame->getSettingLabelClass()}}">登録日時の表示</label><br />
                 <div class="{{$frame->getSettingInputClass(true)}}">
                     <div class="custom-control custom-radio custom-control-inline">
-                        @if(old('view_posted_at', $searchs->view_posted_at)  == 1)
-                            <input type="radio" value="1" id="view_posted_at_1" name="view_posted_at" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="1" id="view_posted_at_1" name="view_posted_at" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="view_posted_at_1">表示する</label>
-                    </div>
-                    <div class="custom-control custom-radio custom-control-inline">
                         @if(old('view_posted_at', $searchs->view_posted_at) == 0)
                             <input type="radio" value="0" id="view_posted_at_0" name="view_posted_at" class="custom-control-input" checked="checked">
                         @else
                             <input type="radio" value="0" id="view_posted_at_0" name="view_posted_at" class="custom-control-input">
                         @endif
                         <label class="custom-control-label" for="view_posted_at_0">表示しない</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if(old('view_posted_at', $searchs->view_posted_at)  == 1)
+                            <input type="radio" value="1" id="view_posted_at_1" name="view_posted_at" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="view_posted_at_1" name="view_posted_at" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="view_posted_at_1">表示する</label>
                     </div>
                 </div>
             </div>
@@ -129,20 +129,20 @@
                 <label class="{{$frame->getSettingLabelClass()}}">他ページからのキーワード</label><br />
                 <div class="{{$frame->getSettingInputClass(true)}}">
                     <div class="custom-control custom-radio custom-control-inline">
-                        @if(old('recieve_keyword', $searchs->recieve_keyword) == 1)
-                            <input type="radio" value="1" id="recieve_keyword_1" name="recieve_keyword" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="1" id="recieve_keyword_1" name="recieve_keyword" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="recieve_keyword_1">受け取る</label>
-                    </div>
-                    <div class="custom-control custom-radio custom-control-inline">
                         @if(old('recieve_keyword', $searchs->recieve_keyword) == 0)
                             <input type="radio" value="0" id="recieve_keyword_0" name="recieve_keyword" class="custom-control-input" checked="checked">
                         @else
                             <input type="radio" value="0" id="recieve_keyword_0" name="recieve_keyword" class="custom-control-input">
                         @endif
                         <label class="custom-control-label" for="recieve_keyword_0">受け取らない</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if(old('recieve_keyword', $searchs->recieve_keyword) == 1)
+                            <input type="radio" value="1" id="recieve_keyword_1" name="recieve_keyword" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="recieve_keyword_1" name="recieve_keyword" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="recieve_keyword_1">受け取る</label>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/737

上記の修正です。

# 修正後画面
## 掲示板＞歯車＞新規作成

![image](https://github.com/user-attachments/assets/218b0c5d-9141-4916-87c6-9c5a9efababe)

## サイト内検索＞歯車＞新規作成
![image](https://github.com/user-attachments/assets/4fd2606b-fb4e-400d-be5a-f3cd7f1c90cb)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
