### PR TITLE
[テーマ管理] テンプレート編集時、上部に画面名を表示するよう対応

### DIFF
--- a/resources/views/plugins/manage/theme/theme_manage_tab.blade.php
+++ b/resources/views/plugins/manage/theme/theme_manage_tab.blade.php
@@ -21,32 +21,37 @@
                 @endif
                 </li>
                 <li role="presentation" class="nav-item">
-                @if ($function == "generate")
+                @if ($function == "generateIndex")
                     <span class="nav-link"><span class="active">カスタムテーマ生成</span></span>
                 @else
                     <a href="{{url('/manage/theme/generateIndex')}}" class="nav-link">カスタムテーマ生成</a></li>
                 @endif
                 </li>
-                <li role="presentation" class="nav-item">
                 @if ($function == "editCss")
-                    <span class="nav-link"><span class="active">CSS編集</span></span>
+                    <li role="presentation" class="nav-item">
+                        <span class="nav-link"><span class="active">CSS編集</span></span>
+                    </li>
                 @endif
-                </li>
-                <li role="presentation" class="nav-item">
                 @if ($function == "editJs")
-                    <span class="nav-link"><span class="active">JavaScript編集</span></span>
+                    <li role="presentation" class="nav-item">
+                        <span class="nav-link"><span class="active">JavaScript編集</span></span>
+                    </li>
                 @endif
-                </li>
-                <li role="presentation" class="nav-item">
-                @if ($function == "editName")
-                    <span class="nav-link"><span class="active">テーマ名編集</span></span>
-                @endif
-                </li>
-                <li role="presentation" class="nav-item">
                 @if ($function == "listImages")
-                    <span class="nav-link"><span class="active">画像管理</span></span>
+                    <li role="presentation" class="nav-item">
+                        <span class="nav-link"><span class="active">画像管理</span></span>
+                    </li>
                 @endif
-                </li>
+                @if ($function == "editTemplate")
+                    <li role="presentation" class="nav-item">
+                        <span class="nav-link"><span class="active">テンプレート編集</span></span>
+                    </li>
+                @endif
+                @if ($function == "editName")
+                    <li role="presentation" class="nav-item">
+                        <span class="nav-link"><span class="active">テーマ名編集</span></span>
+                    </li>
+                @endif
             </ul>
         </div>
     </nav>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* テンプレート編集時、上部に画面名を表示するよう対応
* カスタムテーマ生成時、上部の画面名を表示状態にする

# 修正後画面
## テーマ管理＞テンプレート編集

![image](https://github.com/user-attachments/assets/d7fa9a0b-b12f-4fb7-85ca-9c27917f7e2f)

## テーマ管理＞カスタムテーマ生成

![image](https://github.com/user-attachments/assets/fc2fbfaf-642e-403a-af07-74a7b383e72a)


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
