### PR TITLE
[課題管理]親ページ継承のメンバーシップが正常に機能しない問題を修正しました

### DIFF
--- a/app/Models/Common/Page.php
+++ b/app/Models/Common/Page.php
@@ -714,4 +714,24 @@ class Page extends Model
         }
         return;
     }
+
+    /**
+     * 継承元のメンバーシップのページを取得する。
+     * メンバーシップの設定を先祖ページから継承している場合は、直近の対象ページを返却する。
+     * 該当ページにも先祖にもメンバーシップの設定がなければ、null を返却する。
+     *
+     * @return Page|null
+     */
+    public function getInheritMembershipPage(): ?Page
+    {
+        if ($this->membership_flag == 1) {
+            return $this;
+        }
+
+        if ($this->parent) {
+            return $this->parent->getInheritMembershipPage();
+        }
+
+        return null;
+    }
 }

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -3323,15 +3323,7 @@ class LearningtasksPlugin extends UserPluginBase
         $post = $this->getPost($post_id);
 
         // 配置されているページのメンバーシップの対象ユーザ取得
-        // 複数のページにプラグインは配置されている可能性を考慮
-        $pages = Page::select('pages.*')
-                     ->join('frames', function ($join) use ($post) {
-                         $join->on('frames.page_id', '=', 'pages.id')
-                              ->where('frames.bucket_id', '=', $post->bucket_id);
-                     })
-                     ->where('pages.membership_flag', 1)
-                     ->orderBy('pages._lft')
-                     ->get();
+        $pages = $this->getMembershipPages($post);
 
         // グループID 取得のために、配置されているページRoleを取得
         $page_roles = PageRole::select('group_id')->whereIn('page_id', $pages->pluck('id'))->groupBy('group_id')->get();
@@ -3395,6 +3387,34 @@ class LearningtasksPlugin extends UserPluginBase
             'tool'                     => $tool,
             ]
         );
+    }
+
+    /**
+     * 課題管理プラグインが配置されているページに関するメンバーシップページを取得する。
+     */
+    private function getMembershipPages($post)
+    {
+        // 課題管理プラグインが配置されているページを取得する
+        // 複数のページにプラグインは配置されている可能性を考慮
+        $bucket_pages = Page::select('pages.*')
+            ->join('frames', function ($join) use ($post) {
+                $join->on('frames.page_id', '=', 'pages.id')
+                    ->where('frames.bucket_id', '=', $post->bucket_id);
+            })
+            ->orderBy('pages._lft')
+            ->get();
+
+        // 親ページの継承設定を考慮してメンバーシップのページを抽出する
+        $membership_pages = collect();
+        foreach ($bucket_pages as $page) {
+            $membership_page = $page->getInheritMembershipPage();
+            if (!empty($membership_page)) {
+                $membership_pages->push($membership_page);
+            }
+        }
+        $membership_pages = $membership_pages->unique('id');
+
+        return $membership_pages;
     }
 
     /**

--- a/app/Plugins/User/Learningtasks/LearningtasksTool.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksTool.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Log;
 use App\Enums\DayOfWeek;
 use App\Models\Common\PageRole;
 use App\Models\Common\GroupUser;
+use App\Models\Common\Page;
 use App\Models\Core\UsersRoles;
 use App\Models\User\Learningtasks\LearningtasksConfigs;
 use App\Models\User\Learningtasks\LearningtasksUsers;
@@ -81,6 +82,11 @@ use Carbon\Carbon;
  */
 class LearningtasksTool
 {
+    /**
+     * ページ
+     */
+    private $page = null;
+
     /**
      * 課題バケツ
      */
@@ -157,6 +163,7 @@ class LearningtasksTool
         $this->examination_statuses = new Collection();
         $this->evaluate_statuses = new Collection();
 
+        $this->page = Page::findOrFail($page_id);
         $this->learningtask = $learningtask;
         $this->post = $post;
 
@@ -249,8 +256,9 @@ class LearningtasksTool
             if ($this->post->student_join_flag == 2) {
                 // 配置ページのメンバーシップユーザ全員
                 // ページから参加グループ取得
+                $membership_page = $this->page->getInheritMembershipPage();
                 $group_ids = PageRole::select('group_id')
-                                     ->where('page_id', $page_id)
+                                     ->where('page_id', optional($membership_page)->id)
                                      ->groupBy('group_id')
                                      ->orderBy('group_id')
                                      ->get();

--- a/tests/Unit/Models/Common/PageTest.php
+++ b/tests/Unit/Models/Common/PageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Unit\Models\Common;
+
 use App\Models\Common\Page;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;

--- a/tests/Unit/Models/Common/PageTest.php
+++ b/tests/Unit/Models/Common/PageTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Models\Common\Page;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 初期設定
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * getInheritMembershipPage()テスト
+     */
+    public function testGetInheritMembershipPage()
+    {
+        $top_page = Page::factory()->create(['membership_flag' => 0]);
+        $child_page = Page::factory()->create(['membership_flag' => 0,'parent_id' => $top_page->id]);
+        $grand_child_page = Page::factory()->create(['membership_flag' => 0, 'parent_id' => $child_page->id]);
+        Page::fixTree();
+        $top_page->refresh();
+        $child_page->refresh();
+        $grand_child_page->refresh();
+
+        // 親ページをさかのぼってもメンバーシップページがない場合
+        $this->assertNull($grand_child_page->getInheritMembershipPage());
+
+        // 二階層上でメンバーシップページが設定されている場合、そのページを返す
+        $top_page->membership_flag = 1;
+        $top_page->save();
+        $grand_child_page->refresh();
+        $this->assertEquals($top_page->id, $grand_child_page->getInheritMembershipPage()->id);
+
+        // 一階層上でメンバーシップページが設定されている場合、そのページを返す
+        $child_page->membership_flag = 1;
+        $child_page->save();
+        $grand_child_page->refresh();
+        $this->assertEquals($child_page->id, $grand_child_page->getInheritMembershipPage()->id);
+
+        // 当該ページがメンバーシップページの場合、そのページを返す
+        $grand_child_page->membership_flag = 1;
+        $grand_child_page->save();
+        $grand_child_page->refresh();
+        $this->assertEquals($grand_child_page->id, $grand_child_page->getInheritMembershipPage()->id);
+    }
+}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
課題管理プラグインにおいて、親ページ継承のメンバーシップ設定が正常に機能しない不具合を修正しました。

**当該ページの限定公開設定が親の継承である場合**
親ページの設定を使用せず、当該ページの設定を使用していました。
そのため、ある学生が親ページの設定でグループ参加していても、当該ページの課題管理プラグインに学生として出てこない問題などがありました。

## 変更の目的

不具合の解消

## 変更内容

以下箇所において、親ページのページ権限設定が子ページにも適用されるようにしました。

*   設定 > 参加設定 > 受講者 > 配置ページのメンバーシップ受講者から選ぶ > リスト
*   設定 > 参加設定 > 教員 > 配置ページのメンバーシップ教員から選ぶ > リスト
*   科目詳細 > 受講者選択（教員用）> 評価する受講者 > プルダウン
*   （参加方式：配置ページのメンバーシップ教員全員）教員へのメール送信先

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

OW-2529