### PR TITLE
[robots.txt] 他システムから移行後に不要な検索botのクロールを除外

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,14 @@
 User-agent: *
+# CC
 Disallow: /plugin/*?frame_*_page=
 Disallow: /json/
 Disallow: /redirect/
+# NC2
 Disallow: *?*action=
 Disallow: *?*active_action=
+# NC3
+Disallow: *multidatabases/multidatabase_contents/
+Disallow: *blogs/blog_entries/
+Disallow: *wysiwyg/image/download/
+Disallow: *calendars/calendars/
+Disallow: *cabinets/cabinet_files/


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* NC3から移行後に、bot系からくるNC3系のアクセスをrobots.txtで除外する設定を追加しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1788

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
