### PR TITLE
[課題管理]学生がレポート提出内容の修正を行えるようにしました

### DIFF
--- a/app/Enums/LearningtaskUseFunction.php
+++ b/app/Enums/LearningtaskUseFunction.php
@@ -32,6 +32,7 @@ final class LearningtaskUseFunction extends EnumsBase
     const use_report_mail = 'use_'.self::report.'_mail';
     const use_report_end = 'use_'.self::report.'_end';
     const report_end_at = 'report_end_at';
+    const use_report_revising = 'use_'.self::report.'_revising';
     // [利用する評価機能]
     const use_report_evaluate_file = 'use_'.self::report.'_evaluate_file';
     const use_report_evaluate_comment = 'use_'.self::report.'_evaluate_comment';
@@ -98,6 +99,7 @@ final class LearningtaskUseFunction extends EnumsBase
         self::use_report_mail => 'メール送信（教員宛）',
         self::use_report_end => 'レポート提出終了日時で制御する',
         self::report_end_at => 'レポート提出終了日時',
+        self::use_report_revising => '提出修正',
         // 利用する評価機能
         self::use_report_evaluate_file => 'アップロード',
         self::use_report_evaluate_comment => 'コメント入力',

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -3031,6 +3031,11 @@ class LearningtasksPlugin extends UserPluginBase
             $this->sendMailLocal($post, $task_status, $tool, $student_user_id);
         }
 
+        // 評価前の再提出は、直前の提出の進捗ステータスを削除することで、提出の修正とする。
+        if ($task_status == 1 && $tool->shouldReviseReportSubmission($post->id)) {
+            $tool->prepareRevisingReportSubmission();
+        }
+
         // ユーザーの進捗ステータス保存
         LearningtasksUsersStatuses::create([
             'post_id'        => $post_id,

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -1122,6 +1122,7 @@ class LearningtasksPlugin extends UserPluginBase
             'examination_files' => $examination_files,
             'examinations' => $examinations,
             'tool' => $tool,
+            'deleted_submissions' => $tool->fetchDeletedSubmissions(),
         ]);
     }
 

--- a/app/Plugins/User/Learningtasks/LearningtasksTool.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksTool.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 use App\Enums\DayOfWeek;
+use App\Enums\LearningtaskUseFunction;
 use App\Models\Common\PageRole;
 use App\Models\Common\GroupUser;
 use App\Models\Common\Page;
@@ -926,7 +927,9 @@ class LearningtasksTool
             }
             // D 評価がくれば再提出でtrue
             // 提出済みは締め切り前であれば修正可能
-            if ($report_status->task_status == 1) {
+            if ($report_status->task_status == 1 && !$this->checkFunction(LearningtaskUseFunction::use_report_revising)) {
+                $can_report_upload = array(false, '提出済みのため、現在は提出できません。');
+            } elseif ($report_status->task_status == 1 && $this->checkFunction(LearningtaskUseFunction::use_report_revising)) {
                 $can_report_upload = $this->checkReportUploadDeadline($can_report_upload);
             } elseif ($report_status->task_status == 2 && $report_status->grade == 'D') {
                 $can_report_upload = array(true, '再提出が必要');

--- a/app/Plugins/User/Learningtasks/LearningtasksTool.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksTool.php
@@ -1611,4 +1611,22 @@ class LearningtasksTool
             $last_submission->delete();
         }
     }
+
+    /**
+     * 削除された提出内容を取得
+     */
+    public function fetchDeletedSubmissions(): Collection
+    {
+        $query = LearningtasksUsersStatuses::onlyTrashed()
+            ->where('task_status', 1)
+            ->where('user_id', $this->student_id)
+            ->orderBy('id', 'asc');
+
+        // ログインユーザが学生の場合は自身で削除した提出内容のみ
+        if ($this->isStudent()) {
+            $query->where('user_id', $this->student_id);
+        }
+
+        return $query->get();
+    }
 }

--- a/app/Plugins/User/Learningtasks/LearningtasksTool.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksTool.php
@@ -924,9 +924,10 @@ class LearningtasksTool
             if ($report_status->task_status == 2 && ($report_status->grade == 'A' || $report_status->grade == 'B' || $report_status->grade == 'C')) {
                 return array(false, 'すでに合格しているため、提出不要です。');
             }
-            // 提出済みがくればfalse、D 評価がくれば再提出でtrue
+            // D 評価がくれば再提出でtrue
+            // 提出済みは締め切り前であれば修正可能
             if ($report_status->task_status == 1) {
-                $can_report_upload = array(false, '提出済みのため、現在は提出できません。');
+                $can_report_upload = $this->checkReportUploadDeadline($can_report_upload);
             } elseif ($report_status->task_status == 2 && $report_status->grade == 'D') {
                 $can_report_upload = array(true, '再提出が必要');
 
@@ -1564,5 +1565,50 @@ class LearningtasksTool
             return true;
         }
         return false;
