### PR TITLE
[GitHub Actions] DuskテストのInvalid path to Chromedriver対応

### DIFF
--- a/.github/workflows/laravel_dusk_connect-cms-test-matrix.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test-matrix.yml
@@ -129,6 +129,7 @@ jobs:
 
       # https://readouble.com/laravel/9.x/ja/dusk.html#managing-chromedriver-installations
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
+      # Chrome Version と Chrome Driverを同じにする
       - name: Upgrade Chrome Driver
         # run: php artisan dusk:chrome-driver --detect
         # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`

--- a/.github/workflows/laravel_dusk_connect-cms-test-matrix.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test-matrix.yml
@@ -130,7 +130,17 @@ jobs:
       # https://readouble.com/laravel/9.x/ja/dusk.html#managing-chromedriver-installations
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver --detect
+        # run: php artisan dusk:chrome-driver --detect
+        # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3`
+
+      - name: Chrome Driver Copy
+        run: sudo \cp -f ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
+
+      - name: Chrome Driver Permission Denied 対応
+        run: |
+          sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver
+          sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
 
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
@@ -147,7 +157,7 @@ jobs:
       #   run: php artisan dusk:chrome-driver 114
 
       - name: Start Chrome Driver
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
 
       - name: Run Laravel Server
         run: php artisan serve &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -140,7 +140,7 @@ jobs:
       # https://github.com/laravel/dusk/issues/1109
       # https://github.com/browser-actions/setup-chrome (community)
       - name: Downgrade Chrome browser to v126
-        uses: browser-actions/setup-chrome@1
+        uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 126
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -144,21 +144,17 @@ jobs:
         id: setup-chrome
         with:
           chrome-version: 126
-
-      - name: Chrome Version No.2
-        run: chrome --version
-
-      - name: echo $PATH
-        run: echo $PATH
+          install-chromedriver: true
 
       - name: Chrome bin-path Override
         run: sudo ln -nfs `which chrome` /usr/bin/chrome
 
-      - name: Downgrade Chrome driver to v126
-        run: php artisan dusk:chrome-driver 126
+      # - name: Downgrade Chrome driver to v126
+      #   run: php artisan dusk:chrome-driver 126
 
       - name: Start Chrome Driver
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+        # run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+        run: ${{ steps.setup-chrome.outputs.chromedriver-path }} &
       - name: Run Laravel Server
         run: php artisan serve &
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -135,7 +135,8 @@ jobs:
       # https://readouble.com/laravel/9.x/ja/dusk.html#managing-chromedriver-installations
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver --detect
+        # run: php artisan dusk:chrome-driver --detect
+        run: php artisan dusk:chrome-driver 126 --detect
 
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
@@ -151,10 +152,8 @@ jobs:
       # - name: Downgrade Chrome driver to v114
       #   run: php artisan dusk:chrome-driver 114
 
-      # https://laravel.com/docs/11.x/dusk#running-tests-on-github-actions
       - name: Start Chrome Driver
-        # run: ./vendor/laravel/dusk/bin/chromedriver-linux &
-        run: .vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver --port=9515 &
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
       - name: Run Laravel Server
         run: php artisan serve &
 
@@ -520,4 +519,3 @@ jobs:
           path: |
             tests/Browser/console
             storage/logs
-            vendor/laravel/dusk/bin/

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -520,3 +520,4 @@ jobs:
           path: |
             tests/Browser/console
             storage/logs
+            vendor/laravel/dusk/bin/

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -145,8 +145,11 @@ jobs:
         with:
           chrome-version: 126
 
