### PR TITLE
[GitHub Actions] Connect 1.x系のDuskテストのChrome failed to start: crashed. 対応

### DIFF
--- a/.github/workflows/laravel_dusk_connect-cms-test-matrix-daily.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test-matrix-daily.yml
@@ -134,19 +134,38 @@ jobs:
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)
-      - name: Downgrade Chrome browser to v114
-        uses: browser-actions/setup-chrome@latest
+      # - name: Downgrade Chrome browser to v114
+      #   uses: browser-actions/setup-chrome@latest
+      #   with:
+      #     chrome-version: 1134343 # Last commit number for Chrome v114
+
+      # - name: Chrome bin-path Override
+      #   run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+
+      # - name: Downgrade Chrome driver to v114
+      #   run: php artisan dusk:chrome-driver 114
+
+      - name: Set env CHROME_VERSION
+        run: |
+          echo CHROME_VERSION=`/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1` >> $GITHUB_ENV
+
+      # https://github.com/browser-actions/setup-chrome (community)
+      - name: Download Chrome and Chrome Driver(use Chrome Driver Only)
+        uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
         with:
-          chrome-version: 1134343 # Last commit number for Chrome v114
+          chrome-version: ${{ env.CHROME_VERSION }}
+          install-chromedriver: true
 
-      - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+      - name: Chrome Driver Copy
+        run: sudo \cp -f ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
 
-      - name: Downgrade Chrome driver to v114
-        run: php artisan dusk:chrome-driver 114
+      - name: Chrome Driver Permission Denied 対応
+        run: |
+          sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
 
       - name: Run Laravel Server
         run: php artisan serve &

--- a/.github/workflows/laravel_dusk_connect-cms-test-matrix.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test-matrix.yml
@@ -134,19 +134,38 @@ jobs:
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)
-      - name: Downgrade Chrome browser to v114
-        uses: browser-actions/setup-chrome@latest
+      # - name: Downgrade Chrome browser to v114
+      #   uses: browser-actions/setup-chrome@latest
+      #   with:
+      #     chrome-version: 1134343 # Last commit number for Chrome v114
+
+      # - name: Chrome bin-path Override
+      #   run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+
+      # - name: Downgrade Chrome driver to v114
+      #   run: php artisan dusk:chrome-driver 114
+
+      - name: Set env CHROME_VERSION
+        run: |
+          echo CHROME_VERSION=`/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1` >> $GITHUB_ENV
+
+      # https://github.com/browser-actions/setup-chrome (community)
+      - name: Download Chrome and Chrome Driver(use Chrome Driver Only)
+        uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
         with:
-          chrome-version: 1134343 # Last commit number for Chrome v114
+          chrome-version: ${{ env.CHROME_VERSION }}
+          install-chromedriver: true
 
-      - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+      - name: Chrome Driver Copy
+        run: sudo \cp -f ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
 
-      - name: Downgrade Chrome driver to v114
-        run: php artisan dusk:chrome-driver 114
+      - name: Chrome Driver Permission Denied 対応
+        run: |
+          sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
 
       - name: Run Laravel Server
         run: php artisan serve &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -143,17 +143,26 @@ jobs:
       # https://github.com/browser-actions/setup-chrome (community)
       - name: Downgrade Chrome browser to v114
         uses: browser-actions/setup-chrome@latest
+        id: setup-chrome
         with:
           # chrome-version: 1134343 # Last commit number for Chrome v114
           chrome-version: 114.0.5735.90
+          install-chromedriver: true
 
       - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+        run: sudo ln -nfs `which chrome` /usr/bin/chrome
 
       - name: Downgrade Chrome driver to v114
         run: php artisan dusk:chrome-driver 114
         # run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
         # run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3 | cut -d "." -f1`
+
+      - name: Chrome Driver Copy
+        run: sudo \cp -f ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
+
+      - name: Chrome Driver Permission Denied 対応
+        run: |
+          sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -135,9 +135,9 @@ jobs:
         run: /opt/google/chrome/chrome --version
 
       # https://readouble.com/laravel/8.x/ja/dusk.html#managing-chromedriver-installations
-      - name: Upgrade Chrome Driver
-        # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
-        run: php artisan dusk:chrome-driver 114
+      # - name: Upgrade Chrome Driver
+      #   # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+      #   run: php artisan dusk:chrome-driver 114
 
       - name: Set env CHROME_VERSION
         run: |
@@ -146,7 +146,7 @@ jobs:
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)
-      - name: Downgrade Chrome browser to v131
+      - name: Download Chrome and Chrome Driver(use Chrome Driver Only)
         uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -136,8 +136,9 @@ jobs:
 
       # https://readouble.com/laravel/8.x/ja/dusk.html#managing-chromedriver-installations
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
-        
+        # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+        run: php artisan dusk:chrome-driver 114
+
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -139,17 +139,22 @@ jobs:
         # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
         run: php artisan dusk:chrome-driver 114
 
