### PR TITLE
[PHP8.2] Using ${var} in strings is deprecated fix

### DIFF
--- a/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_database.blade.php
@@ -128,19 +128,19 @@
                 <input
                     type="radio"
                     value="{{ $key }}"
-                    id="{{ "full_text_search_${key}" }}"
+                    id="{{ "full_text_search_{$key}" }}"
                     name="full_text_search"
                     class="custom-control-input"
                     {{ old('full_text_search', $database->full_text_search) == $key ? 'checked' : '' }}
                 >
-                <label class="custom-control-label" for="{{ "full_text_search_${key}" }}">
+                <label class="custom-control-label" for="{{ "full_text_search_{$key}" }}">
                     {{ $value }}
                 </label>
             </div>
         @endforeach
         </div>
     </div>
-    
+
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass()}}">検索キーワードの記録</label>
         <div class="{{$frame->getSettingInputClass()}}">
@@ -149,12 +149,12 @@
                 <input
                     type="radio"
                     value="{{ $key }}"
-                    id="{{ "save_searched_word_${key}" }}"
+                    id="{{ "save_searched_word_{$key}" }}"
                     name="save_searched_word"
                     class="custom-control-input"
                     {{ old('save_searched_word', $database->save_searched_word) == $key ? 'checked' : '' }}
                 >
-                <label class="custom-control-label" for="{{ "save_searched_word_${key}" }}">
+                <label class="custom-control-label" for="{{ "save_searched_word_{$key}" }}">
                     {{ $value }}
                 </label>
             </div>

--- a/resources/views/plugins/user/photoalbums/default/frame.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/frame.blade.php
@@ -46,12 +46,12 @@
                         <input
                             type="radio"
                             value="{{ $key }}"
-                            id="{{ "download_${key}" }}"
+                            id="{{ "download_{$key}" }}"
                             name="download"
                             class="custom-control-input"
                             {{ FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::download, 0) == $key ? 'checked' : '' }}
                         >
-                        <label class="custom-control-label" for="{{ "download_${key}" }}">
+                        <label class="custom-control-label" for="{{ "download_{$key}" }}">
                             {{ $value }}
                         </label>
                     </div>
@@ -71,12 +71,12 @@
                         <input
                             type="radio"
                             value="{{ $key }}"
-                            id="{{ "posted_at_${key}" }}"
+                            id="{{ "posted_at_{$key}" }}"
                             name="posted_at"
                             class="custom-control-input"
                             {{ FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::posted_at, 0) == $key ? 'checked' : '' }}
                         >
-                        <label class="custom-control-label" for="{{ "posted_at_${key}" }}">
+                        <label class="custom-control-label" for="{{ "posted_at_{$key}" }}">
                             {{ $value }}
                         </label>
                     </div>
@@ -93,12 +93,12 @@
                         <input
                             type="radio"
                             value="{{ $key }}"
-                            id="{{ "shooting_at_${key}" }}"
+                            id="{{ "shooting_at_{$key}" }}"
                             name="shooting_at"
                             class="custom-control-input"
                             {{ FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::shooting_at, 0) == $key ? 'checked' : '' }}
                         >
-                        <label class="custom-control-label" for="{{ "shooting_at_${key}" }}">
+                        <label class="custom-control-label" for="{{ "shooting_at_{$key}" }}">
                             {{ $value }}
                         </label>
                     </div>
@@ -115,14 +115,14 @@
                         <input
                             type="radio"
                             value="{{ $key }}"
-                            id="{{ "embed_code_${key}" }}"
+                            id="{{ "embed_code_{$key}" }}"
                             name="embed_code"
                             class="custom-control-input"
                             {{ FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::embed_code, 0) == $key ? 'checked' : '' }}
                         >
                         <label class="custom-control-label"
-                               for="{{ "embed_code_${key}" }}"
-                               id="{{ "label_embed_code_${key}" }}">
+                               for="{{ "embed_code_{$key}" }}"
+                               id="{{ "label_embed_code_{$key}" }}">
                             {{ $value }}
                         </label>
                     </div>

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_slideshow.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_slideshow.blade.php
@@ -71,12 +71,12 @@
                             <input
                                 type="radio"
                                 value="{{ $key }}"