-      - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` ${{ steps.setup-chrome.outputs.chrome-path }}
+      - name: Chrome Version No.2
+        run: chrome --version
+
+      # - name: Chrome bin-path Override
+      #   run: sudo ln -nfs `which chrome` ${{ steps.setup-chrome.outputs.chrome-path }}
 
       - name: Downgrade Chrome driver to v126
         run: php artisan dusk:chrome-driver 126

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -163,6 +163,9 @@ jobs:
       #   # run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
       #   run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
 
+      - name: Chrome Driver Permission Denied 対応
+        run: sudo chmod=+x ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver
+
       - name: Start Chrome Driver
         # run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
         run: ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver --port=9515 &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -135,8 +135,9 @@ jobs:
       # https://readouble.com/laravel/9.x/ja/dusk.html#managing-chromedriver-installations
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver --detect
+        # run: php artisan dusk:chrome-driver --detect
         # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3`
 
       # エラー対応: Facebook\WebDriver\Exception\SessionNotCreatedException: session not created: probably user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir
       # - name: Uninstall Chrome
@@ -158,12 +159,13 @@ jobs:
       # - name: Downgrade Chrome driver to v126
       #   run: php artisan dusk:chrome-driver 126
 
-      - name: Chrome Driver bin-path Override
-        # run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
-        run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
+      # - name: Chrome Driver bin-path Override
+      #   # run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
+      #   run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
+        # run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver --port=9515 &
       - name: Run Laravel Server
         run: php artisan serve &
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -137,6 +137,10 @@ jobs:
       - name: Upgrade Chrome Driver
         run: php artisan dusk:chrome-driver --detect
 
+      # エラー対応: Facebook\WebDriver\Exception\SessionNotCreatedException: session not created: probably user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir
+      - name: Uninstall Chrome
+        run: sudo apt-get remove google-chrome-stable
+
       # https://github.com/laravel/dusk/issues/1109
       # https://github.com/browser-actions/setup-chrome (community)
       - name: Downgrade Chrome browser to v126

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -148,8 +148,11 @@ jobs:
       - name: Chrome Version No.2
         run: chrome --version
 
+      - name: echo $PATH
+        run: echo $PATH
+
       - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+        run: sudo ln -nfs `which chrome` /usr/bin/chrome
 
       - name: Downgrade Chrome driver to v126
         run: php artisan dusk:chrome-driver 126

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -164,6 +164,7 @@ jobs:
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
+
       - name: Run Laravel Server
         run: php artisan serve &
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -134,23 +134,21 @@ jobs:
 
       # https://readouble.com/laravel/9.x/ja/dusk.html#managing-chromedriver-installations
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
-      - name: Upgrade Chrome Driver
-        # run: php artisan dusk:chrome-driver --detect
-        run: php artisan dusk:chrome-driver 126
+      # - name: Upgrade Chrome Driver
+      #   run: php artisan dusk:chrome-driver --detect
 
-      # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
-      # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
+      # https://github.com/laravel/dusk/issues/1109
       # https://github.com/browser-actions/setup-chrome (community)
-      # - name: Downgrade Chrome browser to v114
-      #   uses: browser-actions/setup-chrome@latest
-      #   with:
-      #     chrome-version: 1134343 # Last commit number for Chrome v114
+      - name: Downgrade Chrome browser to v126
+        uses: browser-actions/setup-chrome@1
+        with:
+          chrome-version: 126
 
-      # - name: Chrome bin-path Override
-      #   run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+      - name: Chrome bin-path Override
+        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
 
-      # - name: Downgrade Chrome driver to v114
-      #   run: php artisan dusk:chrome-driver 114
+      - name: Downgrade Chrome driver to v126
+        run: php artisan dusk:chrome-driver 126
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -136,7 +136,7 @@ jobs:
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
       - name: Upgrade Chrome Driver
         # run: php artisan dusk:chrome-driver --detect
-        run: php artisan dusk:chrome-driver 126 --detect
+        run: php artisan dusk:chrome-driver 126
 
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -151,9 +151,10 @@ jobs:
       # - name: Downgrade Chrome driver to v114
       #   run: php artisan dusk:chrome-driver 114
 
