### PR TITLE
[NC2移行] メモリ使用量オーバー対応

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -8337,7 +8337,7 @@ trait MigrationTrait
         $uploads_ini_detail = "";
 
         // メモリ使用量オーバー対応
-        $nc2_uploads_query->orderBy('upload_id')->chunk(1000, function($nc2_uploads) use ($uploads_path, &$uploads_ini, &$uploads_ini_detail) {
+        $nc2_uploads_query->orderBy('upload_id')->chunk(1000, function ($nc2_uploads) use ($uploads_path, &$uploads_ini, &$uploads_ini_detail) {
             // アップロード・ファイルのループ
             foreach ($nc2_uploads as $nc2_upload) {
                 // NC2 バックアップは対象外


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

大量のuploadsがあるNC2移行を実行時に、memory_limit=1Gを指定してもメモリ使用量オーバーエラーになるため、対応しました。

# エラー
## エクスポートコマンド（1Gメモリ指定）

```shell
# php -d memory_limit=1G artisan command:ExportNc2 all redo
page_id,block_id,category,message
,,Start exportNc2.,
,,Start this->nc2ExportBasic.,
,,Start this->nc2ExportUploads.,
PHP Fatal error:  Allowed memory size of 1073741824 bytes exhausted (tried to allocate 20480 bytes) in /srv/public_html/example.com/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php on line 262
PHP Fatal error:  Allowed memory size of 1073741824 bytes exhausted (tried to allocate 65536 bytes) in /srv/public_html/example.com/vendor/composer/ClassLoader.php on line 576
```

## インポートコマンド（1Gメモリ指定）

```shell
# php -d memory_limit=1G artisan command:ImportSite all redo
page_id,block_id,category,message
,,importSite() Start.,
,,Basic import Start.,
,,uploads import Start.,
PHP Fatal error:  Allowed memory size of 1073741824 bytes exhausted (tried to allocate 20480 bytes) in /srv/public_html/example.com/app/Traits/Migration/MigrationTrait.php on line 1445
PHP Fatal error:  Allowed memory size of 1073741824 bytes exhausted (tried to allocate 65536 bytes) in /srv/public_html/example.com/vendor/composer/ClassLoader.php on line 576
```

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
