### PR TITLE
[メール通知] 削除通知が送信先グループに通知されない不具合修正

### DIFF
--- a/app/Jobs/DeleteNoticeJob.php
+++ b/app/Jobs/DeleteNoticeJob.php
@@ -57,17 +57,16 @@ class DeleteNoticeJob implements ShouldQueue
         // buckets_mails の取得
         $bucket_mail = BucketsMail::firstOrNew(['buckets_id' => $this->bucket->id]);
 
-        // 現状(2024-10-03)、削除通知は「送信先メールアドレス」のみで通知している。
-        // エラーチェック（とりあえずデバックログに出力。管理画面で確認できるエラーテーブルに移すこと）
-        if (!$bucket_mail->notice_addresses) {
-            Log::debug("送信先メールアドレスの指定なし。buckets_id = " . $this->bucket->id);
-        }
+        // 送信者メールとグループから、通知するメールアドレス取得
+        $notice_addresses = $bucket_mail->getEmailFromAddressesAndGroups($bucket_mail->notice_addresses, $bucket_mail->notice_groups, $bucket_mail->notice_everyone);
 
-        // メール送信
-        $notice_addresses = explode(',', $bucket_mail->notice_addresses);
+        // エラーチェック（とりあえずデバックログに出力。管理画面で確認できるエラーテーブルに移すこと）
         if (empty($notice_addresses)) {
+            Log::debug("送信メールアドレスなし。buckets_id = " . $this->bucket->id);
             return;
         }
+
+        // *** メール送信
         foreach ($notice_addresses as $notice_address) {
             Mail::to($notice_address)->send(new DeleteNotice($this->notice_embedded_tags, $bucket_mail));
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/2140

上記の不具合修正です。

# github actionsで簡易テスト

* メール通知のテストは、確かないと思いますが、念のためテスト
* https://github.com/opensource-workshop/connect-cms/actions/runs/14236013800
  * エラーなしを確認

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし


# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