+      # https://laravel.com/docs/11.x/dusk#running-tests-on-github-actions
       - name: Start Chrome Driver
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
-
+        # run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+        run: .vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver --port=9515 &
       - name: Run Laravel Server
         run: php artisan serve &
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -141,11 +141,12 @@ jobs:
       # https://github.com/browser-actions/setup-chrome (community)
       - name: Downgrade Chrome browser to v126
         uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
         with:
           chrome-version: 126
 
       - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+        run: sudo ln -nfs `which chrome` ${{ steps.setup-chrome.outputs.chrome-path }}
 
       - name: Downgrade Chrome driver to v126
         run: php artisan dusk:chrome-driver 126

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -134,34 +134,13 @@ jobs:
 
       # https://readouble.com/laravel/9.x/ja/dusk.html#managing-chromedriver-installations
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
+      # Chrome Version と Chrome Driverを同じにする
       - name: Upgrade Chrome Driver
         # run: php artisan dusk:chrome-driver --detect
         # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
         run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3`
 
-      # エラー対応: Facebook\WebDriver\Exception\SessionNotCreatedException: session not created: probably user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir
-      # - name: Uninstall Chrome
-      #   run: sudo apt-get remove google-chrome-stable
-
-      # https://github.com/laravel/dusk/issues/1109
-      # https://github.com/browser-actions/setup-chrome (community)
-      # - name: Downgrade Chrome browser to v126
-      #   uses: browser-actions/setup-chrome@v1
-      #   id: setup-chrome
-      #   with:
-      #     chrome-version: 132
-      #     install-chromedriver: true
-
-      # - name: Chrome bin-path Override
-      #   run: sudo ln -nfs `which chrome` /usr/bin/chrome
-
-      # RuntimeException: Invalid path to Chromedriver対応
-      # - name: Downgrade Chrome driver to v126
-      #   run: php artisan dusk:chrome-driver 126
-
-      - name: Chrome Driver bin-path Override
-        # run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
-        # run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
+      - name: Chrome Driver Copy
         run: sudo \cp -f ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Chrome Driver Permission Denied 対応
@@ -169,9 +148,22 @@ jobs:
           sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver
           sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
 
+      # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
+      # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
+      # https://github.com/browser-actions/setup-chrome (community)
+      # - name: Downgrade Chrome browser to v114
+      #   uses: browser-actions/setup-chrome@latest
+      #   with:
+      #     chrome-version: 1134343 # Last commit number for Chrome v114
+
+      # - name: Chrome bin-path Override
+      #   run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+
+      # - name: Downgrade Chrome driver to v114
+      #   run: php artisan dusk:chrome-driver 114
+
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
-        # run: ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver --port=9515 &
       - name: Run Laravel Server
         run: php artisan serve &
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -147,7 +147,7 @@ jobs:
         uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          # chrome-version: 126
+          chrome-version: 132
           install-chromedriver: true
 
       - name: Chrome bin-path Override

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -134,8 +134,8 @@ jobs:
 
       # https://readouble.com/laravel/9.x/ja/dusk.html#managing-chromedriver-installations
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
-      # - name: Upgrade Chrome Driver
-      #   run: php artisan dusk:chrome-driver --detect
+      - name: Upgrade Chrome Driver
+        run: php artisan dusk:chrome-driver --detect
 
       # https://github.com/laravel/dusk/issues/1109
       # https://github.com/browser-actions/setup-chrome (community)
@@ -143,21 +143,21 @@ jobs:
         uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          chrome-version: 126
+          # chrome-version: 126
           install-chromedriver: true
 
       - name: Chrome bin-path Override
         run: sudo ln -nfs `which chrome` /usr/bin/chrome
 
       # RuntimeException: Invalid path to Chromedriver対応
-      - name: Downgrade Chrome driver to v126
-        run: php artisan dusk:chrome-driver 126
+      # - name: Downgrade Chrome driver to v126
+      #   run: php artisan dusk:chrome-driver 126
 
       - name: Chrome Driver bin-path Override
         run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
       - name: Run Laravel Server
         run: php artisan serve &
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -164,7 +164,7 @@ jobs:
       #   run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Chrome Driver Permission Denied 対応
-        run: sudo chmod=+x ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver
+        run: sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver
 
       - name: Start Chrome Driver
         # run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -149,12 +149,15 @@ jobs:
       - name: Chrome bin-path Override
         run: sudo ln -nfs `which chrome` /usr/bin/chrome
 
-      # - name: Downgrade Chrome driver to v126
-      #   run: php artisan dusk:chrome-driver 126
+      # RuntimeException: Invalid path to Chromedriver対応
+      - name: Downgrade Chrome driver to v126
+        run: php artisan dusk:chrome-driver 126
+
+      - name: Chrome Driver bin-path Override
+        run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
-        # run: ./vendor/laravel/dusk/bin/chromedriver-linux &
-        run: ${{ steps.setup-chrome.outputs.chromedriver-path }} &
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
       - name: Run Laravel Server
         run: php artisan serve &
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -135,8 +135,8 @@ jobs:
       # https://readouble.com/laravel/9.x/ja/dusk.html#managing-chromedriver-installations
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
       - name: Upgrade Chrome Driver
-        # run: php artisan dusk:chrome-driver --detect
-        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+        run: php artisan dusk:chrome-driver --detect
+        # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
 
       # エラー対応: Facebook\WebDriver\Exception\SessionNotCreatedException: session not created: probably user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir
       # - name: Uninstall Chrome
@@ -160,7 +160,7 @@ jobs:
 
       - name: Chrome Driver bin-path Override
         # run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
-        run: sudo ln -nfs .vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
+        run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -158,8 +158,9 @@ jobs:
       # - name: Downgrade Chrome driver to v126
       #   run: php artisan dusk:chrome-driver 126
 
-      # - name: Chrome Driver bin-path Override
-      #   run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
+      - name: Chrome Driver bin-path Override
+        # run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
+        run: sudo ln -nfs .vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -135,30 +135,31 @@ jobs:
       # https://readouble.com/laravel/9.x/ja/dusk.html#managing-chromedriver-installations
       # https://readouble.com/laravel/9.x/ja/dusk.html#running-tests-on-github-actions
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver --detect
+        # run: php artisan dusk:chrome-driver --detect
+        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
 
       # エラー対応: Facebook\WebDriver\Exception\SessionNotCreatedException: session not created: probably user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir
-      - name: Uninstall Chrome
-        run: sudo apt-get remove google-chrome-stable
+      # - name: Uninstall Chrome
+      #   run: sudo apt-get remove google-chrome-stable
 
       # https://github.com/laravel/dusk/issues/1109
       # https://github.com/browser-actions/setup-chrome (community)
-      - name: Downgrade Chrome browser to v126
-        uses: browser-actions/setup-chrome@v1
-        id: setup-chrome
-        with:
-          chrome-version: 132
-          install-chromedriver: true
+      # - name: Downgrade Chrome browser to v126
+      #   uses: browser-actions/setup-chrome@v1
+      #   id: setup-chrome
+      #   with:
+      #     chrome-version: 132
+      #     install-chromedriver: true
 
-      - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` /usr/bin/chrome
+      # - name: Chrome bin-path Override
+      #   run: sudo ln -nfs `which chrome` /usr/bin/chrome
 
       # RuntimeException: Invalid path to Chromedriver対応
       # - name: Downgrade Chrome driver to v126
       #   run: php artisan dusk:chrome-driver 126
 
