### PR TITLE
[課題管理]レポート提出状況をCSVで出力する機能を追加しました

### DIFF
--- a/app/Models/Common/PageRole.php
+++ b/app/Models/Common/PageRole.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\Core\UsersRoles;
 
 use App\UserableNohistory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class PageRole extends Model
 {
@@ -20,6 +21,7 @@ class PageRole extends Model
 
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
+    use HasFactory;
 
     /**
      * create()やupdate()で入力を受け付ける ホワイトリスト

--- a/app/Models/Core/UsersRoles.php
+++ b/app/Models/Core/UsersRoles.php
@@ -2,12 +2,14 @@
 
 namespace App\Models\Core;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
 
 class UsersRoles extends Model
 {
+    use HasFactory;
 
     /**
      * create()やupdate()で入力を受け付ける ホワイトリスト

--- a/app/Models/User/Learningtasks/Learningtasks.php
+++ b/app/Models/User/Learningtasks/Learningtasks.php
@@ -20,7 +20,7 @@ class Learningtasks extends Model
     /**
      * 使用設定を取得（科目の設定は除く）
      */
-    public function learningtask_settings()
+    public function learningtask_settings() // phpcs:ignore
     {
         // post_id = 0はバケツの設定となっている
         return $this->hasMany(LearningtasksUseSettings::class, 'learningtasks_id', 'id')->where('post_id', 0);

--- a/app/Models/User/Learningtasks/Learningtasks.php
+++ b/app/Models/User/Learningtasks/Learningtasks.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 use App\UserableNohistory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Learningtasks extends Model
 {
@@ -14,4 +15,14 @@ class Learningtasks extends Model
 
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
+    use HasFactory;
+
+    /**
+     * 使用設定を取得（科目の設定は除く）
+     */
+    public function learningtask_settings()
+    {
+        // post_id = 0はバケツの設定となっている
+        return $this->hasMany(LearningtasksUseSettings::class, 'learningtasks_id', 'id')->where('post_id', 0);
+    }
 }

--- a/app/Models/User/Learningtasks/LearningtasksPosts.php
+++ b/app/Models/User/Learningtasks/LearningtasksPosts.php
@@ -32,7 +32,7 @@ class LearningtasksPosts extends Model
     /**
      * 使用設定を取得
      */
-    public function post_settings()
+    public function post_settings() // phpcs:ignore
     {
         return $this->hasMany(LearningtasksUseSettings::class, 'post_id', 'id');
     }

--- a/app/Models/User/Learningtasks/LearningtasksPosts.php
+++ b/app/Models/User/Learningtasks/LearningtasksPosts.php
@@ -46,6 +46,14 @@ class LearningtasksPosts extends Model
     }
 
     /**
+     * 教員を取得する
+     */
+    public function teachers()
+    {
+        return $this->hasMany(LearningtasksUsers::class, 'post_id', 'id')->where('role_name', RoleName::teacher)->orderBy('user_id');
+    }
+
+    /**
      * リスト表示用タイトル
      * 改行を取り除いたもの。
      */

--- a/app/Models/User/Learningtasks/LearningtasksPosts.php
+++ b/app/Models/User/Learningtasks/LearningtasksPosts.php
@@ -2,10 +2,12 @@
 
 namespace App\Models\User\Learningtasks;
 
+use App\Enums\RoleName;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 use App\UserableNohistory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class LearningtasksPosts extends Model
 {
@@ -14,9 +16,34 @@ class LearningtasksPosts extends Model
 
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
+    use HasFactory;
 
     // Carbonインスタンス（日付）に自動的に変換
     protected $dates = ['posted_at'];
+
+    /**
+     * 課題管理を取得
+     */
+    public function learningtask()
+    {
+        return $this->belongsTo(Learningtasks::class, 'learningtasks_id', 'id');
+    }
+
+    /**
+     * 使用設定を取得
+     */
+    public function post_settings()
+    {
+        return $this->hasMany(LearningtasksUseSettings::class, 'post_id', 'id');
+    }
+
+    /**
+     * 学生を取得する
+     */
+    public function students()
+    {
+        return $this->hasMany(LearningtasksUsers::class, 'post_id', 'id')->where('role_name', RoleName::student)->orderBy('user_id');
+    }
 
     /**
      * リスト表示用タイトル

--- a/app/Models/User/Learningtasks/LearningtasksUseSettings.php
+++ b/app/Models/User/Learningtasks/LearningtasksUseSettings.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 use App\UserableNohistory;
 use App\Enums\LearningtaskUseFunction;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class LearningtasksUseSettings extends Model
 {
@@ -15,6 +16,7 @@ class LearningtasksUseSettings extends Model
 
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
+    use HasFactory;
 
     // create()やupdate()で入力を受け付ける ホワイトリスト
     protected $fillable = [

--- a/app/Models/User/Learningtasks/LearningtasksUsers.php
+++ b/app/Models/User/Learningtasks/LearningtasksUsers.php
@@ -2,10 +2,12 @@
 
 namespace App\Models\User\Learningtasks;
 
+use App\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 use App\UserableNohistory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class LearningtasksUsers extends Model
 {
@@ -14,7 +16,16 @@ class LearningtasksUsers extends Model
 
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
+    use HasFactory;
 
     // 更新する項目の定義
     protected $fillable = ['post_id', 'user_id', 'role_name'];
+
+    /**
+     * ユーザーを取得する
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
 }

--- a/app/Models/User/Learningtasks/LearningtasksUsersStatuses.php
+++ b/app/Models/User/Learningtasks/LearningtasksUsersStatuses.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 use App\Models\Common\Uploads;
 use App\UserableNohistory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class LearningtasksUsersStatuses extends Model
 {
@@ -15,6 +16,7 @@ class LearningtasksUsersStatuses extends Model
 
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
+    use HasFactory;
 
     /**
      * create()やupdate()で入力を受け付ける ホワイトリスト

--- a/app/Plugins/User/Learningtasks/LearningtasksReportCsvExporter.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksReportCsvExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Plugins\User\Learningtasks;
+
 use App\Enums\LearningtaskUseFunction;
 use App\Models\Common\Page;
 use App\Models\User\Learningtasks\LearningtasksPosts;
@@ -73,8 +75,8 @@ class LearningtasksReportCsvExporter
                 'ユーザ名' => $student->name,
             ];
 
-            $student_submits = $submits->where('user_id', $student->id)->sortBy('id', 'desc')->get();
-            $student_evaluations = $evaluations->where('user_id', $student->id)->sortBy('id', 'desc')->get();
+            $student_submits = $submits->where('user_id', $student->id)->sortByDesc('id');
+            $student_evaluations = $evaluations->where('user_id', $student->id)->sortByDesc('id');
 
             // 最後の提出と評価の組み合わせを出力する
             $last_submit = $student_submits->first();
@@ -90,7 +92,7 @@ class LearningtasksReportCsvExporter
             }
 
             if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_file)) {
-                $row['ファイルURL'] = optional($last_submit)->upload_id ? $site_url . '/file/' . optional($last_submit)->file_id : null;
+                $row['ファイルURL'] = optional($last_submit)->upload_id ? $site_url . '/file/' . optional($last_submit)->upload_id : null;
             }
 
             if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_evaluate)) {

--- a/app/Plugins/User/Learningtasks/LearningtasksReportCsvExporter.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksReportCsvExporter.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Enums\LearningtaskUseFunction;
+use App\Models\Common\Page;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Models\User\Learningtasks\LearningtasksUsersStatuses;
+use App\Traits\Learningtasks\LearningtaskPostTrait;
+
+/**
+ * 課題管理のレポート機能におけるCSVエクスポーター
+ */
+class LearningtasksReportCsvExporter
+{
+    use LearningtaskPostTrait;
+
+    public function __construct(int $learningtask_post_id, int $page_id)
+    {
+        $this->learningtask_post = LearningtasksPosts::findOrFail($learningtask_post_id);
+        $this->page = Page::findOrFail($page_id);
+    }
+
+    /**
+     * ヘッダーの項目を取得する
+     * @return array ヘッダーの項目
+     */
+    public function getHeaderColumns(): array
+    {
+        $header_columns = ['ログインID', 'ユーザ名', '提出日時'];
+
+        // 本文
+        if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_comment)) {
+            $header_columns[] = '本文';
+        }
+
+        // 提出ファイルのURL
+        if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_file)) {
+            $header_columns[] = 'ファイルURL';
+        }
+
+        // 評価
+        if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_evaluate)) {
+            $header_columns[] = '評価';
+        }
+
+        // 評価コメント
+        if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_evaluate_comment)) {
+            $header_columns[] = '評価コメント';
+        }
+
+        return $header_columns;
+    }
+
+    /**
+     * 行データを取得する
+     * @param string $site_url サイトURL
+     * @return array 行データ
+     */
+    public function getRows(string $site_url): array
+    {
+        $rows = [];
+
+        $students = $this->fetchStudentUsers();
+        $submits = LearningtasksUsersStatuses::where('post_id', $this->learningtask_post->id)
+            ->where('task_status', 1) // 提出
+            ->get();
+        $evaluations = LearningtasksUsersStatuses::where('post_id', $this->learningtask_post->id)
+            ->where('task_status', 2) // 評価
+            ->get();
+
+        foreach ($students as $student) {
+            $row = [
+                'ログインID' => $student->userid,
+                'ユーザ名' => $student->name,
+            ];
+
+            $student_submits = $submits->where('user_id', $student->id)->sortBy('id', 'desc')->get();
+            $student_evaluations = $evaluations->where('user_id', $student->id)->sortBy('id', 'desc')->get();
+
+            // 最後の提出と評価の組み合わせを出力する
+            $last_submit = $student_submits->first();
+            // 提出と評価で数が合わないということは、最後の提出の評価がまだされていないということ
+            $last_evaluation = null;
+            if ($student_submits->count() === $student_evaluations->count()) {
+                $last_evaluation = $student_evaluations->first();
+            }
+            $row['提出日時'] = optional($last_submit)->created_at;
+
+            if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_comment)) {
+                $row['本文'] = optional($last_submit)->comment;
+            }
+
+            if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_file)) {
+                $row['ファイルURL'] = optional($last_submit)->upload_id ? $site_url . '/file/' . optional($last_submit)->file_id : null;
+            }
+
+            if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_evaluate)) {
+                $row['評価'] = optional($last_evaluation)->grade;
+            }
+
+            if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_evaluate_comment)) {
+                $row['評価コメント'] = optional($last_evaluation)->comment;
+            }
+
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+}

