### PR TITLE
[移行-インポート] DBインデックス追加によるパフォーマンス改善

### DIFF
--- a/database/migrations/2025_02_17_174343_add_target_source_table_and_source_key_index_from_migration_mappings.php
+++ b/database/migrations/2025_02_17_174343_add_target_source_table_and_source_key_index_from_migration_mappings.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTargetSourceTableAndSourceKeyIndexFromMigrationMappings extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('migration_mappings', function (Blueprint $table) {
+            $table->index(['target_source_table', 'source_key'], 'target_source_table_and_source_key_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('migration_mappings', function (Blueprint $table) {
+            $table->dropIndex('target_source_table_and_source_key_index');
+        });
+    }
+}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

移行のインポート時に、既に移行済みか確認するテーブル MigrationMapping を1件1件参照していますが、DBインデックスがありませんでした。
DBインデックスを追加したところ、参照速度が改善されましたので、プルリクエストを作成しました。

## 参考：MigrationMapping を1件1件参照
```php
// マッピングテーブルの取得
$mapping = MigrationMapping::where('target_source_table', 'uploads')->where('source_key', $upload_key)->first();
```

## SQL参照速度

```sql
SELECT * FROM `migration_mappings` WHERE target_source_table = 'uploads' and source_key = '11'; 

-- 行 0 - 0 の表示 (合計 1, クエリの実行時間： 0.0060 秒。) 
-- ↓index追加後
-- 行 0 - 0 の表示 (合計 1, クエリの実行時間： 0.0001 秒。) 
```

移行データ1件につき、1Selectしているため、
例えば10万件などの大量データの移行時、速度改善が期待できます。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
