### PR TITLE
[メール通知] 送信メールアドレスなしの場合、ログ管理にログ登録するように対応

### DIFF
--- a/app/Jobs/ApprovalNoticeJob.php
+++ b/app/Jobs/ApprovalNoticeJob.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 class ApprovalNoticeJob implements ShouldQueue
@@ -53,9 +52,9 @@ class ApprovalNoticeJob implements ShouldQueue
         // 送信者メールとグループから、通知するメールアドレス取得
         $approval_addresses = $bucket_mail->getEmailFromAddressesAndGroups($bucket_mail->approval_addresses, $bucket_mail->approval_groups);
 
-        // エラーチェック（とりあえずデバックログに出力。管理画面で確認できるエラーテーブルに移すこと）
+        // エラーチェック
         if (empty($approval_addresses)) {
-            Log::debug("送信先メールアドレスの指定なし。buckets_id = " . $this->bucket->id);
+            $this->saveAppLog($bucket_mail->plugin_name, "送信メールアドレスなし。bucket_name = {$this->bucket->bucket_name} buckets_id = {$this->bucket->id}");
             return;
         }
 

--- a/app/Jobs/ApprovedNoticeJob.php
+++ b/app/Jobs/ApprovedNoticeJob.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 class ApprovedNoticeJob implements ShouldQueue
@@ -56,9 +55,9 @@ class ApprovedNoticeJob implements ShouldQueue
         // 承認済み通知の 送信者メール,グループ,投稿者へ通知 から、通知するメールアドレス取得
         $approved_addresses = $bucket_mail->getApprovedEmailFromAddressesAndGroups($bucket_mail->approved_addresses, $bucket_mail->approved_groups, $this->created_id);
 
-        // エラーチェック（とりあえずデバックログに出力。管理画面で確認できるエラーテーブルに移すこと）
+        // エラーチェック
         if (empty($approved_addresses)) {
-            Log::debug("送信先メールアドレスの指定なし。buckets_id = " . $this->bucket->id);
+            $this->saveAppLog($bucket_mail->plugin_name, "送信メールアドレスなし。bucket_name = {$this->bucket->bucket_name} buckets_id = {$this->bucket->id}");
             return;
         }
 

--- a/app/Jobs/DeleteNoticeJob.php
+++ b/app/Jobs/DeleteNoticeJob.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 class DeleteNoticeJob implements ShouldQueue
@@ -29,6 +28,9 @@ class DeleteNoticeJob implements ShouldQueue
      */
     public $tries = 1;
 
+    /**
+     * @var \App\Models\Common\Buckets
+     */
     private $bucket = null;
     // change: $postは Eloquent モデルのため 物理削除時にキューで再取得できない。代わりに配列変数を使う。
     // private $post = null;
@@ -60,9 +62,9 @@ class DeleteNoticeJob implements ShouldQueue
         // 送信者メールとグループから、通知するメールアドレス取得
         $notice_addresses = $bucket_mail->getEmailFromAddressesAndGroups($bucket_mail->notice_addresses, $bucket_mail->notice_groups, $bucket_mail->notice_everyone);
 
-        // エラーチェック（とりあえずデバックログに出力。管理画面で確認できるエラーテーブルに移すこと）
+        // エラーチェック
         if (empty($notice_addresses)) {
-            Log::debug("送信メールアドレスなし。buckets_id = " . $this->bucket->id);
+            $this->saveAppLog($bucket_mail->plugin_name, "送信メールアドレスなし。bucket_name = {$this->bucket->bucket_name} buckets_id = {$this->bucket->id}");
             return;
         }
 

--- a/app/Jobs/PostNoticeJob.php
+++ b/app/Jobs/PostNoticeJob.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 class PostNoticeJob implements ShouldQueue
@@ -53,9 +52,9 @@ class PostNoticeJob implements ShouldQueue
         // 送信者メールとグループから、通知するメールアドレス取得
         $notice_addresses = $bucket_mail->getEmailFromAddressesAndGroups($bucket_mail->notice_addresses, $bucket_mail->notice_groups, $bucket_mail->notice_everyone);
 
-        // エラーチェック（とりあえずデバックログに出力。管理画面で確認できるエラーテーブルに移すこと）
+        // エラーチェック
         if (empty($notice_addresses)) {
-            Log::debug("送信メールアドレスなし。buckets_id = " . $this->bucket->id);
+            $this->saveAppLog($bucket_mail->plugin_name, "送信メールアドレスなし。bucket_name = {$this->bucket->bucket_name} buckets_id = {$this->bucket->id}");
             return;
         }
 

--- a/resources/views/plugins/manage/log/log.blade.php
+++ b/resources/views/plugins/manage/log/log.blade.php
@@ -265,7 +265,7 @@
                     <td nowrap>{{$app_log->userid}}</td>
                     <td nowrap>{{$app_log->ip_address}}</td>
                     <td nowrap>{{$app_log->type}}</td>
-                    <td nowrap>{{$app_log->value}}</td>
+                    <td>{{$app_log->value}}</td>
                     <td nowrap>{{$app_log->method}}</td>
                     <td nowrap>{{$app_log->plugin_name}}</td>
                     <td nowrap>{{$app_log->route_name}}</th>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* 今まで
  * メール通知時に送信メールアドレスなしの場合、ログ出力していました。
  * 残っていたコメントに、管理画面で確認できる形でログ出力したい旨の記載がありました。
* これから
  * ログ管理でメール通知ログをONにしていた場合、メール通知時に送信メールアドレスなしのログを登録します。
  * 送信メールアドレスなしのログには、バケツIDに加えて、バケツ名も出力するようにしました。（例えばブログ名（=バケツ名）でログを見た管理者が、判別つけられるようにするため）

# 修正後画面
## ログ管理＞ログ一覧

送信メールアドレスなしのログ

![image](https://github.com/user-attachments/assets/eee284de-1266-4743-8dbe-9ebde3b1de79)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
