### PR TITLE
[テスト] DuskテストがChrome 134系になって出るエラーの修正

### DIFF
--- a/tests/Browser/Common/FrameTest.php
+++ b/tests/Browser/Common/FrameTest.php
@@ -524,6 +524,9 @@ class FrameTest extends DuskTestCase
                         ->screenshot('user/bbses/createBuckets/images/createBuckets')
                         ->press('登録確定');
 
+                // 画面表示がおいつかない場合があるので、ちょっと待つ
+                $browser->pause(500);
+
                 // 一度、選択確定させる。
                 $bucket = Buckets::where('plugin_name', 'bbses')->first();
                 $browser->visit('/plugin/bbses/listBuckets/' . $page->id . '/' . $frame->id . '#frame-' . $frame->id)

--- a/tests/Browser/Common/PasswordPageTest.php
+++ b/tests/Browser/Common/PasswordPageTest.php
@@ -85,7 +85,8 @@ class PasswordPageTest extends DuskTestCase
                     ->screenshot('common/password_page/viewPage/images/viewPage1')
                     ->type('password', 'pass123')
                     ->screenshot('common/password_page/viewPage/images/inputPassword')
-                    ->press('ページ閲覧');
+                    ->press('ページ閲覧')
+                    ->pause(500);    // github actionsの安定性のためにpress後に少し待つ
         });
 
         // *** データクリア
@@ -103,12 +104,6 @@ class PasswordPageTest extends DuskTestCase
         // *** ログインして固定記事を作成
         // ※ $this->browse()内で$this->login(), $this->logout() はなるべく使わない。$this->login(), $this->logout() は内部で$this->browse()を使っているため、入れ子呼び出しになり、ログインできたり・できなかったりする事あり（github actions+php8.1等）
         $this->login(1);
-
-        $this->browse(function (Browser $browser) {
-            // ログイン後に管理機能が表示されるか確認のため、スクリーンショットを撮る
-            $browser->visit('/password')
-                    ->screenshot('common/password_page/viewPage/images/viewPage2-0');
-        });
 
         // 固定記事を作成
         // ※ $this->browse() 入れ子対応。下記メソッドはなるべく$this->browse()内で使わない

--- a/tests/Browser/Common/PasswordPageTest.php
+++ b/tests/Browser/Common/PasswordPageTest.php
@@ -103,6 +103,12 @@ class PasswordPageTest extends DuskTestCase
         // ※ $this->browse()内で$this->login(), $this->logout() はなるべく使わない。$this->login(), $this->logout() は内部で$this->browse()を使っているため、入れ子呼び出しになり、ログインできたり・できなかったりする事あり（github actions+php8.1等）
         $this->login(1);
 
+        $this->browse(function (Browser $browser) {
+            // ログイン後に管理機能が表示されるか確認のため、スクリーンショットを撮る
+            $browser->visit('/password')
+                    ->screenshot('common/password_page/viewPage/images/viewPage2-0');
+        });
+
         // 固定記事を作成
         // ※ $this->browse() 入れ子対応。下記メソッドはなるべく$this->browse()内で使わない
         $this->addPluginModal('contents', '/password', 2, false);

--- a/tests/Browser/Common/PasswordPageTest.php
+++ b/tests/Browser/Common/PasswordPageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Browser\Common;
 
+use App\Enums\AreaType;
 use App\Models\Common\Buckets;
 use App\Models\Common\Frame;
 use App\Models\Common\Page;
@@ -111,7 +112,7 @@ class PasswordPageTest extends DuskTestCase
 
         // 固定記事を作成
         // ※ $this->browse() 入れ子対応。下記メソッドはなるべく$this->browse()内で使わない
-        $this->addPluginModal('contents', '/password', 2, false);
+        $this->addPluginModal('contents', '/password', AreaType::main, false);
 
         $bucket = Buckets::create(['bucket_name' => 'パスワード付きページテスト', 'plugin_name' => 'contents']);
 

--- a/tests/Browser/Common/PasswordPageTest.php
+++ b/tests/Browser/Common/PasswordPageTest.php
@@ -45,7 +45,8 @@ class PasswordPageTest extends DuskTestCase
                     ->type('password', 'pass123')
                     ->screenshot('common/password_page/index/images/setPassword')
                     ->scrollIntoView('footer')
-                    ->press('ページ更新');
+                    ->press('ページ更新')
+                    ->pause(500);    // github actionsの安定性のためにpress後に少し待つ
         });
 
         // マニュアル用データ出力
@@ -78,9 +79,6 @@ class PasswordPageTest extends DuskTestCase
     {
         // *** ログアウト状態でパスワードページ＞パスワード入力＞ページの閲覧
         $this->browse(function (Browser $browser) {
-            // 画面表示がおいつかない場合があるので、ちょっと待つ
-            $browser->pause(500);
-
             $browser->visit('/password')
                     ->assertTitleContains('Connect-CMS')
                     ->screenshot('common/password_page/viewPage/images/viewPage1')

--- a/tests/Browser/Common/PasswordPageTest.php
+++ b/tests/Browser/Common/PasswordPageTest.php
@@ -2,17 +2,13 @@
 
 namespace Tests\Browser\Common;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
 use App\Models\Common\Buckets;
 use App\Models\Common\Frame;
 use App\Models\Common\Page;
 use App\Models\Core\Dusks;
 use App\Models\User\Contents\Contents;
-
-use App\Enums\PluginName;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * パスワード付きページテスト
@@ -85,6 +81,7 @@ class PasswordPageTest extends DuskTestCase
             $browser->visit('/password')
                     ->assertTitleContains('Connect-CMS')
                     ->screenshot('common/password_page/viewPage/images/viewPage1')
+                    ->pause(500)
                     ->type('password', 'pass123')
                     ->screenshot('common/password_page/viewPage/images/inputPassword')
                     ->press('ページ閲覧');
@@ -105,16 +102,20 @@ class PasswordPageTest extends DuskTestCase
                 }
                 $frame->forceDelete();
             }
+        });
 
