### PR TITLE
[ページ管理][ユーザ管理] 数万ユーザでもページ開ける, ダウンロードできるように対応

### DIFF
--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -1050,13 +1050,14 @@ class PageManage extends ManagePluginBase
         }
 
         // グループの取得
+        // ※ with('group_user')は、数万ユーザの場合、1Gでもメモリ不足になる。
         $groups = Group::orderBy('display_sequence', 'asc')->get();
 
-        // グループ参加ユーザ
-        $users = User::whereIn('id', GroupUser::pluck('user_id')->unique())->get();
-
         foreach ($groups as $group) {
-            $group->group_user_names = $users->whereIn('id', $group->group_user->pluck('user_id'))->pluck('name')->implode('<br />');
+            // 数万ユーザでメモリ不足になるため、DB呼び出し
+            $group->group_user_names = User::whereIn('id', GroupUser::where('group_id', $group->id)->pluck('user_id'))
+                ->pluck('name')
+                ->implode('<br />');
         }
 
         // 管理画面プラグインの戻り値の返し方

--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -750,12 +750,13 @@ class PageManage extends ManagePluginBase
             ->orderBy('group_id', 'asc')
             ->get();
 
-        // グループ参加ユーザ
-        $users = User::whereIn('id', GroupUser::pluck('user_id')->unique())->get();
-
         foreach ($groups as $group) {
             $group->page_roles = $page_roles->where('group_id', $group->id);
-            $group->group_user_names = $users->whereIn('id', $group->group_user->pluck('user_id'))->pluck('name')->implode(', ');
+
+            // 数万ユーザでメモリ不足になるため、DB呼び出し
+            $group->group_user_names = User::whereIn('id', GroupUser::where('group_id', $group->id)->pluck('user_id'))
+                ->pluck('name')
+                ->implode(', ');
         }
 
         // 自分のページから親を遡って取得

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -2,36 +2,6 @@
 
 namespace App\Plugins\Manage\UserManage;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\Rule;
-
-use App\Models\Core\Configs;
-use App\Models\Core\UsersColumns;
-use App\Models\Core\UsersColumnsSelects;
-use App\Models\Core\UsersColumnsSet;
-use App\Models\Core\UsersRoles;
-use App\Models\Core\UsersInputCols;
-use App\Models\Core\UsersLoginHistories;
-use App\Models\Common\Group;
-use App\Models\Common\GroupUser;
-use App\User;
-
-use App\Traits\ConnectMailTrait;
-
-use App\Plugins\Manage\ManagePluginBase;
-
-use App\Rules\CustomValiUserEmailUnique;
-use App\Rules\CustomValiEmails;
-use App\Rules\CustomValiCsvExistsName;
-
-use App\Utilities\Csv\CsvUtils;
-use App\Utilities\String\StringUtils;
-
 use App\Enums\CsvCharacterCode;
 use App\Enums\EditType;
 use App\Enums\Required;
@@ -40,8 +10,33 @@ use App\Enums\UserColumnType;
 use App\Enums\UserRegisterNoticeEmbeddedTag;
 use App\Enums\UserStatus;
 use App\Enums\UseType;
+use App\Models\Core\Configs;
 use App\Models\Core\Section;
+use App\Models\Core\UsersColumns;
+use App\Models\Core\UsersColumnsSelects;
+use App\Models\Core\UsersColumnsSet;
+use App\Models\Core\UsersRoles;
+use App\Models\Core\UsersInputCols;
+use App\Models\Core\UsersLoginHistories;
 use App\Models\Core\UserSection;
+use App\Models\Common\Group;
+use App\Models\Common\GroupUser;
+use App\Plugins\Manage\ManagePluginBase;
+use App\Rules\CustomValiUserEmailUnique;
+use App\Rules\CustomValiEmails;
+use App\Rules\CustomValiCsvExistsName;
+use App\Traits\ConnectMailTrait;
+use App\User;
+use App\Utilities\Csv\CsvUtils;
+use App\Utilities\String\StringUtils;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
  * ユーザ管理クラス
@@ -118,15 +113,15 @@ class UserManage extends ManagePluginBase
     }
 
     /**
-     * データgetで取得
+     * ユーザquery取得
      */