--- a/app/Plugins/User/Learningtasks/LearningtasksReportCsvExporter.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksReportCsvExporter.php
@@ -54,7 +54,7 @@ class LearningtasksReportCsvExporter
      */
     public function getHeaderColumns(): array
     {
-        $header_columns = ['ログインID', 'ユーザ名', '提出日時'];
+        $header_columns = ['ログインID', 'ユーザ名', '提出日時', '提出回数'];
 
         // 本文
         if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_comment)) {
@@ -113,6 +113,7 @@ class LearningtasksReportCsvExporter
                 $last_evaluation = $student_evaluations->first();
             }
             $row['提出日時'] = optional($last_submit)->created_at;
+            $row['提出回数'] = $student_submits->count();
 
             if ($this->isSettingEnabled(LearningtaskUseFunction::use_report_comment)) {
                 $row['本文'] = optional($last_submit)->comment;

--- a/app/Traits/Learningtasks/LearningtaskPostTrait.php
+++ b/app/Traits/Learningtasks/LearningtaskPostTrait.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Traits\Learningtasks;
+
+use App\Enums\RoleName;
+use App\Models\Common\Page;
+use App\Models\Common\PageRole;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\User;
+
+trait LearningtaskPostTrait
+{
+    /**
+     * 科目
+     * @var \App\Models\User\Learningtasks\LearningtasksPosts|null
+     */
+    protected ?LearningtasksPosts $learningtask_post = null;
+
+    /**
+     * 配置ページ
+     * @var \App\Models\Common\Page|null
+     */
+    protected ?Page $page = null;
+
+    /**
+     * 設定が有効であるか
+     * @param string $setting_name 設定名
+     * @return bool 有効であるか
+     */
+    public function isSettingEnabled(string $setting_name): bool
+    {
+        // 科目に設定されている値を優先する
+        $setting = $this->learningtask_post->post_settings->where('use_function', $setting_name)->first();
+        if ($setting) {
+            return $setting->value === 'on';
+        }
+
+        // 科目の設定がない場合は、課題管理の設定を参照する
+        $setting = $this->learningtask_post->learningtask->learningtask_settings->where('use_function', $setting_name)->first();
+        if ($setting) {
+            return $setting->value === 'on';
+        }
+        return false;
+    }
+
+    /**
+     * 科目に設定されている受講生を取得する
+     */
+    public function fetchStudentUsers()
+    {
+        // student_join_flag = 0: 未使用
+        // student_join_flag = 1: 未使用
+        // student_join_flag = 2: 配置ページのメンバーシップユーザ全員
+        // student_join_flag = 3: 配置ページのメンバーシップユーザから選ぶ
+
+        // 配置ページのメンバーシップユーザ全員
+        if ($this->learningtask_post->student_join_flag == 2) {
+            return $this->fetchMembershipStudents();
+        }
+
+        return $this->fetchLearningtaskPostStudents();
+    }
+
+    /**
+     * 配置ページのメンバーシップユーザの受講生を全員を取得する
+     * ＠return \Illuminate\Database\Eloquent\Collection
+     */
+    private function fetchMembershipStudents(): \Illuminate\Database\Eloquent\Collection
+    {
+        // メンバーシップ設定は親ページから継承している場合がある
+        $membership_page = $this->page->getInheritMembershipPage();
+        $group_ids = PageRole::select('group_id')
+            ->where('page_id', optional($membership_page)->id)
+            ->groupBy('group_id')
+            ->get()
+            ->pluck('group_id');
+        return User::query()
+            ->whereHas('group_users', function ($query) use ($group_ids) {
+                $query->whereIn('group_id', $group_ids);
+            })
+            ->whereExists(function ($query) {
+                $query->select(\DB::raw(1))
+                    ->from('users_roles')
+                    ->whereRaw('users_roles.users_id = users.id')
+                    ->where('users_roles.target', '=', 'original_role')
+                    ->where('users_roles.role_name', '=', RoleName::student);
+            })
+            ->orderBy('users.id')
+            ->get();
+    }
+
+    /**
+     * 科目に設定された受講生を取得する
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    private function fetchLearningtaskPostStudents(): \Illuminate\Database\Eloquent\Collection
+    {
+        return User::whereIn('id', $this->learningtask_post->students->pluck('user_id'))->orderBy('id')->get();
+    }
+}

--- a/app/Utilities/File/FileUtils.php
+++ b/app/Utilities/File/FileUtils.php
@@ -86,4 +86,28 @@ class FileUtils
             setlocale(LC_ALL, 'ja_JP.UTF-8');
         }
     }
+
+    /**
+     * ファイル名を有効なものに変換する
+     * Windowsで禁止されている半角文字を全角に変換
+     * @param string $filename
+     * @return string
+     * @see https://docs.microsoft.com/ja-jp/windows/win32/fileio/naming-a-file
+     */
+    public static function toValidFilename(string $filename): string
+    {
+        // Windowsで禁止されている半角文字を全角に変換
+        $invalid_chars = [
+            '<' => '＜',
+            '>' => '＞',
+            ':' => '：',
+            '"' => '”',
+            '/' => '／',
+            '\\' => '＼',
+            '|' => '｜',
+            '?' => '？',
+            '*' => '＊',
+        ];
+        return strtr($filename, $invalid_chars);
+    }
 }

--- a/database/factories/Common/PageRoleFactory.php
+++ b/database/factories/Common/PageRoleFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories\Common;
+
+use App\Models\Common\Group;
+use App\Models\Common\Page;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PageRoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'page_id' => Page::factory(),
+            'group_id' => Group::factory(),
+            'target' => 'base',
+            'role_name' => 'role_guest',
+            'role_value' => 1,
+        ];
+    }
+}

