### PR TITLE
[移行インポート＞ユーザ移行] ユーザーのメールアドレスがRFC違反時のエラーメッセージ修正

### DIFF
--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -1774,7 +1774,7 @@ trait MigrationTrait
                     try {
                         Validator::validate(['email' => $email], ['email' => ['email', 'nullable']]);
                     } catch (\Exception $e) {
-                        $this->putError(3, 'ユーザーのメールアドレスがRFC違反。', " userid = " . $user_item['userid'] . " name = " . $user_item['name'] . " email='" . $email . "' error = " . $e->getMessage());
+                        $this->putError(3, 'ユーザーのメールアドレスがRFC違反。（ユーザ移行はされますが、新システムではユーザ変更時の入力チェックでエラーになりますのでご留意ください。又、入力ミスしたメールアドレスや、;区切りの複数メールアドレスがある場合は、メールが届きませんのでご注意ください。）', " userid = " . $user_item['userid'] . " name = " . $user_item['name'] . " email='" . $email . "' error = " . $e->getMessage());
                     }
                 }
                 // emailの duplicate entry 制約があるので、空文字ならnull に変換


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

移行インポートでユーザ移行時に「ユーザーのメールアドレスがRFC違反」チェックがあり、エラーメッセージを表示していましたが、エラーメッセージから、ユーザ移行されないように読めたため（実際はRFC違反でもユーザ移行される）、
ユーザ移行される旨をエラーメッセージに追記しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