-    private function getUsers($request, $users_columns, int $columns_set_id)
+    private function getUsersQuery($request, $users_columns, int $columns_set_id)
     {
         return $this->getUsersPaginate($request, null, $users_columns, $columns_set_id, false);
     }
 
     /**
-     * データ取得(paginate or get)
+     * ユーザデータ取得(paginate or query)
      */
     private function getUsersPaginate($request, $page, $users_columns, int $columns_set_id, $is_paginate = true)
     {
@@ -372,11 +367,20 @@ class UserManage extends ManagePluginBase
         if ($is_paginate) {
             // ページャーで取得
             $users = $users_query->paginate(10, null, 'page', $page);
-        } else {
-            // getで取得
-            $users = $users_query->get();
-        }
+            // ユーザデータ取得後の追加処理
+            return $this->getUsersAfter($users);
 
+        } else {
+            // query取得
+            return $users_query;
+        }
+    }
+
+    /**
+     * ユーザデータ取得後の追加処理
+     */
+    private function getUsersAfter($users)
+    {
         // ユーザデータからID の配列生成
         $user_ids = array();
         foreach ($users as $user) {
@@ -1595,8 +1599,8 @@ class UserManage extends ManagePluginBase
         // ユーザーのカラム
         $users_columns = UsersTool::getUsersColumns($id);
 
-        // User データの取得
-        $users = $this->getUsers($request, $users_columns, $id);
+        // ユーザquery取得
+        $users_query = $this->getUsersQuery($request, $users_columns, $id);
 
         /*
         ダウンロード前の配列イメージ。
@@ -1619,55 +1623,19 @@ class UserManage extends ManagePluginBase
             45 =>
         ]
         */
-        // 返却用配列
-        $csv_array = array();
-
         // データ行用の空配列
         $copy_base = array();
+
+        // 見出し行
+        $head = array();
 
         // インポートカラムの取得
         $import_column = $this->getImportColumn($users_columns);
 
         // 見出し行
         foreach ($import_column as $key => $column_name) {
-            $csv_array[0][$key] = $column_name;
+            $head[$key] = $column_name;
             $copy_base[$key] = '';
-        }
-
-        // $data_output_flag = falseは、CSVフォーマットダウンロード処理
-        if ($data_output_flag) {
-            // usersデータ
-            foreach ($users as $user) {
-                // ベースをセット
-                $csv_array[$user->id] = $copy_base;
-
-                // 初回で固定項目をセット
-                $csv_array[$user->id]['id'] = $user->id;
-                $csv_array[$user->id]['userid'] = $user->userid;     // ログインID
-                $csv_array[$user->id]['name'] = $user->name;
-
-                // グループ
-                $csv_array[$user->id]['group'] = $user->convertLoopValue('group_users', 'name', UsersTool::CHECKBOX_SEPARATOR);
-
-                $csv_array[$user->id]['email'] = $user->email;
-                $csv_array[$user->id]['password'] = '';              // パスワード、中身は空で出力
-
-                // 権限
-                $csv_array[$user->id]['view_user_roles'] = $user->convertLoopValue('view_user_roles', 'role_name', UsersTool::CHECKBOX_SEPARATOR);
-
-                // 役割設定
-                $csv_array[$user->id]['user_original_roles'] = $user->convertLoopValue('user_original_roles', 'value', UsersTool::CHECKBOX_SEPARATOR);
-
-                $csv_array[$user->id]['status'] = $user->status;
-            }
-
-            // 追加項目データの取得
-            $input_cols = UsersTool::getUsersInputCols($users->pluck('id')->all());
-
-            // 追加項目データ
-            foreach ($input_cols as $input_col) {
-                $csv_array[$input_col->users_id][$input_col->users_columns_id] = UsersTool::getUsersInputColValue($input_col);
-            }
         }
 
         // レスポンス
@@ -1682,10 +1650,85 @@ class UserManage extends ManagePluginBase
             'Content-Disposition' => 'attachment; filename="'.$filename.'"',
         ];
 
-        // データ
-        $csv_data = CsvUtils::getResponseCsvData($csv_array, $request->character_code);
+        $character_code = $request->character_code;
 
-        return response()->make($csv_data, 200, $headers);
+        // $data_output_flag = falseは、CSVフォーマットダウンロード処理
+        if (!$data_output_flag) {
+            // データ
+            $csv_array[0] = $head;
+            $csv_data = CsvUtils::getResponseCsvData($csv_array, $character_code);
+            return response()->make($csv_data, 200, $headers);
+        }
+
+        // Symfony の StreamedResponse で出力 ＆ chunk でデータ取得することにより
+        // 大容量の出力に対応
+        return new StreamedResponse(
+            function () use ($users_query, $head, $copy_base, $character_code) {
+                $stream = fopen('php://output', 'w');
+
+                // 文字コード変換
+                if ($character_code == CsvCharacterCode::utf_8) {
+                    mb_convert_variables(CsvCharacterCode::utf_8, CsvCharacterCode::utf_8, $head);
+                    // BOM付きにさせる場合にファイルの先頭に書き込む
+                    fwrite($stream, CsvUtils::bom);
+                } else {
+                    mb_convert_variables(CsvCharacterCode::sjis_win, CsvCharacterCode::utf_8, $head);
+                }
+                fputcsv($stream, $head);
+
+                // データの処理
+                $users_query->chunk(1000, function ($users) use ($stream, $copy_base, $character_code) {
+
+                    // ユーザデータ取得後の追加処理
+                    $users = $this->getUsersAfter($users);
+
+                    // 追加項目データの取得
+                    $input_cols = UsersTool::getUsersInputCols($users->pluck('id')->all());
+
+                    foreach ($users as $user) {
+                        // ベースをセット
+                        $csv_array = $copy_base;
+
+                        // 初回で固定項目をセット
+                        $csv_array['id'] = $user->id;
+                        $csv_array['userid'] = $user->userid;     // ログインID
+                        $csv_array['name'] = $user->name;
+
+                        // グループ
+                        $csv_array['group'] = $user->convertLoopValue('group_users', 'name', UsersTool::CHECKBOX_SEPARATOR);
+
+                        $csv_array['email'] = $user->email;
+                        $csv_array['password'] = '';              // パスワード、中身は空で出力
+
+                        // 権限
+                        $csv_array['view_user_roles'] = $user->convertLoopValue('view_user_roles', 'role_name', UsersTool::CHECKBOX_SEPARATOR);
+
+                        // 役割設定
+                        $csv_array['user_original_roles'] = $user->convertLoopValue('user_original_roles', 'value', UsersTool::CHECKBOX_SEPARATOR);
+
+                        $csv_array['status'] = $user->status;
+
+                        $input_cols_solo = $input_cols->where('users_id', $user->id);
+
+                        // 追加項目データ
+                        foreach ($input_cols_solo as $input_col) {
+                            $csv_array[$input_col->users_columns_id] = UsersTool::getUsersInputColValue($input_col);
+                        }
+
+                        // 文字コード変換
+                        if ($character_code == CsvCharacterCode::utf_8) {
+                            mb_convert_variables(CsvCharacterCode::utf_8, CsvCharacterCode::utf_8, $csv_array);
+                        } else {
+                            mb_convert_variables(CsvCharacterCode::sjis_win, CsvCharacterCode::utf_8, $csv_array);
+                        }
+                        fputcsv($stream, $csv_array);
+                    }
+                });
+                fclose($stream);
+            },
+            200,
+            $headers
+        );
     }
 
     /**

--- a/app/Traits/Migration/MigrationTrait.php
+++ b/app/Traits/Migration/MigrationTrait.php
@@ -1964,6 +1964,8 @@ trait MigrationTrait
                     'group_id'   => $group->id,
                     'user_id'    => $user_id,
                     'group_role' => 'general',
+                    'created_at' => date('Y-m-d H:i:s'),
+                    'updated_at' => date('Y-m-d H:i:s'),
                 ];
             }
             // バルクINSERT

--- a/resources/views/plugins/manage/group/edit.blade.php
+++ b/resources/views/plugins/manage/group/edit.blade.php
@@ -167,8 +167,8 @@
                             <tr>
                                 <td>{{$group_user->user_name}}</td>
                                 {{-- <td>{{GroupType::getDescription($group_user->group_role)}}</td> --}}
-                                <td>{{$group_user->created_at->format('Y/m/d')}}</td>
-                                <td>{{$group_user->updated_at->format('Y/m/d')}}</td>
+                                <td>{{ optional($group_user->created_at)->format('Y/m/d') }}</td>
+                                <td>{{ optional($group_user->updated_at)->format('Y/m/d') }}</td>
                                 <td>
                                     <button type="button" class="btn btn-danger btn-sm" onclick="removeUser({{$group_user->user_id}}, '{{$group_user->user_name}}');">
                                         <i class="fas fa-trash-alt"></i>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* [change: ページ管理＞ページ権限一覧, 数万ユーザでもページ開けるように対応](https://github.com/opensource-workshop/connect-cms/commit/4c1487d2c7cdb75d406371696b3d990a169d3118)
* [change: ページ管理＞ページ権限設定, 数万ユーザでもページ開けるように対応](https://github.com/opensource-workshop/connect-cms/commit/72d6c9864b14fa3f6bb8746dc61edb806e63cc6f)
* [change: ユーザ管理＞ユーザ一覧＞ダウンロード, 数万ユーザでもダウンロードできるように対応](https://github.com/opensource-workshop/connect-cms/commit/8772754b8364ac44623b11fb3b2fa4fa139e1118)
* 関連修正
  * [bugfix: グループ管理＞グループ変更, 移行後のグループユーザーに作成日・更新日なしで500エラーの修正](https://github.com/opensource-workshop/connect-cms/pull/2165/commits/c88747b417cde71d31c76cd59b68727041bc4856)

# github actionsで簡易テスト

* https://github.com/opensource-workshop/connect-cms/actions/runs/14310931682
  * エラーなしを確認しました

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
