### PR TITLE
[施設管理][ユーザ管理] 管理画面は幅100%表示のため、項目設定のボタン名は常時表示に変更

### DIFF
--- a/resources/views/plugins/manage/reservation/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/reservation/edit_column_detail.blade.php
@@ -145,7 +145,7 @@
                                         @if (count($selects) > 0)
                                             <th class="text-center" nowrap>表示順</th>
                                             <th class="text-center" nowrap>選択肢名</th>
-                                            <th class="text-center" nowrap>非表示 <span class="fas fa-info-circle" data-toggle="tooltip" title="チェックした選択肢を非表示にします。"></th>
+                                            <th class="text-center" nowrap>非表示</th>
                                             <th class="text-center" nowrap>更新</th>
                                             <th class="text-center" nowrap>削除</th>
                                         @endif
@@ -175,26 +175,26 @@
 
                                             {{-- 非表示フラグ --}}
                                             <td class="align-middle text-center">
-                                                <input name="hide_flag_{{ $select->id }}" id="hide_flag_{{ $select->id }}" value="1" type="checkbox" @if (old('hide_flag_'.$select->id, $select->hide_flag)) checked="checked" @endif>
+                                                <input name="hide_flag_{{ $select->id }}" id="hide_flag_{{ $select->id }}" value="1" type="checkbox"  data-toggle="tooltip" title="チェックした選択肢を非表示にします。" @if (old('hide_flag_'.$select->id, $select->hide_flag)) checked="checked" @endif>
                                             </td>
 
                                             {{-- 更新ボタン --}}
                                             <td class="align-middle text-center">
                                                 <button
-                                                    class="btn btn-primary cc-font-90 text-nowrap"
+                                                    class="btn btn-primary btn-sm text-nowrap"
                                                     onclick="javascript:submit_update_select({{ $select->id }});"
                                                 >
-                                                    <i class="fas fa-check"></i> <span class="d-sm-none">更新</span>
+                                                    <i class="fas fa-check"></i> 更新
                                                 </button>
                                             </td>
 
                                             {{-- 削除ボタン --}}
                                             <td class="text-center">
                                                 <button
-                                                    class="btn btn-danger cc-font-90 text-nowrap"
+                                                    class="btn btn-danger btn-sm text-nowrap"
                                                     onclick="javascript:return submit_delete_select({{ $select->id }});"
                                                 >
-                                                    <i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span>
+                                                    <i class="fas fa-trash-alt"></i> 削除
                                                 </button>
                                             </td>
                                         </tr>
@@ -210,9 +210,9 @@
                                             {{-- 選択肢名 --}}
                                             <input class="form-control @if ($errors && $errors->has('select_name')) border-danger @endif" type="text" name="select_name" value="{{ old('select_name') }}" placeholder="選択肢名">
                                         </td>
-                                        <td class="text-center">
+                                        <td class="text-center align-middle ">
                                             {{-- ＋ボタン --}}
-                                            <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_add_select(this);"><i class="fas fa-plus"></i> <span class="d-sm-none">追加</span></button>
+                                            <button class="btn btn-primary btn-sm text-nowrap" onclick="javascript:submit_add_select(this);"><i class="fas fa-plus"></i> 選択肢追加</button>
                                         </td>
                                         <td></td>
                                         <td></td>

--- a/resources/views/plugins/manage/reservation/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/reservation/edit_column_detail.blade.php
@@ -226,7 +226,7 @@
             @endif
 
             {{-- ボタンエリア --}}
-            <div class="form-group text-center">
+            <div class="text-center">
                 <a href="{{url('/')}}/manage/reservation/editColumns/{{$columns_set->id}}" class="btn btn-secondary">
                     <i class="fas fa-chevron-left"></i> 項目設定へ
                 </a>

--- a/resources/views/plugins/manage/reservation/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/reservation/edit_column_detail.blade.php
@@ -215,6 +215,7 @@
                                             <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_add_select(this);"><i class="fas fa-plus"></i> <span class="d-sm-none">追加</span></button>
                                         </td>
                                         <td></td>
