### PR TITLE
[ブログ] 最後の記事だけクラス属性が付与されない不具合修正

### DIFF
--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -69,11 +69,7 @@
 
     @forelse($blogs_posts as $post)
 
-        @if ($loop->last)
-        <article>
-        @else
         <article class="cc_article">
-        @endif
 
         @if (isset($is_template_datafirst))
             {{-- datafirstテンプレート --}}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/2085

上記issueの修正です。

# 修正後画面
## ブログの初期表示（記事一覧画面）
![image](https://github.com/user-attachments/assets/0ffa1533-32ee-4d70-aab4-8bae36afbd9f)

# 調査

https://github.com/opensource-workshop/connect-cms/commit/32157c5835f148358cb5317b52e05842c6f3e7d0

該当箇所はブログのアクセシビリティ対応で入れた修正でした。
しかし、アクセシビリティとclassありなしは関係ないので、最後の記事にもclassを追加しました。（最後の記事の下に下線が付くのを気にしてclass抜いたのかもです）

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
