### PR TITLE
[アイコン] fontawesome6にfa-facebook-messengerがないため、fa-commentに修正

### DIFF
--- a/resources/views/plugins/user/databases/default/databases_input.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_input.blade.php
@@ -124,7 +124,7 @@
                 <div class="col-xl-3"></div>
                 <div class="col-9 col-xl-6">
                     <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}#frame-{{$frame_id}}'"><i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass('lg')}}"> キャンセル</span></button>
-                    <button class="btn btn-primary"><i class="fab fa-facebook-messenger"></i> 確認画面へ</button>
+                    <button class="btn btn-primary"><i class="fa-solid fa-comment"></i> 確認画面へ</button>
                 </div>
                 @if (!empty($id))
                 <div class="col-3 col-xl-3 text-right">

--- a/resources/views/plugins/user/forms/default/forms.blade.php
+++ b/resources/views/plugins/user/forms/default/forms.blade.php
@@ -150,7 +150,7 @@
         @endforeach
         {{-- ボタンエリア --}}
         <div class="form-group text-center">
-            <button class="btn btn-primary"><i class="fab fa-facebook-messenger"></i> {{__('messages.to_confirm')}}</button>
+            <button class="btn btn-primary"><i class="fa-solid fa-comment"></i> {{__('messages.to_confirm')}}</button>
         </div>
     </fieldset>
 </form>

--- a/resources/views/plugins/user/forms/default/index_tandem.blade.php
+++ b/resources/views/plugins/user/forms/default/index_tandem.blade.php
@@ -120,7 +120,7 @@
         @endforeach
         {{-- ボタンエリア --}}
         <div class="form-group text-center">
-            <button class="btn btn-primary"><i class="fab fa-facebook-messenger"></i> {{__('messages.to_confirm')}}</button>
+            <button class="btn btn-primary"><i class="fa-solid fa-comment"></i> {{__('messages.to_confirm')}}</button>
         </div>
     </fieldset>
 </form>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

fontawesome6にfa-facebook-messengerの対応アイコンは無くなったが、表示はできていた。
fontawesome6に対応した似たようなアイコンfa-commentに修正しました。

# 修正後画面
## フォーム（初期表示の投稿）

![image](https://github.com/user-attachments/assets/feb9953d-949f-484b-8e01-8e0127525baa)

## データベース＞記事の登録・編集

![image](https://github.com/user-attachments/assets/297fe446-9ab7-40de-9a0d-e44f93681aa8)



# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/2137

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

* fa-facebook-messengerアイコン
  * https://fontawesome.com/icons/facebook-messenger?s=brands
* fa-commentアイコン
  * https://fontawesome.com/icons/comment?f=classic&s=solid

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