+    }
+
+    /**
+     * 提出内容が修正可能かを判定する
+     * @return bool
+     */
+    public function shouldReviseReportSubmission($post_id): bool
+    {
+        if ($this->isOutOfDeadlineReportUpload()) {
+            // 提出期限オーバーなら、修正不可
+            return false;
+        }
+
+        // 提出内容が未評価の状態であれば、提出内容の修正を可能とする
+        $submissions = $this->report_statuses->where('post_id', $post_id)->where('task_status', 1);
+        $evaluations = $this->report_statuses->where('post_id', $post_id)->where('task_status', 2);
+        $evaluated = $submissions->count() > 0 && $submissions->count() === $evaluations->count(); # 提出は評価済みか
+        if ($submissions->count() > 0 && !$evaluated) {
+            return true;
+        }
+
+        Log::debug('shouldReviseReportSubmission checked', [
+            'submissions_count' => $submissions->count(),
+            'submissions_details' => $submissions->toArray(),
+            'evaluations_count' => $evaluations->count(),
+            'evaluations_details' => $evaluations->toArray(),
+            'evaluated' => $evaluated,
+        ]);
+
+        return false;
+    }
+
+    /**
+     * 提出内容の修正の前準備
+     */
+    public function prepareRevisingReportSubmission(): void
+    {
+        $last_submission = LearningtasksUsersStatuses::where('user_id', $this->student_id)
+            ->where('task_status', 1)
+            ->orderBy('id', 'desc')
+            ->first();
+
+        if ($last_submission) {
+            $last_submission->delete();
+        }
     }
 }

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_edit_learningtasks.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_edit_learningtasks.blade.php
@@ -221,7 +221,22 @@
                 </div>
             </div>
         </div>
-
+        <div class="form-group row mb-0">
+            <label class="{{$frame->getSettingLabelClass()}}">提出後の修正</label>
+            <div class="{{$frame->getSettingInputClass(true)}}">
+                <div class="custom-control custom-checkbox mr-3">
+                    <input type="checkbox"
+                        name="base_settings[{{LearningtaskUseFunction::use_report_revising}}]"
+                        value="on"
+                        class="custom-control-input"
+                        id="{{LearningtaskUseFunction::use_report_revising}}"
+                        @if(old("base_settings." . LearningtaskUseFunction::use_report_revising, $tool->getFunction(LearningtaskUseFunction::use_report_revising, true)) == 'on') checked="checked" @endif
+                    >
+                    <label class="custom-control-label" for="{{LearningtaskUseFunction::use_report_revising}}">提出後の修正を許可する</label>
+                    <small class="form-text text-muted">評価前もしくは提出期限まで、学生が提出内容の修正を行えます。</small>
+                </div>
+            </div>
+        </div>
         <div class="form-group row mb-0">
             <label class="{{$frame->getSettingLabelClass()}}">提出期限</label>
             <div class="{{$frame->getSettingInputClass(true)}}">

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_edit_report.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_edit_report.blade.php
@@ -112,7 +112,22 @@
                         </div>
                     </div>
                 </div>
-
+                <div class="form-group row mb-0">
+                    <label class="{{$frame->getSettingLabelClass()}}">提出後の修正</label>
+                    <div class="{{$frame->getSettingInputClass(true)}}">
+                        <div class="custom-control custom-checkbox mr-3">
+                            <input type="checkbox"
+                                name="post_settings[{{LearningtaskUseFunction::use_report_revising}}]"
+                                value="on"
+                                class="custom-control-input"
+                                id="{{LearningtaskUseFunction::use_report_revising}}"
+                                @if(old("post_settings." . LearningtaskUseFunction::use_report_revising, $tool->getFunction(LearningtaskUseFunction::use_report_revising, true)) == 'on') checked="checked" @endif
+                            >
+                            <label class="custom-control-label" for="{{LearningtaskUseFunction::use_report_revising}}">提出後の修正を許可する</label>
+                            <small class="form-text text-muted">評価前もしくは提出期限まで、学生が提出内容の修正を行えます。</small>
+                        </div>
+                    </div>
+                </div>
                 <div class="form-group row mb-0">
                     <label class="{{$frame->getSettingLabelClass()}}">提出期限</label>
                     <div class="{{$frame->getSettingInputClass(true)}}">

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
@@ -162,7 +162,9 @@
                             @if ($tool->checkFunction(LearningtaskUseFunction::use_report_file) || $tool->checkFunction(LearningtaskUseFunction::use_report_comment))
 
                                 <h5 class="mb-1"><span class="badge badge-secondary" for="status1">提出</span></h5>
