### PR TITLE
[移行インポート＞Groups] 数万件のデータ移行に対応するため、バルクINSERT／upsert対応 他4件

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -1016,6 +1016,9 @@ trait MigrationTrait
 
         // 新ページの取り込み
         if ($this->isTarget('cc_import', 'pages')) {
+            $this->putMonitor(3, "Pages import start.");
+            $timer_start = $this->timerStart();
+
             // データクリア
             if ($redo === true) {
                 // トップページ以外の削除
@@ -1165,6 +1168,8 @@ trait MigrationTrait
                 // ページの中身の作成
                 $this->importHtmlImpl($page, $path);
             }
+
+            $this->putMonitor(3, "Pages import End.", $this->timerEnd($timer_start));
         }
 
         // シンプル動画単独実行用
@@ -1403,6 +1408,7 @@ trait MigrationTrait
     private function importBasic($redo)
     {
         $this->putMonitor(3, "Basic import Start.");
+        $timer_start = $this->timerStart();
 
         // サイト基本設定ファイル読み込み
         $basic_file_path = $this->getImportPath('basic/basic.ini');
@@ -1422,6 +1428,8 @@ trait MigrationTrait
             // サイト概要
             MigrationUtils::updateConfig('description', $basic_ini, 'meta');
         }
+
+        $this->putMonitor(3, "Basic import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -1429,7 +1437,8 @@ trait MigrationTrait
      */
     private function importUploads($redo)
     {
-        $this->putMonitor(3, "uploads import Start.");
+        $this->putMonitor(3, "Uploads import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -1516,6 +1525,8 @@ trait MigrationTrait
                 }
             }
         }
+
+        $this->putMonitor(3, "Uploads import End.", $this->timerEnd($timer_start));
     }
 
     // delete: 全体カテゴリは作らない
@@ -1607,6 +1618,7 @@ trait MigrationTrait
     private function importUsers($redo)
     {
         $this->putMonitor(3, "Users import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -1824,6 +1836,8 @@ trait MigrationTrait
                 $this->importUsersRoles($user, 'manage', $user_item);
             }
         }
