### PR TITLE
[コア]CSVの項目にダブルクォーテーションが含まれると正しく出力されない事象を修正しました

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -51,6 +51,7 @@ use App\Models\User\Blogs\Blogs;
 use App\Models\User\Blogs\BlogsPosts;
 use App\Models\User\Faqs\Faqs;
 use App\Models\User\Faqs\FaqsPosts;
+use App\Utilities\Csv\CsvUtils;
 
 /**
  * フォーム・プラグイン
@@ -2536,25 +2537,7 @@ ORDER BY forms_inputs_id, forms_columns_id
         ];
 
         // データ
-        $csv_data = '';
-        foreach ($csv_array as $csv_line) {
-            foreach ($csv_line as $csv_col) {
-                $csv_data .= '"' . $csv_col . '",';
-            }
-            // 末尾カンマを削除
-            $csv_data = substr($csv_data, 0, -1);
-            $csv_data .= "\n";
-        }
-
-        // 文字コード変換
-        // $csv_data = mb_convert_encoding($csv_data, "SJIS-win");
-        if ($request->character_code == CsvCharacterCode::utf_8) {
-            $csv_data = mb_convert_encoding($csv_data, CsvCharacterCode::utf_8);
-            //「UTF-8」の「BOM」であるコード「0xEF」「0xBB」「0xBF」をカンマ区切りにされた文字列の先頭に連結
-            $csv_data = pack('C*', 0xEF, 0xBB, 0xBF) . $csv_data;
-        } else {
-            $csv_data = mb_convert_encoding($csv_data, CsvCharacterCode::sjis_win);
-        }
+        $csv_data = CsvUtils::getResponseCsvData($csv_array, $request->character_code);
 
         return response()->make($csv_data, 200, $headers);
     }

--- a/app/Utilities/Csv/CsvUtils.php
+++ b/app/Utilities/Csv/CsvUtils.php
@@ -172,7 +172,7 @@ class CsvUtils
         foreach ($csv_array as $csv_line) {
             foreach ($csv_line as $csv_col) {
                 // RFC4180に準拠するため、フィールドの値に含まれるダブルクォーテーションをエスケープする
-                $csv_col = str_replace('"', '""', $csv_col);
+                $csv_col = $csv_col !== null ? str_replace('"', '""', $csv_col) : '';
                 // RFC4180に準拠するため、ダブルクォーテーションで囲む
                 $csv_data .= '"' . $csv_col . '",';
             }

--- a/app/Utilities/Csv/CsvUtils.php
+++ b/app/Utilities/Csv/CsvUtils.php
@@ -171,6 +171,9 @@ class CsvUtils
         $csv_data = '';
         foreach ($csv_array as $csv_line) {
             foreach ($csv_line as $csv_col) {
+                // RFC4180に準拠するため、フィールドの値に含まれるダブルクォーテーションをエスケープする
+                $csv_col = str_replace('"', '""', $csv_col);
+                // RFC4180に準拠するため、ダブルクォーテーションで囲む
                 $csv_data .= '"' . $csv_col . '",';
             }
             // 末尾カンマを削除


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

CSV出力時、項目にダブルクォーテーションが含まれる場合、正しくエスケープするよう修正しました。

## 変更の目的

ExcelなどのスプレッドシートソフトでCSVを開いた際に、ダブルクォーテーションが正しく表示されない問題を解決するため。

## 変更内容

- ダブルクォーテーションをエスケープする処理を追加しました。

## テスト

- ダブルクォーテーションを含むCSVを出力し、Excelで開いて正しく表示されることを確認しました。

## 影響範囲

CSVを出力する以下の機能に適応されます。

- コード管理
- ユーザ管理
- フォームプラグイン
- ~~カウンタープラグイン~~
  - 項目にダブルクォーテーションが入ることはない 
- データベースプラグイン
- 課題管理プラグイン
- OPACプラグイン

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