-
+                                <div class="alert alert-info">
+                                    <span class="text-info submit-info-message">評価が確定するまでは提出内容を修正できます。提出済みの内容を修正する場合は、再度レポート提出を行ってください。</span>
+                                </div>
                                 <form action="{{url('/')}}/redirect/plugin/learningtasks/changeStatus1/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame_id}}" method="POST" name="form_status1" enctype="multipart/form-data">
                                     {{ csrf_field() }}
                                     <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/learningtasks/show/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame_id}}">

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
@@ -186,9 +186,12 @@
                             @if ($tool->checkFunction(LearningtaskUseFunction::use_report_file) || $tool->checkFunction(LearningtaskUseFunction::use_report_comment))
 
                                 <h5 class="mb-1"><span class="badge badge-secondary" for="status1">提出</span></h5>
-                                <div class="alert alert-info">
-                                    <span class="text-info submit-info-message">評価が確定するまでは提出内容を修正できます。提出済みの内容を修正する場合は、再度レポート提出を行ってください。</span>
-                                </div>
+                                {{-- 修正可能のメッセージ --}}
+                                @if ($tool->checkFunction(LearningtaskUseFunction::use_report_revising))
+                                    <div class="alert alert-info">
+                                        <span class="text-info submit-info-message">評価が確定するまでは提出内容を修正できます。提出済みの内容を修正する場合は、再度レポート提出を行ってください。</span>
+                                    </div>
+                                @endif
                                 <form action="{{url('/')}}/redirect/plugin/learningtasks/changeStatus1/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame_id}}" method="POST" name="form_status1" enctype="multipart/form-data">
                                     {{ csrf_field() }}
                                     <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/learningtasks/show/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame_id}}">

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_show_report_status.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_show_report_status.blade.php
@@ -1,0 +1,38 @@
+{{--
+ * 課題管理記事詳細のレポート履歴テンプレート。
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 石垣　佑樹 <ishigaki@opensource-workshop.co.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category 課題管理プラグイン
+--}}
+<table class="table table-bordered table-sm report_table">
+    <tbody>
+        <tr>
+            <th>{{$user_status->getStstusPostTimeName()}}</th>
+            <td>{{$user_status->created_at}}</td>
+        </tr>
+        @if ($tool->isUseFunction($user_status->task_status, 'file'))
+            <tr>
+                <th>{{$user_status->getUploadFileName()}}</th>
+                @if (empty($user_status->upload_id))
+                    <td>なし</td>
+                @else
+                    <td><a href="{{url('/')}}/file/{{$user_status->upload_id}}" target="_blank">{{$user_status->upload->client_original_name}}</a></td>
+                @endif
+            </tr>
+        @endif
+        @if ($user_status->hasGrade())
+            <tr>
+                <th>評価</th>
+                <td><span class="text-danger font-weight-bold">{{$user_status->grade}}</span></td>
+            </tr>
+        @endif
+            @if ($tool->isUseFunction($user_status->task_status, 'comment'))
+            <tr>
+                <th>コメント</th>
+                <td>{!!nl2br(e($user_status->comment))!!}</td>
+            </tr>
+        @endif
+    </tbody>
+</table>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
学生がレポート提出後に提出内容を修正できるようにします。

## 変更の目的

- 現状、学生が提出内容を修正するためには、教員が提出履歴を削除する必要があり、システム外でのやり取りが発生していました。
- この変更により、学生は提出後に誤りに気づいたり、内容を改善したくなったりした場合でも、システム内で修正・再提出が可能になります。
- 教員・学生双方の手間を削減し、より効率的な課題管理を実現します。

## 変更内容

課題提出後に、学生自身が提出内容を編集・再提出できる機能を追加しました。

- 評価前で提出期限内であれば、何度でも修正可能です
- 修正履歴は保存され、教員が確認可能です
- 修正可否は設定で変更可能です

### UIの変更箇所

- 修正可能であることを示すメッセージを表示します
<img width="" alt="image" src="https://github.com/user-attachments/assets/52066c8e-e9fe-4a69-a26f-9dc92ef7132c" />

- （教員、管理者のみ）修正履歴をモーダルダイアログで確認できます
<img width="500" alt="image" src="https://github.com/user-attachments/assets/28ba1d6b-ddc3-4c50-bb17-3f5ad6c0377a" />

- 修正がある場合、”（修正済み）”を表示します
<img width="700" alt="image" src="https://github.com/user-attachments/assets/8350761c-ee67-4d72-a781-6977c9c882fd" />

- レポート設定 「提出内容の修正」で修正可否を設定します
<img width="593" alt="image" src="https://github.com/user-attachments/assets/72d73c4a-1130-4be2-b709-dd8d5f67e596" />



# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

OW-2533