-                                id="{{ "control_display_flag_${key}" }}"
+                                id="{{ "control_display_flag_{$key}" }}"
                                 name="control_display_flag"
                                 class="custom-control-input"
                                 {{ $slideshow->control_display_flag == $key ? 'checked' : '' }}
                             >
-                            <label class="custom-control-label" for="{{ "control_display_flag_${key}" }}" id="{{ "label_control_display_flag_${key}" }}">
+                            <label class="custom-control-label" for="{{ "control_display_flag_{$key}" }}" id="{{ "label_control_display_flag_{$key}" }}">
                                 {{ $value }}
                             </label>
                         </div>
@@ -93,12 +93,12 @@
                             <input
                                 type="radio"
                                 value="{{ $key }}"
-                                id="{{ "indicators_display_flag_${key}" }}"
+                                id="{{ "indicators_display_flag_{$key}" }}"
                                 name="indicators_display_flag"
                                 class="custom-control-input"
                                 {{ $slideshow->indicators_display_flag == $key ? 'checked' : '' }}
                             >
-                            <label class="custom-control-label" for="{{ "indicators_display_flag_${key}" }}" id="{{ "label_indicators_display_flag_${key}" }}">
+                            <label class="custom-control-label" for="{{ "indicators_display_flag_{$key}" }}" id="{{ "label_indicators_display_flag_{$key}" }}">
                                 {{ $value }}
                             </label>
                         </div>
@@ -115,12 +115,12 @@
                             <input
                                 type="radio"
                                 value="{{ $key }}"
-                                id="{{ "fade_use_flag_${key}" }}"
+                                id="{{ "fade_use_flag_{$key}" }}"
                                 name="fade_use_flag"
                                 class="custom-control-input"
                                 {{ $slideshow->fade_use_flag == $key ? 'checked' : '' }}
                             >
-                            <label class="custom-control-label" for="{{ "fade_use_flag_${key}" }}" id="{{ "label_fade_use_flag_${key}" }}">
+                            <label class="custom-control-label" for="{{ "fade_use_flag_{$key}" }}" id="{{ "label_fade_use_flag_{$key}" }}">
                                 {{ $value }}
                             </label>
                         </div>

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_edit_whatsnew.blade.php
@@ -107,7 +107,7 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
                     <input
                         type="radio"
                         value="{{ $key }}"
-                        id="{{ "rss_${key}" }}"
+                        id="{{ "rss_{$key}" }}"
                         name="rss"
                         class="custom-control-input"
                         {{ old('rss', $whatsnew->rss) == $key ? 'checked' : '' }}
@@ -117,7 +117,7 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
                             data-toggle="collapse" data-target="#collapse_rss_count{{$frame_id}}:not(.show)" aria-expanded="true" aria-controls="collapse_rss_count{{$frame_id}}"
                         @endif
                     >
-                    <label class="custom-control-label" for="{{ "rss_${key}" }}">
+                    <label class="custom-control-label" for="{{ "rss_{$key}" }}">
                         {{ $value }}
                     </label>
                 </div>
@@ -145,14 +145,14 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
                     <input
                         type="radio"
                         value="{{ $key }}"
-                        id="{{ "view_posted_name_${key}" }}"
+                        id="{{ "view_posted_name_{$key}" }}"
                         name="view_posted_name"
                         class="custom-control-input"
                         {{ old('view_posted_name', $whatsnew->view_posted_name) == $key ? 'checked' : '' }}
                     >
                     <label class="custom-control-label"
-                           for="{{ "view_posted_name_${key}" }}"
-                           id="{{ "label_view_posted_name_${key}" }}">
+                           for="{{ "view_posted_name_{$key}" }}"
+                           id="{{ "label_view_posted_name_{$key}" }}">
                         {{ $value }}
                     </label>
                 </div>
@@ -169,14 +169,14 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
                     <input
                         type="radio"
                         value="{{ $key }}"
-                        id="{{ "view_posted_at_${key}" }}"
+                        id="{{ "view_posted_at_{$key}" }}"
                         name="view_posted_at"
                         class="custom-control-input"
                         {{ old('view_posted_at', $whatsnew->view_posted_at) == $key ? 'checked' : '' }}
                     >
                     <label class="custom-control-label"
-                           for="{{ "view_posted_at_${key}" }}"
-                           id="{{ "label_view_posted_at_${key}" }}">
+                           for="{{ "view_posted_at_{$key}" }}"
+                           id="{{ "label_view_posted_at_{$key}" }}">
                         {{ $value }}
                     </label>
                 </div>