+                                        <td></td>
                                     </tr>
                                 </tbody>
                             </table>

--- a/resources/views/plugins/manage/reservation/edit_columns.blade.php
+++ b/resources/views/plugins/manage/reservation/edit_columns.blade.php
@@ -113,8 +113,8 @@
                                 <th class="text-center" nowrap>表示順</th>
                                 <th class="text-center" style="min-width: 150px" nowrap>項目名</th>
                                 <th class="text-center" nowrap>型</th>
-                                <th class="text-center" nowrap>必須 <span class="fas fa-info-circle" data-toggle="tooltip" title="必須項目として指定します。"></th>
-                                <th class="text-center" nowrap>非表示 <span class="fas fa-info-circle" data-toggle="tooltip" title="チェックした項目を非表示にします。"></th>
+                                <th class="text-center" nowrap>必須</th>
+                                <th class="text-center" nowrap>非表示</th>
                                 <th class="text-center" nowrap>詳細</th>
                                 <th class="text-center" nowrap>更新</th>
                                 <th class="text-center" nowrap>削除</th>

--- a/resources/views/plugins/manage/reservation/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/reservation/include_edit_column_row.blade.php
@@ -34,17 +34,17 @@
     </td>
     {{-- 必須 --}}
     <td class="align-middle text-center">
-        <input type="checkbox" name="required_{{ $column->id }}" value="1" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif>
+        <input type="checkbox" name="required_{{ $column->id }}" value="1" data-toggle="tooltip" title="必須項目として指定します。" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif>
     </td>
     {{-- 非表示フラグ --}}
     <td class="align-middle text-center">
-        <input name="hide_flag_{{ $column->id }}" id="hide_flag_{{ $column->id }}" value="1" type="checkbox" @if (old('hide_flag_'.$column->id, $column->hide_flag)) checked="checked" @endif>
+        <input name="hide_flag_{{ $column->id }}" id="hide_flag_{{ $column->id }}" value="1" type="checkbox" data-toggle="tooltip" title="チェックした項目を非表示にします。" @if (old('hide_flag_'.$column->id, $column->hide_flag)) checked="checked" @endif>
     </td>
     {{-- 選択肢の設定ボタン --}}
     <td class="text-center px-2">
         <button
             type="button"
-            class="btn btn-success btn-xs cc-font-90 text-nowrap"
+            class="btn btn-success btn-sm text-nowrap"
             @if ($column->column_type == ReservationColumnType::radio)
                 {{-- 選択肢の設定がない場合のみツールチップを表示 --}}
                 @if ($column->select_count == 0)
@@ -53,19 +53,19 @@
             @endif
             onclick="location.href='{{url('/')}}/manage/reservation/editColumnDetail/{{ $column->id }}'"
         >
-            <i class="far fa-window-restore"></i> <span class="d-sm-none">詳細</span>
+            <i class="far fa-window-restore"></i> 詳細編集
         </button>
     </td>
     {{-- 更新ボタン --}}
     <td class="text-center px-2">
-        <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_update_column({{ $column->id }});">
-            <i class="fas fa-check"></i> <span class="d-sm-none">更新</span>
+        <button class="btn btn-primary btn-sm text-nowrap" onclick="javascript:submit_update_column({{ $column->id }});">
+            <i class="fas fa-check"></i> 更新
         </button>
     </td>
 
     {{-- 削除ボタン --}}
     <td class="text-center px-2">
-        <button class="btn btn-danger cc-font-90 text-nowrap" onclick="javascript:return submit_delete_column({{ $column->id }});"><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+        <button class="btn btn-danger btn-sm text-nowrap" onclick="javascript:return submit_delete_column({{ $column->id }});"><i class="fas fa-trash-alt"></i> 削除</button>
     </td>
 </tr>
 {{-- 選択肢の設定内容の表示行 --}}

