### PR TITLE
[WYSIWYG] ディレクトリインストールでTinyMCE関連のcssが404になる不具合対応

### DIFF
--- a/public/themes/Defaults/Blue/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Blue/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Blue/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Blue/themes.css", // スタイル

--- a/public/themes/Defaults/CornflowerBlue/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/CornflowerBlue/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/CornflowerBlue/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/CornflowerBlue/themes.css", // スタイル

--- a/public/themes/Defaults/DarkBlue/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/DarkBlue/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/DarkBlue/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/DarkBlue/themes.css", // スタイル

--- a/public/themes/Defaults/DarkGoldenrod/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/DarkGoldenrod/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/DarkGoldenrod/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/DarkGoldenrod/themes.css", // スタイル

--- a/public/themes/Defaults/DarkGreen/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/DarkGreen/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/DarkGreen/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/DarkGreen/themes.css", // スタイル

--- a/public/themes/Defaults/DarkOrange/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/DarkOrange/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/DarkOrange/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/DarkOrange/themes.css", // スタイル

--- a/public/themes/Defaults/DarkOrchid/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/DarkOrchid/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/DarkOrchid/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/DarkOrchid/themes.css", // スタイル

--- a/public/themes/Defaults/DarkRed/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/DarkRed/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/DarkRed/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/DarkRed/themes.css", // スタイル

--- a/public/themes/Defaults/DeepPink/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/DeepPink/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/DeepPink/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/DeepPink/themes.css", // スタイル

--- a/public/themes/Defaults/Default/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Default/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Default/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Default/themes.css", // スタイル

--- a/public/themes/Defaults/DefaultAccessibility/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/DefaultAccessibility/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/DefaultAccessibility/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/DefaultAccessibility/themes.css", // スタイル

--- a/public/themes/Defaults/Gray/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Gray/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Gray/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Gray/themes.css", // スタイル

--- a/public/themes/Defaults/Green/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Green/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Green/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Green/themes.css", // スタイル

--- a/public/themes/Defaults/HotPink/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/HotPink/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/HotPink/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/HotPink/themes.css", // スタイル

--- a/public/themes/Defaults/LightGreen/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/LightGreen/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/LightGreen/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/LightGreen/themes.css", // スタイル

--- a/public/themes/Defaults/Lime/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Lime/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Lime/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Lime/themes.css", // スタイル

--- a/public/themes/Defaults/MediumOrchid/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/MediumOrchid/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/MediumOrchid/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/MediumOrchid/themes.css", // スタイル

--- a/public/themes/Defaults/MediumPurple/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/MediumPurple/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/MediumPurple/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/MediumPurple/themes.css", // スタイル

--- a/public/themes/Defaults/Olive/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Olive/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Olive/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Olive/themes.css", // スタイル

--- a/public/themes/Defaults/Orange/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Orange/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Orange/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Orange/themes.css", // スタイル

--- a/public/themes/Defaults/OrangeRed/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/OrangeRed/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/OrangeRed/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/OrangeRed/themes.css", // スタイル

--- a/public/themes/Defaults/Orchid/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Orchid/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Orchid/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Orchid/themes.css", // スタイル

--- a/public/themes/Defaults/Pink/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Pink/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Pink/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Pink/themes.css", // スタイル

--- a/public/themes/Defaults/Purple/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Purple/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Purple/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Purple/themes.css", // スタイル

--- a/public/themes/Defaults/Red/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Red/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Red/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Red/themes.css", // スタイル

--- a/public/themes/Defaults/Teal/wysiwyg/content_css.txt
+++ b/public/themes/Defaults/Teal/wysiwyg/content_css.txt
@@ -1,1 +1,1 @@
-        content_css: "/css/app.css, /css/connect.css, /themes/Defaults/Teal/themes.css", // スタイル
+        content_css: "css/app.css, css/connect.css, themes/Defaults/Teal/themes.css", // スタイル


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/2171

上記不具合の修正です。
ディレクトリインストール時にブログ記事の編集時なのに表示しているTinyMCEで、CSSが読み込めていませんでした(404)
TinyMCEのパラメータを修正して、CSSを相対パスで読み込むように修正しました。

# 修正後画面
## 例）ブログ記事編集

ディレクトリインストール時に404になっていたapp.css等が読み込めていることを確認しました。
![image](https://github.com/user-attachments/assets/5eace4d6-6657-438e-8550-083868b614e5)

# github actionsで簡易テスト

* https://github.com/opensource-workshop/connect-cms/actions/runs/14461205823
  * エラーなしを確認しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [ ] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