@@ -236,7 +236,7 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
                     <input
                         type="radio"
                         value="{{ $key }}"
-                        id="{{ "read_more_use_flag_${key}" }}"
+                        id="{{ "read_more_use_flag_{$key}" }}"
                         name="read_more_use_flag"
                         class="custom-control-input"
                         {{ old('read_more_use_flag', $whatsnew->read_more_use_flag) == $key ? 'checked' : '' }}
@@ -248,8 +248,8 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
                         @endif
                     >
                     <label class="custom-control-label"
-                           for="{{ "read_more_use_flag_${key}" }}"
-                           id="{{ "label_read_more_use_flag_${key}" }}">
+                           for="{{ "read_more_use_flag_{$key}" }}"
+                           id="{{ "label_read_more_use_flag_{$key}" }}">
                         {{ $value }}
                     </label>
                 </div>
@@ -324,13 +324,13 @@ use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
                         <input
                             type="radio"
                             value="{{ $key }}"
-                            id="{{ "read_more_btn_transparent_flag_${key}" }}"
+                            id="{{ "read_more_btn_transparent_flag_{$key}" }}"
                             name="read_more_btn_transparent_flag"
                             class="custom-control-input"
                             {{ old('read_more_btn_transparent_flag', $whatsnew->read_more_btn_transparent_flag) == $key ? 'checked' : '' }}
                             v-model="read_more_btn_transparent_flag"
                         >
-                        <label class="custom-control-label" for="{{ "read_more_btn_transparent_flag_${key}" }}">
+                        <label class="custom-control-label" for="{{ "read_more_btn_transparent_flag_{$key}" }}">
                             {{ $value }}
                         </label>
                     </div>

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
@@ -39,12 +39,12 @@
                     <input
                         type="radio"
                         value="{{ $key }}"
-                        id="{{ "post_detail_${key}" }}"
+                        id="{{ "post_detail_{$key}" }}"
                         name="post_detail"
                         class="custom-control-input"
                         {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail, 0) == $key ? 'checked' : '' }}
                     >
-                    <label class="custom-control-label" for="{{ "post_detail_${key}" }}">
+                    <label class="custom-control-label" for="{{ "post_detail_{$key}" }}">
                         {{ $value }}
                     </label>
                 </div>
@@ -73,12 +73,12 @@
                     <input
                         type="radio"
                         value="{{ $key }}"
-                        id="{{ "thumbnail_${key}" }}"
+                        id="{{ "thumbnail_{$key}" }}"
                         name="thumbnail"
                         class="custom-control-input"
                         {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail, 0) == $key ? 'checked' : '' }}
                     >
-                    <label class="custom-control-label" for="{{ "thumbnail_${key}" }}">
+                    <label class="custom-control-label" for="{{ "thumbnail_{$key}" }}">
                         {{ $value }}
                     </label>
                 </div>
@@ -107,12 +107,12 @@
                     <input
                         type="radio"
                         value="{{ $key }}"
-                        id="{{ "border_${key}" }}"
+                        id="{{ "border_{$key}" }}"
                         name="border"
                         class="custom-control-input"
                         {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::border, 0) == $key ? 'checked' : '' }}
                     >
-                    <label class="custom-control-label" for="{{ "border_${key}" }}">
+                    <label class="custom-control-label" for="{{ "border_{$key}" }}">
                         {{ $value }}
                     </label>
                 </div>
@@ -131,12 +131,12 @@
                     <input
                         type="radio"
                         value="{{ $key }}"
-                        id="{{ "async_${key}" }}"
+                        id="{{ "async_{$key}" }}"
                         name="async"
                         class="custom-control-input"
                         {{ FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::async, 0) == $key ? 'checked' : '' }}
                     >
-                    <label class="custom-control-label" for="{{ "async_${key}" }}">
+                    <label class="custom-control-label" for="{{ "async_{$key}" }}">
                         {{ $value }}
                     </label>
                 </div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1785

上記修正です。

# 単体テスト

https://github.com/opensource-workshop/connect-cms/actions/runs/12021772987/job/33512856001

php8.2で画面表示にエラーがない事を確認しました。
（※ Connect1.x系のため、実際にはphp8.2はメール処理が動かないです。）

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
急ぎません

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
