### PR TITLE
[フレーム編集] 公開日時From、Toが限定公開以外でも入力できる不具合修正

### DIFF
--- a/resources/views/core/cms_frame_edit.blade.php
+++ b/resources/views/core/cms_frame_edit.blade.php
@@ -214,6 +214,7 @@
                     <input
                         type="text"
                         name="content_open_date_from"
+                        id="content_open_date_from_input"
                         value="{{old('content_open_date_from', $frame ? $frame->content_open_date_from : '')}}"
                         class="form-control datetimepicker-input {{ $errors->has('content_open_date_from') ? ' border-danger' : '' }}"
                         data-target="#content_open_date_from"
@@ -242,6 +243,7 @@
                     <input
                         type="text"
                         name="content_open_date_to"
+                        id="content_open_date_to_input"
                         value="{{old('content_open_date_to', $frame ? $frame->content_open_date_to : '')}}"
                         class="form-control datetimepicker-input {{ $errors->has('content_open_date_to') ? ' border-danger' : '' }}"
                         data-target="#content_open_date_to"
@@ -341,11 +343,13 @@
     </form>
 </div>
 <script>
+    let content_open_type = '{{ old('content_open_type', $frame->content_open_type) }}';
+
     new Vue({
       el: "#app_{{ $frame->id }}",
       data: {
         // コンテンツ公開区分
-        v_content_open_type: '{{ old('content_open_type', $frame->content_open_type) }}'
+        v_content_open_type: content_open_type
       }
     })
 
@@ -365,5 +369,11 @@
             dayViewHeaderFormat: 'YYYY年 M月',
             format: 'YYYY-MM-DD HH:mm:ss'
         });
+
+        // 初期非表示の場合、日時入力をreadonlyにする（初期表示vueでdatetimepickerのinputをreadonlyしているが、datetimepicker側で強制解除されるため追加対応）
+        if (content_open_type != '{{ ContentOpenType::limited_open }}') {
+            $("#content_open_date_from_input").attr("readonly", "readonly");
+            $("#content_open_date_to_input").attr("readonly", "readonly");
+        }
     });
 </script>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* #2074

上記不具合の修正です。

vue＋datetimepicker同時使用で不具合でした。
・vueは正常動作。
・使用しているdatetimepickerで初期表示時にreadonlyを強制解除されていました。
・datetimepicker定義後に、追加で公開日時From、Toをreadonlyする処理を追加して対応しました。

# 修正後画面
## フレーム編集

https://github.com/user-attachments/assets/2e28d96e-7b6c-409c-ae74-a32f99c78409

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
急ぎません

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://github.com/tempusdominus/bootstrap-4/issues/362

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
