### PR TITLE
[ユーザ管理] ダウンロードの出力値をカスタマイズできるように対応

### DIFF
--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -1666,7 +1666,7 @@ class UserManage extends ManagePluginBase
 
             // 追加項目データ
             foreach ($input_cols as $input_col) {
-                $csv_array[$input_col->users_id][$input_col->users_columns_id] = $input_col->value;
+                $csv_array[$input_col->users_id][$input_col->users_columns_id] = UsersTool::getUsersInputColValue($input_col);
             }
         }
 

--- a/app/Plugins/Manage/UserManage/UsersTool.php
+++ b/app/Plugins/Manage/UserManage/UsersTool.php
@@ -103,6 +103,23 @@ class UsersTool
     }
 
     /**
+     * カラムの値 取得
+     */
+    public static function getUsersInputColValue(UsersInputCols $input_col)
+    {
+        $class_name = self::getOptionClass();
+        // オプションクラス有＋メソッド有なら呼ぶ
+        if ($class_name) {
+            if (method_exists($class_name, 'getUsersInputColValue')) {
+                return $class_name::getUsersInputColValue($input_col);
+            }
+        }
+
+        // 通常の処理
+        return $input_col->value;
+    }
+
+    /**
      * セットすべきバリデータールールが存在する場合、受け取った配列にセットして返す
      *
      * @param array $validator_array 二次元配列


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

開発者向けの対応です。
ユーザ管理＞ダウンロードの出力値を、独自に設定できるよう対応しました。

app\PluginsOption\Manage\UserManage\UsersToolOption.php に getUsersInputColValue() メソッドを作ることで、独自の出力値に変更できます。
（ここでダウンロードの出力値を変更できますが、同時にインポートできない値（DB登録値とは異なる値）になりますので、ユーザ管理＞インポートを使用しない前提での変更になります）

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1906

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
