### PR TITLE
[施設管理] 予約一覧の絞込条件に利用日を追加 OW-2441

### DIFF
--- a/app/Plugins/Manage/ReservationManage/ReservationManage.php
+++ b/app/Plugins/Manage/ReservationManage/ReservationManage.php
@@ -1080,7 +1080,7 @@ class ReservationManage extends ManagePluginBase
 
         // カスタムエラーメッセージ
         $validator->setCustomMessages([
-            'app_reservation_search_condition.end_datetime' => ':attributeには:date以降の日時を指定してください。',
+            'app_reservation_search_condition.end_datetime.after_or_equal' => ':attributeには:date以降の日時を指定してください。',
         ]);
 
         // エラーがあった場合は入力画面に戻る。

--- a/app/Plugins/Manage/ReservationManage/ReservationManage.php
+++ b/app/Plugins/Manage/ReservationManage/ReservationManage.php
@@ -1071,7 +1071,7 @@ class ReservationManage extends ManagePluginBase
         // エラーチェック
         $validator = Validator::make($request->all(), [
             'app_reservation_search_condition.start_datetime' => ['nullable'],
-            'app_reservation_search_condition.end_datetime' => ['nullable', 'after:app_reservation_search_condition.start_datetime'],
+            'app_reservation_search_condition.end_datetime' => ['nullable', 'after_or_equal:app_reservation_search_condition.start_datetime'],
         ]);
         $validator->setAttributeNames([
             'app_reservation_search_condition.start_datetime' => '利用日From',

--- a/app/Plugins/Manage/ReservationManage/ReservationManage.php
+++ b/app/Plugins/Manage/ReservationManage/ReservationManage.php
@@ -1067,6 +1067,27 @@ class ReservationManage extends ManagePluginBase
         // 画面上、検索条件は app_reservation_search_condition という名前で配列になっているので、
         // app_reservation_search_condition をセッションに持つことで、条件の持ち回りが可能。
         session(["app_reservation_search_condition" => $request->input('app_reservation_search_condition')]);
+
+        // エラーチェック
+        $validator = Validator::make($request->all(), [
+            'app_reservation_search_condition.start_datetime' => ['nullable'],
+            'app_reservation_search_condition.end_datetime' => ['nullable', 'after:app_reservation_search_condition.start_datetime'],
+        ]);
+        $validator->setAttributeNames([
+            'app_reservation_search_condition.start_datetime' => '利用日From',
+            'app_reservation_search_condition.end_datetime' => '利用日To',
+        ]);
+
+        // カスタムエラーメッセージ
+        $validator->setCustomMessages([
+            'app_reservation_search_condition.end_datetime' => ':attributeには:date以降の日時を指定してください。',
+        ]);
+
+        // エラーがあった場合は入力画面に戻る。
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
         return redirect("/manage/reservation/bookings");
     }
 

--- a/app/Plugins/Manage/ReservationManage/ReservationManage.php
+++ b/app/Plugins/Manage/ReservationManage/ReservationManage.php
@@ -930,16 +930,15 @@ class ReservationManage extends ManagePluginBase
 
         // 利用日From
         if (session()->has('app_reservation_search_condition.start_datetime')) {
-            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (input-S)2024-12-10 15:00 <= (E) o
-            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (input-S)2024-12-10 15:01 <= (E) x
-            $inputs_query->where('reservations_inputs.end_datetime', '>', session()->get('app_reservation_search_condition.start_datetime'));
+            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (input-S)2024-12-10 15:00 <= (E) o：含む
+            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (input-S)2024-12-10 15:01 <= (E) x：含まない
+            $inputs_query->where('reservations_inputs.end_datetime', '>=', session()->get('app_reservation_search_condition.start_datetime'));
         }
 
         // 利用日To
         if (session()->has('app_reservation_search_condition.end_datetime')) {
-            // 予約終了時間は、利用時間内か
-            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (S) <= (input-E)2024-12-09 13:00 o
-            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (S) <= (input-E)2024-12-09 12:59 x
+            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (S) <= (input-E)2024-12-09 13:00 o：含む
+            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (S) <= (input-E)2024-12-09 12:59 x：含まない
             $inputs_query->where('reservations_inputs.start_datetime', '<=', session()->get('app_reservation_search_condition.end_datetime'));
         }
 

--- a/app/Plugins/Manage/ReservationManage/ReservationManage.php
+++ b/app/Plugins/Manage/ReservationManage/ReservationManage.php
@@ -928,6 +928,21 @@ class ReservationManage extends ManagePluginBase
             $inputs_query->where('reservations_facilities.facility_name', 'like', '%' . session()->get('app_reservation_search_condition.facility_name') . '%');
         }
 
