### PR TITLE
[ページ管理] 同じ固定リンクを登録できないように重複チェックを追加

### DIFF
--- a/app/Enums/PageCvsIndex.php
+++ b/app/Enums/PageCvsIndex.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * ページ-CSVのインデックス
+ *
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category ページ管理
+ * @package Enums
+ */
+final class PageCvsIndex extends EnumsBase
+{
+    // 定数メンバ
+    const page_name = 0;
+    const permanent_link = 1;
+    const background_color = 2;
+    const header_color = 3;
+    const theme = 4;
+    const layout = 5;
+    const base_display_flag = 6;
+
+    /** key/valueの連想配列 */
+    const enum = [
+        self::page_name => 'page_name',
+        self::permanent_link => 'permanent_link',
+        self::background_color => 'background_color',
+        self::header_color => 'header_color',
+        self::theme => 'theme',
+        self::layout => 'layout',
+        self::base_display_flag => 'base_display_flag',
+    ];
+}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

- [x] ページ登録
- [x] ページ変更
- [x] CSVインポート

# 修正後画面
## ページ管理＞ページ登録（固定リンク重複時）

![image](https://github.com/user-attachments/assets/e5a86441-6a7c-4997-a3ad-b7e0467ff574)

## ページ管理＞ページ変更（固定リンク重複時）

![image](https://github.com/user-attachments/assets/fb3ffcf6-3a69-44d1-8c34-b75e6d12ce0d)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