+      - name: Set env CHROME_VERSION
+        run: |
+          echo CHROME_VERSION=`/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1` >> $GITHUB_ENV
+
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)
-      - name: Downgrade Chrome browser to v114
+      - name: Downgrade Chrome browser to v131
         uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
           # chrome-version: 1134343 # Last commit number for Chrome v114
           # chrome-version: 114.0.5735.90
           # chrome-version: 114
-          chrome-version: 131
+          # chrome-version: 131
+          chrome-version: ${{ env.CHROME_VERSION }}
           install-chromedriver: true
 
       # - name: Chrome bin-path Override

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -145,9 +145,9 @@ jobs:
         uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          # chrome-version: 1134343 # Last commit number for Chrome v114
+          chrome-version: 1134343 # Last commit number for Chrome v114
           # chrome-version: 114.0.5735.90
-          chrome-version: 114
+          # chrome-version: 114
           install-chromedriver: true
 
       - name: Chrome bin-path Override

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -135,44 +135,34 @@ jobs:
         run: /opt/google/chrome/chrome --version
 
       # https://readouble.com/laravel/8.x/ja/dusk.html#managing-chromedriver-installations
-      # - name: Upgrade Chrome Driver
-      #   # run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+      #- name: Upgrade Chrome Driver
+      #  run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+
+      # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
+      # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
+      # https://github.com/browser-actions/setup-chrome (community)
+      # - name: Downgrade Chrome browser to v114
+      #   uses: browser-actions/setup-chrome@latest
+      #   with:
+      #     chrome-version: 1134343 # Last commit number for Chrome v114
+
+      # - name: Chrome bin-path Override
+      #   run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+
+      # - name: Downgrade Chrome driver to v114
       #   run: php artisan dusk:chrome-driver 114
 
       - name: Set env CHROME_VERSION
         run: |
           echo CHROME_VERSION=`/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1` >> $GITHUB_ENV
 
-      # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
-      # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)
       - name: Download Chrome and Chrome Driver(use Chrome Driver Only)
         uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
-          # chrome-version: 1134343 # Last commit number for Chrome v114
-          # chrome-version: 114.0.5735.90
-          # chrome-version: 114
-          # chrome-version: 131
           chrome-version: ${{ env.CHROME_VERSION }}
           install-chromedriver: true
-
-      # - name: Chrome bin-path Override
-      #   run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
-
-      # - name: Chrome Copy
-      #   run: sudo \cp -f `which chrome` /usr/bin/google-chrome
-
-      # - name: Downgrade Chrome browser to v114
-      #   run: |
-      #     VERSION_STRING="114.0.5735.90"
-      #     wget "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${VERSION_STRING}_amd64.deb"
-      #     sudo dpkg -i "google-chrome-stable_${VERSION_STRING}_amd64.deb"
-
-      # - name: Downgrade Chrome driver to v114
-      #   run: php artisan dusk:chrome-driver 114
-        # run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
-        # run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3 | cut -d "." -f1`
 
       - name: Chrome Driver Copy
         run: sudo \cp -f ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -142,11 +142,12 @@ jobs:
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)
       - name: Downgrade Chrome browser to v114
-        uses: browser-actions/setup-chrome@latest
+        uses: browser-actions/setup-chrome@v1
         id: setup-chrome
         with:
           # chrome-version: 1134343 # Last commit number for Chrome v114
-          chrome-version: 114.0.5735.90
+          # chrome-version: 114.0.5735.90
+          chrome-version: 114
           install-chromedriver: true
 
       - name: Chrome bin-path Override

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -144,14 +144,15 @@ jobs:
       - name: Downgrade Chrome browser to v114
         uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: 1134343 # Last commit number for Chrome v114
+          # chrome-version: 1134343 # Last commit number for Chrome v114
+          chrome-version: 114.0.5735.90
 
       - name: Chrome bin-path Override
         run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
 
       - name: Downgrade Chrome driver to v114
         # run: php artisan dusk:chrome-driver 114
-        run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
+        run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3`
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -149,6 +149,7 @@ jobs:
           # chrome-version: 1134343 # Last commit number for Chrome v114
           # chrome-version: 114.0.5735.90
           # chrome-version: 114
+          chrome-version: 131
           install-chromedriver: true
 
       # - name: Chrome bin-path Override

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -135,9 +135,9 @@ jobs:
         run: /opt/google/chrome/chrome --version
 
       # https://readouble.com/laravel/8.x/ja/dusk.html#managing-chromedriver-installations
-      #- name: Upgrade Chrome Driver
-      #  run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
-
+      # - name: Upgrade Chrome Driver
+      #   run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+        
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)
@@ -150,7 +150,8 @@ jobs:
         run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
 
       - name: Downgrade Chrome driver to v114
-        run: php artisan dusk:chrome-driver 114
+        # run: php artisan dusk:chrome-driver 114
+        run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3`
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Downgrade Chrome driver to v114
         # run: php artisan dusk:chrome-driver 114
