### PR TITLE
[Trait] ConnectRoleTrait::choiceUserRolesOrPageRoles()で$user->user_rolesがnullの場合の再取得する処理を追加

### DIFF
--- a/app/Traits/ConnectRoleTrait.php
+++ b/app/Traits/ConnectRoleTrait.php
@@ -12,6 +12,7 @@ use App\Models\Common\Frame;
 use App\User;
 use App\Models\Common\Page;
 use App\Models\Common\PageRole;
+use App\Models\Core\UsersRoles;
 
 trait ConnectRoleTrait
 {
@@ -229,6 +230,14 @@ trait ConnectRoleTrait
         // $user_roles['base'] = ['role_reporter' => 1];    // ←ページ権限あれば上書き
         // $user_roles['manage'] = ['admin_system' => 1];   // ←ページ権限ではセットしてないので、そのまま
         $user_roles = $user->user_roles;
+        if (is_null($user_roles)) {
+            // ユーザーオブジェクトにロールデータを付与
+            // app\Providers\ConnectEloquentUserProvider::judgmentLogin() よりコピー. 通常の画面ログインであれば、
+            // judgmentLogin() でセットされているが、APIだとセットされていないため対応
+            $users_roles = new UsersRoles();
+            $user_roles = $users_roles->getUsersRoles($user->id);
+            $user->user_roles = $user_roles;
+        }
 
         // 所属グループのページ権限取得
         $user_page_roles = $this->getUserPageRoles($user, $page_roles);


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

開発者向け修正です。
ConnectRoleTrait::choiceUserRolesOrPageRoles()で$user->user_rolesがnullの場合の再取得する処理を追加しました。

## 補足
元々はapp\Providers\ConnectEloquentUserProvider::judgmentLogin()で画面ログイン時の入力チェックで $user->user_roles をセットしていましたが、API時は未セットだったため、ConnectRoleTrait::choiceUserRolesOrPageRoles()側で対応しました。


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
