### PR TITLE
[ブログ] 記事の中に → (&rarr;) があると「RSS2.0」アイコンをクリック時にエラーになる不具合対応

### DIFF
--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1450,6 +1450,7 @@ EOD;
                 $replaceTarget = array('<br>', '&nbsp;', '&emsp;', '&ensp;');
                 $description = str_replace($replaceTarget, '', $description);
             }
+            $description = StringUtils::xmlspecialchars(strip_tags(html_entity_decode($description)));
             $pub_date = date(DATE_RSS, strtotime($blogs_post->posted_at));
             $content = StringUtils::xmlspecialchars(strip_tags(html_entity_decode($blogs_post->post_text)));
             echo <<<EOD

--- a/app/Utilities/String/StringUtils.php
+++ b/app/Utilities/String/StringUtils.php
@@ -107,7 +107,9 @@ class StringUtils
      */
     public static function xmlspecialchars(string $string) :string
     {
-        return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1);
+        $string = htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1);
+        $string = str_replace('&', '&amp;', $string);
+        return $string;
     }
 
     // /**


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/2086

上記を修正しました。

# 対応後画面
## ブログ＞RSS2.0 押下時 （Edge）

記事の中に → (&rarr;) があってもRSSが表示できることを確認しました。

![image](https://github.com/user-attachments/assets/5bb8581c-a95e-4fd3-9bf7-42013c076d09)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* PHPエラー対処方法「RSSをXML取得時に不正文字が存在する場合」
https://deaimobi.com/mbnk-264/

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