+        // 利用日From
+        if (session()->has('app_reservation_search_condition.start_datetime')) {
+            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (input-S)2024-12-10 15:00 <= (E) o
+            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (input-S)2024-12-10 15:01 <= (E) x
+            $inputs_query->where('reservations_inputs.end_datetime', '>', session()->get('app_reservation_search_condition.start_datetime'));
+        }
+
+        // 利用日To
+        if (session()->has('app_reservation_search_condition.end_datetime')) {
+            // 予約終了時間は、利用時間内か
+            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (S) <= (input-E)2024-12-09 13:00 o
+            // 例) (S)2024-12-09 13:00 ～ (E)2024-12-10 15:00  = (S) <= (input-E)2024-12-09 12:59 x
+            $inputs_query->where('reservations_inputs.start_datetime', '<=', session()->get('app_reservation_search_condition.end_datetime'));
+        }
+
         // 登録者名
         if (session()->has('app_reservation_search_condition.created_name')) {
             $inputs_query->where('reservations_inputs.created_name', 'like', '%' . session()->get('app_reservation_search_condition.created_name') . '%');
@@ -1060,7 +1075,7 @@ class ReservationManage extends ManagePluginBase
      */
     public function clearSearch($request, $id)
     {
-        $request->session()->forget('app_reservation_search_condition');
+        session()->forget('app_reservation_search_condition');
         return redirect("/manage/reservation/bookings");
     }
 }

--- a/resources/views/plugins/manage/reservation/bookings.blade.php
+++ b/resources/views/plugins/manage/reservation/bookings.blade.php
@@ -62,14 +62,15 @@
         @include('plugins.common.flash_message')
 
         <div class="accordion" id="search_accordion">
-            <div class="card">
+            {{-- datetimepicerの小窓がcardの枠内に隠れないようにstyle指定で対応 --}}
+            <div class="card" style="overflow: visible;">
                 <button class="btn btn-link p-0 text-left collapsed" type="button" data-toggle="collapse" data-target="#search_collapse" aria-expanded="false" aria-controls="search_collapse" id="app_reservation_search_condition_button">
                     <div class="card-header" id="app_reservation_search_condition">
                         絞り込み条件 <i class="fas fa-angle-down"></i>@if (Session::has('app_reservation_search_condition'))<span class="badge badge-pill badge-primary ml-2">条件設定中</span>@endif
                    </div>
                 </button>
                 <div id="search_collapse" class="collapse @if ($errors && count($errors) > 0) show @endif" aria-labelledby="app_reservation_search_condition" data-parent="#search_accordion">
-                    <div class="card-body border-bottom">
+                    <div class="card-body">
 
                         <form name="form_search" id="form_search" class="form-horizontal" method="post" action="{{url('/')}}/manage/reservation/search">
                             {{ csrf_field() }}
@@ -117,12 +118,12 @@
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
+                                    </div><!-- /.form-row -->
                                     @include('plugins.common.errors_inline', ['name' => 'app_reservation_search_condition.start_datetime'])
                                     @include('plugins.common.errors_inline', ['name' => 'app_reservation_search_condition.end_datetime'])
 
-                                </div>
-                            </div>
+                                </div><!-- /.col-md-9 -->
+                            </div><!-- /.row -->
 
                             <!-- 登録者 -->
                             <div class="form-group row">
@@ -147,7 +148,7 @@
                             </div>
 
                             <!-- ボタンエリア -->
-                            <div class="form-group text-center pb-4">
+                            <div class="text-center">
                                 <div class="row">
                                     <div class="mx-auto">
                                         <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/reservation/clearSearch')}}'">
@@ -159,13 +160,11 @@
                                     </div>
                                 </div>
                             </div>
-                            {{-- datetimepicerの小ウィンドウが絞込条件の枠内で隠れてしまうため、余白確保 --}}
-                            <div><br></div>
                         </form>
-                    </div>
-                </div>
-            </div>
-        </div>
+                    </div><!-- /.card-body -->
+                </div><!-- /#search_collapse -->
+            </div><!-- /.card -->
+        </div><!-- /#search_accordion -->
 
         {{-- <div class="row mt-2"> --}}
         <div class="row">

--- a/resources/views/plugins/manage/reservation/bookings.blade.php
+++ b/resources/views/plugins/manage/reservation/bookings.blade.php
@@ -98,7 +98,7 @@
                                                 @endphp
                                                 <input type="text" name="app_reservation_search_condition[start_datetime]" value="{{$start_datetime}}" class="form-control datetimepicker-input" data-target="#start_datetime">
                                                 <div class="input-group-append" data-target="#start_datetime" data-toggle="datetimepicker">
-                                                    <div class="input-group-text"><i class="far fa-clock"></i></div>
+                                                    <div class="input-group-text"><i class="fas fa-calendar-alt"></i></div>
                                                 </div>
                                                 <div class="form-text pl-2">
                                                     ～