+
+        $this->putMonitor(3, "Users import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -1866,6 +1880,7 @@ trait MigrationTrait
     private function importGroups($redo)
     {
         $this->putMonitor(3, "Groups import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -2036,6 +2051,8 @@ trait MigrationTrait
                 $upload->save();
             }
         }
+
+        $this->putMonitor(3, "Groups import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -2072,6 +2089,7 @@ trait MigrationTrait
     private function importPermalinks($redo)
     {
         $this->putMonitor(3, "Permalinks import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -2159,6 +2177,8 @@ trait MigrationTrait
                 DB::table('permalinks')->insert($bulk);
             }
         }
+
+        $this->putMonitor(3, "Permalinks import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -2167,6 +2187,7 @@ trait MigrationTrait
     private function importBlogs($redo)
     {
         $this->putMonitor(3, "Blogs import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -2422,6 +2443,8 @@ trait MigrationTrait
                 }
             }
         }
+
+        $this->putMonitor(3, "Blogs import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -2430,6 +2453,7 @@ trait MigrationTrait
     private function importFaqs($redo)
     {
         $this->putMonitor(3, "Faqs import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -2569,6 +2593,8 @@ trait MigrationTrait
                 }
             }
         }
+
+        $this->putMonitor(3, "Faqs import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -2577,6 +2603,7 @@ trait MigrationTrait
     private function importLinklists($redo)
     {
         $this->putMonitor(3, "Linklists import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -2699,6 +2726,8 @@ trait MigrationTrait
                 }
             }
         }
+
+        $this->putMonitor(3, "Linklists import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -2707,6 +2736,7 @@ trait MigrationTrait
     private function importDatabases($redo)
     {
         $this->putMonitor(3, "Databases import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -3035,6 +3065,8 @@ trait MigrationTrait
                 }
             }
         }
+
+        $this->putMonitor(3, "Databases import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -3043,6 +3075,7 @@ trait MigrationTrait
     private function importForms($redo)
     {
         $this->putMonitor(3, "Forms import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -3304,8 +3337,9 @@ trait MigrationTrait
                 DB::table('forms_input_cols')->insert($bulks);
             }
         }
-    }
 
+        $this->putMonitor(3, "Forms import End.", $this->timerEnd($timer_start));
+    }
 
     /**
      * Connect-CMS 移行形式の新着情報をインポート
@@ -3313,6 +3347,7 @@ trait MigrationTrait
     private function importWhatsnews($redo)
     {
         $this->putMonitor(3, "Whatsnews import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -3403,6 +3438,8 @@ trait MigrationTrait
                 'destination_key'      => $whatsnew->id,
             ]);
         }
+
+        $this->putMonitor(3, "Whatsnews import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -3411,6 +3448,7 @@ trait MigrationTrait
     private function importCabinets($redo)
     {
         $this->putMonitor(3, "Cabinets import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -3594,6 +3632,8 @@ trait MigrationTrait
                 CabinetContent::fixTree();
             }
         }
+
+        $this->putMonitor(3, "Cabinets import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -3602,6 +3642,7 @@ trait MigrationTrait
     private function importBbses($redo)
     {
         $this->putMonitor(3, "Bbses import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -3779,6 +3820,8 @@ trait MigrationTrait
                 }
             }
         }
+
+        $this->putMonitor(3, "Bbses import End.", $this->timerEnd($timer_start));
     }
 
     private function fetchMigratedKey($target_table, $key)
@@ -3798,6 +3841,7 @@ trait MigrationTrait
     private function importCounters($redo)
     {
         $this->putMonitor(3, "Counters import start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -3878,6 +3922,8 @@ trait MigrationTrait
                 'destination_key'      => $counter->id,
             ]);
         }
+
+        $this->putMonitor(3, "Counters import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -3886,6 +3932,7 @@ trait MigrationTrait
     private function importCalendars($redo)
     {
         $this->putMonitor(3, "Calendars import start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -4070,8 +4117,9 @@ trait MigrationTrait
                     'destination_key'      => $calendar->id,
                 ]);
             }
-
         }
+
+        $this->putMonitor(3, "Calendars import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -4080,6 +4128,7 @@ trait MigrationTrait
     private function importSlideshows($redo)
     {
         $this->putMonitor(3, "Slideshows import start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -4207,8 +4256,9 @@ trait MigrationTrait
                     'destination_key'      => $slideshows->id,
                 ]);
             }
-
         }
+
+        $this->putMonitor(3, "Slideshows import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -4217,6 +4267,7 @@ trait MigrationTrait
     private function importSimplemovie($redo)
     {
         $this->putMonitor(3, "Simplemovie import start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -4297,6 +4348,8 @@ trait MigrationTrait
                 'destination_key'      => $content->id, //固定記事のID
             ]);
         }
+
+        $this->putMonitor(3, "Simplemovie import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -4305,6 +4358,7 @@ trait MigrationTrait
     private function importReservations($redo)
     {
         $this->putMonitor(3, "Reservations import start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -4691,6 +4745,8 @@ trait MigrationTrait
                 'destination_key'      => $reservation->id,
             ]);
         }
+
+        $this->putMonitor(3, "Reservations import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -4699,6 +4755,7 @@ trait MigrationTrait
     private function importPhotoalbums($redo)
     {
         $this->putMonitor(3, "Photoalbums import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -5037,6 +5094,8 @@ trait MigrationTrait
             }
 
         }
+
+        $this->putMonitor(3, "Photoalbums import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -5149,6 +5208,7 @@ trait MigrationTrait
     private function importSearchs($redo)
     {
         $this->putMonitor(3, "Searchs import Start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -5224,6 +5284,8 @@ trait MigrationTrait
                 'destination_key'      => $search->id,
             ]);
         }
+
+        $this->putMonitor(3, "Searchs import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -5232,6 +5294,7 @@ trait MigrationTrait
     private function importRsses($redo)
     {
         $this->putMonitor(3, "Rsses import start.");
+        $timer_start = $this->timerStart();
 
         // データクリア
         if ($redo === true) {
@@ -5330,8 +5393,9 @@ trait MigrationTrait
                     'destination_key'      => $rsses->id,
                 ]);
             }
-
         }
+
+        $this->putMonitor(3, "Rsses import End.", $this->timerEnd($timer_start));
     }
 
     /**
@@ -15098,5 +15162,23 @@ trait MigrationTrait
     private function convertNc3PluginPermalinkCalToConnect(?string $content, string $url, string $db_colum, string $from_nc3_plugin_permalink, string $to_cc_plugin_permalink, string $content_target_source_table): ?string
     {
         return $this->convertNc3PluginPermalinkToConnect($content, $url, $db_colum, $from_nc3_plugin_permalink, $to_cc_plugin_permalink, $content_target_source_table, true);
+    }
+
+    /**
+     * タイマースタート
+     */
+    private function timerStart(): float
+    {
+        return microtime(true);
+    }
+
+    /**
+     * タイマー終了
+     */
+    private function timerEnd(float $timer_start): string
+    {
+        $time = (int)(microtime(true) - $timer_start);
+        $time = round($time, 0);
+        return $time . '秒';
     }
 }

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -343,6 +343,12 @@ trait MigrationTrait
     private $import_base = 'import/';
 
     /**
+     * Connect-CMSのユーザID
+     * @var array key=login_id, value=user_id
+     */
+    private $cc_user_ids = [];
+
+    /**
      * migration 各データのパス取得
      */
     private function getImportPath($target, $import_base = null)