--- a/database/factories/Core/UsersRolesFactory.php
+++ b/database/factories/Core/UsersRolesFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories\Core;
+
+use App\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class UsersRolesFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'users_id' => User::factory(),
+            'target' => 'base',
+            'role_name' => 'role_guest',
+            'role_value' => 1,
+        ];
+    }
+}

--- a/database/factories/User/Learningtasks/LearningtasksFactory.php
+++ b/database/factories/User/Learningtasks/LearningtasksFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories\User\Learningtasks;
+
+use App\Models\Common\Buckets;
+use App\Models\User\Learningtasks\Learningtasks;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LearningtasksFactory extends Factory
+{
+    protected $model = Learningtasks::class;
+
+    public function definition()
+    {
+        return [
+            'bucket_id' => Buckets::factory(),
+            'learningtasks_name' => $this->faker->word,
+            'view_count' => $this->faker->numberBetween(0, 100),
+            'rss' => 0,
+            'rss_count' => $this->faker->numberBetween(0, 50),
+            'sequence_conditions' => $this->faker->numberBetween(0, 50),
+        ];
+    }
+}

--- a/database/factories/User/Learningtasks/LearningtasksPostsFactory.php
+++ b/database/factories/User/Learningtasks/LearningtasksPostsFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories\User\Learningtasks;
+
+use App\Models\User\Learningtasks\Learningtasks;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LearningtasksPostsFactory extends Factory
+{
+    protected $model = LearningtasksPosts::class;
+
+    public function definition()
+    {
+        return [
+            'contents_id' => null,
+            'learningtasks_id' => Learningtasks::factory(),
+            'post_title' => $this->faker->sentence(),
+            'post_text' => $this->faker->paragraph(),
+            'post_text2' => $this->faker->paragraph(),
+            'categories_id' => null,
+            'important' => null,
+            'use_canvas' => 0,
+            'required_canvas_answer' => 0,
+            'student_join_flag' => 2,
+            'teacher_join_flag' => 2,
+            'display_sequence' => $this->faker->unique()->randomNumber(),
+            'status' => 0,
+            'posted_at' => $this->faker->dateTime(),
+        ];
+    }
+}

--- a/database/factories/User/Learningtasks/LearningtasksUseSettingsFactory.php
+++ b/database/factories/User/Learningtasks/LearningtasksUseSettingsFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories\User\Learningtasks;
+
+use App\Enums\LearningtaskUseFunction;
+use App\Models\User\Learningtasks\Learningtasks;
+use App\Models\User\Learningtasks\LearningtasksUseSettings;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LearningtasksUseSettingsFactory extends Factory
+{
+    protected $model = LearningtasksUseSettings::class;
+
+    public function definition()
+    {
+        return [
+            'learningtasks_id' => Learningtasks::factory(),
+            'post_id' => 0,
+            'use_function' => $this->faker->randomElement(LearningtaskUseFunction::getMemberKeys()),
+            'value' => $this->faker->randomElement(['on', 'off']),
+            'datetime_value' => null,
+        ];
+    }
+}

--- a/database/factories/User/Learningtasks/LearningtasksUsersFactory.php
+++ b/database/factories/User/Learningtasks/LearningtasksUsersFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories\User\Learningtasks;
+
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Models\User\Learningtasks\LearningtasksUsers;
+use App\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LearningtasksUsersFactory extends Factory
+{
+    protected $model = LearningtasksUsers::class;
+
+    public function definition()
+    {
+        return [
+            'post_id' => LearningtasksPosts::factory(),
+            'user_id' => User::factory(),
+            'role_name' => $this->faker->randomElement(['student', 'teacher']),
+        ];
+    }
+}