--- a/resources/views/plugins/manage/reservation/include_edit_column_row_add.blade.php
+++ b/resources/views/plugins/manage/reservation/include_edit_column_row_add.blade.php
@@ -27,9 +27,9 @@
         <input type="checkbox" name="required" value="1" @if (old('required') == Required::on) checked="checked" @endif data-toggle="tooltip" title="必須項目として指定します。">
     </td>
     {{-- ＋ボタン --}}
-    <td class="text-center">
-        <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_add_column(this);">
-            <i class="fas fa-plus"></i> <span class="d-sm-none">追加</span>
+    <td class="text-center align-middle">
+        <button class="btn btn-primary btn-sm text-nowrap" onclick="javascript:submit_add_column(this);">
+            <i class="fas fa-plus"></i> 項目追加
         </button>
     </td>
     {{-- 表示上の区切り線が切れてしまう為、空のtdタグを設置 --}}

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -204,20 +204,20 @@ use App\Models\Core\UsersColumns;
                                             {{-- 更新ボタン --}}
                                             <td class="align-middle text-center">
                                                 <button
-                                                    class="btn btn-primary cc-font-90 text-nowrap"
+                                                    class="btn btn-primary btn-sm text-nowrap"
                                                     onclick="javascript:submit_update_select({{ $select->id }});"
                                                 >
-                                                    <i class="fas fa-check"></i> <span class="d-sm-none">更新</span>
+                                                    <i class="fas fa-check"></i> 更新
                                                 </button>
                                             </td>
 
                                             {{-- 削除ボタン --}}
-                                            <td class="text-center">
+                                            <td class="align-middle text-center">
                                                 <button
-                                                    class="btn btn-danger cc-font-90 text-nowrap"
+                                                    class="btn btn-danger btn-sm text-nowrap"
                                                     onclick="javascript:return submit_delete_select({{ $select->id }});"
                                                 >
-                                                    <i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span>
+                                                    <i class="fas fa-trash-alt"></i> 削除
                                                 </button>
                                             </td>
                                         </tr>
@@ -233,9 +233,9 @@ use App\Models\Core\UsersColumns;
                                             {{-- 選択肢名 --}}
                                             <input class="form-control @if ($errors && $errors->has('select_name')) border-danger @endif" type="text" name="select_name" value="{{ old('select_name') }}" placeholder="選択肢名">
                                         </td>
-                                        <td class="text-center">
+                                        <td class="align-middle text-center">
                                             {{-- ＋ボタン --}}
-                                            <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_add_select(this);"><i class="fas fa-plus"></i> <span class="d-sm-none">追加</span></button>
+                                            <button class="btn btn-primary btn-sm text-nowrap" onclick="javascript:submit_add_select(this);"><i class="fas fa-plus"></i> 選択肢追加</button>
                                         </td>
                                         <td></td>
                                     </tr>
@@ -448,22 +448,22 @@ use App\Models\Core\UsersColumns;
                                             {{-- 更新ボタン --}}
                                             <td class="align-middle text-center">
                                                 <button
-                                                    class="btn btn-primary cc-font-90 text-nowrap"
+                                                    class="btn btn-primary btn-sm text-nowrap"
                                                     onclick="javascript:submit_update_section({{ $section->id }});"
                                                 >
-                                                    <i class="fas fa-check"></i> <span class="d-sm-none">更新</span>
+                                                    <i class="fas fa-check"></i> 更新
                                                 </button>
                                             </td>
 
                                             {{-- 削除ボタン --}}
-                                            <td class="text-center">
+                                            <td class="align-middle text-center">
                                                 <div class="button-wrapper" @if ($section->users->count()) data-toggle="tooltip" title="所属しているユーザがいるため削除できません。" @endif>
                                                 <button
-                                                    class="btn btn-danger cc-font-90 text-nowrap"
+                                                    class="btn btn-danger btn-sm text-nowrap"
                                                     onclick="javascript:return submit_delete_section({{ $section->id }});"
                                                     @if ($section->users->count()) disabled @endif
                                                 >
-                                                    <i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span>
+                                                    <i class="fas fa-trash-alt"></i> 削除
                                                 </button>
                                                 </div>
                                             </td>
