### PR TITLE
[グループ管理] グループ削除時に、関連するページ権限・グループユーザーを削除する

### DIFF
--- a/app/Plugins/Manage/GroupManage/GroupManage.php
+++ b/app/Plugins/Manage/GroupManage/GroupManage.php
@@ -5,6 +5,7 @@ namespace App\Plugins\Manage\GroupManage;
 use App\Enums\UserStatus;
 use App\Models\Common\Group;
 use App\Models\Common\GroupUser;
+use App\Models\Common\PageRole;
 use App\Plugins\Manage\ManagePluginBase;
 use App\User;
 use App\Utilities\String\StringUtils;
@@ -182,7 +183,17 @@ class GroupManage extends ManagePluginBase
      */
     public function delete($request, $id)
     {
-        // カテゴリ削除
+        // deleted_id, deleted_nameを自動セットするため、複数件削除する時はdestroy()を利用する。
+        $page_role_ids = PageRole::where('group_id', $id)->pluck('id');
+        $group_user_ids = GroupUser::where('group_id', $id)->pluck('id');
+
+        // ページ権限削除
+        PageRole::destroy($page_role_ids);
+
+        // グループユーザー削除
+        GroupUser::destroy($group_user_ids);
+
+        // グループ削除
         Group::find($id)->delete();
 
         // 削除後は一覧画面へ


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1898

上記の対応です。

# 修正後動作

グループ削除時に、関連するページ権限、グループユーザーのみが論理削除される事を目検しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
