### PR TITLE
[FAQ] 投稿日時が同値の場合、前へ／次へボタンで同値の投稿が飛ばされて表示される

### DIFF
--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -530,19 +530,33 @@ class FaqsPlugin extends UserPluginBase
         $after_post = null;
         if ($faqs_post) {
             $before_post = FaqsPosts::where('faqs_id', $faqs_post->faqs_id)
-                                     ->where('posted_at', '<', $faqs_post->posted_at)
-                                     ->where(function ($query) {
-                                         $query = $this->appendAuthWhere($query);
-                                     })
-                                     ->orderBy('posted_at', 'desc')
-                                     ->first();
+                                    ->where(function ($query) use ($faqs_post) {
+                                        $query->where('posted_at', '<', $faqs_post->posted_at)
+                                            ->orWhere(function ($subQuery) use ($faqs_post) {
+                                                $subQuery->where('posted_at', '=', $faqs_post->posted_at)
+                                                        ->where('id', '<', $faqs_post->id);
+                                            });
+                                    })
+                                    ->where(function ($query) {
+                                        $query = $this->appendAuthWhere($query);
+                                    })
+                                    ->orderBy('posted_at', 'desc')
+                                    ->orderBy('id', 'desc')
+                                    ->first();
             $after_post = FaqsPosts::where('faqs_id', $faqs_post->faqs_id)
-                                     ->where('posted_at', '>', $faqs_post->posted_at)
-                                     ->where(function ($query) {
-                                         $query = $this->appendAuthWhere($query);
-                                     })
-                                     ->orderBy('posted_at', 'asc')
-                                     ->first();
+                                    ->where(function ($query) use ($faqs_post) {
+                                        $query->where('posted_at', '>', $faqs_post->posted_at)
+                                              ->orWhere(function ($subQuery) use ($faqs_post) {
+                                                  $subQuery->where('posted_at', '=', $faqs_post->posted_at)
+                                                           ->where('id', '>', $faqs_post->id);
+                                              });
+                                    })
+                                    ->where(function ($query) {
+                                        $query = $this->appendAuthWhere($query);
+                                    })
+                                    ->orderBy('posted_at', 'asc')
+                                    ->orderBy('id', 'asc')
+                                    ->first();
         }
 
         // 詳細画面を呼び出す。


### PR DESCRIPTION
# 概要
 - FAQプラグインの詳細画面で前へ／次へボタン押下時、投稿日時が同値のデータが飛ばされる事象があった為、これの解消対応です。

# レビュー完了希望日
バグなので早目がよいかと思います。

# 関連Pull requests/Issues
* https://github.com/opensource-workshop/connect-cms/issues/2082

# 参考

* https://github.com/opensource-workshop/connect-cms/blob/master/app/Plugins/User/Blogs/BlogsPlugin.php `show()`

# DB変更の有無
なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