@@ -484,9 +484,9 @@ use App\Models\Core\UsersColumns;
                                             {{-- コード --}}
                                             <input class="form-control @if ($errors && $errors->has('section_code')) border-danger @endif" type="text" name="section_code" value="{{ old('section_code') }}" placeholder="コード">
                                         </td>
-                                        <td class="text-center">
+                                        <td class="align-middle text-center">
                                             {{-- ＋ボタン --}}
-                                            <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_add_section(this);"><i class="fas fa-plus"></i> <span class="d-sm-none">追加</span></button>
+                                            <button class="btn btn-primary btn-sm text-nowrap" onclick="javascript:submit_add_section(this);"><i class="fas fa-plus"></i> 組織追加</button>
                                         </td>
                                         <td></td>
                                     </tr>

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -714,7 +714,7 @@ use App\Models\Core\UsersColumns;
             </div>
 
             {{-- ボタンエリア --}}
-            <div class="form-group text-center">
+            <div class="text-center">
                 <a href="{{url('/')}}/manage/user/editColumns/{{$columns_set->id}}" class="btn btn-secondary">
                     <i class="fas fa-chevron-left"></i> 項目設定へ
                 </a>

--- a/resources/views/plugins/manage/user/edit_columns.blade.php
+++ b/resources/views/plugins/manage/user/edit_columns.blade.php
@@ -100,7 +100,7 @@
                                 <th class="text-center" nowrap>表示順</th>
                                 <th class="text-center" style="min-width: 150px" nowrap>項目名</th>
                                 <th class="text-center" nowrap>型</th>
-                                <th class="text-center" nowrap>必須 <span class="fas fa-info-circle" data-toggle="tooltip" title="必須項目として指定します。"></th>
+                                <th class="text-center" nowrap>必須</th>
                                 <th class="text-center" nowrap>詳細</th>
                                 <th class="text-center" nowrap>更新</th>
                                 <th class="text-center" nowrap>削除</th>

--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -52,17 +52,19 @@ use App\Models\Core\UsersColumns;
                     disabled data-toggle="tooltip" title="ユーザに必ず必要な項目は、必須チェックを変更できません。"
                 @elseif (UsersColumns::isShowOnlyColumnType($column->column_type))
                     disabled data-toggle="tooltip" title="表示のみの項目のため、必須チェックOFFから変更できません。"
+                @else
+                    data-toggle="tooltip" title="必須項目として指定します。"
                 @endif
             >
         @else
-            <input type="checkbox" name="required_{{ $column->id }}" value="1" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif>
+            <input type="checkbox" name="required_{{ $column->id }}" value="1" data-toggle="tooltip" title="必須項目として指定します。" @if (old('required_'.$column->id, $column->required) == Required::on) checked="checked" @endif>
         @endif
     </td>
     {{-- 選択肢の設定ボタン --}}
-    <td class="text-center px-2">
+    <td class="align-middle text-center px-2">
         <button
             type="button"
-            class="btn btn-success btn-xs cc-font-90 text-nowrap @if (UsersColumns::isSelectColumnType($column->column_type)) detail-button-tip @endif"
+            class="btn btn-success btn-sm text-nowrap @if (UsersColumns::isSelectColumnType($column->column_type)) detail-button-tip @endif"
             id="button_user_column_detail_{{ $column->id }}"
             @if (UsersColumns::isSelectColumnType($column->column_type))
                 {{-- 選択肢の設定がない場合のみツールチップを表示 --}}
@@ -72,30 +74,30 @@ use App\Models\Core\UsersColumns;
             @endif
             onclick="location.href='{{url('/')}}/manage/user/editColumnDetail/{{ $column->id }}'"
         >
-            <i class="far fa-window-restore"></i> <span class="d-sm-none">詳細</span>
+            <i class="far fa-window-restore"></i> 詳細編集
         </button>
     </td>
     {{-- 更新ボタン --}}