@@ -853,8 +859,17 @@ trait MigrationTrait
      */
     private function getUserIdFromLoginId($users, $login_id)
     {
+        if (array_key_exists($login_id, $this->cc_user_ids)) {
+            // クラス変数に保持済みのログインＩＤなら、配列から返す
+            return $this->cc_user_ids[$login_id];
+        }
+
         $user = $users->firstWhere('userid', $login_id);
         $user = $user ?? new User();
+
+        // クラス変数に保持
+        $this->cc_user_ids[$login_id] = $user->id;
+
         return $user->id;
     }
 

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -910,7 +910,7 @@ trait MigrationTrait
         $this->redo          = $redo;
         $this->added         = $added;
 
-        $this->putMonitor(3, "importSite() Start.");
+        $this->putMonitor(3, "importSite() import_base={$this->import_base} Start.");
 
         // 移行の初期処理
         if ($added == false && $redo === true) {


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [移行インポート＞Groups] パフォーマンス改善
  * [change: 移行インポート＞Groups, 数万件のデータ移行に対応するため、バルクINSERT／upsert対応](https://github.com/opensource-workshop/connect-cms/commit/74a495ec963ccbb064118fb312eb144118e0ef55)
* 他対応
  * [bugfix: 移行インポート, フォトアルバムインポート時にUploadsが40万件程度あるとメモリオーバーになる不具合修正2](https://github.com/opensource-workshop/connect-cms/commit/b159f0d8cc9d9568dbd699b96a088977a5fc1ec4)
  *  [add: 移行インポート, 移行時間計測追加](https://github.com/opensource-workshop/connect-cms/commit/0aaa9a8002dc648cf9c1cb010fe8ad031d8c8318)
  * [add: 移行インポート, 1度検索したCCユーザIDはクラス変数に保持して再利用する](https://github.com/opensource-workshop/connect-cms/commit/9d77cffe17a11ab0b2ca44c2e75e84c4d130dcbf)
  * [change: 移行インポート, 出力メッセージ「importSite() Start.」に import_base の内容を出力](https://github.com/opensource-workshop/connect-cms/commit/dc0d015f17c27ddfe776f2142792abfd068194d1)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/2130

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* モデルの挿入と更新＞更新／挿入 - 8.x Eloquentの準備 Laravel 
https://readouble.com/laravel/8.x/ja/eloquent.html#upserts
* MySQL :: MySQL 8.0 リファレンスマニュアル :: 13.2.6.2 INSERT ... ON DUPLICATE KEY UPDATE ステートメント
https://dev.mysql.com/doc/refman/8.0/ja/insert-on-duplicate.html
* MySQLのINSERT ... ON DUPLICATE KEY UPDATEでレコードの挿入/更新を便利に実行 #Java - Qiita
https://qiita.com/Yuki_Oshima/items/2a73cf70ccbf67bd5215

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
