### PR TITLE
[課題管理]履歴ファイルへのアクセス権限を適正化しました

### DIFF
--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -3568,9 +3568,9 @@ class LearningtasksPlugin extends UserPluginBase
             // 課題管理ツールを利用してチェックする。
             $tool = new LearningtasksTool($request, $frame->page_id, $learningtask, $post, $frame->id);
 
-            // 提出に対する権限はあるか。
+            // 提出関係のファイルに対する権限はあるか。
             // この結果がNG でも、複数ページの場合に次のページをチェックするため、return false はしない。
-            if ($tool->canPostView()) {
+            if ($tool->canDownloadStatusFile($learningtasks_users_status)) {
                 return [true, 'OK'];
             }
         }

--- a/app/Plugins/User/Learningtasks/LearningtasksTool.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksTool.php
@@ -671,6 +671,31 @@ class LearningtasksTool
     }
 
     /**
+     * 課題の履歴に関するファイルをダウンロードできるか
+     */
+    public function canDownloadStatusFile(LearningtasksUsersStatuses $learningtasks_users_status)
+    {
+        // 管理者は常にダウンロード可能
+        if ($this->isLearningtaskAdmin()) {
+            return true;
+        }
+
+        // 課題の教員であればダウンロード可能
+        if ($this->isTeacher() && $this->teachers->where('id', $this->getUserId())->isNotEmpty()) {
+            return true;
+        }
+
+        // 学生は自身の履歴であればダウンロード可能
+        if ($this->isStudent()
+            && $this->students->where('id', $this->getUserId())->isNotEmpty()
+            && $learningtasks_users_status->user_id == $this->getUserId()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      *  レポートの履歴有無
      */
     public function hasReportStatuses($post_id)


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

課題の履歴に関するファイルのダウンロード権限チェックを変更し、ファイルへのアクセス権限を適正にしました。

## 変更の目的

*   課題の履歴に関するファイルへのアクセス制御を強化し、ファイルアクセスを適正にする。
*   適切な権限を持つユーザーのみが課題の履歴に関するファイルをダウンロードできるようにする。

## 変更内容

*  以下のいずれかの条件を満たす場合に、ダウンロードできるようにしました。
    *   ログインユーザが管理者である
    *   ログインユーザが課題の教員である
    *   ログインユーザが学生であり、自身の履歴のファイルである

## テスト

*   学生アカウントでログインし、他者のレポートファイルをダウンロードできないことを確認しました。
*   教員アカウントでログインし、自身の担当する課題のレポートファイルをダウンロードできることを確認しました。
*   管理者アカウントでログインし、全てのレポートファイルをダウンロードできることを確認しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

OW-2531