@@ -114,7 +114,7 @@
                                                 @endphp
                                                 <input type="text" name="app_reservation_search_condition[end_datetime]" value="{{$end_datetime}}" class="form-control datetimepicker-input" data-target="#end_datetime">
                                                 <div class="input-group-append" data-target="#end_datetime" data-toggle="datetimepicker">
-                                                    <div class="input-group-text"><i class="far fa-clock"></i></div>
+                                                    <div class="input-group-text"><i class="fas fa-calendar-alt"></i></div>
                                                 </div>
                                             </div>
                                         </div>

--- a/resources/views/plugins/manage/reservation/bookings.blade.php
+++ b/resources/views/plugins/manage/reservation/bookings.blade.php
@@ -23,12 +23,13 @@
             dayViewHeaderFormat: 'YYYY年 M月',
         @endif
         locale: '{{ App::getLocale() }}',
+        // 日時の両方入力
         format: 'YYYY-MM-DD HH:mm',
         sideBySide: true
     };
 
     $(function () {
-        // カレンダー時計ボタン押下の設定
+        // カレンダーボタン押下の設定
         $('#start_datetime').datetimepicker(calendar_setting);
         $('#end_datetime').datetimepicker(calendar_setting);
     });

--- a/resources/views/plugins/manage/reservation/bookings.blade.php
+++ b/resources/views/plugins/manage/reservation/bookings.blade.php
@@ -56,7 +56,8 @@
         @include('plugins.manage.reservation.reservation_manage_tab')
     </div>
     <div class="card-body">
-
+        {{-- 共通エラーメッセージ 呼び出し --}}
+        @include('plugins.common.errors_form_line')
         {{-- 登録後メッセージ表示 --}}
         @include('plugins.common.flash_message')
 
@@ -67,7 +68,7 @@
                         絞り込み条件 <i class="fas fa-angle-down"></i>@if (Session::has('app_reservation_search_condition'))<span class="badge badge-pill badge-primary ml-2">条件設定中</span>@endif
                    </div>
                 </button>
-                <div id="search_collapse" class="collapse" aria-labelledby="app_reservation_search_condition" data-parent="#search_accordion">
+                <div id="search_collapse" class="collapse @if ($errors && count($errors) > 0) show @endif" aria-labelledby="app_reservation_search_condition" data-parent="#search_accordion">
                     <div class="card-body border-bottom">
 
                         <form name="form_search" id="form_search" class="form-horizontal" method="post" action="{{url('/')}}/manage/reservation/search">
@@ -117,6 +118,8 @@
                                             </div>
                                         </div>
                                     </div>
+                                    @include('plugins.common.errors_inline', ['name' => 'app_reservation_search_condition.start_datetime'])
+                                    @include('plugins.common.errors_inline', ['name' => 'app_reservation_search_condition.end_datetime'])
 
                                 </div>
                             </div>

--- a/resources/views/plugins/manage/reservation/bookings.blade.php
+++ b/resources/views/plugins/manage/reservation/bookings.blade.php
@@ -18,7 +18,22 @@
 </form>
 
 <script type="text/javascript">