-            // 固定記事を作成
-            $this->addPluginModal('contents', '/password', 2, false);
+        // 固定記事を作成
+        // ※ $this->browse() 入れ子対応。下記メソッドはなるべく$this->browse()内で使わない
+        $this->addPluginModal('contents', '/password', 2, false);
+
+        $this->browse(function (Browser $browser) {
             $bucket = Buckets::create(['bucket_name' => 'パスワード付きページテスト', 'plugin_name' => 'contents']);
 
             // 初めは記事は文字のみ。
-            $this->content = Contents::create(['bucket_id' => $bucket->id, 'content_text' => '<p>パスワード付きページのテストです。</p>', 'status' => 0]);
+            $content = Contents::create(['bucket_id' => $bucket->id, 'content_text' => '<p>パスワード付きページのテストです。</p>', 'status' => 0]);
 
-            $this->frame = Frame::orderBy('id', 'desc')->first();
-            $this->frame->update(['bucket_id' => $bucket->id]);
+            $frame = Frame::orderBy('id', 'desc')->first();
+            $frame->update(['bucket_id' => $bucket->id]);
         });
         // パスワード入力済みセッションをクリアさせないため、ログアウトしない
         // $this->logout();

--- a/tests/Browser/Common/PasswordPageTest.php
+++ b/tests/Browser/Common/PasswordPageTest.php
@@ -78,10 +78,12 @@ class PasswordPageTest extends DuskTestCase
     {
         // *** ログアウト状態でパスワードページ＞パスワード入力＞ページの閲覧
         $this->browse(function (Browser $browser) {
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('/password')
                     ->assertTitleContains('Connect-CMS')
                     ->screenshot('common/password_page/viewPage/images/viewPage1')
-                    ->pause(500)
                     ->type('password', 'pass123')
                     ->screenshot('common/password_page/viewPage/images/inputPassword')
                     ->press('ページ閲覧');

--- a/tests/Browser/Common/WysiwygTest.php
+++ b/tests/Browser/Common/WysiwygTest.php
@@ -2,15 +2,14 @@
 
 namespace Tests\Browser\Common;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
+use App\Enums\AreaType;
 use App\Models\Common\Buckets;
-use App\Models\Common\Page;
+
 use App\Models\Common\Frame;
 use App\Models\Core\Dusks;
 use App\Models\User\Contents\Contents;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * WYSIWYGテスト
@@ -76,7 +75,7 @@ class WysiwygTest extends DuskTestCase
         }
 
         // 固定記事を作成
-        $this->addPluginModal('contents', '/test/content', 2, false);
+        $this->addPluginModal('contents', '/test/content', AreaType::main, false);
         $bucket = Buckets::create(['bucket_name' => 'WYSIWYGエディタ', 'plugin_name' => 'contents']);
 
         // 初めは記事は文字のみ。

--- a/tests/Browser/ConnectStudy/DroneStudyTest.php
+++ b/tests/Browser/ConnectStudy/DroneStudyTest.php
@@ -79,6 +79,9 @@ class DroneStudyTest extends DuskTestCase
                     ->screenshot('study/dronestudies/createBuckets/images/createBuckets2')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'dronestudies')->first();
             $browser->visit('/plugin/dronestudies/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/Manage/ReservationManageTest.php
+++ b/tests/Browser/Manage/ReservationManageTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Browser\Manage;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
 use Artisan;
@@ -131,6 +130,9 @@ class ReservationManageTest extends DuskTestCase
                     $reservations_category = '3';
                 }
 
+                // ループの連続実行で画面表示がおいついてないので、ちょっと待つ
+                $browser->pause(500);
+
                 $browser->visit('/manage/reservation/regist')
                         ->type('facility_name', $name)
                         ->select('reservations_categories_id', $reservations_category)
@@ -150,7 +152,9 @@ class ReservationManageTest extends DuskTestCase
             $browser->visit('/manage/reservation/categories')
                     ->type('add_display_sequence', '2')
                     ->type('add_category', '会議室')
-                    ->press('変更')
+                    ->press('変更');
+
+            $browser->visit('/manage/reservation/categories')
                     ->type('add_display_sequence', '3')
                     ->type('add_category', 'ドローン')
                     ->press('変更');

--- a/tests/Browser/User/BbsesPluginTest.php
+++ b/tests/Browser/User/BbsesPluginTest.php
@@ -183,6 +183,9 @@ class BbsesPluginTest extends DuskTestCase
                     ->screenshot('user/bbses/createBuckets/images/createBuckets')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'bbses')->first();
             $browser->visit('/plugin/bbses/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/BlogsPluginTest.php
+++ b/tests/Browser/User/BlogsPluginTest.php
@@ -206,6 +206,9 @@ class BlogsPluginTest extends DuskTestCase
                     ->screenshot('user/blogs/createBuckets/images/createBuckets')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'blogs')->first();
             $browser->visit('/plugin/blogs/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/CabinetsPluginTest.php
+++ b/tests/Browser/User/CabinetsPluginTest.php
@@ -174,6 +174,9 @@ class CabinetsPluginTest extends DuskTestCase
                     ->screenshot('user/cabinets/createBuckets/images/createBuckets')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'cabinets')->first();
             $browser->visit('/plugin/cabinets/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/CalendarsPluginTest.php
+++ b/tests/Browser/User/CalendarsPluginTest.php
@@ -108,10 +108,8 @@ class CalendarsPluginTest extends DuskTestCase
                     ->type('end_date', $ym . '-01')
                     ->type('end_time', '12:00')
                     ->screenshot('user/calendars/edit/images/edit1')
+                    ->pause(500)
                     ->press('登録確定');
-
-            // 画面表示がおいつかない場合があるので、ちょっと待つ
-            $browser->pause(500);
 
             $browser->visit('plugin/calendars/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '?date=' . $ym . '-08#frame-' . $this->test_frame->id)
                     ->assertPathBeginsWith('/')
@@ -121,6 +119,7 @@ class CalendarsPluginTest extends DuskTestCase
                     ->driver->executeScript('tinyMCE.get(0).setContent(\'この予定は全日予定です。\')');
 
             $browser->screenshot('user/calendars/edit/images/edit2')
+                    ->pause(500)
                     ->press('登録確定');
 
             $browser->visit('plugin/calendars/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '?date=' . $ym . '-20#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/CalendarsPluginTest.php
+++ b/tests/Browser/User/CalendarsPluginTest.php
@@ -108,8 +108,8 @@ class CalendarsPluginTest extends DuskTestCase
                     ->type('end_date', $ym . '-01')
                     ->type('end_time', '12:00')
                     ->screenshot('user/calendars/edit/images/edit1')
-                    ->pause(500)
-                    ->press('登録確定');
+                    ->press('登録確定')
+                    ->pause(500);    // github actionsの安定性のためにpress後に少し待つ
 
             $browser->visit('plugin/calendars/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '?date=' . $ym . '-08#frame-' . $this->test_frame->id)
                     ->assertPathBeginsWith('/')
@@ -119,8 +119,8 @@ class CalendarsPluginTest extends DuskTestCase
                     ->driver->executeScript('tinyMCE.get(0).setContent(\'この予定は全日予定です。\')');
 
             $browser->screenshot('user/calendars/edit/images/edit2')
-                    ->pause(500)
-                    ->press('登録確定');
+                    ->press('登録確定')
+                    ->pause(500);    // github actionsの安定性のためにpress後に少し待つ
 
             $browser->visit('plugin/calendars/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '?date=' . $ym . '-20#frame-' . $this->test_frame->id)
                     ->assertPathBeginsWith('/')

--- a/tests/Browser/User/CalendarsPluginTest.php
+++ b/tests/Browser/User/CalendarsPluginTest.php
@@ -116,6 +116,9 @@ class CalendarsPluginTest extends DuskTestCase
                     ->screenshot('user/calendars/edit/images/edit1')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('plugin/calendars/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '?date=' . $ym . '-08#frame-' . $this->test_frame->id)
                     ->assertPathBeginsWith('/')
                     ->type('title', 'テストの予定２')

--- a/tests/Browser/User/CalendarsPluginTest.php
+++ b/tests/Browser/User/CalendarsPluginTest.php
@@ -2,18 +2,12 @@
 
 namespace Tests\Browser\User;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
-use App\Enums\PluginName;
 use App\Models\Common\Buckets;
-use App\Models\Common\Frame;
-use App\Models\Common\Uploads;
-use App\Models\Core\Dusks;
 use App\Models\User\Calendars\Calendar;
 use App\Models\User\Calendars\CalendarFrame;
 use App\Models\User\Calendars\CalendarPost;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * カレンダーテスト
@@ -178,6 +172,9 @@ class CalendarsPluginTest extends DuskTestCase
                     ->type('name', 'テストのカレンダー')
                     ->screenshot('user/calendars/createBuckets/images/createBuckets')
                     ->press('登録確定');
+
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
 
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'calendars')->first();

--- a/tests/Browser/User/CountersPluginTest.php
+++ b/tests/Browser/User/CountersPluginTest.php
@@ -110,6 +110,9 @@ class CountersPluginTest extends DuskTestCase
                     ->screenshot('user/counters/createBuckets/images/createBuckets')
                     ->press("登録確定");
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'counters')->first();
             $browser->visit('/plugin/counters/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/CountersPluginTest.php
+++ b/tests/Browser/User/CountersPluginTest.php
@@ -2,18 +2,14 @@
 
 namespace Tests\Browser\User;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
-use App\Enums\PluginName;
+use App\Enums\AreaType;
 use App\Models\Common\Buckets;
 use App\Models\Common\Frame;
-use App\Models\Common\Uploads;
-use App\Models\Core\Dusks;
 use App\Models\User\Counters\Counter;
 use App\Models\User\Counters\CounterCount;
 use App\Models\User\Counters\CounterFrame;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * カウンターテスト
@@ -40,7 +36,7 @@ class CountersPluginTest extends DuskTestCase
         $this->listBuckets();
 
         // 左エリアの下にもカウンターを置く。バケツはメインエリアと同じものを参照。順番は、上にメニュー、下にカウンター
-        $this->addPluginModal('counters', '/', 1, false);
+        $this->addPluginModal('counters', '/', AreaType::left, false);
         Frame::where('area_id', 1)->where('plugin_name', 'menus')->update(['display_sequence' => 1]);
         $frame = Frame::where('area_id', 2)->where('plugin_name', 'counters')->first();
         Frame::where('area_id', 1)->where('plugin_name', 'counters')->update(['display_sequence' => 2, 'bucket_id' => $frame->bucket_id]);

--- a/tests/Browser/User/DatabasesPluginTest.php
+++ b/tests/Browser/User/DatabasesPluginTest.php
@@ -2,15 +2,8 @@
 
 namespace Tests\Browser\User;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
-use App\Enums\PluginName;
 use App\Models\Common\Buckets;
-use App\Models\Common\Frame;
 use App\Models\Common\Uploads;
-use App\Models\Core\Dusks;
 use App\Models\User\Databases\Databases;
 use App\Models\User\Databases\DatabasesColumns;
 use App\Models\User\Databases\DatabasesColumnsRole;
@@ -19,6 +12,8 @@ use App\Models\User\Databases\DatabasesFrames;
 use App\Models\User\Databases\DatabasesInputCols;
 use App\Models\User\Databases\DatabasesInputs;
 use App\Models\User\Databases\DatabasesRole;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * データベーステスト
@@ -253,6 +248,9 @@ class DatabasesPluginTest extends DuskTestCase
                     ->screenshot('user/databases/createBuckets/images/createBuckets')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'databases')->first();
             $browser->visit('/plugin/databases/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
@@ -340,6 +338,9 @@ class DatabasesPluginTest extends DuskTestCase
                     ->type('row_group', '1')
                     ->type('column_group', '1')
                     ->press('#button_column');
+
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
 
             // 都道府県名
             $browser->visit('/plugin/databases/editColumnDetail/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '/2#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/DatabasesearchesPluginTest.php
+++ b/tests/Browser/User/DatabasesearchesPluginTest.php
@@ -90,6 +90,9 @@ class DatabasesearchesPluginTest extends DuskTestCase
                     ->screenshot('user/databasesearches/editBuckets/images/editBuckets2')
                     ->press("登録");
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'databasesearches')->first();
             $browser->visit('/plugin/databasesearches/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -78,6 +78,7 @@ class FaqsPluginTest extends DuskTestCase
         $this->login(1);
         $this->browse(function (Browser $browser) {
             $browser->visit("/plugin/faqs/editBuckets/" . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
+                    ->pause(500)
                     ->assertPathBeginsWith('/')
                     ->click('#label_narrowing_down_type_dropdown')
                     ->press("変更確定");
@@ -85,9 +86,6 @@ class FaqsPluginTest extends DuskTestCase
         $this->logout();
 
         $this->browse(function (Browser $browser) {
-            // 画面表示がおいつかない場合があるので、ちょっと待つ
-            $browser->pause(500);
-
             $browser->visit('/test/faq')
                     ->click('#categories_id_' . $this->test_frame->id)
                     ->pause(500)

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -77,8 +77,10 @@ class FaqsPluginTest extends DuskTestCase
         // ※ $this->browse() 入れ子対応。$this->login(), $this->logout()はなるべく$this->browse()内で使わない
         $this->login(1);
         $this->browse(function (Browser $browser) {
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit("/plugin/faqs/editBuckets/" . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
-                    ->pause(500)
                     ->assertPathBeginsWith('/')
                     ->click('#label_narrowing_down_type_dropdown')
                     ->press("変更確定");

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -80,6 +80,7 @@ class FaqsPluginTest extends DuskTestCase
             $browser->visit("/plugin/faqs/editBuckets/" . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
                     ->assertPathBeginsWith('/')
                     ->click('#label_narrowing_down_type_dropdown')
+                    ->pause(500)    // github actionsの安定性のためにclick後に少し待つ
                     ->screenshot('user/faqs/createBuckets/images/editBuckets2')
                     ->press("変更確定");
         });

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -78,20 +78,18 @@ class FaqsPluginTest extends DuskTestCase
         $this->login(1);
         $this->browse(function (Browser $browser) {
             $browser->visit("/plugin/faqs/editBuckets/" . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
-                    ->pause(500)
                     ->assertPathBeginsWith('/')
                     ->click('#label_narrowing_down_type_dropdown')
+                    ->screenshot('user/faqs/createBuckets/images/editBuckets2')
                     ->press("変更確定");
         });
         $this->logout();
 
         $this->browse(function (Browser $browser) {
             $browser->visit('/test/faq')
-                    ->pause(500)
                     ->assertPathBeginsWith('/')
-                    // ドロップダウンを開く。github actionsでUnable to locate element with selector エラーになるためpress()で開く
-                    // ->click('#categories_id_' . $this->test_frame->id)
-                    ->press('#categories_id_' . $this->test_frame->id)
+                    ->screenshot('user/faqs/index/images/index3-0')
+                    ->click('#categories_id_' . $this->test_frame->id)  // ドロップダウンを開く
                     ->screenshot('user/faqs/index/images/index3');
 
             $post = FaqsPosts::first();
@@ -178,6 +176,9 @@ class FaqsPluginTest extends DuskTestCase
     {
         // 実行
         $this->browse(function (Browser $browser) {
+            // ループの連続実行で画面表示がおいついてないので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('/plugin/faqs/listCategories/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
                     ->pause(500)
                     ->assertPathBeginsWith('/')

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -89,7 +89,9 @@ class FaqsPluginTest extends DuskTestCase
             $browser->visit('/test/faq')
                     ->pause(500)
                     ->assertPathBeginsWith('/')
+                    // ドロップダウンを開く。github actionsでUnable to locate element with selector エラーになるためpress()で開く
                     // ->click('#categories_id_' . $this->test_frame->id)
+                    ->press('#categories_id_' . $this->test_frame->id)
                     ->screenshot('user/faqs/index/images/index3');
 
             $post = FaqsPosts::first();

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -82,14 +82,12 @@ class FaqsPluginTest extends DuskTestCase
                     ->click('#label_narrowing_down_type_dropdown')
                     ->pause(500)    // github actionsの安定性のためにclick後に少し待つ
                     ->screenshot('user/faqs/createBuckets/images/editBuckets2')
-                    ->press("変更確定");
+                    ->press("変更確定")
+                    ->pause(500);    // github actionsの安定性のためにpress後に少し待つ
         });
         $this->logout();
 
         $this->browse(function (Browser $browser) {
-            // 画面表示がおいつかない場合があるので、ちょっと待つ
-            $browser->pause(500);
-
             $browser->visit('/test/faq')
                     ->assertPathBeginsWith('/')
                     ->screenshot('user/faqs/index/images/index3-0')

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -87,6 +87,9 @@ class FaqsPluginTest extends DuskTestCase
         $this->logout();
 
         $this->browse(function (Browser $browser) {
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('/test/faq')
                     ->assertPathBeginsWith('/')
                     ->screenshot('user/faqs/index/images/index3-0')

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -85,6 +85,9 @@ class FaqsPluginTest extends DuskTestCase
         $this->logout();
 
         $this->browse(function (Browser $browser) {
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('/test/faq')
                     ->click('#categories_id_' . $this->test_frame->id)
                     ->pause(500)

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -89,7 +89,7 @@ class FaqsPluginTest extends DuskTestCase
             $browser->visit('/test/faq')
                     ->pause(500)
                     ->assertPathBeginsWith('/')
-                    ->click('#categories_id_' . $this->test_frame->id)
+                    // ->click('#categories_id_' . $this->test_frame->id)
                     ->screenshot('user/faqs/index/images/index3');
 
             $post = FaqsPosts::first();

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -65,27 +65,33 @@ class FaqsPluginTest extends DuskTestCase
     {
         // 実行
         $this->browse(function (Browser $browser) {
-            $post = FaqsPosts::first();
             $category = PluginCategory::where('target', 'faqs')->first();
             $browser->visit('/test/faq')
                     ->assertPathBeginsWith('/')
                     ->screenshot('user/faqs/index/images/index1')
                     ->click('#a_category_button_' . $category->categories_id)
                     ->screenshot('user/faqs/index/images/index2');
+        });
 
-            // ドロップダウン形式の絞り込みの例
-            $this->login(1);
+        // ドロップダウン形式の絞り込みの例
+        // ※ $this->browse() 入れ子対応。$this->login(), $this->logout()はなるべく$this->browse()内で使わない
+        $this->login(1);
+        $this->browse(function (Browser $browser) {
             $browser->visit("/plugin/faqs/editBuckets/" . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
                     ->assertPathBeginsWith('/')
                     ->click('#label_narrowing_down_type_dropdown')
                     ->press("変更確定");
-            $this->logout();
+        });
+        $this->logout();
 
+        $this->browse(function (Browser $browser) {
             $browser->visit('/test/faq')
                     ->click('#categories_id_' . $this->test_frame->id)
                     ->pause(500)
                     ->assertPathBeginsWith('/')
                     ->screenshot('user/faqs/index/images/index3');
+
+            $post = FaqsPosts::first();
 
             // 本文表示
             $browser->click('#button_collapse_faq' . $post->id)

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -2,25 +2,20 @@
 
 namespace Tests\Browser\User;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
-use App\Enums\PluginName;
 use App\Models\Common\Buckets;
 use App\Models\Common\Categories;
-use App\Models\Common\Frame;
 use App\Models\Common\PluginCategory;
-use App\Models\Common\Uploads;
-use App\Models\Core\Dusks;
 use App\Models\User\Faqs\Faqs;
 use App\Models\User\Faqs\FaqsPosts;
 use App\Models\User\Faqs\FaqsPostsTags;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * FAQテスト
  *
  * @see https://github.com/opensource-workshop/connect-cms/wiki/Dusk#テスト実行 [How to test]
+ * @see \Tests\Browser\Manage\SiteManageTest 実行後に実行すること（共通カテゴリが作成される）
  */
 class FaqsPluginTest extends DuskTestCase
 {
@@ -138,6 +133,9 @@ class FaqsPluginTest extends DuskTestCase
                     ->screenshot('user/faqs/createBuckets/images/createBuckets')
                     ->press("登録確定");
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'faqs')->first();
             $browser->visit('/plugin/faqs/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
@@ -202,6 +200,9 @@ class FaqsPluginTest extends DuskTestCase
 
         // 個別カテゴリの作成
         $this->browse(function (Browser $browser) {
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('/plugin/faqs/listCategories/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
                     ->click('#div_add_view_flag')
                     ->type('add_display_sequence', '3')
@@ -249,6 +250,9 @@ class FaqsPluginTest extends DuskTestCase
      */
     private function postOne($browser, $title, $body, $category_id, $img_no1, $img_no2)
     {
+        // 画面表示がおいつかない場合があるので、ちょっと待つ
+        $browser->pause(500);
+
         $browser->visit('/plugin/faqs/create/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
                 ->type('post_title', $title)
                 ->driver->executeScript('tinyMCE.get(0).setContent(\'' . $body . '\')');

--- a/tests/Browser/User/FaqsPluginTest.php
+++ b/tests/Browser/User/FaqsPluginTest.php
@@ -77,10 +77,8 @@ class FaqsPluginTest extends DuskTestCase
         // ※ $this->browse() 入れ子対応。$this->login(), $this->logout()はなるべく$this->browse()内で使わない
         $this->login(1);
         $this->browse(function (Browser $browser) {
-            // 画面表示がおいつかない場合があるので、ちょっと待つ
-            $browser->pause(500);
-
             $browser->visit("/plugin/faqs/editBuckets/" . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
+                    ->pause(500)
                     ->assertPathBeginsWith('/')
                     ->click('#label_narrowing_down_type_dropdown')
                     ->press("変更確定");
@@ -89,9 +87,9 @@ class FaqsPluginTest extends DuskTestCase
 
         $this->browse(function (Browser $browser) {
             $browser->visit('/test/faq')
-                    ->click('#categories_id_' . $this->test_frame->id)
                     ->pause(500)
                     ->assertPathBeginsWith('/')
+                    ->click('#categories_id_' . $this->test_frame->id)
                     ->screenshot('user/faqs/index/images/index3');
 
             $post = FaqsPosts::first();
@@ -179,9 +177,9 @@ class FaqsPluginTest extends DuskTestCase
         // 実行
         $this->browse(function (Browser $browser) {
             $browser->visit('/plugin/faqs/listCategories/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
-                    ->click('#div_general_view_flag_1')  // カスタムチェックボックスのインプットとラベルをくくるdivは自動テスト時、ラベルが空の場合にクリックできないための対応
                     ->pause(500)
                     ->assertPathBeginsWith('/')
+                    ->click('#div_general_view_flag_1')  // カスタムチェックボックスのインプットとラベルをくくるdivは自動テスト時、ラベルが空の場合にクリックできないための対応
                     ->press('変更')
                     ->screenshot('user/faqs/listCategories/images/listCategories');
         });

--- a/tests/Browser/User/FormsPluginTest.php
+++ b/tests/Browser/User/FormsPluginTest.php
@@ -115,6 +115,9 @@ class FormsPluginTest extends DuskTestCase
                     ->screenshot('user/forms/createBuckets/images/createBuckets3')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'forms')->first();
             $browser->visit('/plugin/forms/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
@@ -488,6 +491,9 @@ class FormsPluginTest extends DuskTestCase
             $browser->scrollIntoView('footer')
                     ->screenshot('user/questionnaires/createBuckets/images/createBuckets2')
                     ->press('登録確定');
+
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
 
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'forms')->orderBy('id', 'desc')->first();

--- a/tests/Browser/User/LinklistsPluginTest.php
+++ b/tests/Browser/User/LinklistsPluginTest.php
@@ -2,18 +2,12 @@
 
 namespace Tests\Browser\User;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
-use App\Enums\PluginName;
 use App\Models\Common\Buckets;
-use App\Models\Common\Frame;
-use App\Models\Common\Uploads;
-use App\Models\Core\Dusks;
 use App\Models\User\Linklists\Linklist;
 use App\Models\User\Linklists\LinklistFrame;
 use App\Models\User\Linklists\LinklistPost;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * リンクリストテスト
@@ -184,16 +178,20 @@ class LinklistsPluginTest extends DuskTestCase
     {
         // 実行
         $this->browse(function (Browser $browser) {
+            // ループの連続実行で画面表示がおいついてないので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('/plugin/linklists/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
-                    ->pause(500)
                     ->type('title', 'Connect-CMS公式')
                     ->type('url', 'https://connect-cms.jp/')
                     ->type('description', 'Connect-CMSの情報はこのサイトから。')
                     ->screenshot('user/linklists/edit/images/create')
                     ->press('登録確定');
 
+            // ループの連続実行で画面表示がおいついてないので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('/plugin/linklists/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
-                    ->pause(500)
                     ->type('title', '株式会社オープンソース・ワークショップ')
                     ->type('url', 'https://opensource-workshop.jp/')
                     ->type('description', 'Connect-CMSのクラウドサービス')

--- a/tests/Browser/User/LinklistsPluginTest.php
+++ b/tests/Browser/User/LinklistsPluginTest.php
@@ -88,6 +88,9 @@ class LinklistsPluginTest extends DuskTestCase
                     ->screenshot('user/linklists/createBuckets/images/createBuckets')
                     ->press("登録確定");
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'linklists')->first();
             $browser->visit('/plugin/linklists/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/LinklistsPluginTest.php
+++ b/tests/Browser/User/LinklistsPluginTest.php
@@ -184,10 +184,8 @@ class LinklistsPluginTest extends DuskTestCase
     {
         // 実行
         $this->browse(function (Browser $browser) {
-            // ループの連続実行で画面表示がおいついてないので、ちょっと待つ
-            $browser->pause(500);
-
             $browser->visit('/plugin/linklists/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
+                    ->pause(500)
                     ->type('title', 'Connect-CMS公式')
                     ->type('url', 'https://connect-cms.jp/')
                     ->type('description', 'Connect-CMSの情報はこのサイトから。')
@@ -195,6 +193,7 @@ class LinklistsPluginTest extends DuskTestCase
                     ->press('登録確定');
 
             $browser->visit('/plugin/linklists/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
+                    ->pause(500)
                     ->type('title', '株式会社オープンソース・ワークショップ')
                     ->type('url', 'https://opensource-workshop.jp/')
                     ->type('description', 'Connect-CMSのクラウドサービス')

--- a/tests/Browser/User/LinklistsPluginTest.php
+++ b/tests/Browser/User/LinklistsPluginTest.php
@@ -184,6 +184,9 @@ class LinklistsPluginTest extends DuskTestCase
     {
         // 実行
         $this->browse(function (Browser $browser) {
+            // ループの連続実行で画面表示がおいついてないので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('/plugin/linklists/edit/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
                     ->type('title', 'Connect-CMS公式')
                     ->type('url', 'https://connect-cms.jp/')

--- a/tests/Browser/User/OpacsPluginTest.php
+++ b/tests/Browser/User/OpacsPluginTest.php
@@ -2,20 +2,14 @@
 
 namespace Tests\Browser\User;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
-use App\Enums\PluginName;
 use App\Models\Common\Buckets;
-use App\Models\Common\Frame;
-use App\Models\Common\Uploads;
-use App\Models\Core\Dusks;
 use App\Models\User\Opacs\Opacs;
 use App\Models\User\Opacs\OpacsBooks;
 use App\Models\User\Opacs\OpacsBooksLents;
 use App\Models\User\Opacs\OpacsConfigs;
 use App\Models\User\Opacs\OpacsFrames;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * Opacテスト
@@ -163,10 +157,12 @@ class OpacsPluginTest extends DuskTestCase
     {
         // 実行
         $this->browse(function (Browser $browser) {
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             $browser->visit('/plugin/opacs/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
                     ->assertPathBeginsWith('/')
                     ->screenshot('user/opacs/listBuckets/images/listBuckets')
-                    ->pause(500)
                     ->press("表示OPAC変更");
         });
 

--- a/tests/Browser/User/OpacsPluginTest.php
+++ b/tests/Browser/User/OpacsPluginTest.php
@@ -166,6 +166,7 @@ class OpacsPluginTest extends DuskTestCase
             $browser->visit('/plugin/opacs/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)
                     ->assertPathBeginsWith('/')
                     ->screenshot('user/opacs/listBuckets/images/listBuckets')
+                    ->pause(500)
                     ->press("表示OPAC変更");
         });
 

--- a/tests/Browser/User/OpacsPluginTest.php
+++ b/tests/Browser/User/OpacsPluginTest.php
@@ -127,6 +127,9 @@ class OpacsPluginTest extends DuskTestCase
                     ->screenshot('user/opacs/createBuckets/images/createBuckets')
                     ->press("登録確定");
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'opacs')->first();
             $browser->visit('/plugin/opacs/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/OpeningcalendarsPluginTest.php
+++ b/tests/Browser/User/OpeningcalendarsPluginTest.php
@@ -2,18 +2,13 @@
 
 namespace Tests\Browser\User;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
-use App\Enums\PluginName;
 use App\Models\Common\Buckets;
-use App\Models\Common\Frame;
-use App\Models\Common\Uploads;
 use App\Models\User\Openingcalendars\Openingcalendars;
 use App\Models\User\Openingcalendars\OpeningcalendarsDays;
 use App\Models\User\Openingcalendars\OpeningcalendarsMonths;
 use App\Models\User\Openingcalendars\OpeningcalendarsPatterns;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * 開館カレンダーテスト
@@ -152,6 +147,9 @@ class OpeningcalendarsPluginTest extends DuskTestCase
                     ->type('view_after_month', '3')
                     ->screenshot('user/openingcalendars/createBuckets/images/createBuckets')
                     ->press('登録');
+
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
 
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'openingcalendars')->first();

--- a/tests/Browser/User/PhotoalbumsPluginTest.php
+++ b/tests/Browser/User/PhotoalbumsPluginTest.php
@@ -2,17 +2,11 @@
 
 namespace Tests\Browser\User;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
-use App\Enums\PluginName;
 use App\Models\Common\Buckets;
-use App\Models\Common\Frame;
-use App\Models\Common\Uploads;
-use App\Models\Core\Dusks;
 use App\Models\User\Photoalbums\Photoalbum;
 use App\Models\User\Photoalbums\PhotoalbumContent;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * フォトアルバムテスト
@@ -256,6 +250,9 @@ class PhotoalbumsPluginTest extends DuskTestCase
                     ->select('video_upload_max_size', '51200')
                     ->screenshot('user/photoalbums/createBuckets/images/createBuckets')
                     ->press('登録確定');
+
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
 
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'photoalbums')->first();

--- a/tests/Browser/User/QuestionnairesPluginTest.php
+++ b/tests/Browser/User/QuestionnairesPluginTest.php
@@ -112,6 +112,9 @@ class QuestionnairesPluginTest extends DuskTestCase
                     ->screenshot('user/forms/createBuckets/images/createBuckets2')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'forms')->first();
             $browser->visit('/plugin/forms/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/ReservationsPluginTest.php
+++ b/tests/Browser/User/ReservationsPluginTest.php
@@ -168,6 +168,9 @@ class ReservationsPluginTest extends DuskTestCase
                     ->screenshot('user/reservations/createBuckets/images/createBuckets')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'reservations')->first();
             $browser->visit('/plugin/reservations/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/RssesPluginTest.php
+++ b/tests/Browser/User/RssesPluginTest.php
@@ -123,6 +123,9 @@ class RssesPluginTest extends DuskTestCase
                     ->screenshot('user/rsses/createBuckets/images/createBuckets')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'rsses')->first();
             $browser->visit('/plugin/rsses/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/SearchsPluginTest.php
+++ b/tests/Browser/User/SearchsPluginTest.php
@@ -103,6 +103,9 @@ class SearchsPluginTest extends DuskTestCase
                     ->screenshot('user/searchs/createBuckets/images/createBuckets2')
                     ->press("登録");
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'searchs')->first();
             $browser->visit('/plugin/searchs/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/SlideshowsPluginTest.php
+++ b/tests/Browser/User/SlideshowsPluginTest.php
@@ -258,6 +258,9 @@ class SlideshowsPluginTest extends DuskTestCase
                     ->screenshot('user/slideshows/createBuckets/images/createBuckets')
                     ->press('登録確定');
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'slideshows')->first();
             $browser->visit('/plugin/slideshows/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/Browser/User/TabsPluginTest.php
+++ b/tests/Browser/User/TabsPluginTest.php
@@ -2,18 +2,14 @@
 
 namespace Tests\Browser\User;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
-use Tests\DuskTestCase;
-
-use App\Enums\PluginName;
+use App\Enums\AreaType;
 use App\Models\Common\Buckets;
 use App\Models\Common\Frame;
 use App\Models\Common\Page;
-use App\Models\Common\Uploads;
-use App\Models\Core\Dusks;
 use App\Models\User\Contents\Contents;
 use App\Models\User\Tabs\Tabs;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
 
 /**
  * タブテスト
@@ -64,13 +60,13 @@ class TabsPluginTest extends DuskTestCase
         }
 
         // 固定記事×2、タブ×1を配置
-        $this->addPluginModal('contents', '/test/tab', 2, false);
+        $this->addPluginModal('contents', '/test/tab', AreaType::main, false);
         $bucket = Buckets::create(['bucket_name' => 'タブテスト②', 'plugin_name' => 'contents']);
         $content = Contents::create(['bucket_id' => $bucket->id, 'content_text' => '<p>タブテストのための固定記事<span style="color: red; font-size: 150%; font-weight: bold;"> ② </span>です。</p>', 'status' => 0]);
         $this->page_frames[0] = Frame::orderBy('id', 'desc')->first();
         $this->page_frames[0]->update(['bucket_id' => $bucket->id, 'frame_title' => '固定記事②', 'default_hidden' => 1]);
 
-        $this->addPluginModal('contents', '/test/tab', 2, false);
+        $this->addPluginModal('contents', '/test/tab', AreaType::main, false);
         $bucket = Buckets::create(['bucket_name' => 'タブテスト①', 'plugin_name' => 'contents']);
         $content = Contents::create(['bucket_id' => $bucket->id, 'content_text' => '<p>タブテストのための固定記事<span style="color: red; font-size: 150%; font-weight: bold;"> ① </span>です。</p>', 'status' => 0]);
         $this->page_frames[1] = Frame::orderBy('id', 'desc')->first();

--- a/tests/Browser/User/ThemechangersPluginTest.php
+++ b/tests/Browser/User/ThemechangersPluginTest.php
@@ -70,17 +70,17 @@ class ThemechangersPluginTest extends DuskTestCase
                     ->visit("/test")
                     ->visit("/")
                     ->screenshot('user/themechangers/select/images/select2');
+        });
 
-            $this->login(1);
-
+        $this->login(1);
+        $this->browse(function (Browser $browser) {
             // フレームを下移動
             $browser->visit("/")
                     ->click('#frame_down_' . $this->test_frame->id)
                     ->pause(500)
                     ->click('#frame_down_' . $this->test_frame->id);
-
-            $this->logout();
         });
+        $this->logout();
 
         // マニュアル用データ出力
         $this->putManualData('[

--- a/tests/Browser/User/WhatsnewsPluginTest.php
+++ b/tests/Browser/User/WhatsnewsPluginTest.php
@@ -104,6 +104,9 @@ class WhatsnewsPluginTest extends DuskTestCase
                     ->assertPathBeginsWith('/')
                     ->press("登録");
 
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 一度、選択確定させる。
             $bucket = Buckets::where('plugin_name', 'whatsnews')->first();
             $browser->visit('/plugin/whatsnews/listBuckets/' . $this->test_frame->page_id . '/' . $this->test_frame->id . '#frame-' . $this->test_frame->id)

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -300,6 +300,9 @@ abstract class DuskTestCase extends BaseTestCase
     public function addPluginModal($add_plugin, $permanent_link = '/', $area = 0, $screenshot = true)
     {
         $this->browse(function (Browser $browser) use ($add_plugin, $permanent_link, $area, $screenshot) {
+            // 画面表示がおいつかない場合があるので、ちょっと待つ
+            $browser->pause(500);
+
             // 管理機能からプラグイン追加で指定されたプラグインを追加する。
             $browser->visit($permanent_link)
                     ->clickLink('管理機能')

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -302,7 +302,7 @@ abstract class DuskTestCase extends BaseTestCase
         $this->browse(function (Browser $browser) use ($add_plugin, $permanent_link, $area, $screenshot) {
             // 管理機能からプラグイン追加で指定されたプラグインを追加する。
             $browser->visit($permanent_link)
-                    ->waitForText('管理機能', 10)   // テキストの待機
+                    ->waitForText('管理機能')   // テキストの待機
                     ->clickLink('管理機能')
                     ->assertPathBeginsWith('/');
             if ($screenshot) {

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -302,7 +302,7 @@ abstract class DuskTestCase extends BaseTestCase
         $this->browse(function (Browser $browser) use ($add_plugin, $permanent_link, $area, $screenshot) {
             // 管理機能からプラグイン追加で指定されたプラグインを追加する。
             $browser->visit($permanent_link)
-                    ->waitForText('管理機能')   // テキストの待機
+                    ->waitForText('管理機能', 10)   // テキストの待機
                     ->clickLink('管理機能')
                     ->assertPathBeginsWith('/');
             if ($screenshot) {

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -2,15 +2,7 @@
 
 namespace Tests;
 
-use Facebook\WebDriver\Chrome\ChromeOptions;
-use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
-
-use Laravel\Dusk\TestCase as BaseTestCase;
-use Laravel\Dusk\Browser;
-
-use Illuminate\Support\Facades\Storage;
-
+use App\Enums\AreaType;
 use App\Models\Common\Buckets;
 use App\Models\Common\Frame;
 use App\Models\Common\Page;
@@ -20,8 +12,12 @@ use App\Models\Core\Plugins;
 use App\Models\User\Contents\Contents;
 use App\Traits\ConnectCommonTrait;
 use App\User;
-
-use TruncateAllTables;
+use Facebook\WebDriver\Chrome\ChromeOptions;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Dusk\TestCase as BaseTestCase;
+use Laravel\Dusk\Browser;
 
 abstract class DuskTestCase extends BaseTestCase
 {
@@ -250,7 +246,7 @@ abstract class DuskTestCase extends BaseTestCase
     /**
      * プラグイン追加
      */
-    public function addPlugin($add_plugin, $permanent_link = '/', $area = 0, $screenshot = true)
+    public function addPlugin($add_plugin, $permanent_link = '/', $area = AreaType::header, $screenshot = true)
     {
         $this->addPluginModal($add_plugin, $permanent_link, $area, $screenshot);
 
@@ -261,7 +257,7 @@ abstract class DuskTestCase extends BaseTestCase
     /**
      * プラグイン追加（なければ）+ ページ追加（なければ）
      */
-    public function addPluginFirst($add_plugin, $permanent_link = '/', $area = 0, $screenshot = true, $plugin_name_full = null)
+    public function addPluginFirst($add_plugin, $permanent_link = '/', $area = AreaType::header, $screenshot = true, $plugin_name_full = null)
     {
         $plugin = Plugins::where('plugin_name', ucfirst($add_plugin))->first();
         if (empty($plugin)) {
@@ -297,7 +293,7 @@ abstract class DuskTestCase extends BaseTestCase
     /**
      * プラグイン追加
      */
-    public function addPluginModal($add_plugin, $permanent_link = '/', $area = 0, $screenshot = true)
+    public function addPluginModal($add_plugin, $permanent_link = '/', $area = AreaType::header, $screenshot = true)
     {
         $this->browse(function (Browser $browser) use ($add_plugin, $permanent_link, $area, $screenshot) {
             // 管理機能からプラグイン追加で指定されたプラグインを追加する。

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -300,11 +300,9 @@ abstract class DuskTestCase extends BaseTestCase
     public function addPluginModal($add_plugin, $permanent_link = '/', $area = 0, $screenshot = true)
     {
         $this->browse(function (Browser $browser) use ($add_plugin, $permanent_link, $area, $screenshot) {
-            // 画面表示がおいつかない場合があるので、ちょっと待つ
-            $browser->pause(500);
-
             // 管理機能からプラグイン追加で指定されたプラグインを追加する。
             $browser->visit($permanent_link)
+                    ->waitForText('管理機能')   // テキストの待機
                     ->clickLink('管理機能')
                     ->assertPathBeginsWith('/');
             if ($screenshot) {


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/2141

上記の修正です。

## 対応
一部のDuskテストでエラーになった箇所に「画面表示がおいつかない場合があるので、ちょっと待つ」処理を追加して、対応しました。

## 修正後のgithub actions

* Laravel Dusk Connect-cms-test matrix · opensource-workshop/connect-cms@a3a3b58
https://github.com/opensource-workshop/connect-cms/actions/runs/13889293334

エラーが解消したことを確認しました。

## 推測上の原因
検証と推測をしたのですが、github actionsのブラウザがChrome 133 → 134 に変わったことで、ブラウザの画面表示が少し遅くなったようで、
ブラウザテストのプラグラム実行の方が早くなってしまい、ブラウザ画面表示をしきる前にボタン押下等の処理が走り、
一部のテストエラーが発生していたようです。

上記テストエラーは、ローカル環境で再現するものと、しないものがありました。
その点もテストしているPCやgithub actionsのサーバ環境の違いが影響しているかもしれません。


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* assertPathBeginsWith < 8.x Laravel Dusk Laravel
https://readouble.com/laravel/8.x/ja/dusk.html#assert-path-begins-with

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