-    <td class="text-center px-2">
-        <button class="btn btn-primary cc-font-90 text-nowrap" onclick="javascript:submit_update_column({{ $column->id }});">
-            <i class="fas fa-check"></i> <span class="d-sm-none">更新</span>
+    <td class="align-middle text-center px-2">
+        <button class="btn btn-primary btn-sm text-nowrap" onclick="javascript:submit_update_column({{ $column->id }});">
+            <i class="fas fa-check"></i> 更新
         </button>
     </td>
 
     {{-- 削除ボタン --}}
-    <td class="text-center px-2">
+    <td class="align-middle text-center px-2">
         {{-- 所属が登録されてたら項目の削除はさせない --}}
         @if ($column->column_type == UserColumnType::affiliation && $exists_user_sections)
             <div class="button-wrapper" data-toggle="tooltip" title="{{$column->column_name}}登録済みのユーザがいるため項目を削除できません。">
-                <button class="btn btn-danger cc-font-90 text-nowrap" disabled><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+                <button class="btn btn-danger btn-sm text-nowrap" disabled><i class="fas fa-trash-alt"></i> 削除</button>
             </div>
         @elseif ($column->is_fixed_column)
             {{-- 固定項目 --}}
             <div class="button-wrapper" data-toggle="tooltip" title="ユーザに必ず必要な項目のため削除できません。">
-                <button class="btn btn-danger cc-font-90 text-nowrap" disabled><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+                <button class="btn btn-danger btn-sm text-nowrap" disabled><i class="fas fa-trash-alt"></i> 削除</button>
             </div>
         @else
-            <button class="btn btn-danger cc-font-90 text-nowrap" onclick="javascript:return submit_delete_column({{ $column->id }});"><i class="fas fa-trash-alt"></i> <span class="d-sm-none">削除</span></button>
+            <button class="btn btn-danger btn-sm text-nowrap" onclick="javascript:return submit_delete_column({{ $column->id }});"><i class="fas fa-trash-alt"></i> 削除</button>
         @endif
     </td>
 </tr>

--- a/resources/views/plugins/manage/user/include_edit_column_row_add.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row_add.blade.php
@@ -26,9 +26,9 @@
         <input type="checkbox" name="required" value="1" @if (old('required') == Required::on) checked="checked" @endif data-toggle="tooltip" title="必須項目として指定します。">
     </td>
     {{-- ＋ボタン --}}
-    <td class="text-center">
-        <button class="btn btn-primary cc-font-90 text-nowrap" id="button_user_olumn_add" onclick="javascript:submit_add_column(this);">
-            <i class="fas fa-plus"></i> <span class="d-sm-none">追加</span>
+    <td class="align-middle text-center">
+        <button class="btn btn-primary btn-sm text-nowrap" id="button_user_olumn_add" onclick="javascript:submit_add_column(this);">
+            <i class="fas fa-plus"></i> 項目追加
         </button>
     </td>
     {{-- 表示上の区切り線が切れてしまう為、空のtdタグを設置 --}}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

管理画面は幅100%表示で横幅に余裕があるため、項目設定のボタン名をPC・スマホどちらでも表示するよう変更しました。

# 修正後画面
## 施設管理＞項目設定
![image](https://github.com/user-attachments/assets/d53b54b9-1623-4278-99ea-9dbdf217d50b)

## 施設管理＞項目詳細設定（選択肢）＞選択肢の設定
![image](https://github.com/user-attachments/assets/6af292c9-6b56-4419-97da-7505d1672531)

## ユーザ管理＞項目設定

![image](https://github.com/user-attachments/assets/ffe1ca16-0567-469c-a282-35705d6be110)

## ユーザ管理＞項目詳細設定（選択肢）＞選択肢の設定

![image](https://github.com/user-attachments/assets/15bfec23-e149-4383-a6bb-72ed826100ba)

## ユーザ管理＞項目詳細設定（所属型）＞選択肢の設定

![image](https://github.com/user-attachments/assets/8532409f-dff5-4f3e-b96e-712f7fed91b0)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/issues/2144

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