-    {{-- ダウンロードのsubmit JavaScript --}}
+    let calendar_setting = {
+        @if (App::getLocale() == ConnectLocale::ja)
+            dayViewHeaderFormat: 'YYYY年 M月',
+        @endif
+        locale: '{{ App::getLocale() }}',
+        format: 'YYYY-MM-DD HH:mm',
+        sideBySide: true
+    };
+
+    $(function () {
+        // カレンダー時計ボタン押下の設定
+        $('#start_datetime').datetimepicker(calendar_setting);
+        $('#end_datetime').datetimepicker(calendar_setting);
+    });
+
+    /** ダウンロードのsubmit JavaScript */
     function submit_download_shift_jis() {
         if( !confirm('{{CsvCharacterCode::enum[CsvCharacterCode::sjis_win]}}で現在の絞り込み条件のユーザをダウンロードします。\nよろしいですか？') ) {
             return;
@@ -58,7 +73,7 @@
                         <form name="form_search" id="form_search" class="form-horizontal" method="post" action="{{url('/')}}/manage/reservation/search">
                             {{ csrf_field() }}
 
-                            {{-- 施設名 --}}
+                            <!-- 施設名 -->
                             <div class="form-group row">
                                 <label for="app_reservation_search_condition_facility_name" class="col-md-3 col-form-label text-md-right">施設名</label>
                                 <div class="col-md-9">
@@ -66,7 +81,47 @@
                                 </div>
                             </div>
 
-                            {{-- 登録者 --}}
+                            <!-- 利用日 -->
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right">利用日</label>
+                                <div class="col-md-9">
+
+                                    <div class="form-row">
+                                        <!-- 利用日From -->
+                                        <div class="col-md-6">
+                                            <div class="input-group" id="start_datetime" data-target-input="nearest">
+                                                @php
+                                                    $start_datetime = Session::get("app_reservation_search_condition.start_datetime");
+                                                    $start_datetime = $start_datetime ? (new Carbon($start_datetime)) : '';
+                                                @endphp
+                                                <input type="text" name="app_reservation_search_condition[start_datetime]" value="{{$start_datetime}}" class="form-control datetimepicker-input" data-target="#start_datetime">
+                                                <div class="input-group-append" data-target="#start_datetime" data-toggle="datetimepicker">
+                                                    <div class="input-group-text"><i class="far fa-clock"></i></div>
+                                                </div>
+                                                <div class="form-text pl-2">
+                                                    ～
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <!-- 利用日To -->
+                                        <div class="col-md-6">
+                                            <div class="input-group" id="end_datetime" data-target-input="nearest">
+                                                @php
+                                                    $end_datetime = Session::get("app_reservation_search_condition.end_datetime");
+                                                    $end_datetime = $end_datetime ? (new Carbon($end_datetime)) : '';
+                                                @endphp
+                                                <input type="text" name="app_reservation_search_condition[end_datetime]" value="{{$end_datetime}}" class="form-control datetimepicker-input" data-target="#end_datetime">
+                                                <div class="input-group-append" data-target="#end_datetime" data-toggle="datetimepicker">
+                                                    <div class="input-group-text"><i class="far fa-clock"></i></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+
+                            <!-- 登録者 -->
                             <div class="form-group row">
                                 <label for="app_reservation_search_condition_created_name" class="col-md-3 col-form-label text-md-right">登録者</label>
                                 <div class="col-md-9">
@@ -74,7 +129,7 @@
                                 </div>
                             </div>
 
-                            {{-- 並べ替え --}}
+                            <!-- 並べ替え -->
                             <div class="form-group row">
                                 <label for="sort" class="col-md-3 col-form-label text-md-right">並べ替え</label>
                                 <div class="col-md-9">
@@ -88,8 +143,8 @@
                                 </div>
                             </div>
 
-                            {{-- ボタンエリア --}}
-                            <div class="form-group text-center">
+                            <!-- ボタンエリア -->
+                            <div class="form-group text-center pb-4">
                                 <div class="row">
                                     <div class="mx-auto">
                                         <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{url('/manage/reservation/clearSearch')}}'">
@@ -101,6 +156,8 @@
                                     </div>
                                 </div>
                             </div>
+                            {{-- datetimepicerの小ウィンドウが絞込条件の枠内で隠れてしまうため、余白確保 --}}
+                            <div><br></div>
                         </form>
                     </div>
                 </div>
@@ -110,12 +167,12 @@
         {{-- <div class="row mt-2"> --}}
         <div class="row">
             <div class="col-3 text-left d-flex align-items-end">
-                {{-- (左側)件数 --}}
+                <!-- (左側)件数 -->
                 <span class="badge badge-pill badge-light">{{ $inputs->total() }} 件</span>
             </div>
 
             <div class="col text-right">
-                {{-- (右側)ダウンロードボタン --}}
+                <!-- (右側)ダウンロードボタン -->
                 <div class="btn-group">
                     <button type="button" class="btn btn-link" onclick="submit_download_shift_jis();">
                         <i class="fas fa-file-download"></i> ダウンロード
@@ -131,7 +188,7 @@
             </div>
         </div>
 
-        {{-- 一覧エリア --}}
+        <!-- 一覧エリア -->
         <table class="table table-hover cc-font-90">
             <thead>
                 <tr class="d-none d-sm-table-row">

--- a/resources/views/plugins/manage/reservation/bookings.blade.php
+++ b/resources/views/plugins/manage/reservation/bookings.blade.php
@@ -70,6 +70,7 @@
                         絞り込み条件 <i class="fas fa-angle-down"></i>@if (Session::has('app_reservation_search_condition'))<span class="badge badge-pill badge-primary ml-2">条件設定中</span>@endif
                    </div>
                 </button>
+                {{-- 入力エラー時、絞り込み条件を開いたままにする(.show) --}}
                 <div id="search_collapse" class="collapse @if ($errors && count($errors) > 0) show @endif" aria-labelledby="app_reservation_search_condition" data-parent="#search_accordion">
                     <div class="card-body">
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms-ideas/issues/177

上記の対応です。

# 修正後画面
## 管理者メニュー＞施設管理＞予約一覧
![image](https://github.com/user-attachments/assets/e7e8dd44-b9a2-4c5f-a1b6-382c983d7c40)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/wiki/Datetimepicker
* https://getdatepicker.com/5-4/Options/#date
* https://momentjs.com/docs/#/displaying/format/
* https://developer.mozilla.org/ja/docs/Web/CSS/overflow

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
