### PR TITLE
[ユーザ管理] CSVインポート時の状態で承認待ち(4)に変更できないように修正

### DIFF
--- a/app/Enums/UserStatus.php
+++ b/app/Enums/UserStatus.php
@@ -10,10 +10,15 @@ use App\Enums\EnumsBase;
 final class UserStatus extends EnumsBase
 {
     // 定数メンバ
+    /** 利用可能 */
     const active = 0;
+    /** 利用不可 */
     const not_active = 1;
+    /** 仮削除 */
     const temporary_delete = 3;
+    /** 仮登録 */
     const temporary = 2;
+    /** 承認待ち */
     const pending_approval = 4;
 
     // key/valueの連想配列
@@ -31,9 +36,9 @@ final class UserStatus extends EnumsBase
     public static function getChooseableKeys()
     {
         $enum = self::enum;
-        // 仮登録は外す
+        // 仮登録, 承認待ちは外す
         unset($enum[self::temporary]);
-        // dd($enum);
+        unset($enum[self::pending_approval]);
 
         return array_keys($enum);
     }

--- a/app/User.php
+++ b/app/User.php
@@ -163,7 +163,7 @@ class User extends Authenticatable
     /**
      * 仮登録のinput disable 属性の要否を判断して返す。
      */
-    public function getStstusTemporaryDisabled($enum_value)
+    private function getStstusTemporaryDisabled($enum_value)
     {
         // 選択肢が仮登録の場合のみ、disabled の判定をする。
         if ($enum_value != UserStatus::temporary) {

--- a/resources/views/plugins/manage/user/import.blade.php
+++ b/resources/views/plugins/manage/user/import.blade.php
@@ -192,17 +192,13 @@
             </div>
 
             {{-- Submitボタン --}}
-            <div class="form-group text-center">
-                <div class="row">
-                    <div class="offset-sm-3 col-sm-6">
-                        <button type="submit" class="btn btn-primary">
-                            <i class="fas fa-check"></i>
-                            <span class="" onclick="return confirm('インポートします。\nよろしいですか？')">
-                                インポート
-                            </span>
-                        </button>
-                    </div>
-                </div>
+            <div class="text-center">
+                <button type="submit" class="btn btn-primary" onclick="return confirm('インポートします。\nよろしいですか？')">
+                    <i class="fas fa-check"></i>
+                    <span >
+                        インポート
+                    </span>
+                </button>
             </div>
         </form>
 

--- a/resources/views/plugins/manage/user/import.blade.php
+++ b/resources/views/plugins/manage/user/import.blade.php
@@ -133,15 +133,11 @@
                         <input type="file" class="custom-file-input" id="users_csv" name="users_csv" accept=".csv">
                         <label class="custom-file-label @if ($errors->has('users_csv')) border-danger @endif" for="users_csv" data-browse="参照"></label>
                     </div>
-                    @if ($errors && $errors->has('users_csv'))
-                        @foreach ($errors->get('users_csv') as $message)
-                            <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{$message}}</div>
-                        @endforeach
-                    @endif
-                    <small class="text-muted">※ アップロードできる１ファイルの最大サイズ: {{ini_get('upload_max_filesize')}}</small><br />
-                    <small class="text-muted">※ ログインユーザ（自分）の更新はできません。ログインユーザの更新はユーザ一覧より更新してください。</small><br />
-                    <small class="text-muted">※ ユーザを新規登録するする場合、「id」列には「""(空)」を設定してください。</small><br />
+                    @include('plugins.common.errors_inline', ['name' => 'users_csv'])
                     <small class="text-muted">
+                        ※ アップロードできる１ファイルの最大サイズ: {{ini_get('upload_max_filesize')}}<br />
+                        ※ ログインユーザ（自分）の更新はできません。ログインユーザの更新はユーザ一覧より更新してください。<br />
+                        ※ ユーザを新規登録するする場合、「id」列には「""(空)」を設定してください。<br />
                         ※ 既存のユーザを更新する場合、「id」列には既存ユーザのidを設定してください。既存ユーザのidは下部のダウンロードファイルで確認できます。
                         <div class="col text-left">
                             {{-- (右側)ダウンロードボタン --}}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [ユーザ管理] CSVインポート時の状態で承認待ち(4)に変更できないように修正
*  関連修正
    * [change: ユーザ管理, CSVインポート時のエラー表示は、共通画面を使う](https://github.com/opensource-workshop/connect-cms/pull/2121/commits/b87a60753555f5a13dd85d0ece2d2a436691e6ef)
    * [change: Userモデル, getStstusTemporaryDisabled()はクラス外から使われてないためprivateに変更](https://github.com/opensource-workshop/connect-cms/pull/2121/commits/41d7fdc06339844e973a821da141c402808fe784)
    * [change: ユーザ管理, CSVインポートのインポートボタン下部の不要な余白削除](https://github.com/opensource-workshop/connect-cms/pull/2121/commits/03138a39cd923c69159ee464bd2015ecbba5a98c)

# 修正後画面
## ユーザ管理＞CSVインポート

![image](https://github.com/user-attachments/assets/aa0cf7b4-5066-4468-8a74-8eb32b783123)

# 参考画面
## ユーザ管理＞ユーザ変更

ユーザ変更で変更できるのは、利用不可(1)、利用可能(0)、仮削除(3)の３つ
![image](https://github.com/user-attachments/assets/25bbc26a-dd33-48c1-8431-5a80b8c24ca8)

# テスト

ざっくりテストを実行、OK
https://github.com/opensource-workshop/connect-cms/actions/runs/13321167405

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