-      - name: Chrome Driver bin-path Override
-        run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
+      # - name: Chrome Driver bin-path Override
+      #   run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -149,7 +149,7 @@ jobs:
         run: chrome --version
 
       - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` /opt/google/chrome/chrome
+        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
 
       - name: Downgrade Chrome driver to v126
         run: php artisan dusk:chrome-driver 126

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -148,8 +148,8 @@ jobs:
       - name: Chrome Version No.2
         run: chrome --version
 
-      # - name: Chrome bin-path Override
-      #   run: sudo ln -nfs `which chrome` ${{ steps.setup-chrome.outputs.chrome-path }}
+      - name: Chrome bin-path Override
+        run: sudo ln -nfs `which chrome` /opt/google/chrome/chrome
 
       - name: Downgrade Chrome driver to v126
         run: php artisan dusk:chrome-driver 126

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -159,16 +159,16 @@ jobs:
       # - name: Downgrade Chrome driver to v126
       #   run: php artisan dusk:chrome-driver 126
 
-      # - name: Chrome Driver bin-path Override
-      #   # run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
-      #   run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
-
       - name: Chrome Driver Permission Denied 対応
         run: sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver
 
+      - name: Chrome Driver bin-path Override
+        # run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
+        run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
+
       - name: Start Chrome Driver
-        # run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver --port=9515 &
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
+        # run: ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver --port=9515 &
       - name: Run Laravel Server
         run: php artisan serve &
 

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -159,12 +159,15 @@ jobs:
       # - name: Downgrade Chrome driver to v126
       #   run: php artisan dusk:chrome-driver 126
 
-      - name: Chrome Driver Permission Denied 対応
-        run: sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver
-
       - name: Chrome Driver bin-path Override
         # run: sudo ln -nfs ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
-        run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
+        # run: sudo ln -nfs ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
+        run: sudo \cp -f ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver ./vendor/laravel/dusk/bin/chromedriver-linux
+
+      - name: Chrome Driver Permission Denied 対応
+        run: |
+          sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver
+          sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

Connect 2.x系のDuskテストがgithub actionsのエラーで動かなくなっていました。
エラーは RuntimeException: Invalid path to Chromedriver で対応しました。

# エラー内容

```shell
Run php artisan dusk tests/Browser/Manage/LogManageTest.php no_manual
Warning: TTY mode requires /dev/tty to be read/writable.
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 00:00.002, Memory: 10.00 MB

