### PR TITLE
[サンプルコピーシェル] option_plugin_resources_dirの全小文字変換に対応

### DIFF
--- a/sync_dev_2_option_private.sh.example
+++ b/sync_dev_2_option_private.sh.example
@@ -15,7 +15,8 @@ dist_root_dir='/path_to_option_private_dir/'
 # プラグイン名
 option_plugin="pluginname"
 option_plugin_controller_dir="${option_plugin}"
-option_plugin_resources_dir="${option_plugin}"
+# ${変数,,}はbashの機能で、全小文字に変換する
+option_plugin_resources_dir="${option_plugin,,}"
 option_plugin_model_dir=$option_plugin_controller_dir
 option_plugin_command_dir=$option_plugin_controller_dir
 

--- a/sync_option_private_2_dev.sh.example
+++ b/sync_option_private_2_dev.sh.example
@@ -15,7 +15,8 @@ dist_root_dir='/path_to_dev_connect-cms/'
 # プラグイン名
 option_plugin="pluginname"
 option_plugin_controller_dir="${option_plugin}"
-option_plugin_resources_dir="${option_plugin}"
+# ${変数,,}はbashの機能で、全小文字に変換する
+option_plugin_resources_dir="${option_plugin,,}"
 option_plugin_model_dir=$option_plugin_controller_dir
 option_plugin_command_dir=$option_plugin_controller_dir
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* sync_dev_2_option_private.sh.example
* sync_option_private_2_dev.sh.example

上記のoption_plugin_resources_dir変数に対して、以前記載のあった小文字変換を復活させました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