-        run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3`
+        run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Downgrade Chrome driver to v114
         # run: php artisan dusk:chrome-driver 114
-        run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3`
+        run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -152,7 +152,8 @@ jobs:
 
       - name: Downgrade Chrome driver to v114
         # run: php artisan dusk:chrome-driver 114
-        run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
+        # run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
+        run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3 | cut -d "." -f1`
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -151,7 +151,7 @@ jobs:
           install-chromedriver: true
 
       - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` /usr/bin/chrome
+        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
 
       - name: Downgrade Chrome driver to v114
         run: php artisan dusk:chrome-driver 114

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -135,20 +135,20 @@ jobs:
         run: /opt/google/chrome/chrome --version
 
       # https://readouble.com/laravel/8.x/ja/dusk.html#managing-chromedriver-installations
-      # - name: Upgrade Chrome Driver
-      #   run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+      - name: Upgrade Chrome Driver
+        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
         
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)
-      # - name: Downgrade Chrome browser to v114
-      #   uses: browser-actions/setup-chrome@v1
-      #   id: setup-chrome
-      #   with:
-      #     chrome-version: 1134343 # Last commit number for Chrome v114
-      #     # chrome-version: 114.0.5735.90
-      #     # chrome-version: 114
-      #     install-chromedriver: true
+      - name: Downgrade Chrome browser to v114
+        uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        with:
+          # chrome-version: 1134343 # Last commit number for Chrome v114
+          # chrome-version: 114.0.5735.90
+          # chrome-version: 114
+          install-chromedriver: true
 
       # - name: Chrome bin-path Override
       #   run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
@@ -156,26 +156,26 @@ jobs:
       # - name: Chrome Copy
       #   run: sudo \cp -f `which chrome` /usr/bin/google-chrome
 
-      - name: Downgrade Chrome browser to v114
-        run: |
-          VERSION_STRING="114.0.5735.90"
-          wget "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${VERSION_STRING}_amd64.deb"
-          sudo dpkg -i "google-chrome-stable_${VERSION_STRING}_amd64.deb"
+      # - name: Downgrade Chrome browser to v114
+      #   run: |
+      #     VERSION_STRING="114.0.5735.90"
+      #     wget "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${VERSION_STRING}_amd64.deb"
+      #     sudo dpkg -i "google-chrome-stable_${VERSION_STRING}_amd64.deb"
 
-      - name: Downgrade Chrome driver to v114
-        run: php artisan dusk:chrome-driver 114
+      # - name: Downgrade Chrome driver to v114
+      #   run: php artisan dusk:chrome-driver 114
         # run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
         # run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3 | cut -d "." -f1`
 
-      # - name: Chrome Driver Copy
-      #   run: sudo \cp -f ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
+      - name: Chrome Driver Copy
+        run: sudo \cp -f ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
 
-      # - name: Chrome Driver Permission Denied 対応
-      #   run: |
-      #     sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
+      - name: Chrome Driver Permission Denied 対応
+        run: |
+          sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+        run: ./vendor/laravel/dusk/bin/chromedriver-linux --port=9515 &
 
       - name: Run Laravel Server
         run: php artisan serve &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -150,8 +150,11 @@ jobs:
           # chrome-version: 114
           install-chromedriver: true
 
-      - name: Chrome bin-path Override
-        run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+      # - name: Chrome bin-path Override
+      #   run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
+
+      - name: Chrome Copy
+        run: sudo \cp -f `which chrome` /usr/bin/google-chrome
 
       - name: Downgrade Chrome driver to v114
         run: php artisan dusk:chrome-driver 114

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -141,32 +141,38 @@ jobs:
       # https://stackoverflow.com/questions/76980975/chrome-driver-failing-in-laravel-dusk-failed-to-open-stream-http-request-fai
       # https://voicetechno-jp.secure-web.jp/ChromeDriverV115orNewer.html
       # https://github.com/browser-actions/setup-chrome (community)
-      - name: Downgrade Chrome browser to v114
-        uses: browser-actions/setup-chrome@v1
-        id: setup-chrome
-        with:
-          chrome-version: 1134343 # Last commit number for Chrome v114
-          # chrome-version: 114.0.5735.90
-          # chrome-version: 114
-          install-chromedriver: true
+      # - name: Downgrade Chrome browser to v114
+      #   uses: browser-actions/setup-chrome@v1
+      #   id: setup-chrome
+      #   with:
+      #     chrome-version: 1134343 # Last commit number for Chrome v114
+      #     # chrome-version: 114.0.5735.90
+      #     # chrome-version: 114
+      #     install-chromedriver: true
 
       # - name: Chrome bin-path Override
       #   run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
 