There was 1 error:

1) Tests\Browser\Manage\LogManageTest::testInvoke
RuntimeException: Invalid path to Chromedriver [/home/runner/work/connect-cms/connect-cms/vendor/laravel/dusk/src/Chrome/../../bin/chromedriver-linux]. Make sure to install the Chromedriver first by running the dusk:chrome-driver command. in /home/runner/work/connect-cms/connect-cms/vendor/laravel/dusk/src/Chrome/ChromeProcess.php:56
Stack trace:
#0 /home/runner/work/connect-cms/connect-cms/vendor/laravel/dusk/src/Chrome/SupportsChrome.php(62): Laravel\Dusk\Chrome\ChromeProcess->toProcess()
#1 /home/runner/work/connect-cms/connect-cms/vendor/laravel/dusk/src/Chrome/SupportsChrome.php(31): Laravel\Dusk\TestCase::buildChromeProcess()
#2 /home/runner/work/connect-cms/connect-cms/tests/DuskTestCase.php(72): Laravel\Dusk\TestCase::startChromeDriver()
#3 /home/runner/work/connect-cms/connect-cms/vendor/phpunit/phpunit/src/Framework/TestSuite.php(629): Tests\DuskTestCase::prepare()
#4 /home/runner/work/connect-cms/connect-cms/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(651): PHPUnit\Framework\TestSuite->run()
#5 /home/runner/work/connect-cms/connect-cms/vendor/phpunit/phpunit/src/TextUI/Command.php([14](https://github.com/opensource-workshop/connect-cms/actions/runs/12459278909/job/34775914873#step:21:15)6): PHPUnit\TextUI\TestRunner->run()
#6 /home/runner/work/connect-cms/connect-cms/vendor/phpunit/phpunit/src/TextUI/Command.php(99): PHPUnit\TextUI\Command->run()
#7 /home/runner/work/connect-cms/connect-cms/vendor/phpunit/phpunit/phpunit(107): PHPUnit\TextUI\Command::main()
#8 {main}
ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
Error: Process completed with exit code 2.
```

## エラー詳細
* https://github.com/opensource-workshop/connect-cms/actions/runs/12459278909/job/34775914873

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* php - "Invalid path to Chromedriver" when running Laravel Dusk - Stack Overflow
https://stackoverflow.com/questions/78827506/invalid-path-to-chromedriver-when-running-laravel-dusk
  * Laravel9はEOLで、対象バージョンのDuskは修正されないようです。
* ChromeDriver(EdgeDriver)のVer.128からデフォルトポート9515がランダムに変更されました。 #Excel - Qiita
https://qiita.com/yaju/items/3c4e516746c8db830c9c

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