--- a/database/factories/User/Learningtasks/LearningtasksUsersStatusesFactory.php
+++ b/database/factories/User/Learningtasks/LearningtasksUsersStatusesFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories\User\Learningtasks;
+
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LearningtasksUsersStatusesFactory extends Factory
+{
+    public function definition()
+    {
+        return [
+            'post_id' => LearningtasksPosts::factory(),
+            'user_id' => User::factory(),
+            'task_status' => 1, // 提出
+            'comment' => $this->faker->sentence,
+            'upload_id' => null,
+            'examination_id' => null,
+            'grade' => null,
+        ];
+    }
+}

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
@@ -48,7 +48,7 @@
         <div id="data-management-{{$frame_id}}" class="collapse p-2 bg-light border border-light rounded mb-3">
             {{-- CSV出力 --}}
             <div class="form-group row">
-                <label class="col-sm-3 text-sm-right">CSV出力</label>
+                <label class="col-sm-3 text-sm-right">提出状況CSV</label>
                 <div class="col-sm-9">
                     <form action="{{url('/')}}/download/plugin/learningtasks/downloadCsvReport/{{$page->id}}/{{$frame_id}}/{{$post->id}}" name="csv_export{{$frame_id}}" method="GET">
                         <input type="hidden" id="csv-export-character-code{{$frame_id}}" name="character_code" value="{{CsvCharacterCode::sjis_win}}">
@@ -63,6 +63,9 @@
                                 <a class="dropdown-item" href="javascript:void(0);" onclick="downloadCsvReportShiftJis{{$frame_id}}();">ダウンロード（Shift-JIS）</a>
                                 <a class="dropdown-item" href="javascript:void(0);" onclick="downloadCsvReportUtf8{{$frame_id}}();">ダウンロード（UTF-8 BOM付）</a>
                             </div>