-      - name: Chrome Copy
-        run: sudo \cp -f `which chrome` /usr/bin/google-chrome
+      # - name: Chrome Copy
+      #   run: sudo \cp -f `which chrome` /usr/bin/google-chrome
+
+      - name: Downgrade Chrome browser to v114
+        run: |
+          VERSION_STRING="114.0.5735.90"
+          wget "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${VERSION_STRING}_amd64.deb"
+          sudo dpkg -i "google-chrome-stable_${VERSION_STRING}_amd64.deb"
 
       - name: Downgrade Chrome driver to v114
         run: php artisan dusk:chrome-driver 114
         # run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
         # run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3 | cut -d "." -f1`
 
-      - name: Chrome Driver Copy
-        run: sudo \cp -f ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
+      # - name: Chrome Driver Copy
+      #   run: sudo \cp -f ${{ steps.setup-chrome.outputs.chromedriver-path }} ./vendor/laravel/dusk/bin/chromedriver-linux
 
-      - name: Chrome Driver Permission Denied 対応
-        run: |
-          sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
+      # - name: Chrome Driver Permission Denied 対応
+      #   run: |
+      #     sudo chmod +x ./vendor/laravel/dusk/bin/chromedriver-linux
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &

--- a/.github/workflows/laravel_dusk_connect-cms-test.yml
+++ b/.github/workflows/laravel_dusk_connect-cms-test.yml
@@ -151,9 +151,9 @@ jobs:
         run: sudo ln -nfs `which chrome` /usr/bin/google-chrome
 
       - name: Downgrade Chrome driver to v114
-        # run: php artisan dusk:chrome-driver 114
+        run: php artisan dusk:chrome-driver 114
         # run: php artisan dusk:chrome-driver `chrome --version | cut -d " " -f3`
-        run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3 | cut -d "." -f1`
+        # run: php artisan dusk:chrome-driver `/usr/bin/google-chrome --version | cut -d " " -f3 | cut -d "." -f1`
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

Connect 1.x系のDuskテストがgithub actionsのエラーで動かなくなっていました。
エラーは Facebook\WebDriver\Exception\UnknownErrorException: unknown error: Chrome failed to start: crashed. で対応しました。

# エラー内容

```shell
Run php artisan dusk tests/Browser/Manage/LogManageTest.php no_manual
Warning: TTY mode requires /dev/tty to be read/writable.
PHPUnit [9](https://github.com/opensource-workshop/connect-cms/actions/runs/12483864336/job/34840363665#step:23:10).6.21 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 ([10](https://github.com/opensource-workshop/connect-cms/actions/runs/12483864336/job/34840363665#step:23:11)0%)

Time: 00:03.198, Memory: 28.00 MB

There was 1 error:

1) Tests\Browser\Manage\LogManageTest::testInvoke
Facebook\WebDriver\Exception\UnknownErrorException: unknown error: Chrome failed to start: crashed.
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)

/home/runner/work/connect-cms/connect-cms/vendor/php-webdriver/webdriver/lib/Exception/WebDriverException.php:146
/home/runner/work/connect-cms/connect-cms/vendor/php-webdriver/webdriver/lib/Remote/HttpCommandExecutor.php:359
/home/runner/work/connect-cms/connect-cms/vendor/php-webdriver/webdriver/lib/Remote/RemoteWebDriver.php:129
/home/runner/work/connect-cms/connect-cms/tests/DuskTestCase.php:92
/home/runner/work/connect-cms/connect-cms/vendor/laravel/dusk/src/Concerns/ProvidesBrowser.php:219
/home/runner/work/connect-cms/connect-cms/vendor/laravel/framework/src/Illuminate/Support/helpers.php:234
/home/runner/work/connect-cms/connect-cms/vendor/laravel/dusk/src/Concerns/ProvidesBrowser.php:220
/home/runner/work/connect-cms/connect-cms/vendor/laravel/dusk/src/Concerns/ProvidesBrowser.php:98
/home/runner/work/connect-cms/connect-cms/vendor/laravel/dusk/src/Concerns/ProvidesBrowser.php:66
/home/runner/work/connect-cms/connect-cms/tests/DuskTestCase.php:[11](https://github.com/opensource-workshop/connect-cms/actions/runs/12483864336/job/34840363665#step:23:12)2

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
Error: Process completed with exit code 2.
```

## エラー詳細
* https://github.com/opensource-workshop/connect-cms/actions/runs/12483864336/job/34840363665

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/2088

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* https://github.com/browser-actions/setup-chrome

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