+                        </div>
+                        <div>
+                            <small class="text-info">複数回提出がある場合は、最後の提出内容を出力します。</small>
                         </div>
                         <script>
                             function downloadCsvReportShiftJis{{$frame_id}}() {

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
@@ -39,6 +39,46 @@
 
     {{-- 受講者選択：教員機能 --}}
     @if ($tool->isTeacher() || $tool->isLearningtaskAdmin())
+        {{-- CSV入出力機能 --}}
+        <div class="mb-2">
+            <button class="btn btn-success btn-sm" type="button" data-toggle="collapse" data-target="#data-management-{{$frame_id}}" aria-expanded="true" aria-controls="data-management-{{$frame_id}}">
+                データ管理
+            </button>
+        </div>
+        <div id="data-management-{{$frame_id}}" class="collapse p-2 bg-light border border-light rounded mb-3">
+            {{-- CSV出力 --}}
+            <div class="form-group row">
+                <label class="col-sm-3 text-sm-right">CSV出力</label>
+                <div class="col-sm-9">
+                    <form action="{{url('/')}}/download/plugin/learningtasks/downloadCsvReport/{{$page->id}}/{{$frame_id}}/{{$post->id}}" name="csv_export{{$frame_id}}" method="GET">
+                        <input type="hidden" id="csv-export-character-code{{$frame_id}}" name="character_code" value="{{CsvCharacterCode::sjis_win}}">
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-primary btn-sm" onclick="downloadCsvReportShiftJis{{$frame_id}}();">
+                                <i class="fas fa-file-download"></i> ダウンロード
+                            </button>
+                            <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="sr-only">CSVの文字コードを選択する</span>
+                            </button>
+                            <div class="dropdown-menu">
+                                <a class="dropdown-item" href="javascript:void(0);" onclick="downloadCsvReportShiftJis{{$frame_id}}();">ダウンロード（Shift-JIS）</a>
+                                <a class="dropdown-item" href="javascript:void(0);" onclick="downloadCsvReportUtf8{{$frame_id}}();">ダウンロード（UTF-8 BOM付）</a>
+                            </div>
+                        </div>
+                        <script>
+                            function downloadCsvReportShiftJis{{$frame_id}}() {
+                                document.getElementById('csv-export-character-code{{$frame_id}}').value='{{CsvCharacterCode::sjis_win}}';
+                                document.csv_export{{$frame_id}}.submit();
+                            }
+                            function downloadCsvReportUtf8{{$frame_id}}() {
+                                document.getElementById('csv-export-character-code{{$frame_id}}').value='{{CsvCharacterCode::utf_8}}';
+                                document.csv_export{{$frame_id}}.submit();
+                            }
+                        </script>
+                    </form>
+                </div>
+            </div>
+        </div>
+
         <h5><span class="badge badge-warning">評価中の受講者</span></h5>
         <div class="card mb-3 border-danger">
             <div class="card-body">

--- a/tests/Unit/Plugins/User/Learningtasks/LearningtasksReportCsvExporterTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/LearningtasksReportCsvExporterTest.php
@@ -37,7 +37,7 @@ class LearningtasksReportCsvExporterTest extends TestCase
         $exporter->shouldReceive('isSettingEnabled')->andReturn(false);
         $exporter = new LearningtasksReportCsvExporter($learningtask_post->id, $page->id);
 
-        $this->assertEquals(['ログインID', 'ユーザ名', '提出日時'], $exporter->getHeaderColumns());
+        $this->assertEquals(['ログインID', 'ユーザ名', '提出日時', '提出回数'], $exporter->getHeaderColumns());
     }
 
     /**
@@ -55,7 +55,7 @@ class LearningtasksReportCsvExporterTest extends TestCase
         $exporter = Mockery::mock(LearningtasksReportCsvExporter::class, [$learningtask_post->id, $page->id])->makePartial();
         $exporter->shouldReceive('isSettingEnabled')->andReturn(true);
         $this->assertEquals(
-            ['ログインID', 'ユーザ名', '提出日時', '本文', 'ファイルURL', '評価', '評価コメント'],
+            ['ログインID', 'ユーザ名', '提出日時', '提出回数', '本文', 'ファイルURL', '評価', '評価コメント'],
             $exporter->getHeaderColumns()
         );
     }
@@ -83,7 +83,7 @@ class LearningtasksReportCsvExporterTest extends TestCase
             ->with(LearningtaskUseFunction::use_report_evaluate_comment)->andReturn(false);
 
         $this->assertEquals(
-            ['ログインID', 'ユーザ名', '提出日時', '本文', '評価'],
+            ['ログインID', 'ユーザ名', '提出日時', '提出回数', '本文', '評価'],
             $exporter->getHeaderColumns()
         );
     }
@@ -169,6 +169,7 @@ class LearningtasksReportCsvExporterTest extends TestCase
         $this->assertEquals('student1', $rows[0]['ログインID']);
         $this->assertEquals('Student One', $rows[0]['ユーザ名']);
         $this->assertEquals($submit1_student1->created_at, $rows[0]['提出日時']);
+        $this->assertEquals(1, $rows[0]['提出回数']);
         $this->assertEquals('Test comment1', $rows[0]['本文']);
         $this->assertEquals($site_url . '/file/1', $rows[0]['ファイルURL']);
         $this->assertEquals('A', $rows[0]['評価']);
@@ -179,6 +180,7 @@ class LearningtasksReportCsvExporterTest extends TestCase
         $this->assertEquals('student2', $rows[1]['ログインID']);
         $this->assertEquals('Student Two', $rows[1]['ユーザ名']);
         $this->assertEquals($submit2_student2->created_at, $rows[1]['提出日時']);
+        $this->assertEquals(2, $rows[1]['提出回数']);
         $this->assertEquals('submit again', $rows[1]['本文']);
         $this->assertEquals($site_url . '/file/3', $rows[1]['ファイルURL']);
         $this->assertEquals(null, $rows[1]['評価']);
@@ -189,6 +191,7 @@ class LearningtasksReportCsvExporterTest extends TestCase
         $this->assertEquals('student3', $rows[2]['ログインID']);
         $this->assertEquals('Student Three', $rows[2]['ユーザ名']);
         $this->assertEquals(null, $rows[2]['提出日時']);
+        $this->assertEquals(0, $rows[2]['提出回数']);
         $this->assertEquals(null, $rows[2]['本文']);
         $this->assertEquals(null, $rows[2]['ファイルURL']);
         $this->assertEquals(null, $rows[2]['評価']);
@@ -236,6 +239,7 @@ class LearningtasksReportCsvExporterTest extends TestCase
         $this->assertEquals('student1', $rows[0]['ログインID']);
         $this->assertEquals('Student One', $rows[0]['ユーザ名']);
         $this->assertEquals($submit1_student1->created_at, $rows[0]['提出日時']);
+        $this->assertEquals(1, $rows[0]['提出回数']);
         $this->assertArrayNotHasKey('本文', $rows[0]); // 本文は設定が無効なので含まれない
         $this->assertArrayNotHasKey('ファイルURL', $rows[0]); // ファイルURLは設定が無効なので含まれない
         $this->assertArrayNotHasKey('評価', $rows[0]); // 評価は設定が無効なので含まれない
@@ -290,6 +294,7 @@ class LearningtasksReportCsvExporterTest extends TestCase
         $this->assertEquals('student1', $rows[0]['ログインID']);
         $this->assertEquals('Student One', $rows[0]['ユーザ名']);
         $this->assertEquals($submit1_student1->created_at, $rows[0]['提出日時']);
+        $this->assertEquals(1, $rows[0]['提出回数']);
         $this->assertEquals('Test comment1', $rows[0]['本文']); // 本文は有効なので含まれる
         $this->assertArrayNotHasKey('ファイルURL', $rows[0]); // ファイルURLは無効なので含まれない
         $this->assertArrayHasKey('評価', $rows[0]); // 評価は有効なので含まれる

--- a/tests/Unit/Plugins/User/Learningtasks/LearningtasksReportCsvExporterTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/LearningtasksReportCsvExporterTest.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks;
+
+use Tests\TestCase;
+use App\Enums\LearningtaskUseFunction;
+use App\Models\Common\Page;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Models\User\Learningtasks\LearningtasksUsersStatuses;
+use App\Plugins\User\Learningtasks\LearningtasksReportCsvExporter;
+use App\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+
+/**
+ * LearningtasksReportCsvExporter のテストクラス
+ */
+class LearningtasksReportCsvExporterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * getHeaderColumns メソッドのテスト
+     *
+     * 設定が無効の場合に正しいヘッダーが返されることを確認します。
+     */
+    public function testGetHeaderColumnsWithSettingsDisabled()
+    {
+        // Mock dependencies
+        $learningtask_post = LearningtasksPosts::factory()->create();
+        $page = Page::factory()->create();
+
+        // 設定がすべて無効の場合
+        $exporter = Mockery::mock(LearningtasksReportCsvExporter::class, [$learningtask_post->id, $page->id])->makePartial();
+        $exporter->shouldReceive('isSettingEnabled')->andReturn(false);
+        $exporter = new LearningtasksReportCsvExporter($learningtask_post->id, $page->id);
+
+        $this->assertEquals(['ログインID', 'ユーザ名', '提出日時'], $exporter->getHeaderColumns());
+    }
+
+    /**
+     * getHeaderColumns メソッドのテスト
+     *
+     * 設定が有効の場合に正しいヘッダーが返されることを確認します。
+     */
+    public function testGetHeaderColumnsWithSettingsEnabled()
+    {
+        // Mock dependencies
+        $learningtask_post = LearningtasksPosts::factory()->create();
+        $page = Page::factory()->create();
+
+        // 設定が有効の場合
+        $exporter = Mockery::mock(LearningtasksReportCsvExporter::class, [$learningtask_post->id, $page->id])->makePartial();
+        $exporter->shouldReceive('isSettingEnabled')->andReturn(true);
+        $this->assertEquals(
+            ['ログインID', 'ユーザ名', '提出日時', '本文', 'ファイルURL', '評価', '評価コメント'],
+            $exporter->getHeaderColumns()
+        );
+    }
+
+    /**
+     * getHeaderColumns メソッドのテスト
+     *
+     * 部分的に設定が有効な場合に正しいヘッダーが返されることを確認します。
+     */
+    public function testGetHeaderColumnsWithPartialSettingsEnabled()
+    {
+        // Mock dependencies
+        $learningtask_post = LearningtasksPosts::factory()->create();
+        $page = Page::factory()->create();
+
+        // 設定が部分的に有効な場合
+        $exporter = Mockery::mock(LearningtasksReportCsvExporter::class, [$learningtask_post->id, $page->id])->makePartial();
+        $exporter->shouldReceive('isSettingEnabled')
+            ->with(LearningtaskUseFunction::use_report_comment)->andReturn(true);
+        $exporter->shouldReceive('isSettingEnabled')
+            ->with(LearningtaskUseFunction::use_report_file)->andReturn(false);
+        $exporter->shouldReceive('isSettingEnabled')
+            ->with(LearningtaskUseFunction::use_report_evaluate)->andReturn(true);
+        $exporter->shouldReceive('isSettingEnabled')
+            ->with(LearningtaskUseFunction::use_report_evaluate_comment)->andReturn(false);
+
+        $this->assertEquals(
+            ['ログインID', 'ユーザ名', '提出日時', '本文', '評価'],
+            $exporter->getHeaderColumns()
+        );
+    }
+
+    /**
+     * getRows メソッドのテスト
+     *
+     * 学生、提出、評価データの組み合わせに応じて正しい行データが返されることを確認します。
+     */
+    public function testGetRows()
+    {
+        // Mock now()
+        $now = CarbonImmutable::now();
+        CarbonImmutable::setTestNow($now);
+
+        // Mock dependencies
+        $learningtask_post = LearningtasksPosts::factory()->create();
+        $page = Page::factory()->create();
+
+        // Create test data
+        $student1 = User::factory()->create(['userid' => 'student1', 'name' => 'Student One']);
+        $student2 = User::factory()->create(['userid' => 'student2', 'name' => 'Student Two']);
+        $student3 = User::factory()->create(['userid' => 'student3', 'name' => 'Student Three']);
+
+        // student1の提出と評価
+        $submit1_student1 = LearningtasksUsersStatuses::factory()->create([
+            'post_id' => $learningtask_post->id,
+            'user_id' => $student1->id,
+            'task_status' => 1, // Submitted
+            'created_at' => $now,
+            'comment' => 'Test comment1',
+            'upload_id' => 1,
+        ]);
+        $evaluation1_student1 = LearningtasksUsersStatuses::factory()->create([
+            'post_id' => $learningtask_post->id,
+            'user_id' => $student1->id,
+            'task_status' => 2, // Evaluated
+            'grade' => 'A',
+            'comment' => 'Good work',
+        ]);
+
+        // student2の提出と評価
+        // 再提出後、再提出の評価はない
+        $submit1_student2 = LearningtasksUsersStatuses::factory()->create([
+            'post_id' => $learningtask_post->id,
+            'user_id' => $student2->id,
+            'task_status' => 1, // Submitted
+            'created_at' => $now->addDay(),
+            'comment' => null,
+            'upload_id' => 2,
+        ]);
+        $evaluation1_student2 = LearningtasksUsersStatuses::factory()->create([
+            'post_id' => $learningtask_post->id,
+            'user_id' => $student2->id,
+            'task_status' => 2, // Evaluated
+            'grade' => 'D',
+            'comment' => 'Needs improvement',
+        ]);
+        $submit2_student2 = LearningtasksUsersStatuses::factory()->create([
+            'post_id' => $learningtask_post->id,
+            'user_id' => $student2->id,
+            'task_status' => 1, // Submitted
+            'created_at' => $now->addDays(2),
+            'comment' => 'submit again',
+            'upload_id' => 3,
+        ]);
+
+        // student3の提出と評価はなし
+
+        // Mock fetchStudentUsers to return test students
+        // Create exporter instance
+        $exporter = Mockery::mock(LearningtasksReportCsvExporter::class, [$learningtask_post->id, $page->id])->makePartial();
+        $exporter->shouldReceive('isSettingEnabled')->andReturn(true);
+        $exporter->shouldReceive('fetchStudentUsers')->andReturn(collect([$student1, $student2, $student3]));
+
+        // Test getRows
+        $site_url = 'http://example.com';
+        $rows = $exporter->getRows($site_url);
+
+        $this->assertCount(3, $rows);
+
+        // student1の行を検証
+        // 提出と評価の組み合わせを出力する
+        $this->assertEquals('student1', $rows[0]['ログインID']);
+        $this->assertEquals('Student One', $rows[0]['ユーザ名']);
+        $this->assertEquals($submit1_student1->created_at, $rows[0]['提出日時']);
+        $this->assertEquals('Test comment1', $rows[0]['本文']);
+        $this->assertEquals($site_url . '/file/1', $rows[0]['ファイルURL']);
+        $this->assertEquals('A', $rows[0]['評価']);
+        $this->assertEquals('Good work', $rows[0]['評価コメント']);
+
+        // student2の行を検証
+        // 再提出の評価はないので、評価に関する項目はnull
+        $this->assertEquals('student2', $rows[1]['ログインID']);
+        $this->assertEquals('Student Two', $rows[1]['ユーザ名']);
+        $this->assertEquals($submit2_student2->created_at, $rows[1]['提出日時']);
+        $this->assertEquals('submit again', $rows[1]['本文']);
+        $this->assertEquals($site_url . '/file/3', $rows[1]['ファイルURL']);
+        $this->assertEquals(null, $rows[1]['評価']);
+        $this->assertEquals(null, $rows[1]['評価コメント']);
+
+        // student3の行を検証
+        // 提出や評価がないので、すべてnull
+        $this->assertEquals('student3', $rows[2]['ログインID']);
+        $this->assertEquals('Student Three', $rows[2]['ユーザ名']);
+        $this->assertEquals(null, $rows[2]['提出日時']);
+        $this->assertEquals(null, $rows[2]['本文']);
+        $this->assertEquals(null, $rows[2]['ファイルURL']);
+        $this->assertEquals(null, $rows[2]['評価']);
+        $this->assertEquals(null, $rows[2]['評価コメント']);
+
+    }
+
+    /**
+     * getRows メソッドのテスト
+     *
+     * 設定がすべて無効な場合に正しい行データが返されることを確認します。
+     */
+    public function testGetRowsWithSettingsDisabled()
+    {
+        // Mock now()
+        $now = CarbonImmutable::now();
+        CarbonImmutable::setTestNow($now);
+
+        // Mock dependencies
+        $learningtask_post = LearningtasksPosts::factory()->create();
+        $page = Page::factory()->create();
+
+        // Create test data
+        $student1 = User::factory()->create(['userid' => 'student1', 'name' => 'Student One']);
+        $submit1_student1 = LearningtasksUsersStatuses::factory()->create([
+            'post_id' => $learningtask_post->id,
+            'user_id' => $student1->id,
+            'task_status' => 1, // Submitted
+            'created_at' => $now,
+            'comment' => 'Test comment1',
+            'upload_id' => 1,
+        ]);
+
+        // Mock fetchStudentUsers to return test students
+        $exporter = Mockery::mock(LearningtasksReportCsvExporter::class, [$learningtask_post->id, $page->id])->makePartial();
+        $exporter->shouldReceive('isSettingEnabled')->andReturn(false); // 設定を無効にする
+        $exporter->shouldReceive('fetchStudentUsers')->andReturn(collect([$student1]));
+
+        // Test getRows
+        $site_url = 'http://example.com';
+        $rows = $exporter->getRows($site_url);
+
+        $this->assertCount(1, $rows);
+
+        // Verify student's row
+        $this->assertEquals('student1', $rows[0]['ログインID']);
+        $this->assertEquals('Student One', $rows[0]['ユーザ名']);
+        $this->assertEquals($submit1_student1->created_at, $rows[0]['提出日時']);
+        $this->assertArrayNotHasKey('本文', $rows[0]); // 本文は設定が無効なので含まれない
+        $this->assertArrayNotHasKey('ファイルURL', $rows[0]); // ファイルURLは設定が無効なので含まれない
+        $this->assertArrayNotHasKey('評価', $rows[0]); // 評価は設定が無効なので含まれない
+        $this->assertArrayNotHasKey('評価コメント', $rows[0]); // 評価コメントは設定が無効なので含まれない
+    }
+
+    /**
+     * getRows メソッドのテスト
+     *
+     * 部分的に設定が有効な場合に正しい行データが返されることを確認します。
+     */
+    public function testGetRowsWithPartialSettingsEnabled()
+    {
+        // Mock now()
+        $now = CarbonImmutable::now();
+        CarbonImmutable::setTestNow($now);
+
+        // Mock dependencies
+        $learningtask_post = LearningtasksPosts::factory()->create();
+        $page = Page::factory()->create();
+
+        // Create test data
+        $student1 = User::factory()->create(['userid' => 'student1', 'name' => 'Student One']);
+        $submit1_student1 = LearningtasksUsersStatuses::factory()->create([
+            'post_id' => $learningtask_post->id,
+            'user_id' => $student1->id,
+            'task_status' => 1, // Submitted
+            'created_at' => $now,
+            'comment' => 'Test comment1',
+            'upload_id' => 1,
+        ]);
+
+        // Mock fetchStudentUsers to return test students
+        $exporter = Mockery::mock(LearningtasksReportCsvExporter::class, [$learningtask_post->id, $page->id])->makePartial();
+        $exporter->shouldReceive('isSettingEnabled')
+            ->with(LearningtaskUseFunction::use_report_comment)->andReturn(true); // 本文は有効
+        $exporter->shouldReceive('isSettingEnabled')
+            ->with(LearningtaskUseFunction::use_report_file)->andReturn(false); // ファイルURLは無効
+        $exporter->shouldReceive('isSettingEnabled')
+            ->with(LearningtaskUseFunction::use_report_evaluate)->andReturn(true); // 評価は有効
+        $exporter->shouldReceive('isSettingEnabled')
+            ->with(LearningtaskUseFunction::use_report_evaluate_comment)->andReturn(false); // 評価コメントは無効
+        $exporter->shouldReceive('fetchStudentUsers')->andReturn(collect([$student1]));
+
+        // Test getRows
+        $site_url = 'http://example.com';
+        $rows = $exporter->getRows($site_url);
+
+        $this->assertCount(1, $rows);
+
+        // Verify student's row
+        $this->assertEquals('student1', $rows[0]['ログインID']);
+        $this->assertEquals('Student One', $rows[0]['ユーザ名']);
+        $this->assertEquals($submit1_student1->created_at, $rows[0]['提出日時']);
+        $this->assertEquals('Test comment1', $rows[0]['本文']); // 本文は有効なので含まれる
+        $this->assertArrayNotHasKey('ファイルURL', $rows[0]); // ファイルURLは無効なので含まれない
+        $this->assertArrayHasKey('評価', $rows[0]); // 評価は有効なので含まれる
+        $this->assertArrayNotHasKey('評価コメント', $rows[0]); // 評価コメントは無効なので含まれない
+    }
+}

--- a/tests/Unit/Plugins/User/Learningtasks/LearningtasksReportCsvExporterTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/LearningtasksReportCsvExporterTest.php
@@ -193,7 +193,6 @@ class LearningtasksReportCsvExporterTest extends TestCase
         $this->assertEquals(null, $rows[2]['ファイルURL']);
         $this->assertEquals(null, $rows[2]['評価']);
         $this->assertEquals(null, $rows[2]['評価コメント']);
-
     }
 
     /**

--- a/tests/Unit/Traits/Learningtasks/LearningtaskPostTraitTest.php
+++ b/tests/Unit/Traits/Learningtasks/LearningtaskPostTraitTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Unit\Traits\Learningtasks;
+
+use Tests\TestCase;
+use App\Enums\LearningtaskUseFunction;
+use App\Enums\RoleName;
+use App\Models\Common\Group;
+use App\Models\Common\GroupUser;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Models\Common\Page;
+use App\Models\Common\PageRole;
+use App\Models\Core\UsersRoles;
+use App\Models\User\Learningtasks\Learningtasks;
+use App\Models\User\Learningtasks\LearningtasksUsers;
+use App\Models\User\Learningtasks\LearningtasksUseSettings;
+use App\Traits\Learningtasks\LearningtaskPostTrait;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class LearningtaskPostTraitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var App\Traits\Learningtasks\LearningtaskPostTrait
+     */
+    protected $trait = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * モックのセットアップ
+     *
+     * @param LearningtasksPosts $learningtask_post
+     * @param Page $page
+     */
+    private function setupTrait($learningtask_post, $page)
+    {
+        $this->trait = new class($learningtask_post, $page) {
+            use LearningtaskPostTrait;
+            public function __construct($learningtask_post, $page)
+            {
+                $this->learningtask_post = $learningtask_post;
+                $this->page = $page;
+            }
+        };
+    }
+
+    /**
+     * 設定が有効かどうかのテスト
+     */
+    public function testIsSettingEnabled()
+    {
+        // データ準備
+        $page = Page::factory()->create();
+        $learningtask = Learningtasks::factory()->create();
+        $learningtask_post = LearningtasksPosts::factory()->create(['learningtasks_id' => $learningtask->id]);
+
+        // 課題と科目に設定する
+        // 科目の設定を優先される = post_id が設定されている設定が優先される
+        LearningtasksUseSettings::factory()->create([
+            'learningtasks_id' => $learningtask->id,
+            'use_function' => LearningtaskUseFunction::use_report_comment,
+            'value' => 'off'
+        ]);
+        LearningtasksUseSettings::factory()->create([
+            'learningtasks_id' => $learningtask->id,
+            'use_function' => LearningtaskUseFunction::use_report_file,
+            'value' => 'on'
+        ]);
+        LearningtasksUseSettings::factory()->create([
+            'learningtasks_id' => $learningtask->id,
+            'post_id' => $learningtask_post->id,
+            'use_function' => LearningtaskUseFunction::use_report_comment,
+            'value' => 'on' #
+        ]);
+        LearningtasksUseSettings::factory()->create([
+            'learningtasks_id' => $learningtask->id,
+            'post_id' => $learningtask_post->id,
+            'use_function' => LearningtaskUseFunction::use_report_file,
+            'value' => 'off'
+        ]);
+
+        // 課題のみに設定する
+        LearningtasksUseSettings::factory()->create([
+            'learningtasks_id' => $learningtask->id,
+            'use_function' => LearningtaskUseFunction::use_report_evaluate,
+            'value' => 'on'
+        ]);
+        LearningtasksUseSettings::factory()->create([
+            'learningtasks_id' => $learningtask->id,
+            'use_function' => LearningtaskUseFunction::use_report_evaluate_comment,
+            'value' => 'off'
+        ]);
+
+        // Traiのモックを作成する
+        $this->setupTrait($learningtask_post, $page);
+
+        // テスト実行
+        $this->assertTrue($this->trait->isSettingEnabled(LearningtaskUseFunction::use_report_comment));
+        $this->assertFalse($this->trait->isSettingEnabled(LearningtaskUseFunction::use_report_file));
+        $this->assertTrue($this->trait->isSettingEnabled(LearningtaskUseFunction::use_report_evaluate));
+        $this->assertFalse($this->trait->isSettingEnabled(LearningtaskUseFunction::use_report_evaluate_comment));
+        $this->assertFalse($this->trait->isSettingEnabled(LearningtaskUseFunction::use_examination)); // 未登録の設定はfalseとなる
+    }
+
+    /**
+     * 学生ユーザーを取得するテスト
+     */
+    public function testFetchStudentUsers()
+    {
+        // データ準備
+        // メンバーシップページを作成する
+        $page = Page::factory()->create(['membership_flag' => 1]);
+        // グループを作成し、ページロールを作成する
+        $group = Group::factory()->create();
+        $page_role = PageRole::factory()->create(['page_id' => $page->id, 'group_id' => $group->id]);
+
+        // 学生ユーザを4人作成する
+        // user1, user2, user3はグループに所属する = メンバーシップユーザとなる
+        // user4はグループに所属しない = メンバーシップユーザでない
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $user3 = User::factory()->create();
+        $user4 = User::factory()->create();
+        UsersRoles::factory()->create(['users_id' => $user1->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        UsersRoles::factory()->create(['users_id' => $user2->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        UsersRoles::factory()->create(['users_id' => $user3->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        UsersRoles::factory()->create(['users_id' => $user4->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        // グループにユーザを追加する
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $user1->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $user2->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $user3->id]);
+
+        $learningtask = Learningtasks::factory()->create();
+        // 配置ページのメンバーシップユーザ全員
+        $learningtask_post_membership_students = LearningtasksPosts::factory()->create(['learningtasks_id' => $learningtask->id, 'student_join_flag' => 2]);
+        // 配置ページのメンバーシップユーザから選ぶ
+        $learningtask_post_students_selected = LearningtasksPosts::factory()->create(['learningtasks_id' => $learningtask->id, 'student_join_flag' => 3]);
+        LearningtasksUsers::factory()->create(['post_id' => $learningtask_post_students_selected->id, 'user_id' => $user1->id, 'role_name' => RoleName::student]);
+        LearningtasksUsers::factory()->create(['post_id' => $learningtask_post_students_selected->id, 'user_id' => $user2->id, 'role_name' => RoleName::student]);
+        // user3はメンバーシップユーザだが、選択されていない
+        // user4はメンバーシップユーザでないし、選択もされていない
+
+        // テスト実行
+        // 配置ページのメンバーシップユーザ全員
+        $this->setupTrait($learningtask_post_membership_students, $page);
+        $students = $this->trait->fetchStudentUsers();
+        $this->assertCount(3, $students);
+        $this->assertEquals($user1->id, $students[0]->id);
+        $this->assertEquals($user2->id, $students[1]->id);
+        $this->assertEquals($user3->id, $students[2]->id);
+        // 配置ページのメンバーシップユーザから選ぶ
+        $this->setupTrait($learningtask_post_students_selected, $page);
+        $students = $this->trait->fetchStudentUsers();
+        $this->assertCount(2, $students);
+        $this->assertEquals($user1->id, $students[0]->id);
+        $this->assertEquals($user2->id, $students[1]->id);
+    }
+}

--- a/tests/Unit/Utilities/File/FileUtilsTest.php
+++ b/tests/Unit/Utilities/File/FileUtilsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\Utilities\File;
+
+use PHPUnit\Framework\TestCase;
+use App\Utilities\File\FileUtils;
+
+class FileUtilsTest extends TestCase
+{
+    /**
+     * ファイル名を有効なものに変換するテスト
+     *
+     * @dataProvider validFilenameProvider
+     */
+    public function testToValidFilename($input, $expected)
+    {
+        $result = FileUtils::toValidFilename($input);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * ファイル名を有効なものに変換するテストのデータプロバイダ
+     */
+    public function validFilenameProvider()
+    {
+        return [
+            // 禁止文字を含むファイル名
+            ['test<file>.txt', 'test＜file＞.txt'],
+            ['invalid|name?.txt', 'invalid｜name？.txt'],
+            ['C:\\path\\to\\file.txt', 'C：＼path＼to＼file.txt'],
+            ['file:name*.txt', 'file：name＊.txt'],
+
+            // 禁止文字を含まないファイル名
+            ['valid_filename.txt', 'valid_filename.txt'],
+
+            // 空文字
+            ['', ''],
+        ];
+    }
+}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
レポート提出状況をCSVで出力する機能を追加しました。

## 変更の目的

レポート提出状況をCSVで出力できるようにすることで、課題の進捗管理および分析の効率化を図ります。

## 変更内容

![image](https://github.com/user-attachments/assets/dafc8c46-31c3-4a86-b90c-67def57cc730)

- レポート詳細画面に、CSV出力ボタンを追加しました。
  - CSV出力ボタンは初期非表示、データ管理ボタンを押下することでアコーディオン表示します。
- CSV出力時に、以下の列を出力するようにしました。
  - ユーザID
  - ユーザ名
  - 提出日時
  - 提出回数
  - 本文（アップロードを使用する場合のみ）
  - ファイルURL（本文を使用する場合のみ）
  - 評価（評価を使用する場合のみ）
  - コメント（評価のコメントを使用する場合のみ）

## テスト

レポート詳細画面からCSVファイルが正常に出力されることを確認しました。
また、ファイルURL、本文、評価、コメントなどの各列が仕様通りに出力されることを確認しました。

## 特記事項

CSVは1ユーザー1行とし、複数回提出がある場合は、最後の提出および評価を出力します。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

OW-2532