### PR TITLE
[課題管理]レポート評価のインポート機能を追加しました

### DIFF
--- a/app/Enums/LearningtaskImportType.php
+++ b/app/Enums/LearningtaskImportType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * 課題管理インポートタイプ
+ */
+final class LearningtaskImportType extends EnumsBase
+{
+    // 定数メンバ
+    const report = 'report';
+
+    // key/valueの連想配列
+    const enum = [
+        self::report => 'レポート評価',
+    ];
+}

--- a/app/Plugins/User/Learningtasks/Contracts/ColumnDefinitionInterface.php
+++ b/app/Plugins/User/Learningtasks/Contracts/ColumnDefinitionInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Contracts;
+
+/**
+ * 課題管理CSVインポートにおけるカラム定義を提供するクラスのためのインターフェース
+ *
+ * 実装クラスは、特定のインポートタイプ（例：レポート評価、試験評価）に応じた
+ * ヘッダーリスト、カラムマッピング、基本的なバリデーションルールを提供する責務を持つ。
+ */
+interface ColumnDefinitionInterface
+{
+    /**
+     * 現在のコンテキスト（例: 課題投稿の設定など）に基づいて、
+     * CSVで期待される（または処理対象となる）ヘッダーカラム名のリストを取得する。
+     *
+     * @return array ヘッダー文字列の配列。例: ['ログインID', '評価', '評価コメント']
+     */
+    public function getHeaders(): array;
+
+    /**
+     * この定義クラスが扱う可能性のある全てのCSVヘッダー名と、
+     * それに対応する内部キー名の完全なマッピング配列を取得する。
+     * Importer が列インデックスと内部キーを紐付けるために利用する。
+     *
+     * @return array ['CSVヘッダー名' => '内部キー名', ...]
+     */
+    public function getColumnMap(): array;
+
+    /**
+     * 指定されたCSVヘッダー名に対応する内部キー名を取得する。
+     * マッピングが存在しない場合は null を返す。
+     *
+     * @param string $header_name CSVヘッダー名。例: '評価コメント'
+     * @return string|null 内部キー名。例: 'comment'。見つからない場合は null。
+     */
+    public function getInternalKey(string $header_name): ?string;
+
+    /**
+     * このカラム定義（インポートタイプ）に対応する基本的なバリデーションルールを取得する。
+     * ルールは内部キー名に対して定義された連想配列として返す。
+     * Importer はこの基本ルールを利用してバリデーションを行う。
+     *
+     * @return array ['内部キー名' => ['ルール1', 'ルール2', ...], ...]
+     * 例: ['userid' => ['required', 'exists:users,userid'], 'grade' => ['nullable']]
+     */
+    public function getValidationRulesBase(): array;
+
+    /**
+     * (任意) このカラム定義に対応するカスタムバリデーションメッセージを取得する。
+     * メッセージは '内部キー名.ルール名' をキーとする連想配列で返す。
+     * 実装クラスで不要な場合は空配列を返せば良い。
+     *
+     * @return array ['内部キー名.ルール名' => 'メッセージ文字列', ...]
+     * 例: ['userid.required' => 'ログインIDは必須です。']
+     */
+    public function getValidationMessages(): array;
+}

--- a/app/Plugins/User/Learningtasks/Contracts/RowProcessorExceptionHandlerInterface.php
+++ b/app/Plugins/User/Learningtasks/Contracts/RowProcessorExceptionHandlerInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Contracts;
+
+use Illuminate\Validation\ValidationException;
+use Throwable;
+
+/**
+ * CSV行処理中の例外ハンドリング戦略を定義するインターフェース
+ */
+interface RowProcessorExceptionHandlerInterface
+{
+    // 結果を表す定数
+    public const OUTCOME_ERROR = 'error';
+    public const OUTCOME_SKIP = 'skip';
+
+    // ログレベルを表す定数 (Log ファサードのメソッド名に合わせる)
+    public const LOG_ERROR = 'error';
+    public const LOG_WARN = 'warning';
+    public const LOG_INFO = 'info';
+    public const LOG_DEBUG = 'debug';
+
+    // 配列キーを示す定数
+    public const KEY_OUTCOME = 'outcome';
+    public const KEY_TYPE = 'type';
+    public const KEY_LOG_LEVEL = 'logLevel';
+
+    /**
+     * 捕捉された例外を処理し、その結果（エラーかスキップか、詳細タイプ、ログレベル）を返す。
+     *
+     * @param Throwable $e 捕捉された例外オブジェクト
+     * @return array|null 処理方法を示す配列 ['outcome' => 'error'|'skip', 'type' => string, 'log_level' => string] を返す。
+     * 処理できない/予期せぬ例外の場合は null を返すことも可能（その場合は Importer 側で 'unexpected_error' として扱われる）。
+     */
+    public function handle(Throwable $e): ?array;
+
+    /**
+     * ValidationException から整形済みのメッセージを取得するヘルパ
+     * @param Throwable $e 捕捉された例外オブジェクト
+     * @return string
+     */
+    public function formatValidationMessage(ValidationException $e): string;
+}

--- a/app/Plugins/User/Learningtasks/Contracts/RowProcessorInterface.php
+++ b/app/Plugins/User/Learningtasks/Contracts/RowProcessorInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Contracts;
+
+use App\Models\Common\Page;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\User;
+use Exception; // エラー発生時に基底例外を投げることを想定
+
+/**
+ * インポート時に検証済みのCSVデータ1行分を処理するためのインターフェース
+ */
+interface RowProcessorInterface
+{
+    /**
+     * 検証済みのデータ1行分を処理する。
+     *
+     * このメソッドの実装クラスが、CSVの1行に対応する
+     * データベースレコードの検索、更新、または作成といった
+     * コアなビジネスロジックを担当します。
+     *
+     * @param array $validated_data 検証済みデータ（内部キー名 => 値 の連想配列）
+     * 例: ['userid' => '123', 'grade' => 'A', 'comment' => 'Good']
+     * @param LearningtasksPosts $post インポート対象の課題投稿コンテキスト
+     * @param User $importer インポート操作を実行しているユーザー (評価者ID等に利用)
+     * @return void
+     * @throws Exception 処理中にエラーが発生した場合 (例: 関連データが見つからない、DBエラー)。
+     * より具体的なカスタム例外を定義して投げるのが望ましい。
+     */
+    public function process(array $validated_data, LearningtasksPosts $post, Page $page, User $importer): void;
+}

--- a/app/Plugins/User/Learningtasks/Csv/LearningtasksCsvImporter.php
+++ b/app/Plugins/User/Learningtasks/Csv/LearningtasksCsvImporter.php
@@ -1,0 +1,428 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Csv;
+
+use App\Enums\CsvCharacterCode;
+use App\Models\Common\Page;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Plugins\User\Learningtasks\Contracts\ColumnDefinitionInterface;
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorExceptionHandlerInterface;
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorInterface;
+use App\Plugins\User\Learningtasks\Exceptions\AlreadyEvaluatedException;
+use App\Plugins\User\Learningtasks\Exceptions\CsvFileOpenException;
+use App\Plugins\User\Learningtasks\Exceptions\CsvHeaderReadException;
+use App\Plugins\User\Learningtasks\Exceptions\CsvInvalidHeaderException;
+use App\Plugins\User\Learningtasks\Exceptions\InvalidStudentException;
+use App\Plugins\User\Learningtasks\Exceptions\SubmissionNotFoundException;
+use App\Plugins\User\Learningtasks\Repositories\LearningtaskUserRepository;
+use App\User;
+use App\Utilities\Csv\CsvUtils;
+use Exception;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * ★ 課題管理の汎用CSVインポートクラス
+ *
+ * ColumnDefinitionInterface と RowProcessorInterface を利用して、
+ * 様々な種類のCSVインポート処理をオーケストレーションする。
+ */
+class LearningtasksCsvImporter
+{
+    // --- 依存性 ---
+    private LearningtasksPosts $learningtask_post;
+    private Page $page;
+    private ColumnDefinitionInterface $column_definition;
+    private RowProcessorInterface $row_processor;
+    private LearningtaskUserRepository $user_repository;
+    private RowProcessorExceptionHandlerInterface $exception_handler;
+
+    /** インポート結果の集計 */
+    private array $results = [
+        'success' => 0,
+        'errors' => 0,
+        'skipped' => 0,
+        'error_details' => [],
+        'skip_details' => [],
+    ];
+
+    /**
+     * コンストラクタ
+     *
+     * @param LearningtasksPosts $learningtask_post
+     * @param Page $page
+     * @param ColumnDefinitionInterface $column_definition インターフェースの実装を受け取る
+     * @param RowProcessorInterface $row_processor インターフェースの実装を受け取る
+     * @param LearningtaskUserRepository $user_repository
+     * @param RowProcessorExceptionHandlerInterface $exception_handler インターフェースの実装を受け取る
+     */
+    public function __construct(
+        LearningtasksPosts $learningtask_post,
+        Page $page,
+        ColumnDefinitionInterface $column_definition,
+        RowProcessorInterface $row_processor,
+        LearningtaskUserRepository $user_repository,
+        RowProcessorExceptionHandlerInterface $exception_handler
+    ) {
+        $this->learningtask_post = $learningtask_post;
+        $this->page = $page;
+        $this->column_definition = $column_definition;
+        $this->row_processor = $row_processor;
+        $this->user_repository = $user_repository;
+        $this->exception_handler = $exception_handler;
+    }
+
+    /**
+     * CSVインポート処理を実行する (メインメソッド)
+     *
+     * @param UploadedFile $file アップロードされたCSVファイル
+     * @param string $character_code 文字コード
+     * @param User $importer インポート操作を行うユーザー
+     * @return array インポート結果の集計配列
+     */
+    public function import(UploadedFile $file, User $importer): array
+    {
+        // 結果を初期化
+        $this->results = ['success' => 0, 'errors' => 0, 'skipped' => 0, 'error_details' => [], 'skip_details' => []];
+        // 注入された $column_definition からヘッダーを取得
+        $expected_headers = $this->column_definition->getHeaders();
+        $file_path = $file->getPathname();
+        $fp = null; // ファイルポインタ
+
+        try {
+            DB::transaction(function () use ($file_path, $expected_headers, $importer, &$fp) {
+                $fp = $this->openCsvFile($file_path);
+                $header_index_map = $this->processHeader($fp, $expected_headers);
+                // データ行を処理 (結果は $this->results に蓄積される)
+                $this->processRows($fp, $header_index_map, $expected_headers, $importer);
+                if ($this->results['errors'] > 0) {
+                    throw new Exception("インポート処理中にエラーが発生したため、データベースへの変更は適用されませんでした。");
+                }
+            });
+        } catch (CsvFileOpenException $e) {
+            Log::error("CSV Import failed: " . $e->getMessage());
+            $this->results['errors']++;
+            $this->addErrorDetail(0, 'ファイルオープンエラー: ' . $e->getMessage(), 'file_open_error');
+        } catch (CsvHeaderReadException $e) {
+            Log::error("CSV Import failed: " . $e->getMessage());
+            $this->results['errors']++;
+            $this->addErrorDetail(1, 'ヘッダー読み取りエラー: ' . $e->getMessage(), 'header_read_error');
+        } catch (CsvInvalidHeaderException $e) {
+            Log::error("CSV Import failed: " . $e->getMessage());
+            $this->results['errors']++;
+            $this->addErrorDetail(1, 'ヘッダー形式エラー: ' . $e->getMessage(), 'header_error');
+        } catch (Exception $e) { // DBエラーやロールバックトリガーなど、その他の例外
+            Log::error("CSV Import failed and potentially rolled back: " . $e->getMessage() . "\n" . $e->getTraceAsString());
+            if ($this->results['errors'] == 0 && $this->results['skipped'] == 0) {
+                // processRows でエラーが記録されずにここにきた場合 (DB接続エラーなど)
+                 $this->results['errors']++;
+                 $this->addErrorDetail(0, '予期せぬエラーにより処理が中断されました。変更は適用されていません。: ' . $e->getMessage(), 'fatal_error');
+            } else {
+                 // processRows でエラーがありロールバックした場合
+                 $this->addErrorDetail(0, 'エラー発生のため処理が中断され、変更は適用されませんでした。詳細は各行のエラー/スキップを確認してください。', 'fatal_error_rollback');
+            }
+        } finally {
+            // ファイルを確実にクローズ
+            if ($fp !== null && is_resource($fp)) {
+                fclose($fp);
+            }
+        }
+
+        return $this->results; // 集計結果を返す
+    }
+
+    // ===============================================
+    // Private Helper Methods for import()
+    // ===============================================
+
+    /**
+     * CSVファイルを開き、文字コード設定を行う
+     *
+     * @param string $file_path ファイルパス
+     * @param string $character_code 文字コード
+     * @return resource|false ファイルポインタ (PHP 8.0未満では resource|false)
+     * @throws Exception ファイルオープン失敗時
+     */
+    private function openCsvFile(string $file_path): mixed
+    {
+        // 文字コード自動判定
+        $detected_code = CsvUtils::getCharacterCodeAuto($file_path);
+
+        // 判定失敗時の処理
+        if ($detected_code === false) {
+            // ユーザーに分かりやすいエラーメッセージを投げる
+            throw new Exception("文字コードを自動判定できませんでした。ファイル形式がUTF-8またはShift-JIS（Windows）であることを確認してください。");
+        }
+
+        // --- ファイルオープンとフィルタ適用 ---
+        CsvUtils::setLocale(); // fgetcsv のためのロケール設定
+        $fp = @fopen($file_path, 'r'); // エラー制御演算子を使用
+        if ($fp === false) {
+            throw new CsvFileOpenException("CSVファイルを開けませんでした: " . $file_path);
+        }
+
+        // 判定結果に基づいてストリームフィルタを適用
+        if ($detected_code === CsvCharacterCode::sjis_win) {
+            // Shift-JIS なら UTF-8 変換フィルタを適用
+            $fp = CsvUtils::setStreamFilterRegisterSjisToUtf8($fp);
+        }
+        // UTF-8 の場合は BOM の有無に関わらずフィルタは不要 (BOMは processHeader で除去)
+
+        return $fp;
+    }
+
+    /**
+     * CSVヘッダー行を読み込み、検証し、ヘッダーインデックスマップを返す
+     *
+     * @param resource $fp ファイルポインタ
+     * @param array $expected_headers 期待されるヘッダーの配列
+     * @return array ヘッダー名 => 列インデックス のマップ
+     * @throws Exception ヘッダー読み込み失敗または検証失敗時
+     */
+    private function processHeader($fp, array $expected_headers): array
+    {
+        $actual_header_raw = fgetcsv($fp, 0, ',');
+        if ($actual_header_raw === false || $actual_header_raw === null) {
+            throw new CsvHeaderReadException("CSVヘッダー行の読み取りに失敗しました。");
+        }
+
+        $actual_header = CsvUtils::removeUtf8Bom($actual_header_raw);
+
+        if (!$this->validateHeader($actual_header, $expected_headers)) {
+            throw new CsvInvalidHeaderException('CSVヘッダーが不正です。期待される形式と異なります。');
+        }
+
+        // ヘッダー名から列インデックスへのマップを作成して返す
+        return array_flip($actual_header);
+    }
+
+    /**
+     * CSVデータ行をループ処理し、検証とデータ処理を行う
+     *
+     * @param resource $fp ファイルポインタ
+     * @param array $header_index_map ヘッダー名 => 列インデックス のマップ
+     * @param array $expected_headers 期待されるヘッダーの配列
+     * @param User $importer インポート実行ユーザー
+     * @return void (結果は $this->results プロパティに格納)
+     */
+    private function processRows($fp, array $header_index_map, array $expected_headers, User $importer): void
+    {
+        $line_number = 2; // データは2行目から
+        while (($csv_columns = fgetcsv($fp, 0, ',')) !== false) {
+            // 空行の可能性をチェックしてスキップ
+            if (count($csv_columns) === 1 && ($csv_columns[0] === null || $csv_columns[0] === '')) {
+                continue;
+            }
+
+            try {
+                $validated_data = $this->validateRow($csv_columns, $header_index_map, $line_number, $expected_headers);
+                $this->row_processor->process($validated_data, $this->learningtask_post, $this->page, $importer);
+                $this->results['success']++;
+            } catch (Throwable $e) {
+                $this->handleRowProcessingException($e, $csv_columns, $header_index_map, $line_number);
+            }
+            $line_number++;
+        } // end while
+    }
+
+    /**
+     * エラー詳細情報を結果配列に追加するヘルパーメソッド
+     *
+     * @param int $line_number 行番号
+     * @param string $message エラーメッセージ
+     * @param string $type エラー種別
+     * @param string|null $user_id 関連ユーザーID (取得できれば)
+     * @return void
+     */
+    private function addErrorDetail(int $line_number, string $message, string $type, ?string $user_id = 'N/A'): void
+    {
+        $this->results['error_details'][] = [
+            'line' => $line_number,
+            'userid' => $user_id ?? 'N/A',
+            'message' => $message,
+            'type' => $type,
+        ];
+    }
+
+    /**
+     * スキップ詳細情報を結果配列に追加するヘルパーメソッド
+     *
+     * @param int $line_number 行番号
+     * @param string $message スキップメッセージ
+     * @param string $type スキップ種別
+     * @param string|null $user_id 関連ユーザーID (取得できれば)
+     * @return void
+     */
+    private function addSkipDetail(int $line_number, string $message, string $type, ?string $user_id = 'N/A'): void
+    {
+        $this->results['skip_details'][] = [
+            'line' => $line_number,
+            'userid' => $user_id ?? 'N/A',
+            'message' => $message,
+            'type' => $type,
+        ];
+    }
+
+    /**
+     * 行処理中の例外をハンドリングするヘルパーメソッド
+     *
+     * @param Throwable $e 捕捉した例外/エラー
+     * @param array $csv_columns エラーが発生した行の元データ
+     * @param array $header_index_map ヘッダーインデックスマップ
+     * @param int $line_number エラーが発生した行番号
+     * @return void
+     */
+    private function handleRowProcessingException(Throwable $e, array $csv_columns, array $header_index_map, int $line_number): void
+    {
+        $user_id = $this->getUserIdFromRow($csv_columns, $header_index_map);
+        $message = $e->getMessage();
+
+        // 注入されたハンドラに例外処理を委譲
+        $handling_config = $this->exception_handler->handle($e);
+
+        if ($handling_config) {
+            // --- ハンドラが処理方法を決定できた場合 ---
+            $outcome = $handling_config[RowProcessorExceptionHandlerInterface::KEY_OUTCOME]; // 'error' or 'skip'
+            $type = $handling_config[RowProcessorExceptionHandlerInterface::KEY_TYPE];
+            $log_level = $handling_config[RowProcessorExceptionHandlerInterface::KEY_LOG_LEVEL];
+
+            // ValidationException の場合はメッセージを整形する
+            if ($e instanceof ValidationException) {
+                $message = $this->exception_handler->formatValidationMessage($e);
+            }
+
+            if ($outcome === RowProcessorExceptionHandlerInterface::OUTCOME_SKIP) {
+                $this->results['skipped']++;
+                $this->addSkipDetail($line_number, $message, $type, $user_id);
+                Log::$log_level("CSV Import Skipped (Line: {$line_number}): Type={$type} - " . $message);
+            } else { // outcome === 'error'
+                $this->results['errors']++;
+                $this->addErrorDetail($line_number, $message, $type, $user_id);
+                Log::$log_level("CSV Import Error (Line: {$line_number}): Type={$type} - " . $message);
+            }
+
+        } else {
+            // --- ハンドラが処理できなかった予期せぬ例外 ---
+            $this->results['errors']++;
+            $this->addErrorDetail($line_number, $message, 'unexpected_error', $user_id);
+            Log::error("CSV Import Unexpected Error (Line: {$line_number}): " . $message . "\n" . $e->getTraceAsString());
+        }
+    }
+
+    // ===============================================
+    // Core Validation/Permission Methods
+    // ===============================================
+
+    /**
+     * CSVヘッダー行を検証する
+     * (期待されるヘッダーが全て含まれているかを確認する)
+     *
+     * @param array $actual_header CSVファイルから読み込んだヘッダー
+     * @param array $expected_headers 動的に決定された期待されるヘ Dダー
+     * @return bool 検証OKなら true
+     */
+    protected function validateHeader(array $actual_header, array $expected_headers): bool
+    {
+        // 期待されるヘッダーが実際のヘッダーに全て含まれているか (順不同)
+        return count(array_diff($expected_headers, $actual_header)) === 0;
+    }
+
+    /**
+     * CSVデータ1行分を検証する (ColumnDefinition からルール/メッセージを取得)
+     *
+     * @param array $csv_columns fgetcsv からの数値インデックス配列
+     * @param array $header_index_map ヘッダー名 => 列インデックス のマップ
+     * @param int $line_number 現在の行番号
+     * @param array $expected_headers この課題で期待されるヘッダーリスト
+     * @return array 検証済みデータ (内部キー名 => 値)
+     * @throws ValidationException バリデーション失敗時
+     */
+    protected function validateRow(array $csv_columns, array $header_index_map, int $line_number, array $expected_headers): array
+    {
+        $mapped_data = [];
+        $rules = $this->column_definition->getValidationRulesBase();
+        // メッセージを $column_definition から取得 (存在すれば)
+        $messages = method_exists($this->column_definition, 'getValidationMessages')
+                    ? $this->column_definition->getValidationMessages()
+                    : []; // 存在しない or 不要な場合は空配列
+
+        // カラムマップも $column_definition から取得
+        $column_map = $this->column_definition->getColumnMap();
+
+        // 期待ヘッダーに基づいてデータをマップし、適用するルールを決定
+        $active_rules = []; // この行で実際に適用するルール
+        foreach ($expected_headers as $header_name) {
+            $internal_key = $column_map[$header_name] ?? null;
+            if ($internal_key === null) {
+                // ヘッダー名がマップに存在しない場合はスキップ
+                continue;
+            }
+            // 値を取得
+            $column_index = $header_index_map[$header_name] ?? null;
+            $value = ($column_index !== null && array_key_exists($column_index, $csv_columns))
+                    ? $csv_columns[$column_index]
+                    : null;
+            $mapped_data[$internal_key] = $value;
+
+            // この内部キーに対応するルールが存在すれば、適用対象に追加
+            if (array_key_exists($internal_key, $rules)) {
+                $active_rules[$internal_key] = $rules[$internal_key];
+            }
+        }
+
+        // 実際に適用するルール ($active_rules) で Validator を作成
+        $validator = Validator::make($mapped_data, $active_rules, $messages);
+        $validator->validate(); // 失敗時は ValidationException
+
+        return $validator->validated(); // 内部キー名 => 値 の配列
+    }
+
+    /**
+     * エラー報告用に、数値インデックスの行データからユーザーIDを取得する試み
+     *
+     * @param array $csv_columns fgetcsv からの数値インデックス配列
+     * @param array $header_index_map ヘッダー名 => 列インデックス のマップ
+     * @return string ユーザーID または 'N/A'
+     */
+    private function getUserIdFromRow(array $csv_columns, array $header_index_map): string
+    {
+        $login_id_header = 'ログインID'; // ログインIDのヘッダー名
+        if (isset($header_index_map[$login_id_header])) {
+            $index = $header_index_map[$login_id_header];
+            if (isset($csv_columns[$index])) {
+                return (string) $csv_columns[$index]; // 文字列として返す
+            }
+        }
+        return 'N/A'; // 見つからない場合
+    }
+
+    /**
+     * 指定されたユーザーがインポートを実行する権限を持っているかチェックする (管理者 or 担当教員)
+     *
+     * @param User $user インポートを実行しようとしているユーザー
+     * @return bool 許可されていれば true
+     */
+    public function canImport(User $user): bool
+    {
+        // 管理者権限チェック
+        if ($user->can('role_article_admin')) {
+            return true;
+        }
+
+        // 担当教員かチェック
+        $teachers = $this->user_repository->getTeachers($this->learningtask_post, $this->page);
+        // コレクション内にユーザーIDが存在するかどうかで判定
+        if ($teachers->contains('id', $user->id)) {
+            return true;
+        }
+
+        // どちらでもなければ拒否
+        return false;
+    }
+
+}

--- a/app/Plugins/User/Learningtasks/Csv/LearningtasksCsvImporter.php
+++ b/app/Plugins/User/Learningtasks/Csv/LearningtasksCsvImporter.php
@@ -424,5 +424,4 @@ class LearningtasksCsvImporter
         // どちらでもなければ拒否
         return false;
     }
-
 }

--- a/app/Plugins/User/Learningtasks/Exceptions/AlreadyEvaluatedException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/AlreadyEvaluatedException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Exceptions;
+
+use Exception;
+
+class AlreadyEvaluatedException extends Exception
+{
+    /**
+     * AlreadyEvaluatedException のコンストラクタ。
+     *
+     * @param string $message エラーメッセージ。指定されなければデフォルト値を使用。
+     * @param int $code エラーコード。
+     * @param Throwable|null $previous 前の例外（例外チェーン用）。
+     */
+    public function __construct(
+        string $message = "対象の提出は既に評価済みです。", // デフォルトメッセージ
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        // 親クラス (Exception) のコンストラクタを呼び出す
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Plugins/User/Learningtasks/Exceptions/CsvFileOpenException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/CsvFileOpenException.php
@@ -8,7 +8,8 @@ use Throwable;
 /**
  * CSVファイルを開けなかった場合にスローされるカスタム例外クラス。
  */
-class CsvFileOpenException extends Exception {
+class CsvFileOpenException extends Exception
+{
     /**
      * CsvFileOpenException のコンストラクタ。
      *
@@ -17,7 +18,8 @@ class CsvFileOpenException extends Exception {
      * @param Throwable|null $previous 前の例外（例外チェーン用）。
      * @throws Throwable
      */
-    public function __construct(string $message = "CSVファイルを開けませんでした。", int $code = 0, ?Throwable $previous = null) {
+    public function __construct(string $message = "CSVファイルを開けませんでした。", int $code = 0, ?Throwable $previous = null)
+    {
         parent::__construct($message, $code, $previous);
     }
 }

--- a/app/Plugins/User/Learningtasks/Exceptions/CsvFileOpenException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/CsvFileOpenException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Exceptions;
+
+use Exception;
+use Throwable;
+
+/**
+ * CSVファイルを開けなかった場合にスローされるカスタム例外クラス。
+ */
+class CsvFileOpenException extends Exception {
+    /**
+     * CsvFileOpenException のコンストラクタ。
+     *
+     * @param string $message エラーメッセージ。指定されなければデフォルト値を使用。
+     * @param int $code エラーコード。
+     * @param Throwable|null $previous 前の例外（例外チェーン用）。
+     * @throws Throwable
+     */
+    public function __construct(string $message = "CSVファイルを開けませんでした。", int $code = 0, ?Throwable $previous = null) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Plugins/User/Learningtasks/Exceptions/CsvHeaderReadException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/CsvHeaderReadException.php
@@ -8,7 +8,8 @@ use Throwable;
 /**
  * CSVヘッダー行の読み取りに失敗した場合にスローされるカスタム例外クラス。
  */
-class CsvHeaderReadException extends Exception {
+class CsvHeaderReadException extends Exception
+{
     /**
      * CsvHeaderReadException のコンストラクタ。
      *
@@ -17,7 +18,8 @@ class CsvHeaderReadException extends Exception {
      * @param Throwable|null $previous 前の例外（例外チェーン用）。
      * @throws Throwable
      */
-     public function __construct(string $message = "CSVヘッダー行の読み取りに失敗しました。", int $code = 0, ?Throwable $previous = null) {
+    public function __construct(string $message = "CSVヘッダー行の読み取りに失敗しました。", int $code = 0, ?Throwable $previous = null)
+    {
         parent::__construct($message, $code, $previous);
     }
 }

--- a/app/Plugins/User/Learningtasks/Exceptions/CsvHeaderReadException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/CsvHeaderReadException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Exceptions;
+
+use Exception;
+use Throwable;
+
+/**
+ * CSVヘッダー行の読み取りに失敗した場合にスローされるカスタム例外クラス。
+ */
+class CsvHeaderReadException extends Exception {
+    /**
+     * CsvHeaderReadException のコンストラクタ。
+     *
+     * @param string $message エラーメッセージ。指定されなければデフォルト値を使用。
+     * @param int $code エラーコード。
+     * @param Throwable|null $previous 前の例外（例外チェーン用）。
+     * @throws Throwable
+     */
+     public function __construct(string $message = "CSVヘッダー行の読み取りに失敗しました。", int $code = 0, ?Throwable $previous = null) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Plugins/User/Learningtasks/Exceptions/CsvInvalidHeaderException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/CsvInvalidHeaderException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Exceptions;
+
+use Exception;
+use Throwable;
+
+/**
+ * CSVヘッダーが不正な場合にスローされるカスタム例外クラス。
+ */
+class CsvInvalidHeaderException extends Exception {
+    /**
+     * CsvInvalidHeaderException のコンストラクタ。
+     *
+     * @param string $message エラーメッセージ。指定されなければデフォルト値を使用。
+     * @param int $code エラーコード。
+     * @param Throwable|null $previous 前の例外（例外チェーン用）。
+     * @throws Throwable
+     */
+    public function __construct(string $message = "CSVヘッダーが不正です。", int $code = 0, ?Throwable $previous = null) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Plugins/User/Learningtasks/Exceptions/CsvInvalidHeaderException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/CsvInvalidHeaderException.php
@@ -8,7 +8,8 @@ use Throwable;
 /**
  * CSVヘッダーが不正な場合にスローされるカスタム例外クラス。
  */
-class CsvInvalidHeaderException extends Exception {
+class CsvInvalidHeaderException extends Exception
+{
     /**
      * CsvInvalidHeaderException のコンストラクタ。
      *

--- a/app/Plugins/User/Learningtasks/Exceptions/CsvInvalidHeaderException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/CsvInvalidHeaderException.php
@@ -18,7 +18,8 @@ class CsvInvalidHeaderException extends Exception
      * @param Throwable|null $previous 前の例外（例外チェーン用）。
      * @throws Throwable
      */
-    public function __construct(string $message = "CSVヘッダーが不正です。", int $code = 0, ?Throwable $previous = null) {
+    public function __construct(string $message = "CSVヘッダーが不正です。", int $code = 0, ?Throwable $previous = null)
+    {
         parent::__construct($message, $code, $previous);
     }
 }

--- a/app/Plugins/User/Learningtasks/Exceptions/FeatureDisabledException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/FeatureDisabledException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Exceptions;
+
+use Exception;
+use Throwable;
+
+/**
+ * 関連する設定が無効になっているため、機能が利用できない場合にスローされる例外
+ */
+class FeatureDisabledException extends Exception
+{
+    public function __construct(string $message = "指定された機能は無効になっています。", int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Plugins/User/Learningtasks/Exceptions/InvalidStudentException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/InvalidStudentException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Exceptions;
+
+use Exception;
+use Throwable;
+
+/**
+ * インポート対象のユーザーが、当該課題の受講生として登録されていない場合に
+ * スローされるカスタム例外クラス。
+ */
+class InvalidStudentException extends Exception
+{
+    /**
+     * InvalidStudentException のコンストラクタ。
+     *
+     * @param string $message エラーメッセージ。指定されなければデフォルト値を使用。
+     * @param int $code エラーコード。
+     * @param Throwable|null $previous 前の例外（例外チェーン用）。
+     */
+    public function __construct(
+        string $message = "指定されたユーザーはこの課題の受講生ではありません。", // デフォルトメッセージ
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        // 親クラス (Exception) のコンストラクタを呼び出す
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Plugins/User/Learningtasks/Exceptions/SubmissionNotFoundException.php
+++ b/app/Plugins/User/Learningtasks/Exceptions/SubmissionNotFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Exceptions;
+
+use Exception;
+use Throwable;
+
+/**
+ * 評価対象となる提出記録が見つからない場合にスローされる例外
+ */
+class SubmissionNotFoundException extends Exception
+{
+    /**
+     * コンストラクタ
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(string $message = "評価対象の提出記録が見つかりません。", int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Plugins/User/Learningtasks/Factories/ColumnDefinitionFactory.php
+++ b/app/Plugins/User/Learningtasks/Factories/ColumnDefinitionFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Factories;
+
+use App\Enums\LearningtaskImportType;
+use App\Enums\LearningtaskUseFunction;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Plugins\User\Learningtasks\Contracts\ColumnDefinitionInterface;
+use App\Plugins\User\Learningtasks\Exceptions\FeatureDisabledException;
+use App\Plugins\User\Learningtasks\Services\LearningtaskReportColumnDefinition;
+use App\Plugins\User\Learningtasks\Services\LearningtaskSettingChecker;
+use InvalidArgumentException;
+
+/**
+ * インポートタイプに基づいて ColumnDefinition インスタンスを生成する Factory クラス
+ */
+class ColumnDefinitionFactory
+{
+    /**
+     * 指定されたインポートタイプに対応する ColumnDefinition オブジェクトを生成する。
+     *
+     * @param string $import_type インポート種別を示す文字列 ('report', 'exam' など)
+     * @param LearningtasksPosts $post カラム定義のコンテキストとなる課題投稿オブジェクト
+     * @return ColumnDefinitionInterface 生成された ColumnDefinition 実装インスタンス
+     * @throws InvalidArgumentException 未知のインポートタイプが指定された場合
+     */
+    public function make(string $import_type, LearningtasksPosts $post): ColumnDefinitionInterface
+    {
+        // ColumnDefinition (例: Report) は SettingChecker を必要とし、
+        // SettingChecker は $post を必要とするため、ここでまず SettingChecker を生成する。
+        $setting_checker = new LearningtaskSettingChecker($post);
+
+        // インポートタイプに応じて適切な ColumnDefinition を生成
+        switch ($import_type) {
+            case LearningtaskImportType::report:
+                // レポート評価設定が有効かチェック
+                if (!$setting_checker->isEnabled(LearningtaskUseFunction::use_report_evaluate)) {
+                    // 無効なら専用例外をスロー
+                    throw new FeatureDisabledException("この課題ではレポート評価機能が有効になっていません。");
+                }
+                // 有効ならインスタンスを返す (SettingChecker は渡す必要がある)
+                return new LearningtaskReportColumnDefinition($setting_checker);
+            // case 'exam': タイプが追加された場合の例 (実装クラスはまだない)
+            //     return new LearningtaskExamColumnDefinition($setting_checker); // 将来追加
+            default:
+                throw new InvalidArgumentException("未知のカラム定義タイプ（インポートタイプ）です: {$import_type}");
+        }
+    }
+}

--- a/app/Plugins/User/Learningtasks/Factories/ExceptionHandlerFactory.php
+++ b/app/Plugins/User/Learningtasks/Factories/ExceptionHandlerFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Factories;
+
+use App\Enums\LearningtaskImportType;
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorExceptionHandlerInterface;
+use App\Plugins\User\Learningtasks\Handlers\ReportExceptionHandler;
+// use App\Plugins\User\Learningtasks\Handlers\ExamExceptionHandler; // 将来追加するなら
+use InvalidArgumentException;
+
+class ExceptionHandlerFactory
+{
+    /**
+     * 指定されたインポートタイプに対応する例外ハンドラを生成（または解決）する。
+     *
+     * @param string $import_type インポート種別 ('report', 'exam' など)
+     * @return RowProcessorExceptionHandlerInterface
+     * @throws InvalidArgumentException 未知のタイプが指定された場合
+     */
+    public function make(string $import_type): RowProcessorExceptionHandlerInterface
+    {
+        // ハンドラ自体に依存性注入が必要になる可能性を考慮し、app() で解決するのが望ましい
+        // （ServiceProvider で各ハンドラクラスを bind しておくか、Laravel が自動解決可能なら bind 不要）
+        switch ($import_type) { // PHP 7.x 互換のため switch を使用
+            case LearningtaskImportType::report:
+                return app(ReportExceptionHandler::class);
+            // case 'exam':
+            //     return app(ExamExceptionHandler::class); // 将来追加
+            default:
+                throw new InvalidArgumentException("未知のインポートタイプに対応する例外ハンドラが見つかりません: {$import_type}");
+        }
+    }
+}

--- a/app/Plugins/User/Learningtasks/Factories/RowProcessorFactory.php
+++ b/app/Plugins/User/Learningtasks/Factories/RowProcessorFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Factories;
+
+use App\Enums\LearningtaskImportType;
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorInterface;
+use App\Plugins\User\Learningtasks\Services\LearningtaskEvaluationRowProcessor;
+use InvalidArgumentException;
+
+/**
+ * インポートタイプに基づいて RowProcessor インスタンスを生成する Factory クラス (PHP 7.x 互換)
+ */
+class RowProcessorFactory
+{
+    /**
+     * 指定されたインポートタイプに対応する RowProcessor オブジェクトを生成する。
+     *
+     * @param string $import_type インポート種別を示す文字列 ('report', 'exam' など)
+     * @return RowProcessorInterface 生成された RowProcessor 実装インスタンス
+     * @throws InvalidArgumentException 未知のインポートタイプが指定された場合
+     */
+    public function make(string $import_type): RowProcessorInterface
+    {
+        // $import_type の値に応じて、適切な RowProcessor 実装を返す
+        // 各 Processor 実装自体が依存性を持つ可能性も考慮し、
+        // new する代わりに app() ヘルパーでコンテナから解決するのが望ましい
+        // (ServiceProvider で各実装クラスが bind されているか、自動解決可能である前提)
+        switch ($import_type) {
+            case LearningtaskImportType::report:
+                // ServiceProviderで登録済みの実装クラスをコンテナから解決
+                return app(LearningtaskEvaluationRowProcessor::class);
+
+            // case 'exam': // 将来 'exam' タイプが追加された場合
+            //     return app(LearningtaskExamRowProcessor::class);
+
+            default:
+                 // どの case にも一致しない場合
+                throw new InvalidArgumentException("未知の行処理タイプ（インポートタイプ）です: {$import_type}");
+        }
+    }
+}

--- a/app/Plugins/User/Learningtasks/Handlers/ReportExceptionHandler.php
+++ b/app/Plugins/User/Learningtasks/Handlers/ReportExceptionHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Handlers;
+
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorExceptionHandlerInterface as HandlerInterface;
+use App\Plugins\User\Learningtasks\Exceptions\AlreadyEvaluatedException;
+use App\Plugins\User\Learningtasks\Exceptions\InvalidStudentException;
+use App\Plugins\User\Learningtasks\Exceptions\SubmissionNotFoundException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Validation\ValidationException;
+use Throwable;
+
+class ReportExceptionHandler implements HandlerInterface
+{
+    // このハンドラ固有のエラー/スキップタイプ定数
+    public const TYPE_VALIDATION = 'validation_error';
+    public const TYPE_INVALID_STUDENT = 'invalid_student';
+    public const TYPE_ALREADY_EVALUATED = 'already_evaluated';
+    public const TYPE_SUBMISSION_NOT_FOUND = 'submission_not_found';
+    public const TYPE_USER_NOT_FOUND = 'processing_error_user_not_found';
+
+    /**
+     * レポート評価インポートにおける例外を処理する
+     */
+    public function handle(Throwable $e): ?array
+    {
+        if ($e instanceof ValidationException) {
+            // バリデーションエラーは 'error'
+            return [
+                HandlerInterface::KEY_OUTCOME => HandlerInterface::OUTCOME_ERROR,
+                HandlerInterface::KEY_TYPE => self::TYPE_VALIDATION,
+                HandlerInterface::KEY_LOG_LEVEL => HandlerInterface::LOG_WARN
+            ];
+        } elseif ($e instanceof InvalidStudentException) {
+            // 受講生エラーは 'skip'
+            return [
+                HandlerInterface::KEY_OUTCOME => HandlerInterface::OUTCOME_SKIP,
+                HandlerInterface::KEY_TYPE => self::TYPE_INVALID_STUDENT,
+                HandlerInterface::KEY_LOG_LEVEL => HandlerInterface::LOG_INFO
+            ];
+        } elseif ($e instanceof AlreadyEvaluatedException) {
+            // 評価済みエラーは 'skip'
+            return [
+                HandlerInterface::KEY_OUTCOME => HandlerInterface::OUTCOME_SKIP,
+                HandlerInterface::KEY_TYPE => self::TYPE_ALREADY_EVALUATED,
+                HandlerInterface::KEY_LOG_LEVEL => HandlerInterface::LOG_INFO
+            ];
+        } elseif ($e instanceof SubmissionNotFoundException) {
+            // 提出なしエラーは 'error'
+            return [
+                HandlerInterface::KEY_OUTCOME => HandlerInterface::OUTCOME_ERROR,
+                HandlerInterface::KEY_TYPE => self::TYPE_SUBMISSION_NOT_FOUND,
+                HandlerInterface::KEY_LOG_LEVEL => HandlerInterface::LOG_ERROR
+            ];
+        } elseif ($e instanceof ModelNotFoundException) {
+            // ユーザーが見つからないエラーは 'error'
+            return [
+                HandlerInterface::KEY_OUTCOME => HandlerInterface::OUTCOME_ERROR,
+                HandlerInterface::KEY_TYPE => self::TYPE_USER_NOT_FOUND,
+                HandlerInterface::KEY_LOG_LEVEL => HandlerInterface::LOG_ERROR
+            ];
+        }
+        // 上記以外は処理不能（予期せぬエラー）として null を返す
+        return null;
+    }
+
+    /**
+     * ValidationException のメッセージ整形
+     */
+    public function formatValidationMessage(ValidationException $e): string
+    {
+        return implode(' ', array_merge(...array_values($e->errors())));
+    }
+}

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -37,11 +37,20 @@ use App\Plugins\User\UserPluginBase;
 use App\Utilities\Csv\CsvUtils;
 use App\Utilities\String\StringUtils;
 use App\Enums\CsvCharacterCode;
+use App\Enums\LearningtaskImportType;
 use App\Enums\LearningtasksExaminationColumn;
 use App\Enums\LearningtaskUseFunction;
 use App\Enums\RoleName;
-
+use App\Plugins\User\Learningtasks\Csv\LearningtasksCsvImporter;
+use App\Plugins\User\Learningtasks\Exceptions\FeatureDisabledException;
+use App\Plugins\User\Learningtasks\Factories\ColumnDefinitionFactory;
+use App\Plugins\User\Learningtasks\Factories\ExceptionHandlerFactory;
+use App\Plugins\User\Learningtasks\Factories\RowProcessorFactory;
+use App\Plugins\User\Learningtasks\Repositories\LearningtaskUserRepository;
 use App\Rules\CustomValiWysiwygMax;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 /**
  * 課題管理プラグイン
@@ -122,6 +131,7 @@ class LearningtasksPlugin extends UserPluginBase
             'uploadCsvExaminations',
             'downloadCsvFormatExaminations',
             'downloadCsvExaminations',
+            'importCsv',
         ];
         return $functions;
     }
@@ -171,6 +181,7 @@ class LearningtasksPlugin extends UserPluginBase
         $role_check_table["changeStatus7"]    = array('role_guest');
         $role_check_table["changeStatus8"]    = array('role_guest');
         $role_check_table["downloadCsvReport"] = array('role_article_admin', 'role_guest');
+        $role_check_table["importCsv"] = array('role_guest');
         return $role_check_table;
     }
 
@@ -3618,6 +3629,121 @@ class LearningtasksPlugin extends UserPluginBase
 
         // CSV出力
         return $exporter->export(url('/'), $request->character_code);
+    }
+
+    /**
+     * CSVインポート処理 (文字コード自動判定)
+     *
+     * @param Request $request
+     * @param int $page_id
+     * @param int $frame_id
+     * @param int $id LearningtasksPosts の ID
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function importCsv(Request $request, int $page_id, int $frame_id, int $id)
+    {
+        $page = $this->page;
+        $post = LearningtasksPosts::with(['learningtask', 'post_settings'])->findOrFail($id);
+
+        // 画面エラーチェック
+        $validator = Validator::make($request->all(), [
+            'csv_file' => [
+                'required',        // 必須
+                'file',            // アップロードファイル
+                'mimes:csv,txt',   // MIMEタイプ制限
+            ],
+            'import_type' => ['required', Rule::in(LearningtaskImportType::getMemberKeys())]
+        ]);
+        $validator->setAttributeNames(['csv_file' => 'CSVファイル', 'import_type' => 'インポート形式']);
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $uploaded_file = $request->file('csv_file');
+        $import_type = $request->import_type;
+        try {
+            $user_repository = app(LearningtaskUserRepository::class);
+            $column_definition_factory = app(ColumnDefinitionFactory::class);
+            $row_processor_factory = app(RowProcessorFactory::class);
+            $exception_handler_factory = app(ExceptionHandlerFactory::class);
+            $column_definition = $column_definition_factory->make($import_type, $post);
+            $row_processor = $row_processor_factory->make($import_type);
+            $exception_handler = $exception_handler_factory->make($import_type);
+            $importer = new LearningtasksCsvImporter($post, $page, $column_definition, $row_processor, $user_repository, $exception_handler);
+        } catch (FeatureDisabledException $e) { // 評価設定などが無効になっている
+            Log::warning("CSV Import rejected for post ID {$id}: " . $e->getMessage());
+            return back()->with('error', $e->getMessage());
+        } catch (InvalidArgumentException $e) { // Factory での未知のタイプ等
+            Log::warning("CSV Import - Invalid argument for factory: " . $e->getMessage());
+            return back()->with('error', '無効なインポートタイプが指定されたか、処理の準備に失敗しました。');
+        } catch (Exception $e) {
+            Log::error("CSV Import - Service instantiation failed for post ID {$id}: " . $e->getMessage());
+            return redirect()->back()->with('error', 'インポート処理の準備に失敗しました。');
+        }
+
+        // 権限チェック
+        $current_user = Auth::user();
+        if (!$importer->canImport($current_user)) {
+            Log::error("CSV Import - Permission check failed for post ID {$id} by user ID {$current_user->id}");
+            abort(403, 'レポート評価CSVをインポートする権限がありません。');
+        }
+
+        // インポート実行
+        try {
+            $results = $importer->import($uploaded_file, $current_user);
+            // 結果を整形してフィードバックメッセージと共にリダイレクト
+            $request->flash_message = $this->formatImportResultFeedback($results);
+            // リダイレクト先はviewで指定される
+        } catch (Exception $e) {
+            // Importer 内で捕捉されなかった予期せぬ例外、または Importer が投げたファイル/判定エラーなど
+            Log::error("CSV Import - Unhandled exception or file/detection error for post ID {$id}: " . $e->getMessage() . "\n" . $e->getTraceAsString());
+            return redirect()->back()->with('error', 'CSVインポート処理中にエラーが発生しました: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * インポート結果($results配列)をユーザーへのフィードバックメッセージに整形する。
+     * 必要に応じてエラー/スキップ詳細をセッションにフラッシュ格納する。
+     *
+     * @param array $results Importerから返された結果配列
+     * @return string 表示するメッセージ文字列
+     * 例:
+     * - 成功のみ: "CSVインポート処理完了：成功 10件。"
+     * - スキップのみ: "CSVインポート処理完了：成功 8件 / スキップ 2件。一部スキップされた行があります。"
+     * - エラーのみ: "CSVインポート処理完了：成功 7件 / エラー 3件。エラー内容を確認してください。"
+     * - エラーとスキップ混在: "CSVインポート処理完了：成功 5件 / スキップ 2件 / エラー 3件。エラー内容を確認してください。"
+     */
+    private function formatImportResultFeedback(array $results): string
+    {
+        // ベースとなるメッセージを作成
+        $message = "CSVインポート処理完了：";
+        $message .= "成功 {$results['success']}件";
+        if ($results['skipped'] > 0) {
+            $message .= " / スキップ {$results['skipped']}件";
+        }
+        if ($results['errors'] > 0) {
+            $message .= " / エラー {$results['errors']}件";
+        }
+
+        if ($results['errors'] > 0) {
+            // エラーがある場合は詳細をセッションへフラッシュ
+            session()->flash('csv_import_errors', $results['error_details']);
+        }
+        if ($results['skipped'] > 0) {
+            // スキップがある場合は詳細をセッションへフラッシュ
+            session()->flash('csv_import_skipped_details', $results['skip_details']);
+        }
+
+        // 追記メッセージの決定 (エラー優先)
+        if ($results['errors'] > 0) {
+            $message .= '。エラー内容を確認してください。'; // エラーがあればこちら
+        } elseif ($results['skipped'] > 0) {
+            $message .= '。一部スキップされた行があります。'; // エラーがなくスキップがある場合
+        } else {
+             $message .= '。'; // 成功の場合
+        }
+
+        return $message;
     }
 
     // delete: 権限設定廃止のためコメントアウト

--- a/app/Plugins/User/Learningtasks/Providers/LearningtasksServiceProvider.php
+++ b/app/Plugins/User/Learningtasks/Providers/LearningtasksServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorInterface;
+use App\Plugins\User\Learningtasks\Handlers\ReportExceptionHandler;
+use App\Plugins\User\Learningtasks\Services\LearningtaskEvaluationRowProcessor;
+use App\Plugins\User\Learningtasks\Repositories\LearningtaskUserRepository;
+
+class LearningtasksServiceProvider extends ServiceProvider
+{
+    /**
+     * サービスコンテナへの登録を定義する
+     *
+     * @return void
+     */
+    public function register()
+    {
+        // Learningtasks プラグイン固有のサービス登録を行う
+
+        // インターフェースと実装の紐付け
+        $this->app->bind(
+            RowProcessorInterface::class,
+            LearningtaskEvaluationRowProcessor::class,
+        );
+        $this->app->bind(ReportExceptionHandler::class);
+
+        // ステートレスなリポジトリをシングルトンとして登録
+        $this->app->singleton(LearningtaskUserRepository::class);
+    }
+
+    /**
+     * サービスの起動処理を定義する
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        // ルート定義、ビューコンポーザ、設定ファイルの公開などが必要な場合
+    }
+}

--- a/app/Plugins/User/Learningtasks/Repositories/LearningtaskUserRepository.php
+++ b/app/Plugins/User/Learningtasks/Repositories/LearningtaskUserRepository.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Repositories;
+
+use App\Enums\RoleName;
+use App\Models\Common\Page;
+use App\Models\Common\PageRole;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB; // DB ファサードを利用
+
+/**
+ * 課題管理に関連するユーザー（受講生、教員）を取得するリポジトリクラス
+ */
+class LearningtaskUserRepository
+{
+    /**
+     * 指定された課題投稿に関連する受講生を取得する
+     *
+     * 課題投稿の student_join_flag 設定に基づいて取得ロジックを分岐する。
+     *
+     * @param LearningtasksPosts $learningtask_post 対象の課題投稿
+     * @param Page $page 課題が配置されているページ
+     * @return Collection 受講生ユーザーモデルのコレクション
+     */
+    public function getStudents(LearningtasksPosts $learningtask_post, Page $page): Collection
+    {
+        // student_join_flag = 2: 配置ページのメンバーシップユーザー全員
+        if ($learningtask_post->student_join_flag == 2) {
+            // 配置ページのメンバーシップユーザーから受講生ロールを持つユーザーを取得
+            return $this->fetchMembershipUsers($page, RoleName::student);
+        }
+
+        // student_join_flag = 3 (またはその他): 課題投稿に直接紐づけられたユーザー
+        return $this->fetchLearningtaskPostStudents($learningtask_post);
+    }
+
+    /**
+     * 指定された課題投稿に関連する教員を取得する
+     *
+     * 課題投稿の teacher_join_flag 設定に基づいて取得ロジックを分岐する。
+     *
+     * @param LearningtasksPosts $learningtask_post 対象の課題投稿
+     * @param Page $page 課題が配置されているページ
+     * @return Collection 教員ユーザーモデルのコレクション
+     */
+    public function getTeachers(LearningtasksPosts $learningtask_post, Page $page): Collection
+    {
+        // teacher_join_flag = 2: 配置ページのメンバーシップユーザー全員
+        if ($learningtask_post->teacher_join_flag == 2) {
+             // 配置ページのメンバーシップユーザーから教員ロールを持つユーザーを取得
+            return $this->fetchMembershipUsers($page, RoleName::teacher);
+        }
+
+        // teacher_join_flag = 3 (またはその他): 課題投稿に直接紐づけられたユーザー
+        return $this->fetchLearningtaskPostTeachers($learningtask_post);
+    }
+
+    /**
+     * 配置ページのメンバーシップユーザー（指定ロール）を取得する
+     * (Traitから移植した private ヘルパーメソッド)
+     *
+     * @param Page $page 配置ページ
+     * @param string $role_name ロール名 (RoleName enum の値)
+     * @return Collection
+     */
+    private function fetchMembershipUsers(Page $page, string $role_name): Collection
+    {
+        // メンバーシップを継承している親ページを取得
+        $membership_page = $page->getInheritMembershipPage();
+
+        // メンバーシップページに関連づくグループIDを取得
+        $group_ids = PageRole::select('group_id')
+            ->where('page_id', optional($membership_page)->id) // 親ページがない場合も考慮
+            ->groupBy('group_id')
+            ->get()
+            ->pluck('group_id');
+
+        // グループがなければ空のコレクションを返す
+        if ($group_ids->isEmpty()) {
+            return new Collection();
+        }
+
+        // 該当グループに所属し、かつ指定されたロールを持つユーザーを取得
+        return User::query()
+            ->whereHas('group_users', function ($query) use ($group_ids) {
+                $query->whereIn('group_id', $group_ids);
+            })
+            ->whereExists(function ($query) use ($role_name) {
+                $query->select(DB::raw(1))
+                    ->from('users_roles')
+                    ->whereRaw('users_roles.users_id = users.id')
+                    ->where('users_roles.target', '=', 'original_role') // 元々の役割
+                    ->where('users_roles.role_name', '=', $role_name);
+            })
+            ->orderBy('users.id')
+            ->get();
+    }
+
+    /**
+     * 課題投稿に直接紐づけられた受講生を取得する
+     *
+     * @param LearningtasksPosts $learningtask_post
+     * @return Collection
+     */
+    private function fetchLearningtaskPostStudents(LearningtasksPosts $learningtask_post): Collection
+    {
+        // 'students' リレーションからユーザーIDを取得 (リレーションが存在する前提)
+        $student_user_ids = $learningtask_post->students->pluck('user_id');
+
+        if ($student_user_ids->isEmpty()) {
+            return new Collection();
+        }
+
+        return User::whereIn('id', $student_user_ids)->orderBy('id')->get();
+    }
+
+    /**
+     * 課題投稿に直接紐づけられた教員を取得する
+     *
+     * @param LearningtasksPosts $learningtask_post
+     * @return Collection
+     */
+    private function fetchLearningtaskPostTeachers(LearningtasksPosts $learningtask_post): Collection
+    {
+        // 'teachers' リレーションからユーザーIDを取得 (リレーションが存在する前提)
+        $teacher_user_ids = $learningtask_post->teachers->pluck('user_id');
+
+        if ($teacher_user_ids->isEmpty()) {
+            return new Collection();
+        }
+
+        return User::whereIn('id', $teacher_user_ids)->orderBy('id')->get();
+    }
+}

--- a/app/Plugins/User/Learningtasks/Services/LearningtaskEvaluationRowProcessor.php
+++ b/app/Plugins/User/Learningtasks/Services/LearningtaskEvaluationRowProcessor.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Services;
+
+use App\Models\Common\Page;
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorInterface;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Models\User\Learningtasks\LearningtasksUsersStatuses;
+use App\Plugins\User\Learningtasks\Exceptions\AlreadyEvaluatedException;
+use App\Plugins\User\Learningtasks\Exceptions\InvalidStudentException;
+use App\Plugins\User\Learningtasks\Exceptions\SubmissionNotFoundException;
+use App\Plugins\User\Learningtasks\Repositories\LearningtaskUserRepository;
+use App\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * 検証済みのCSVデータ1行を処理し、課題管理の新しい評価記録を作成するクラス
+ * (評価済みチェックを含む)
+ */
+class LearningtaskEvaluationRowProcessor implements RowProcessorInterface
+{
+    /**
+     * ユーザーリポジトリ
+     * @var LearningtaskUserRepository
+     */
+    private LearningtaskUserRepository $user_repository;
+
+    /**
+     * 受講生リストのキャッシュ用プロパティ (初回アクセス時にロード)
+     * @var \Illuminate\Support\Collection|null
+     */
+    private ?Collection $cached_students = null;
+
+    /**
+     * コンストラクタで UserRepository を注入
+     * @param LearningtaskUserRepository $user_repository
+     */
+    public function __construct(LearningtaskUserRepository $user_repository)
+    {
+        $this->user_repository = $user_repository;
+    }
+
+    /**
+     * 検証済みの評価データ1行分を処理し、新しい評価レコードを作成する。
+     *
+     * 最新の提出記録が存在し、かつ、その提出がまだ評価されていない場合にのみ、
+     * 新しい評価レコード (task_status = 2) を作成する。
+     *
+     * @param array $validated_data 検証済みデータ
+     * @param LearningtasksPosts $post 課題投稿コンテキスト
+     * @param Page $page ページ情報
+     * @param User $importer インポート実行ユーザー
+     * @return void
+     * @throws ModelNotFoundException ユーザーが見つからない場合
+     * @throws Exception 提出記録が見つからない場合、DB作成に失敗した場合
+     * @throws Exception (またはカスタム例外) 最新の提出が既に評価済みの場合
+     */
+    public function process(array $validated_data, LearningtasksPosts $post, Page $page, User $importer): void
+    {
+        // 対象となるユーザーを特定
+        try {
+            $user = User::where('userid', $validated_data['userid'])->firstOrFail();
+        } catch (ModelNotFoundException $e) {
+            throw new ModelNotFoundException("指定されたログインIDのユーザーが見つかりません: " . $validated_data['userid'], $e->getCode(), $e);
+        }
+
+        // 受講生チェック
+        $this->ensureUserIsValidStudent($user, $post, $page);
+
+        // このユーザー/課題における最新の「提出」記録を取得
+        $latest_submit = LearningtasksUsersStatuses::where('post_id', $post->id)
+            ->where('user_id', $user->id)
+            ->where('task_status', 1)
+            ->orderByDesc('id')
+            ->first();
+
+        if (!$latest_submit) {
+            throw new SubmissionNotFoundException("評価対象の提出記録がユーザー ({$user->userid}) に見つかりません。");
+        }
+
+        // 最新の提出が既に評価済みかチェック
+        // ヒューリスティック: 最新提出のIDより大きいIDを持つ評価レコード(task_status=2)が存在するか？
+        $already_evaluated = LearningtasksUsersStatuses::where('post_id', $post->id)
+            ->where('user_id', $user->id)
+            ->where('task_status', 2) // 評価ステータス
+            ->where('id', '>', $latest_submit->id) // 最新提出より後のレコード
+            ->exists(); // 存在するかどうかだけチェック
+
+        if ($already_evaluated) {
+            // 既に評価が存在する場合は、エラーとして例外を投げる
+            throw new AlreadyEvaluatedException("ユーザー ({$user->userid}) の最新の提出は既に評価済みのため、インポートできません。");
+        }
+
+        // 保存すべき評価データが validated_data に存在するかチェック
+        if (!$this->hasEvaluation($validated_data)) {
+            Log::info("Skipping evaluation record creation for user {$validated_data['userid']} on post {$post->id}: Validated data does not contain grade to save.");
+            return;
+        }
+
+        // 新しい評価記録 (task_status = 2) を作成
+        // (評価済みチェックを通過した場合のみ実行される)
+        LearningtasksUsersStatuses::create([
+            'post_id'       => $post->id,
+            'user_id'       => $user->id,
+            'task_status'   => 2,
+            'grade'         => $validated_data['grade'] ?? null,
+            'comment'       => $validated_data['comment'] ?? null,
+            'upload_id'     => null,
+            'examination_id'=> 0,
+            'created_id'    => $importer->id,
+            'created_name'  => $importer->name,
+        ]);
+    }
+
+    // ===============================================
+    // Private Helper Methods
+    // ===============================================
+
+    /**
+     * 指定されたユーザーが、与えられた課題投稿の有効な受講生であるか検証する（キャッシュ利用）。
+     * 受講生でない場合は InvalidStudentException をスローする。
+     *
+     * @param User $user 検証対象のユーザー
+     * @param LearningtasksPosts $post 対象の課題投稿
+     * @param Page $page 対象のページ
+     * @return void
+     * @throws InvalidStudentException ユーザーが有効な受講生でない場合
+     * @throws Exception ページ情報がないなど、チェック自体が実行できない場合 (UserRepository側で発生する可能性)
+     */
+    private function ensureUserIsValidStudent(User $user, LearningtasksPosts $post, Page $page): void
+    {
+        // キャッシュがまだなければ取得・格納
+        if ($this->cached_students === null) {
+            $this->cached_students = $this->user_repository->getStudents($post, $page);
+        }
+
+        // キャッシュされたリストに含まれているかチェック
+        if (!$this->cached_students->contains('id', $user->id)) {
+            // 含まれていなければ例外をスロー
+            throw new InvalidStudentException("ユーザー ({$user->userid}) はこの課題 ({$post->post_title}) の受講生として登録されていません。");
+        }
+    }
+
+    /**
+     * 保存すべき評価データが validated_data に存在するかチェック
+     *
+     * @param array $validated_data
+     * @return bool
+     */
+    private function hasEvaluation(array $validated_data): bool
+    {
+        $has_grade_data = array_key_exists('grade', $validated_data)
+                           && !is_null($validated_data['grade'])
+                           && $validated_data['grade'] !== '';
+        // 評価が設定されていればOK
+        if ($has_grade_data) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinition.php
+++ b/app/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinition.php
@@ -55,18 +55,18 @@ class LearningtaskReportColumnDefinition implements ColumnDefinitionInterface //
     {
         // エクスポートと同じヘッダーを期待する
         $header_columns = ['ログインID', 'ユーザ名', '提出日時', '提出回数'];
-         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_comment)) {
-             $header_columns[] = '本文';
-         }
-         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_file)) {
-             $header_columns[] = 'ファイルURL';
-         }
-         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_evaluate)) {
-             $header_columns[] = '評価';
-         }
-         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_evaluate_comment)) {
-             $header_columns[] = '評価コメント';
-         }
+        if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_comment)) {
+            $header_columns[] = '本文';
+        }
+        if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_file)) {
+            $header_columns[] = 'ファイルURL';
+        }
+        if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_evaluate)) {
+            $header_columns[] = '評価';
+        }
+        if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_evaluate_comment)) {
+            $header_columns[] = '評価コメント';
+        }
         return $header_columns;
     }
 

--- a/app/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinition.php
+++ b/app/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinition.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Services;
+
+use App\Enums\LearningtaskUseFunction;
+// use App\Models\User\Learningtasks\LearningtasksPosts; // SettingChecker経由なので直接は不要
+use App\Plugins\User\Learningtasks\Contracts\ColumnDefinitionInterface; // ★ 実装するインターフェース
+use Illuminate\Validation\Rule;
+
+/**
+ * ★ レポート評価CSV用カラム定義クラス
+ *
+ * ColumnDefinitionInterface を実装し、レポート評価インポートに特化した
+ * ヘッダーリスト、カラムマップ、バリデーションルールを提供する。
+ */
+class LearningtaskReportColumnDefinition implements ColumnDefinitionInterface // ★ implements を追加
+{
+    /**
+     * CSVヘッダー名と内部キー名のマッピング定義
+     * (レポート評価インポート/エクスポートで関連する可能性のある全カラム)
+     */
+    private const COLUMN_MAP = [
+        'ログインID' => 'userid',
+        'ユーザ名' => 'username',
+        '提出日時' => 'submitted_at',
+        '提出回数' => 'submit_count',
+        '本文' => 'report_comment',
+        'ファイルURL' => 'file_url',
+        '評価' => 'grade',
+        '評価コメント' => 'comment',
+    ];
+
+    /**
+     * 設定有効性を判定するサービス
+     * @var \App\Plugins\User\Learningtasks\Services\LearningtaskSettingChecker
+     */
+    private LearningtaskSettingChecker $setting_checker;
+
+    /**
+     * コンストラクタ (変更なし)
+     * @param LearningtaskSettingChecker $setting_checker 設定有効性を判定するサービス
+     */
+    public function __construct(LearningtaskSettingChecker $setting_checker)
+    {
+        $this->setting_checker = $setting_checker;
+    }
+
+    /**
+     * レポート評価CSVで期待されるヘッダーカラム名のリストを取得する
+     * (ColumnDefinitionInterface の実装)
+     *
+     * @return array ヘッダー文字列の配列
+     */
+    public function getHeaders(): array
+    {
+        // エクスポートと同じヘッダーを期待する
+        $header_columns = ['ログインID', 'ユーザ名', '提出日時', '提出回数'];
+         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_comment)) {
+             $header_columns[] = '本文';
+         }
+         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_file)) {
+             $header_columns[] = 'ファイルURL';
+         }
+         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_evaluate)) {
+             $header_columns[] = '評価';
+         }
+         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_evaluate_comment)) {
+             $header_columns[] = '評価コメント';
+         }
+        return $header_columns;
+    }
+
+    /**
+     * カラムマッピング配列を取得する
+     * (ColumnDefinitionInterface の実装)
+     *
+     * @return array ['CSVヘッダー名' => '内部キー名', ...]
+     */
+    public function getColumnMap(): array
+    {
+        // このクラスが扱う全カラムのマッピングを返す
+        return self::COLUMN_MAP;
+    }
+
+    /**
+     * ヘッダー名に対応する内部キー名を取得する
+     * (ColumnDefinitionInterface の実装)
+     *
+     * @param string $header_name CSVヘッダー名
+     * @return string|null 内部キー名 or null
+     */
+    public function getInternalKey(string $header_name): ?string
+    {
+        return self::COLUMN_MAP[$header_name] ?? null;
+    }
+
+    /**
+     * ★ レポート評価インポート用の基本バリデーションルールを取得する
+     * (ColumnDefinitionInterface の実装)
+     *
+     * @return array ['内部キー名' => ['ルール', ...], ...]
+     */
+    public function getValidationRulesBase(): array
+    {
+        $rules = [
+            'userid' => ['required', 'string', 'exists:users,userid'],
+        ];
+
+        // 'grade' (評価) のルール
+        if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_evaluate)) {
+            $rules['grade'] = [
+                'nullable',
+                'string',
+                Rule::in(['A', 'B', 'C', 'D']),
+            ];
+        } else {
+            $rules['grade'] = ['prohibited'];
+        }
+
+        // 'comment' (評価コメント) のルール
+        if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_evaluate_comment)) {
+            $rules['comment'] = [
+                'nullable',
+                'string',
+                'max:65535',
+                'required_with:grade',
+            ];
+        } else {
+            $rules['comment'] = ['prohibited'];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * ★ (任意) レポート評価インポート用のカスタムバリデーションメッセージを取得する
+     * (ColumnDefinitionInterface の実装)
+     *
+     * @return array ['内部キー名.ルール名' => 'メッセージ', ...]
+     */
+    public function getValidationMessages(): array
+    {
+        return [
+            'userid.required' => 'ログインID列は必須です。',
+            'userid.exists' => 'ログインID列の値が無効です（存在するユーザーを指定してください）。',
+
+            'grade.in' => '評価列の値は A, B, C, D のいずれかである必要があります。',
+            'grade.prohibited' => '評価機能が無効なため、評価列は入力できません（空にしてください）。',
+
+            'comment.max' => '評価コメント列の文字数が多すぎます（最大65,535文字）。',
+            'comment.required_with' => '評価コメント列を入力する場合、評価列にも有効な値（A,B,C,D）が必要です。',
+            'comment.prohibited' => '評価コメント機能が無効なため、評価コメント列は入力できません（空にしてください）。',
+        ];
+    }
+}

--- a/app/Plugins/User/Learningtasks/Services/LearningtaskSettingChecker.php
+++ b/app/Plugins/User/Learningtasks/Services/LearningtaskSettingChecker.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Plugins\User\Learningtasks\Services;
+
+use App\Models\User\Learningtasks\LearningtasksPosts;
+
+/**
+ * 課題管理の設定が有効かどうかを判定するサービスクラス
+ *
+ * 課題投稿固有の設定を優先し、なければ課題管理全体の設定を参照する。
+ */
+class LearningtaskSettingChecker
+{
+    /**
+     * 設定判定の対象となる課題投稿
+     * @var \App\Models\User\Learningtasks\LearningtasksPosts
+     */
+    private LearningtasksPosts $learningtask_post; // プロパティ名は snake_case
+
+    /**
+     * コンストラクタ
+     *
+     * @param LearningtasksPosts $learningtask_post 設定を判定する対象の課題投稿
+     */
+    public function __construct(LearningtasksPosts $learningtask_post)
+    {
+        $this->learningtask_post = $learningtask_post;
+    }
+
+    /**
+     * 指定された機能設定が有効かどうかを判定する
+     *
+     * @param string $setting_name 判定したい設定名 (LearningtaskUseFunction enum の値)
+     * @return bool 有効であれば true、無効であれば false
+     */
+    public function isEnabled(string $setting_name): bool
+    {
+        // 1. 課題投稿固有の設定 (post_settings) を確認
+        $post_setting = $this->learningtask_post->post_settings
+                            ->where('use_function', $setting_name)
+                            ->first();
+
+        if ($post_setting) {
+            // 設定が存在し、値が 'on' なら有効
+            return $post_setting->value === 'on';
+        }
+
+        // 2. 課題投稿固有の設定がなければ、課題管理全体の設定 (learningtask_settings) を確認
+        //    learningtask リレーションが存在しない、または null の可能性を考慮し、
+        //    Null合体演算子 (?->) を使用する
+        $task_setting = $this->learningtask_post->learningtask?->learningtask_settings
+                            ->where('use_function', $setting_name)
+                            ->first();
+
+        if ($task_setting) {
+            // 設定が存在し、値が 'on' なら有効
+            return $task_setting->value === 'on';
+        }
+
+        // どちらにも設定が見つからなければ無効と判断
+        return false;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -182,6 +182,10 @@ $app_array = [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
 
+        /*
+        * Connect-CMS Plugin Service Providers...
+        */
+        App\Plugins\User\Learningtasks\Providers\LearningtasksServiceProvider::class,
     ],
 
     /*
@@ -273,6 +277,7 @@ $app_array = [
         'RoleName' => \App\Enums\RoleName::class,
         'LearningtaskUserJoinFlag' => \App\Enums\LearningtaskUserJoinFlag::class,
         'LearningtasksExaminationColumn' => \App\Enums\LearningtasksExaminationColumn::class,
+        'LearningtaskImportType' => \App\Enums\LearningtaskImportType::class,
         'CounterDesignType' => \App\Enums\CounterDesignType::class,
         'BaseLoginRedirectPage' => \App\Enums\BaseLoginRedirectPage::class,
         'BlogFrameConfig' => \App\Enums\BlogFrameConfig::class,

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
@@ -84,24 +84,26 @@
                     </form>
                 </div>
             </div>
-            {{-- CSV入力 --}}
-            <div class="form-group row">
-                <label class="col-sm-3 text-sm-right">レポート評価インポート</label>
-                <div class="col-sm-9">
-                    <form action="{{url('/')}}/redirect/plugin/learningtasks/importCsv/{{$page->id}}/{{$frame_id}}/{{$post->id}}" name="csv_inport{{$frame_id}}" method="POST" enctype="multipart/form-data">
-                        {{ csrf_field() }}
-                        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/learningtasks/show/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame_id}}">
-                        <input type="hidden" name="import_type" value="{{LearningtaskImportType::report}}">
-                        <input type="file" name="csv_file" class="form-control-file" required>
-                        @include('plugins.common.errors_inline', ['name' => 'csv_file'])
-                        <div class="btn-group">
-                            <button type="submit" class="btn btn-primary btn-sm" onclick="javascript:return confirm('レポート評価をインポートします。よろしいですか？')">
-                                <i class="fas fa-upload"></i> アップロード
-                            </button>
-                        </div>
-                    </form>
+            {{-- レポート評価CSV入力 評価機能有効時のみ --}}
+            @if ($tool->checkFunction(LearningtaskUseFunction::use_report_evaluate))
+                <div class="form-group row">
+                    <label class="col-sm-3 text-sm-right">レポート評価インポート</label>
+                    <div class="col-sm-9">
+                        <form action="{{url('/')}}/redirect/plugin/learningtasks/importCsv/{{$page->id}}/{{$frame_id}}/{{$post->id}}" name="csv_inport{{$frame_id}}" method="POST" enctype="multipart/form-data">
+                            {{ csrf_field() }}
+                            <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/learningtasks/show/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame_id}}">
+                            <input type="hidden" name="import_type" value="{{LearningtaskImportType::report}}">
+                            <input type="file" name="csv_file" class="form-control-file" required>
+                            @include('plugins.common.errors_inline', ['name' => 'csv_file'])
+                            <div class="btn-group">
+                                <button type="submit" class="btn btn-primary btn-sm" onclick="javascript:return confirm('レポート評価をインポートします。よろしいですか？')">
+                                    <i class="fas fa-upload"></i> アップロード
+                                </button>
+                            </div>
+                        </form>
+                    </div>
                 </div>
-            </div>
+            @endif
         </div>
 
         <h5><span class="badge badge-warning">評価中の受講者</span></h5>

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_show.blade.php
@@ -34,6 +34,10 @@
         </div>
     @endif
 
+    {{-- フラッシュメッセージ --}}
+    @include('plugins.common.flash_message')
+    {{-- CSVインポートメッセージ --}}
+    @include('plugins.user.learningtasks.default.learningtasks_show_csv_import_messages')
     {{-- タイトル --}}
     <h2>{!!$post->post_title!!}</h2>
 
@@ -45,7 +49,7 @@
                 データ管理
             </button>
         </div>
-        <div id="data-management-{{$frame_id}}" class="collapse p-2 bg-light border border-light rounded mb-3">
+        <div id="data-management-{{$frame_id}}" class="collapse p-2 bg-light border border-light rounded mb-3 {{ $errors->has('csv_file') ? 'show' : '' }}">
             {{-- CSV出力 --}}
             <div class="form-group row">
                 <label class="col-sm-3 text-sm-right">提出状況CSV</label>
@@ -77,6 +81,24 @@
                                 document.csv_export{{$frame_id}}.submit();
                             }
                         </script>
+                    </form>
+                </div>
+            </div>
+            {{-- CSV入力 --}}
+            <div class="form-group row">
+                <label class="col-sm-3 text-sm-right">レポート評価インポート</label>
+                <div class="col-sm-9">
+                    <form action="{{url('/')}}/redirect/plugin/learningtasks/importCsv/{{$page->id}}/{{$frame_id}}/{{$post->id}}" name="csv_inport{{$frame_id}}" method="POST" enctype="multipart/form-data">
+                        {{ csrf_field() }}
+                        <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/learningtasks/show/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame_id}}">
+                        <input type="hidden" name="import_type" value="{{LearningtaskImportType::report}}">
+                        <input type="file" name="csv_file" class="form-control-file" required>
+                        @include('plugins.common.errors_inline', ['name' => 'csv_file'])
+                        <div class="btn-group">
+                            <button type="submit" class="btn btn-primary btn-sm" onclick="javascript:return confirm('レポート評価をインポートします。よろしいですか？')">
+                                <i class="fas fa-upload"></i> アップロード
+                            </button>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_show_csv_import_messages.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_show_csv_import_messages.blade.php
@@ -1,0 +1,46 @@
+
+{{--
+ * 課題管理　CSVインポートメッセージ
+ *
+ * @author 石垣 佑樹 <ishigaki@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category 課題管理プラグイン
+--}}
+{{-- 例外などのエラーメッセージ --}}
+@if (session('error'))
+    <div class="alert alert-danger">
+        {{session('error')}}
+    </div>
+@endif
+{{-- エラー詳細 --}}
+@if (session('csv_import_errors'))
+    @php
+        $import_errors = collect(session('csv_import_errors'));
+        // 0行目にエラーの概要が格納される
+        $description = $import_errors->where('line', 0)->first()['message'];
+    @endphp
+    <div class="alert alert-danger">
+        <h4 class="alert-heading">エラー詳細</h4>
+        {{$description}}
+        <ul>
+        @foreach ($import_errors->where('line', '!=', 0) as $error)
+            <li>
+                {{$error['line']}}行目 {{$error['message']}}
+            </li>
+        @endforeach
+        </ul>
+    </div>
+@endif
+{{-- スキップ詳細 --}}
+@if (session('csv_import_skipped_details'))
+    <div class="alert alert-warning">
+        <h4 class="alert-heading">スキップ詳細</h4>
+        <ul>
+        @foreach (session('csv_import_skipped_details') as $skip_detail)
+            <li>
+                {{$skip_detail['line']}}行目 {{$skip_detail['message']}}
+            </li>
+        @endforeach
+        </ul>
+    </div>
+@endif

--- a/tests/Feature/Plugins/User/Learningtasks/LearningtasksPluginImportCsvTest.php
+++ b/tests/Feature/Plugins/User/Learningtasks/LearningtasksPluginImportCsvTest.php
@@ -397,7 +397,8 @@ class LearningtasksPluginImportCsvTest extends TestCase
         $page = Page::factory()->create();
         $learningtask = Learningtasks::factory()->create();
         $post = LearningtasksPosts::factory()->create(
-            ['learningtasks_id' => $learningtask->id, 'student_join_flag' => 3, 'teacher_join_flag' => 3]);
+            ['learningtasks_id' => $learningtask->id, 'student_join_flag' => 3, 'teacher_join_flag' => 3]
+        );
         // この課題で評価インポートを有効にする設定を作成
         LearningtasksUseSettings::factory()->create([
             'post_id' => $post->id,

--- a/tests/Feature/Plugins/User/Learningtasks/LearningtasksPluginImportCsvTest.php
+++ b/tests/Feature/Plugins/User/Learningtasks/LearningtasksPluginImportCsvTest.php
@@ -1,0 +1,753 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Learningtasks;
+
+use App\Enums\CsvCharacterCode;
+use App\Enums\LearningtaskImportType;
+use App\Enums\LearningtaskUseFunction;
+use App\Enums\RoleName;
+use App\Models\Common\Group;
+use App\Models\Common\GroupUser;
+use App\Models\Common\Page;
+use App\Models\Common\PageRole;
+use App\Models\Core\UsersRoles;
+use App\Models\User\Learningtasks\Learningtasks;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Models\User\Learningtasks\LearningtasksUsers;
+use App\Models\User\Learningtasks\LearningtasksUsersStatuses;
+use App\Models\User\Learningtasks\LearningtasksUseSettings;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use App\Utilities\Csv\CsvUtils;
+
+class LearningtasksPluginImportCsvTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 各テスト前のセットアップ
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // DB Seeder を実行して初期データ(configs等)を投入
+        $this->seed();
+    }
+
+
+    /** CSVファイルの内容を生成するヘルパー */
+    private function createCsvContent(array $headers, array $rows): string
+    {
+        $output = fopen('php://temp', 'r+');
+        fputcsv($output, $headers);
+        foreach ($rows as $row) {
+            fputcsv($output, $row);
+        }
+        rewind($output);
+        $content = stream_get_contents($output);
+        fclose($output);
+        return $content;
+    }
+
+    /**
+     * 正常系: 権限のあるユーザーが有効なCSVでレポート評価をインポートできるテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-import
+     */
+    public function authorizedUserCanImportValidReportCsv(): void
+    {
+        // Arrange: テストデータの準備
+        // 1. ページ、課題投稿、インポート実行ユーザー(管理者or教員)を作成
+        $page = Page::factory()->create();
+        // Learningtasks レコードが必要な場合がある
+        $learningtask = Learningtasks::factory()->create();
+        $post = LearningtasksPosts::factory()->create([
+            'learningtasks_id' => $learningtask->id,
+            'student_join_flag' => 3,
+            'teacher_join_flag' => 3,
+        ]);
+        // 課題投稿に関連する設定を作成
+        // (レポート評価機能を有効にするための設定)
+        LearningtasksUseSettings::factory()->create([
+            'post_id' => $post->id,
+            'use_function' => LearningtaskUseFunction::use_report_evaluate,
+            'value' => 'on',
+        ]);
+        LearningtasksUseSettings::factory()->create([
+            'post_id' => $post->id,
+            'use_function' => LearningtaskUseFunction::use_report_evaluate_comment,
+            'value' => 'on',
+        ]);
+        $importer_user = User::factory()->create();
+        UsersRoles::factory()->create([
+            'users_id' => $importer_user->id,
+            'target' => 'base',
+            'role_name' => 'role_guest', // ゲスト
+        ]);
+        UsersRoles::factory()->create([
+            'users_id' => $importer_user->id,
+            'target' => 'original_role',
+            'role_name' => 'teacher', // 教員
+        ]);
+        // 権限設定: このユーザーが教員としてインポートを実行できるようにする
+        LearningtasksUsers::factory()->create([
+            'post_id' => $post->id, 'user_id' => $importer_user->id, 'role_name' => RoleName::teacher
+        ]);
+
+        // 2. インポート対象の学生ユーザーと提出記録を作成
+        $student1 = User::factory()->create(['userid' => 'student001']);
+        $student2 = User::factory()->create(['userid' => 'student002']);
+        // 受講生として登録 (Processor のチェックをパスするため)
+        LearningtasksUsers::factory()->create(['post_id' => $post->id, 'user_id' => $student1->id, 'role_name' => RoleName::student]);
+        LearningtasksUsers::factory()->create(['post_id' => $post->id, 'user_id' => $student2->id, 'role_name' => RoleName::student]);
+        // 最新の提出記録を作成
+        $submission_student1 =LearningtasksUsersStatuses::factory()->create(['post_id' => $post->id, 'user_id' => $student1->id, 'task_status' => 1]);
+        $submission_student2 = LearningtasksUsersStatuses::factory()->create(['post_id' => $post->id, 'user_id' => $student2->id, 'task_status' => 1]);
+
+        // 3. アップロードするCSVファイルの内容と偽ファイルを作成
+        //    (レポート評価インポート用のヘッダーとデータ)
+        $headers = ['ログインID', 'ユーザ名', '提出日時', '提出回数', '評価', '評価コメント'];
+        $rows = [
+            [$student1->userid, $student1->name, $submission_student1->created_at, '1', 'A', 'Comment Good'],
+            [$student2->userid, $student2->name, $submission_student2->created_at, '1', 'B', 'Comment OK'],
+        ];
+        $csv_content = $this->createCsvContent($headers, $rows);
+        $fake_file = UploadedFile::fake()->createWithContent('report_import.csv', $csv_content);
+
+        // 4. リクエストURLとパラメータを準備
+        $frame_id = 1; // 仮のフレームID
+        // ★ URL は実際の Connect-CMS のルーティングに合わせる
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}";
+        $expected_redirect_url = "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}";
+        $post_data = [
+            'csv_file' => $fake_file,
+            'import_type' => LearningtaskImportType::report,
+            'redirect_path' => $expected_redirect_url,
+        ];
+
+        // Act: 認証済みユーザーとしてPOSTリクエストをシミュレート
+        $response = $this->actingAs($importer_user)
+                         ->post($url, $post_data);
+
+        // Assert: レスポンスとDBの状態を検証
+        // 1. 正しいレポート表示画面にリダイレクトされること
+        $response->assertStatus(302); // リダイレクトステータス
+        $response->assertRedirect($expected_redirect_url); // リダイレクト先URL
+
+        // 2. フラッシュメッセージのキーと内容を確認
+        // キー 'flash_message' に期待する成功メッセージ文字列が含まれているか
+        $expected_message = "CSVインポート処理完了：成功 2件。";
+        $response->assertSessionHas('flash_message', $expected_message);
+
+        // 3. エラー関連のセッションがないこと
+        $response->assertSessionHasNoErrors(); // Laravel標準バリデーションエラーがないこと
+        $this->assertNull(session('csv_import_errors'), '詳細エラーがフラッシュされていないこと');
+
+        // 4. データベースに評価レコードが正しく作成されていること
+        $this->assertDatabaseHas('learningtasks_users_statuses', [
+            'post_id' => $post->id, 'user_id' => $student1->id, 'task_status' => 2, 'grade' => 'A', 'comment' => 'Comment Good', 'created_id' => $importer_user->id
+        ]);
+        $this->assertDatabaseHas('learningtasks_users_statuses', [
+            'post_id' => $post->id, 'user_id' => $student2->id, 'task_status' => 2, 'grade' => 'B', 'comment' => 'Comment OK', 'created_id' => $importer_user->id
+        ]);
+        // 提出2件 + 評価2件 = 4件になっているはず
+        $this->assertDatabaseCount('learningtasks_users_statuses', 4);
+    }
+
+    // ===============================================
+    // Feature Tests - File Validation Cases for Import
+    // ===============================================
+
+    /**
+     * ファイルバリデーション(必須): ファイル未選択時にエラーになるテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-import-validation
+     */
+    public function importFailsWithMissingFile(): void
+    {
+        // Arrange: ユーザー、ページ、投稿を準備 (権限のあるユーザーが必要)
+        $page = Page::factory()->create();
+        $post = LearningtasksPosts::factory()->create();
+        $user = User::factory()->create();
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin', // 管理者
+        ]);
+
+        $frame_id = 1; // 仮
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}"; // ★ 実際のURLに合わせる
+        // ★ csv_file を含めないリクエストデータ
+        $post_data = [
+            'import_type' => LearningtaskImportType::report,
+            'redirect_path' => "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}", // リダイレクト先指定(任意)
+        ];
+
+        // Act: 認証済みユーザーとして POST リクエストを実行
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        // Assert: バリデーションエラーでリダイレクトバックされることを確認
+        $response->assertStatus(302); // リダイレクト
+        $response->assertSessionHasErrors(['csv_file' => 'CSVファイルは必須です。']);
+    }
+
+    /**
+     * ファイルバリデーション(MIME): 不正なファイルタイプ時にエラーになるテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-import-validation
+     */
+    public function importFailsWithInvalidMimeType(): void
+    {
+        // Arrange: ユーザー、ページ、投稿を準備
+        $page = Page::factory()->create();
+        $post = LearningtasksPosts::factory()->create();
+        $user = User::factory()->create();
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin', // 管理者
+        ]);
+
+        $frame_id = 1;
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}";
+        // ★ 不正なMIMEタイプ(例: pdf)の偽ファイルを作成
+        $fake_file = UploadedFile::fake()->create('document.pdf', 100, 'application/pdf'); // 100KBのPDFファイル
+        $post_data = [
+            'csv_file' => $fake_file, // 不正なファイルを添付
+            'import_type' => LearningtaskImportType::report,
+            'redirect_path' => "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}",
+         ];
+
+        // Act: 認証済みユーザーとして POST
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        // Assert: バリデーションエラーでリダイレクトバックされること
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors(['csv_file' => 'CSVファイルにはcsv, txt形式のファイルを指定してください。']);
+    }
+
+    /**
+     * インポートタイプバリデーション: 空でエラー
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-import-validation
+     */
+    public function importFailsWithoutImportType(): void
+    {
+        // Arrange: ユーザー、ページ、投稿を準備
+        $page = Page::factory()->create();
+        $post = LearningtasksPosts::factory()->create();
+        $user = User::factory()->create();
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin', // 管理者
+        ]);
+
+        $frame_id = 1;
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}";
+        $fake_file = UploadedFile::fake()->create('document.csv', 100, 'text/csv');
+        $post_data = [
+            'csv_file' => $fake_file,
+            'redirect_path' => "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}",
+         ];
+
+        // Act: 認証済みユーザーとして POST
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        // Assert: バリデーションエラーでリダイレクトバックされること
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors(['import_type' => 'インポート形式は必須です。']);
+    }
+
+    /**
+     * インポートタイプバリデーション: 形式違いでエラー
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-import-validation
+     */
+    public function importFailsWithInvalidImportType(): void
+    {
+        // Arrange: ユーザー、ページ、投稿を準備
+        $page = Page::factory()->create();
+        $post = LearningtasksPosts::factory()->create();
+        $user = User::factory()->create();
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin', // 管理者
+        ]);
+
+        $frame_id = 1;
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}";
+        $fake_file = UploadedFile::fake()->create('document.csv', 100, 'text/csv');
+        $post_data = [
+            'csv_file' => $fake_file,
+            'import_type' => 'new type',
+            'redirect_path' => "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}",
+         ];
+
+        // Act: 認証済みユーザーとして POST
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        // Assert: バリデーションエラーでリダイレクトバックされること
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors(['import_type' => 'インポート形式には「report」のうちいずれかの値を指定してください。']);
+    }
+
+    // ===============================================
+    // Feature Tests - Authorization Cases
+    // ===============================================
+
+    /**
+     * 権限なし(未ログイン): CSVインポート(POST)が403権限エラーになるテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-auth
+     */
+    public function guestCannotImportCsv(): void
+    {
+        // Arrange
+        $page = Page::factory()->create();
+        $post = LearningtasksPosts::factory()->create();
+        $frame_id = 1;
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}";
+        // POSTデータは最小限で良い（どうせ認証で弾かれるはず）
+        $fake_file = UploadedFile::fake()->create('dummy.csv', 1);
+        $post_data = [
+            'csv_file' => $fake_file,
+            'import_type' => LearningtaskImportType::report,
+            'redirect_path' => "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}"
+        ];
+
+        // Act: ログインせずに POST
+        $response = $this->post($url, $post_data);
+
+        // Assert: 403レスポンス
+        $response->assertStatus(200); // canメソッドチェック:Connect-CMSの仕様で200レスポンスとなる
+        $response->assertSeeText('403 Forbidden');
+    }
+
+    /**
+     * 権限なし(ログイン済 & 管理者でも担当教員でもない一般ユーザー): canImport()でCSVインポート(POST)が拒否されるテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-auth
+     */
+    public function unauthorizedUserCannotImportCsv(): void
+    {
+        // Arrange: ページ、投稿、権限のないユーザー、偽ファイル
+        $page = Page::factory()->create();
+        $post = LearningtasksPosts::factory()->create();
+        $unauthorized_user = User::factory()->create();
+        UsersRoles::factory()->create([
+            'users_id' => $unauthorized_user->id,
+            'target' => 'base',
+            'role_name' => 'role_guest', // ゲスト
+        ]);
+        // 課題投稿に関連する設定を作成
+        // (レポート評価機能を有効にするための設定)
+        LearningtasksUseSettings::factory()->create([
+            'post_id' => $post->id,
+            'use_function' => LearningtaskUseFunction::use_report_evaluate,
+            'value' => 'on',
+        ]);
+        // フレーム、ページ、ファイル
+        $frame_id = 1;
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}";
+        $fake_file = UploadedFile::fake()->create('dummy.csv', 1);
+        $post_data = [
+            'csv_file' => $fake_file,
+            'import_type' => LearningtaskImportType::report,
+            'redirect_path' => "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}"
+        ];
+
+        // Act: 権限のないユーザーとして POST
+        $response = $this->actingAs($unauthorized_user)->post($url, $post_data);
+
+        // Assert: アクセス拒否 (Controller の canImport チェック -> abort(403)を想定)
+        $response->assertStatus(403);
+    }
+
+    /**
+     * ヘッダーエラー: 不正なヘッダーのCSVでエラーメッセージ付きリダイレクトになるテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-import
+     */
+    public function importShowsErrorOnInvalidHeader(): void
+    {
+        // Arrange: データ準備
+        // 1. ページ、課題投稿、実行ユーザー
+        $page = Page::factory()->create();
+        $learningtask = Learningtasks::factory()->create();
+        $post = LearningtasksPosts::factory()->create(
+            ['learningtasks_id' => $learningtask->id, 'student_join_flag' => 3, 'teacher_join_flag' => 3]);
+        // この課題で評価インポートを有効にする設定を作成
+        LearningtasksUseSettings::factory()->create([
+            'post_id' => $post->id,
+            'learningtasks_id' => $learningtask->id,
+            'use_function' => LearningtaskUseFunction::use_report_evaluate,
+            'value' => 'on',
+        ]);
+        // ★ ユーザーにインポート権限を付与 (例: 教員として登録)
+        $user = User::factory()->create();
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_guest', // ゲスト
+        ]);
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'original_role',
+            'role_name' => 'teacher', // 教員
+        ]);
+        LearningtasksUsers::factory()->create(['post_id' => $post->id, 'user_id' => $user->id, 'role_name' => RoleName::teacher]);
+
+        // 2. CSVファイル準備 (★ 不正なヘッダー)
+        //    LearningtaskReportColumnDefinition が期待するのは ['ログインID', '評価', '評価コメント'] など
+        $invalid_headers = ['ユーザーID', '評定', '感想']; // 期待と異なるヘッダー
+        $rows = [
+            ['student99', 'A', 'Good'], // データ行の内容はこのテストではあまり重要ではない
+        ];
+        $csv_content = $this->createCsvContent($invalid_headers, $rows);
+        $fake_file = UploadedFile::fake()->createWithContent('invalid_header.csv', $csv_content);
+
+        // 3. URL と POST データ
+        $frame_id = 1; // 仮
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}";
+        $expected_redirect_url = "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}";
+        $post_data = [
+            'csv_file' => $fake_file,
+            'import_type' => LearningtaskImportType::report,
+            'redirect_path' => $expected_redirect_url,
+        ];
+
+        // Act: 認証済みユーザーとしてPOST
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        // Assert: レスポンスの検証
+        // 1. リダイレクトされること
+        $response->assertStatus(302);
+        $response->assertRedirect($expected_redirect_url);
+
+        // 2a. 要約メッセージ ('flash_message') の確認
+        $response->assertSessionHas('flash_message'); // キーの存在
+        // 内容は「エラーがあったこと」を示すものか？
+        $this->assertStringContainsString('エラー 1件', session('flash_message'));
+        $this->assertStringContainsString('エラー内容を確認してください', session('flash_message'));
+        // 具体的なエラー「ヘッダーが不正」はここには含まれないはず
+
+        // 2b. 詳細エラー ('csv_import_errors') の確認
+        $response->assertSessionHas('csv_import_errors');
+        $error_details = session('csv_import_errors');
+        $this->assertIsArray($error_details);
+        $this->assertCount(1, $error_details, 'エラー詳細が1件であること');
+        // 最初の (唯一の) エラー詳細の内容を確認
+        $first_error = $error_details[0];
+        $this->assertEquals(1, $first_error['line'], 'エラー詳細の行番号が1であること');
+        $this->assertEquals('header_error', $first_error['type'], 'エラー詳細のタイプが header_error であること');
+        $this->assertStringContainsString('ヘッダーが不正', $first_error['message'], 'エラー詳細のメッセージに原因が含まれること');
+
+        // 3. DBに変更がないこと
+        $this->assertDatabaseCount('learningtasks_users_statuses', 0);
+    }
+
+    /**
+     * スキップ発生: スキップされる行がある場合に情報メッセージが表示され、成功行はコミットされるテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-import
+     */
+    public function importShowsInfoMessageOnSkips(): void
+    {
+        // Arrange
+        // 1. 基本データと権限設定
+        $page = Page::factory()->create();
+        $learningtask = Learningtasks::factory()->create();
+        $post = LearningtasksPosts::factory()->create([
+            'learningtasks_id' => $learningtask->id,
+            'student_join_flag' => 3,
+            'teacher_join_flag' => 3
+        ]);
+        LearningtasksUseSettings::factory()->create([
+            'post_id' => $post->id,
+            'learningtasks_id' => $learningtask->id,
+            'use_function' => LearningtaskUseFunction::use_report_evaluate,
+            'value' => 'on'
+        ]); // 評価を有効に
+        $user = User::factory()->create(); // インポート実行者
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin', // 管理者
+        ]);
+
+        // 2. 学生と提出・評価データ (★一部評価済みデータを作成)
+        $student1 = User::factory()->create(['userid' => 'student001']); // スキップ対象 (評価済み)
+        $student2 = User::factory()->create(['userid' => 'student002']); // 成功対象
+        // 受講生として登録
+        LearningtasksUsers::factory()->create(['post_id' => $post->id, 'user_id' => $student1->id, 'role_name' => RoleName::student]);
+        LearningtasksUsers::factory()->create(['post_id' => $post->id, 'user_id' => $student2->id, 'role_name' => RoleName::student]);
+        // 提出記録
+        $submission1 = LearningtasksUsersStatuses::factory()->create(['post_id' => $post->id, 'user_id' => $student1->id, 'task_status' => 1]);
+        $submission2 = LearningtasksUsersStatuses::factory()->create(['post_id' => $post->id, 'user_id' => $student2->id, 'task_status' => 1]);
+        // ★ student1 は既に評価済みレコードが存在する (IDは提出より後になるように)
+        $existing_eval1 = LearningtasksUsersStatuses::factory()->create([
+            'post_id' => $post->id, 'user_id' => $student1->id, 'task_status' => 2, 'grade' => 'C'
+        ]);
+
+        // 3. CSV ファイル (student1 は評価済みなのでスキップ、student2 は成功するはず)
+        $headers = ['ログインID', 'ユーザ名', '提出日時', '提出回数', '評価'];
+        $rows = [
+            [$student1->userid, $student1->name, $submission1->created_at, '1', 'A'], // この行は評価済みのためスキップされる
+            [$student2->userid, $student2->name, $submission2->created_at, '1', 'B'], // この行は成功するはず
+        ];
+        $csv_content = $this->createCsvContent($headers, $rows);
+        $fake_file = UploadedFile::fake()->createWithContent('import_with_skips.csv', $csv_content);
+
+        // 4. URL と POST データ
+        $frame_id = 1;
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}";
+        $expected_redirect_url = "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}";
+        $post_data = [
+            'csv_file' => $fake_file,
+            'import_type' => LearningtaskImportType::report,
+            'redirect_path' => $expected_redirect_url
+        ];
+
+        // Act
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        // Assert
+        // 1. リダイレクト確認
+        $response->assertStatus(302);
+        $response->assertRedirect($expected_redirect_url);
+
+        // 2. フラッシュメッセージ ('flash_message') の確認 (★情報メッセージ)
+        $response->assertSessionHas('flash_message');
+        // メッセージに成功件数とスキップ件数が含まれることを確認
+        $this->assertStringContainsString('成功 1件', session('flash_message'));
+        $this->assertStringContainsString('スキップ 1件', session('flash_message'));
+        // メッセージにスキップがあったことを示す文言が含まれるか確認 (formatImportResultFeedback の実装による)
+        $this->assertStringContainsString('一部スキップされた行があります', session('flash_message'));
+
+        // 3. エラー関連セッションがないこと
+        $response->assertSessionHasNoErrors(); // Laravel 標準バリデーションエラーなし
+        $this->assertNull(session('csv_import_errors'), '詳細エラーがフラッシュされていないこと');
+        // スキップ詳細がフラッシュされているはず
+        $response->assertSessionHas('csv_import_skipped_details');
+        // スキップ詳細の内容を確認
+        $skipped_details = session('csv_import_skipped_details');
+        $this->assertIsArray($skipped_details);
+        $this->assertCount(1, $skipped_details); // スキップは1件
+        $first_skip = $skipped_details[0];
+        $this->assertEquals(2, $first_skip['line'], 'スキップ詳細の行番号が2であること');
+        $this->assertEquals('already_evaluated', $first_skip['type'], 'スキップ詳細のタイプが already_evaluated であること');
+        $this->assertStringContainsString('提出は既に評価済み', $first_skip['message'], 'スキップ詳細のメッセージに原因が含まれること');
+
+        // 4. データベースの状態確認 (★コミットされているはず)
+        //    - student2 の評価 (grade=B) は作成されている
+        $this->assertDatabaseHas('learningtasks_users_statuses', [
+            'post_id' => $post->id, 'user_id' => $student2->id, 'task_status' => 2, 'grade' => 'B', 'created_id' => $user->id
+        ]);
+        //    - student1 の評価は元のまま (grade=C)
+        $this->assertDatabaseHas('learningtasks_users_statuses', [
+            'post_id' => $post->id, 'user_id' => $student1->id, 'task_status' => 2, 'grade' => 'C'
+        ]);
+        //    - student1 の評価が意図せず A で追加/更新されていないことを確認
+        $this->assertDatabaseMissing('learningtasks_users_statuses', [
+             'post_id' => $post->id, 'user_id' => $student1->id, 'task_status' => 2, 'grade' => 'A'
+        ]);
+         // 合計件数: 提出2 + 既存評価1 + 新規評価1 = 4件
+         $this->assertDatabaseCount('learningtasks_users_statuses', 4);
+    }
+
+    /**
+     * エラー発生とロールバック: 処理中エラーで行が失敗し、全体がロールバックされるテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-import
+     */
+    public function importRollsBackAndShowsErrorOnProcessingFailure(): void
+    {
+        // Arrange
+        // 1. 基本データ、権限設定、課題設定
+        $page = Page::factory()->create();
+        $learningtask = Learningtasks::factory()->create();
+        $post = LearningtasksPosts::factory()->create([
+            'learningtasks_id' => $learningtask->id,
+            'student_join_flag' => 3,
+            'teacher_join_flag' => 3
+        ]);
+        LearningtasksUseSettings::factory()->create([
+            'post_id' => $post->id,
+            'learningtasks_id' => $learningtask->id,
+            'use_function' => LearningtaskUseFunction::use_report_evaluate,
+            'value' => 'on'
+        ]); // 評価を有効に
+        $user = User::factory()->create(); // インポート実行者
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin', // 管理者
+        ]);
+
+        // 2. 学生データと提出状況 (★ student2 は提出記録なし)
+        $student1 = User::factory()->create(['userid' => 'student1']); // この行の処理は Processor 内では成功するはず
+        $student2 = User::factory()->create(['userid' => 'student2']); // この行の処理で Exception が発生するはず
+        // 受講生登録
+        LearningtasksUsers::factory()->create(['post_id' => $post->id, 'user_id' => $student1->id, 'role_name' => RoleName::student]);
+        LearningtasksUsers::factory()->create(['post_id' => $post->id, 'user_id' => $student2->id, 'role_name' => RoleName::student]);
+        // 提出記録 (student1 のみ作成)
+        $submission1 = LearningtasksUsersStatuses::factory()->create(['post_id' => $post->id, 'user_id' => $student1->id, 'task_status' => 1]);
+        // student2 の提出記録は作成しない
+
+        // 3. CSV ファイル
+        $headers = ['ログインID', 'ユーザ名', '提出日時', '提出回数', '評価'];
+        $rows = [
+            [$student1->userid, $student1->name, $submission1->created_at, '1', 'A'], // この行は成功するはず
+            [$student2->userid, $student2->name, '', '1', 'B'], // 提出なし Exception が発生するはず
+        ];
+        $csv_content = $this->createCsvContent($headers, $rows);
+        $fake_file = UploadedFile::fake()->createWithContent('import_proc_error.csv', $csv_content);
+
+        // 4. URL と POST データ
+        $frame_id = 1;
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}";
+        $expected_redirect_url = "/plugin/learningtasks/showReport/{$page->id}/{$frame_id}/{$post->id}";
+        $post_data = [
+            'csv_file' => $fake_file,
+            'import_type' => LearningtaskImportType::report,
+            'redirect_path' => $expected_redirect_url
+        ];
+
+        // Act: インポート実行
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        // Assert
+        // 1. リダイレクト確認
+        $response->assertStatus(302);
+        $response->assertRedirect($expected_redirect_url);
+
+        // 2. 要約フラッシュメッセージ ('flash_message') の確認 (エラー表示)
+        $response->assertSessionHas('flash_message');
+        // ★ 成功 1件、エラー 1件 となっているはず
+        $this->assertStringContainsString('成功 1件', session('flash_message')); // ロールバックされた
+        $this->assertStringNotContainsString('スキップ', session('flash_message'));
+        $this->assertStringContainsString('エラー 1件', session('flash_message'));
+        $this->assertStringContainsString('エラー内容を確認してください', session('flash_message'));
+
+        // 3. ★★★ エラー詳細 ('csv_import_errors') の個別アサートに変更 ★★★
+        $response->assertSessionHas('csv_import_errors');
+        $error_details = session('csv_import_errors');
+        $this->assertIsArray($error_details);
+        $this->assertCount(2, $error_details, 'エラー詳細が2件であること');
+
+        // 3a. 処理エラー詳細 (Line 3) の内容を個別確認
+        //     タイプ 'submission_not_found' で記録される想定
+        $processing_error = collect($error_details)->firstWhere('line', 3);
+        $this->assertNotNull($processing_error, 'Line 3 の処理エラー詳細が見つかりません');
+        $this->assertEquals($student2->userid, $processing_error['userid'], '処理エラー詳細: userid');
+        $this->assertEquals('submission_not_found', $processing_error['type'], '処理エラーのタイプ');
+        $this->assertStringContainsString("評価対象の提出記録がユーザー ({$student2->userid}) に見つかりません。", $processing_error['message'], '処理エラー詳細: message');
+
+        // 3b. ロールバックエラー詳細 (Line 0) の内容を個別確認
+        $rollback_error = collect($error_details)->firstWhere('line', 0);
+        $this->assertNotNull($rollback_error, 'Line 0 のロールバックエラー詳細が見つかりません');
+        $this->assertEquals('fatal_error_rollback', $rollback_error['type'], 'ロールバックエラー詳細: type');
+        $this->assertStringContainsString('処理が中断され', $rollback_error['message'], 'ロールバックエラー詳細: message prefix');
+        $this->assertEquals('N/A', $rollback_error['userid'], 'ロールバックエラー詳細: userid'); // 行全体のエラーなので N/A
+
+        // 4. スキップ詳細がないこと
+        $this->assertNull(session('csv_import_skipped_details'));
+
+        // 5. データベースの状態確認 (ロールバック)
+        // 最初に処理されたはずの student1 の評価レコードも存在しないことを確認
+        $this->assertDatabaseMissing('learningtasks_users_statuses', [
+            'post_id' => $post->id, 'user_id' => $student1->id, 'task_status' => 2
+        ]);
+        // エラーになった student2 の評価レコードも存在しないことを確認
+        $this->assertDatabaseMissing('learningtasks_users_statuses', [
+            'post_id' => $post->id, 'user_id' => $student2->id, 'task_status' => 2
+        ]);
+        // 存在するレコードは student1 の提出記録のみのはず
+        $this->assertDatabaseCount('learningtasks_users_statuses', 1);
+    }
+
+    /**
+     * 設定無効: 課題設定で評価インポートが無効な場合に処理が中断されるテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-feature
+     * @group learningtasks-import
+     */
+    public function importIsRejectedWhenSettingDisabled(): void
+    {
+        // Arrange:
+        // 1. ページ、投稿、ユーザーを準備
+        $page = Page::factory()->create();
+        $learningtask = Learningtasks::factory()->create();
+        $post = LearningtasksPosts::factory()->create(['learningtasks_id' => $learningtask->id]);
+        $user = User::factory()->create();
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin', // 管理者
+        ]);
+
+        // 2. 課題設定で評価インポートを「無効」にする
+        //    (LearningtasksUseSettings レコードを作成しないか、'off' で作成する)
+        //    ここではレコードを作成しないことで無効とする例
+        LearningtasksUseSettings::factory()->create([
+            'post_id' => $post->id,
+            'use_function' => LearningtaskUseFunction::use_report_evaluate,
+            'value' => 'off', // 明示的に off
+        ]);
+
+        // 3. ダミーの CSV ファイルとリクエストデータ
+        $fake_file = UploadedFile::fake()->create('dummy.csv', 1);
+        $frame_id = 1;
+        $url = "/redirect/plugin/learningtasks/importCsv/{$page->id}/{$frame_id}/{$post->id}"; // ★ importCsv ルート
+        $expected_redirect_url = "/plugin/learningtasks/show/{$page->id}/{$frame_id}/{$post->id}"; // 仮のリダイレクト先
+        $post_data = [
+            'csv_file' => $fake_file,
+            'import_type' => LearningtaskImportType::report, // report を指定
+            'redirect_path' => $expected_redirect_url,
+        ];
+
+        // Act: 認証済みユーザーとして POST
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        // Assert:
+        // 1. リダイレクトバックされることを期待 (withErrors で返るため 302)
+        //    (FeatureDisabledException を catch して back()->with('error', ...) で返す実装)
+        $response->assertStatus(302);
+        // redirect()->back() なのでリダイレクト先は厳密には特定できないが、リダイレクトされること自体を確認
+        $response->assertRedirect();
+
+        // 2. ★ セッションに 'error' キーで特定のエラーメッセージが含まれることを確認
+        //    (Controller が FeatureDisabledException のメッセージを使う場合)
+        $response->assertSessionHas('error', 'この課題ではレポート評価機能が有効になっていません。');
+
+        // 3. DB に変更がないことを確認 (インポート処理は実行されないため)
+        $this->assertDatabaseCount('learningtasks_users_statuses', 0); // 何も登録されない
+    }
+}

--- a/tests/Unit/Plugins/User/Learningtasks/Csv/LearningtasksCsvImporterTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Csv/LearningtasksCsvImporterTest.php
@@ -128,16 +128,14 @@ class LearningtasksCsvImporterTest extends TestCase
             ->once()
             ->withArgs(fn($data, $post, $page, $importer) =>
                 isset($data['userid'], $data['grade']) && // キーの存在確認を追加(より安全)
-                $data['userid'] === $student1->userid && $data['grade'] === 'A'
-            )
+                $data['userid'] === $student1->userid && $data['grade'] === 'A')
             ->andReturnNull(); // 成功時は void (null)
 
         $this->mock_row_processor->shouldReceive('process')
             ->once()
             ->withArgs(fn($data, $post, $page, $importer) =>
                  isset($data['userid'], $data['grade']) &&
-                 $data['userid'] === $student2->userid && $data['grade'] === 'B'
-             )
+                 $data['userid'] === $student2->userid && $data['grade'] === 'B')
             ->andReturnNull();
 
         // 4. CSVファイルの内容と偽のアップロードファイルを作成

--- a/tests/Unit/Plugins/User/Learningtasks/Csv/LearningtasksCsvImporterTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Csv/LearningtasksCsvImporterTest.php
@@ -1,0 +1,473 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks\Csv;
+
+use App\Models\Common\Page;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Plugins\User\Learningtasks\Contracts\ColumnDefinitionInterface;
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorExceptionHandlerInterface;
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorInterface;
+use App\Plugins\User\Learningtasks\Csv\LearningtasksCsvImporter;
+use App\Plugins\User\Learningtasks\Exceptions\AlreadyEvaluatedException;
+use App\Plugins\User\Learningtasks\Exceptions\InvalidStudentException;
+use App\Plugins\User\Learningtasks\Exceptions\SubmissionNotFoundException;
+use App\Plugins\User\Learningtasks\Repositories\LearningtaskUserRepository;
+use App\User;
+use Exception;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+/**
+ * LearningtasksCsvImporter のテストクラス (インテグレーション寄り)
+ * @coversDefaultClass \App\Plugins\User\Learningtasks\Csv\LearningtasksCsvImporter
+ */
+class LearningtasksCsvImporterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var ColumnDefinitionInterface|MockInterface */
+    private $mock_column_definition;
+
+    /** @var RowProcessorInterface|MockInterface */
+    private $mock_row_processor;
+
+    /** @var LearningtaskUserRepository|MockInterface */
+    private $mock_user_repository;
+
+    /** @var RowProcessorExceptionHandlerInterface|MockInterface */
+    private $mock_exception_handler;
+
+    /** @var LearningtasksCsvImporter */
+    private $importer;
+
+    // --- テスト対象の基本データ ---
+    private $page;
+    private $post;
+    private $importer_user;
+
+    /**
+     * 各テスト前に共通の準備
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // モックを作成
+        $this->mock_column_definition = Mockery::mock(ColumnDefinitionInterface::class);
+        $this->mock_row_processor = Mockery::mock(RowProcessorInterface::class);
+        $this->mock_user_repository = Mockery::mock(LearningtaskUserRepository::class);
+        $this->mock_exception_handler =  Mockery::mock(RowProcessorExceptionHandlerInterface::class);
+
+        // 基本的なテストデータを作成
+        $this->page = Page::factory()->create();
+        $this->post = LearningtasksPosts::factory()->create();
+        $this->importer_user = User::factory()->create(); // インポート実行者
+
+        // テスト対象クラスを生成 (モックを注入)
+        $this->importer = new LearningtasksCsvImporter(
+            $this->post,
+            $this->page,
+            $this->mock_column_definition,
+            $this->mock_row_processor,
+            $this->mock_user_repository,
+            $this->mock_exception_handler
+        );
+
+        // Fake storage (任意だがファイルを実際に置かない場合に便利)
+        Storage::fake('local');
+    }
+
+    /**
+     * CSVファイルの内容を生成するヘルパー
+     */
+    private function createCsvContent(array $headers, array $rows): string
+    {
+        $output = fopen('php://temp', 'r+');
+        fputcsv($output, $headers);
+        foreach ($rows as $row) {
+            fputcsv($output, $row);
+        }
+        rewind($output);
+        $content = stream_get_contents($output);
+        fclose($output);
+        return $content;
+    }
+
+    /**
+     * 正常系: 有効なCSVファイルでインポートが成功することをテスト
+     * @test
+     * @covers ::import
+     * @group learningtasks
+     * @group learningtasks-importer
+     */
+    public function importProcessesValidCsvSuccessfully(): void
+    {
+        // Arrange: 準備
+        // 1. テスト用ユーザーデータ
+        $student1 = User::factory()->create(['userid' => 'student1']);
+        $student2 = User::factory()->create(['userid' => 'student2']);
+
+        // 2. ColumnDefinitionInterface のモック設定
+        $expected_headers = ['ログインID', '評価', '評価コメント'];
+        $column_map = ['ログインID' => 'userid', '評価' => 'grade', '評価コメント' => 'comment'];
+        // バリデーションルールはテストシナリオに応じて簡略化または具体的に設定
+        $validation_rules = ['userid' => ['required'], 'grade' => [], 'comment' => []];
+        $this->mock_column_definition->shouldReceive('getHeaders')->once()->andReturn($expected_headers);
+        $this->mock_column_definition->shouldReceive('getColumnMap')->atLeast()->once()->andReturn($column_map); // validateRow で呼ばれる
+        $this->mock_column_definition->shouldReceive('getValidationRulesBase')->atLeast()->once()->andReturn($validation_rules); // validateRow で呼ばれる
+        $this->mock_column_definition->shouldReceive('getValidationMessages')->andReturn([]); // メッセージも取得される可能性がある
+
+        // 3. RowProcessorInterface のモック設定
+        //    process メソッドが期待する引数で、期待する回数呼ばれることを設定
+        $this->mock_row_processor->shouldReceive('process')
+            ->once()
+            ->withArgs(fn($data, $post, $page, $importer) =>
+                isset($data['userid'], $data['grade']) && // キーの存在確認を追加(より安全)
+                $data['userid'] === $student1->userid && $data['grade'] === 'A'
+            )
+            ->andReturnNull(); // 成功時は void (null)
+
+        $this->mock_row_processor->shouldReceive('process')
+            ->once()
+            ->withArgs(fn($data, $post, $page, $importer) =>
+                 isset($data['userid'], $data['grade']) &&
+                 $data['userid'] === $student2->userid && $data['grade'] === 'B'
+             )
+            ->andReturnNull();
+
+        // 4. CSVファイルの内容と偽のアップロードファイルを作成
+        $csv_rows = [
+            [$student1->userid, 'A', 'Comment 1'],
+            [$student2->userid, 'B', 'Comment 2'],
+        ];
+        $csv_content = $this->createCsvContent($expected_headers, $csv_rows);
+        $fake_file = UploadedFile::fake()->createWithContent('import.csv', $csv_content);
+
+        // Act: インポート処理を実行
+        $results = $this->importer->import($fake_file, $this->importer_user);
+
+        // Assert: 結果の検証
+        $this->assertEquals(2, $results['success'], '成功件数が2であること');
+        $this->assertEquals(0, $results['errors'], 'エラー件数が0であること');
+        $this->assertEquals(0, $results['skipped'], 'スキップ件数が0であること');
+        $this->assertCount(0, $results['error_details'], 'エラー詳細が空であること');
+        // RowProcessor が期待通り呼ばれたかは Mockery が内部で検証している
+    }
+
+    /**
+     * ヘッダーエラー: CSVヘッダーが不正な場合にエラー終了し、正しいエラー詳細が記録されるテスト
+     * @test
+     * @covers ::import
+     * @covers ::processHeader
+     * @covers ::validateHeader
+     * @group learningtasks
+     * @group learningtasks-importer
+     */
+    public function importFailsOnInvalidHeader(): void
+    {
+        // Arrange
+        $expected_headers = ['ログインID', '評価'];
+        $invalid_headers = ['ユーザーID', '評定'];
+        $this->mock_column_definition->shouldReceive('getHeaders')->once()->andReturn($expected_headers);
+        $this->mock_row_processor->shouldNotReceive('process');
+        $csv_content = $this->createCsvContent($invalid_headers, [['userA', 'A']]);
+        $fake_file = UploadedFile::fake()->createWithContent('invalid_header.csv', $csv_content);
+
+        // Act
+        $results = $this->importer->import($fake_file, $this->importer_user);
+
+        // Assert
+        $this->assertEquals(0, $results['success']);
+        $this->assertEquals(0, $results['skipped']);
+        // ★ エラー件数は、外側の catch で捕捉されるため 1 になるはず
+        //    (ただし、addErrorDetail の重複追加防止ロジックが完璧なら1)
+        $this->assertEquals(1, $results['errors']);
+        $this->assertCount(1, $results['error_details']); // ★ ヘッダーエラー1件のみのはず
+
+        $error_detail = $results['error_details'][0];
+        $this->assertEquals(1, $error_detail['line']); // ヘッダーエラーは1行目
+
+        // Importer の catch(CsvInvalidHeaderException $e) ブロックで
+        // 'header_error' タイプで addErrorDetail が呼ばれることを期待
+        $this->assertEquals('header_error', $error_detail['type'], 'エラータイプが header_error であること');
+
+        $this->assertStringContainsString('ヘッダーが不正', $error_detail['message']); // メッセージ確認
+
+        // ★ DBに変更がないことを確認
+        $this->assertDatabaseCount('learningtasks_users_statuses', 0);
+    }
+
+    // ===============================================
+    // Exception Handling Tests
+    // ===============================================
+    /**
+     * Skip Outcome: ハンドラが 'skip' を返した場合、スキップとして記録されコミットされるテスト
+     * @test
+     * @covers ::import
+     * @covers ::handleRowProcessingException
+     * @group learningtasks
+     * @group learningtasks-importer
+     */
+    public function importCommitsAndLogsSkipWhenHandlerReturnsSkip(): void
+    {
+        // Arrange
+        $student1 = User::factory()->create(['userid' => 'student1']); // Success row
+        $student2 = User::factory()->create(['userid' => 'student2']); // Row that causes skip
+        $expected_headers = ['ログインID', '評価'];
+        $exception_to_throw = new AlreadyEvaluatedException("Already done"); // 代表的なスキップ例外
+        $skip_type_string = 'test_skip_type_from_handler'; // ハンドラが返すタイプ文字列
+        $skip_log_level = 'info';
+
+        // ColumnDefinition Mock (valid for both rows)...
+        $this->mock_column_definition->shouldReceive('getHeaders')->andReturn($expected_headers);
+        $this->mock_column_definition->shouldReceive('getColumnMap')->andReturn(['ログインID' => 'userid', '評価' => 'grade']);
+        $this->mock_column_definition->shouldReceive('getValidationRulesBase')->andReturn(['userid'=>[],'grade'=>[]]);
+        $this->mock_column_definition->shouldReceive('getValidationMessages')->andReturn([]);
+
+        // RowProcessor Mock: 1回目成功、2回目例外
+        $this->mock_row_processor->shouldReceive('process')->once()->ordered()->andReturnNull();
+        $this->mock_row_processor->shouldReceive('process')->once()->ordered()->andThrow($exception_to_throw);
+
+        // Exception Handler Mock: スキップ設定を返す
+        $this->mock_exception_handler->shouldReceive('handle')
+             ->once()
+             ->with(Mockery::on(fn($e) => $e === $exception_to_throw))
+             ->andReturn(['outcome' => 'skip', 'type' => $skip_type_string, 'log_level' => $skip_log_level]);
+
+        // CSV File...
+        $csv_rows = [ [$student1->userid, 'A'], [$student2->userid, 'B'] ];
+        $csv_content = $this->createCsvContent($expected_headers, $csv_rows);
+        $fake_file = UploadedFile::fake()->createWithContent('import_skip.csv', $csv_content);
+
+        // Act
+        $results = $this->importer->import($fake_file, $this->importer_user);
+
+        // Assert
+        $this->assertEquals(1, $results['success'], '成功は1件');
+        $this->assertEquals(0, $results['errors'], 'エラーは0件');
+        $this->assertEquals(1, $results['skipped'], 'スキップは1件');
+        $this->assertCount(0, $results['error_details'], 'エラー詳細はない'); // エラーはない
+        $this->assertCount(1, $results['skip_details'], 'スキップ詳細は1件'); // スキップ詳細がある
+        $this->assertEquals($skip_type_string, $results['skip_details'][0]['type'], 'スキップ詳細のタイプがハンドラ指定通り');
+        $this->assertEquals(3, $results['skip_details'][0]['line']); // 行番号
+    }
+
+    /**
+     * ★ Error Outcome: ハンドラが 'error' を返した場合、エラーとして記録されロールバックされるテスト
+     * @test
+     * @covers ::import
+     * @covers ::handleRowProcessingException
+     * @group learningtasks
+     * @group learningtasks-importer
+     */
+    public function importRollsBackAndLogsErrorWhenHandlerReturnsError(): void
+    {
+        // Arrange
+        $student1 = User::factory()->create(['userid' => 'student1']); // Success attempt -> Rollback
+        $student2 = User::factory()->create(['userid' => 'student2']); // Row that causes error
+        $expected_headers = ['ログインID', '評価'];
+        $exception_to_throw = new SubmissionNotFoundException("No submission"); // 代表的なエラー例外
+        $error_type_string = 'test_error_type_from_handler'; // ハンドラが返すタイプ文字列
+        $error_log_level = 'error';
+
+        // ColumnDefinition Mock (valid for both rows)...
+        $this->mock_column_definition->shouldReceive('getHeaders')->andReturn($expected_headers);
+        $this->mock_column_definition->shouldReceive('getColumnMap')->andReturn(['ログインID' => 'userid', '評価' => 'grade']);
+        $this->mock_column_definition->shouldReceive('getValidationRulesBase')->andReturn(['userid'=>[],'grade'=>[]]);
+        $this->mock_column_definition->shouldReceive('getValidationMessages')->andReturn([]);
+
+        // RowProcessor Mock: 1回目成功、2回目例外
+        $this->mock_row_processor->shouldReceive('process')->once()->ordered()->andReturnNull();
+        $this->mock_row_processor->shouldReceive('process')->once()->ordered()->andThrow($exception_to_throw);
+
+        // Exception Handler Mock: エラー設定を返す
+        $this->mock_exception_handler->shouldReceive('handle')
+            ->once()
+            ->with(Mockery::on(fn($e) => $e === $exception_to_throw))
+            ->andReturn(['outcome' => 'error', 'type' => $error_type_string, 'log_level' => $error_log_level]);
+
+        // CSV File...
+        $csv_rows = [ [$student1->userid, 'A'], [$student2->userid, 'B'] ];
+        $csv_content = $this->createCsvContent($expected_headers, $csv_rows);
+        $fake_file = UploadedFile::fake()->createWithContent('import_error.csv', $csv_content);
+
+        // Act
+        $results = $this->importer->import($fake_file, $this->importer_user);
+
+        // Assert
+        $this->assertEquals(1, $results['success'], '成功は1件');
+        $this->assertEquals(1, $results['errors'], 'エラーは1件');
+        $this->assertEquals(0, $results['skipped'], 'スキップは0件');
+        $this->assertCount(2, $results['error_details'], 'エラー詳細は2件 (処理エラー + ロールバック)'); // ★ Error + Rollback details
+        $this->assertCount(0, $results['skip_details'], 'スキップ詳細はない');
+
+        // エラー詳細のタイプがハンドラ指定通りか確認
+        $processing_error = collect($results['error_details'])->firstWhere('line', 3);
+        $this->assertNotNull($processing_error);
+        $this->assertEquals($error_type_string, $processing_error['type'], 'エラー詳細のタイプがハンドラ指定通り');
+        // ロールバックエラー詳細の存在確認
+        $rollback_error = collect($results['error_details'])->firstWhere('type', 'fatal_error_rollback');
+        $this->assertNotNull($rollback_error);
+    }
+
+    /**
+     * Unhandled Outcome: ハンドラが null を返した場合、予期せぬエラーとして記録されロールバックされるテスト
+     * @test
+     * @covers ::import
+     * @covers ::handleRowProcessingException
+     * @group learningtasks
+     * @group learningtasks-importer
+     */
+    public function importRollsBackAndLogsErrorWhenHandlerReturnsNull(): void
+    {
+        // Arrange
+        $student1 = User::factory()->create(['userid' => 'student1']);
+        $student2 = User::factory()->create(['userid' => 'student2']);
+        $expected_headers = ['ログインID', '評価'];
+        $exception_to_throw = new Exception("Unhandled error"); // ハンドラが処理しない例外
+
+        // ColumnDefinition Mock...
+        $this->mock_column_definition->shouldReceive('getHeaders')->andReturn($expected_headers);
+        // ... etc ...
+        $this->mock_column_definition->shouldReceive('getColumnMap')->andReturn(['ログインID' => 'userid', '評価' => 'grade']);
+        $this->mock_column_definition->shouldReceive('getValidationRulesBase')->andReturn(['userid'=>[],'grade'=>[]]);
+        $this->mock_column_definition->shouldReceive('getValidationMessages')->andReturn([]);
+
+        // RowProcessor Mock: 1回目成功、2回目例外
+        $this->mock_row_processor->shouldReceive('process')->once()->ordered()->andReturnNull();
+        $this->mock_row_processor->shouldReceive('process')->once()->ordered()->andThrow($exception_to_throw);
+
+        // Exception Handler Mock: null を返す
+        $this->mock_exception_handler->shouldReceive('handle')
+            ->once()
+            ->with(Mockery::on(fn($e) => $e === $exception_to_throw))
+            ->andReturn(null); // ★ null を返す -> Importer が unexpected_error で処理
+
+        // CSV File...
+        $csv_rows = [ [$student1->userid, 'A'], [$student2->userid, 'B'] ];
+        $csv_content = $this->createCsvContent($expected_headers, $csv_rows);
+        $fake_file = UploadedFile::fake()->createWithContent('import_unhandled.csv', $csv_content);
+
+        // Act
+        $results = $this->importer->import($fake_file, $this->importer_user);
+
+        // Assert
+        $this->assertEquals(1, $results['success']);
+        $this->assertEquals(1, $results['errors']);
+        $this->assertEquals(0, $results['skipped']);
+        $this->assertCount(2, $results['error_details']); // Unexpected Error + Rollback Error
+        $this->assertCount(0, $results['skip_details']);
+
+        // 予期せぬエラーの詳細を確認
+        $processing_error = collect($results['error_details'])->firstWhere('line', 3);
+        $this->assertNotNull($processing_error);
+        $this->assertEquals('unexpected_error', $processing_error['type']); // ★ Importer の fallback type
+        $this->assertEquals($exception_to_throw->getMessage(), $processing_error['message']);
+
+        // ロールバックエラー詳細の存在確認 ...
+        $rollback_error = collect($results['error_details'])->firstWhere('line', 0);
+        $this->assertNotNull($rollback_error);
+        $this->assertEquals('fatal_error_rollback', $rollback_error['type']);
+    }
+
+    /**
+     * canImport が管理者ユーザーに対して true を返すことをテスト
+     * @test
+     * @covers ::canImport
+     * @group learningtasks
+     * @group learningtasks-importer
+     * @group learningtasks-permission
+     */
+    public function canImportReturnsTrueForAdminUser(): void
+    {
+        // Arrange: ユーザーを作成
+        $admin_user = User::factory()->create();
+        $partial_mock_admin = Mockery::mock($admin_user)->makePartial();
+        // can メソッドの振る舞いのみ上書き
+        $partial_mock_admin->shouldReceive('can')
+                           ->with('role_article_admin')
+                           ->once()
+                           ->andReturn(true); // 管理者権限ありとみなす
+
+        // UserRepository::getTeachers は呼ばれないはず
+
+        // Act: canImport を実行
+        $result = $this->importer->canImport($partial_mock_admin);
+
+        // Assert: 結果が true であることを確認
+        $this->assertTrue($result, '管理者はインポートできるべき');
+    }
+
+    /**
+     * canImport が担当教員ユーザーに対して true を返すことをテスト
+     * @test
+     * @covers ::canImport
+     * @group learningtasks
+     * @group learningtasks-importer
+     * @group learningtasks-permission
+     */
+    public function canImportReturnsTrueForTeacherUser(): void
+    {
+        // Arrange: 教員ユーザーのモックを作成
+        $teacher_user = User::factory()->create();
+
+        // UserRepository がこの教員（実際のオブジェクト）を含むコレクションを返すように設定
+        $this->mock_user_repository
+            ->shouldReceive('getTeachers')
+            ->with($this->post, $this->page)
+            ->once()
+            ->andReturn(new EloquentCollection([$teacher_user]));
+
+        // can メソッドの振る舞いのみ上書き (管理者ではないとする)
+        $partial_mock_teacher = Mockery::mock($teacher_user)->makePartial();
+        $partial_mock_teacher->shouldReceive('can')
+                             ->with('role_article_admin')
+                             ->once()
+                             ->andReturn(false);
+
+        // Act: canImport を実行
+        $result = $this->importer->canImport($partial_mock_teacher);
+
+        // Assert: 結果が true であることを確認
+        $this->assertTrue($result, '担当教員はインポートできるべき');
+    }
+
+    /**
+     * canImport が管理者でも担当教員でもないユーザーに対して false を返すことをテスト
+     * @test
+     * @covers ::canImport
+     * @group learningtasks
+     * @group learningtasks-importer
+     * @group learningtasks-permission
+     */
+    public function canImportReturnsFalseForOtherUser(): void
+    {
+        // Arrange その他のユーザーを作成
+        $other_user = User::factory()->create();
+
+        // UserRepository が空のコレクションを返すように設定
+        $this->mock_user_repository
+            ->shouldReceive('getTeachers')
+            ->with($this->post, $this->page)
+            ->once()
+            ->andReturn(new EloquentCollection([])); // 空のコレクション
+
+        // can メソッドの振る舞いのみ上書き (管理者ではないとする)
+        $partial_mock_other = Mockery::mock($other_user)->makePartial();
+        $partial_mock_other->shouldReceive('can')
+                        ->with('role_article_admin')
+                        ->once()
+                        ->andReturn(false);
+
+        // Act: canImport
+        $result = $this->importer->canImport($partial_mock_other);
+
+        // Assert
+        $this->assertFalse($result, '管理者でも担当教員でもないユーザーはインポートできないべき');
+    }
+}

--- a/tests/Unit/Plugins/User/Learningtasks/Factories/ColumnDefinitionFactoryTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Factories/ColumnDefinitionFactoryTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks\Factories;
+
+use App\Enums\LearningtaskImportType;
+use App\Enums\LearningtaskUseFunction;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Plugins\User\Learningtasks\Contracts\ColumnDefinitionInterface;
+use App\Plugins\User\Learningtasks\Exceptions\FeatureDisabledException;
+use App\Plugins\User\Learningtasks\Factories\ColumnDefinitionFactory;
+use App\Plugins\User\Learningtasks\Services\LearningtaskReportColumnDefinition;
+use App\Plugins\User\Learningtasks\Services\LearningtaskSettingChecker;
+use InvalidArgumentException;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+/**
+ * ColumnDefinitionFactory のユニットテストクラス
+ * @coversDefaultClass \App\Plugins\User\Learningtasks\Factories\ColumnDefinitionFactory
+ */
+class ColumnDefinitionFactoryTest extends TestCase
+{
+    /** @var ColumnDefinitionFactory */
+    private $factory;
+
+    /** @var LearningtasksPosts|MockInterface */
+    private $mock_post; // make() に渡すためのモック
+
+    /** 各テスト前に Factory を準備 */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new ColumnDefinitionFactory();
+        // テストメソッド内で isEnabled の振る舞いを設定するため、基本的なモックだけ用意
+        $this->mock_post = Mockery::mock(LearningtasksPosts::class);
+    }
+
+    /**
+     * "report" タイプが指定された場合に LearningtaskReportColumnDefinition が返ることをテスト
+     * @test
+     * @covers ::make
+     * @group learningtasks
+     * @group learningtasks-factory
+     */
+    public function makeReturnsReportDefinitionForReportType(): void
+    {
+        // Arrange: SettingChecker の isEnabled が true を返すようにオーバーロードモックを設定
+        // 'overload:' をプレフィックスにつけると、今後 new される SettingChecker がモックになる
+        $mock_checker = Mockery::mock('overload:' . LearningtaskSettingChecker::class);
+        $mock_checker->shouldReceive('isEnabled')
+                     ->with(LearningtaskUseFunction::use_report_evaluate) // 正しい設定名を確認
+                     ->once() // 1回呼ばれるはず
+                     ->andReturn(true); // ★ 機能有効
+
+        // Act: Factory の make メソッドを実行
+        $definition = $this->factory->make(LearningtaskImportType::report, $this->mock_post);
+
+        // Assert: 正しいインスタンスが返ることを確認
+        $this->assertInstanceOf(LearningtaskReportColumnDefinition::class, $definition);
+        $this->assertInstanceOf(ColumnDefinitionInterface::class, $definition);
+        // (任意) 返された Definition が内部にモックされた Checker を持っているかの確認も可能だが複雑になる
+    }
+
+    /**
+     * make - report: 設定無効時に FeatureDisabledException がスローされるテスト
+     * @test
+     * @covers ::make
+     * @group learningtasks
+     * @group learningtasks-factory
+     */
+    public function makeThrowsFeatureDisabledExceptionWhenSettingDisabled(): void
+    {
+        // Arrange: SettingChecker の isEnabled が false を返すようにオーバーロードモックを設定
+        $mock_checker = Mockery::mock('overload:' . LearningtaskSettingChecker::class);
+        $mock_checker->shouldReceive('isEnabled')
+                    ->with(LearningtaskUseFunction::use_report_evaluate)
+                    ->once()
+                    ->andReturn(false); // ★ 機能無効
+
+         // Assert: FeatureDisabledException がスローされることを期待
+         $this->expectException(FeatureDisabledException::class);
+         // 例外メッセージも確認
+         $this->expectExceptionMessageMatches('/レポート評価機能が有効になっていません。/');
+
+         // Act: Factory の make メソッドを実行
+         $this->factory->make(LearningtaskImportType::report, $this->mock_post);
+    }
+
+
+    /**
+     * make - 未知のタイプ: InvalidArgumentException がスローされるテスト (基本的に変更なし)
+     * @test
+     * @covers ::make
+     * @group learningtasks
+     * @group learningtasks-factory
+     */
+    public function makeThrowsExceptionForUnknownType(): void
+    {
+        // Arrange
+        $unknown_type = 'unknown_type_string';
+        $mock_checker = Mockery::mock('overload:' . LearningtaskSettingChecker::class);
+
+        // Assert
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/未知のカラム定義タイプ.*{$unknown_type}/");
+
+        // Act
+        $this->factory->make($unknown_type, $this->mock_post);
+    }
+
+    // 将来 'exam' タイプが追加された際のテストケース例
+    // public function testMakeReturnsExamDefinitionForExamType(): void
+    // {
+    //     // Arrange
+    //     $mock_post = Mockery::mock(LearningtasksPosts::class);
+    //     $import_type = 'exam';
+    //     // Act
+    //     $definition = $this->factory->make($import_type, $mock_post);
+    //     // Assert
+    //     $this->assertInstanceOf(LearningtaskExamColumnDefinition::class, $definition); // Exam用クラスを確認
+    //     $this->assertInstanceOf(ColumnDefinitionInterface::class, $definition);
+    // }
+}

--- a/tests/Unit/Plugins/User/Learningtasks/Factories/ExceptionHandlerFactoryTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Factories/ExceptionHandlerFactoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks\Factories;
+
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorExceptionHandlerInterface;
+use App\Plugins\User\Learningtasks\Factories\ExceptionHandlerFactory;
+use App\Plugins\User\Learningtasks\Handlers\ReportExceptionHandler;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+/**
+ * ExceptionHandlerFactory のユニットテストクラス
+ * @coversDefaultClass \App\Plugins\User\Learningtasks\Factories\ExceptionHandlerFactory
+ */
+class ExceptionHandlerFactoryTest extends TestCase
+{
+    /** @var ExceptionHandlerFactory */
+    private $factory;
+
+    /** 各テスト前に Factory を準備 */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new ExceptionHandlerFactory();
+    }
+
+    /**
+     * make メソッドが "report" タイプに対して ReportExceptionHandler を返すことをテスト
+     * @test
+     * @covers ::make
+     * @group learningtasks
+     * @group learningtasks-factory
+     */
+    public function makeReturnsReportHandlerForReportType(): void
+    {
+        // Arrange
+        $import_type = 'report';
+
+        // Act: Factory の make メソッドを実行
+        $handler = $this->factory->make($import_type);
+
+        // Assert: 正しいインスタンスタイプとインターフェース実装を確認
+        $this->assertInstanceOf(ReportExceptionHandler::class, $handler);
+        $this->assertInstanceOf(RowProcessorExceptionHandlerInterface::class, $handler);
+    }
+
+    /**
+     * make メソッドが未知のタイプに対して InvalidArgumentException をスローすることをテスト
+     * @test
+     * @covers ::make
+     * @group learningtasks
+     * @group learningtasks-factory
+     */
+    public function makeThrowsExceptionForUnknownType(): void
+    {
+        // Arrange
+        $unknown_type = 'some_invalid_type_string';
+
+        // Assert: 例外のスローを期待
+        $this->expectException(InvalidArgumentException::class);
+        // 例外メッセージも検証 (Factory 内のメッセージと一致させる)
+        $this->expectExceptionMessageMatches("/未知のインポートタイプに対応する例外ハンドラが見つかりません.*{$unknown_type}/");
+
+        // Act: Factory の make メソッドを実行
+        $this->factory->make($unknown_type);
+    }
+
+    // 将来 'exam' タイプを追加した場合のテスト例 (今はスキップ)
+    /**
+     * make メソッドが "exam" タイプに対して ExamExceptionHandler を返すテスト (将来用)
+     * @test
+     * @group learningtasks
+     * @group learningtasks-factory
+     * @group learningtasks-future
+     */
+    // public function makeReturnsExamHandlerForExamType(): void
+    // {
+    //     $this->markTestSkipped('ExamExceptionHandler is not yet implemented.');
+    //
+    //     // Arrange
+    //     $import_type = 'exam';
+    //     // bind が setUp になければここで bind
+    //     // $this->app->bind(ExamExceptionHandler::class);
+    //
+    //     // Act
+    //     $handler = $this->factory->make($import_type);
+    //
+    //     // Assert
+    //     $this->assertInstanceOf(ExamExceptionHandler::class, $handler);
+    //     $this->assertInstanceOf(RowProcessorExceptionHandlerInterface::class, $handler);
+    // }
+}

--- a/tests/Unit/Plugins/User/Learningtasks/Factories/RowProcessorFactoryTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Factories/RowProcessorFactoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks\Factories;
+
+use App\Plugins\User\Learningtasks\Contracts\RowProcessorInterface;
+use App\Plugins\User\Learningtasks\Factories\RowProcessorFactory;
+use App\Plugins\User\Learningtasks\Services\LearningtaskEvaluationRowProcessor;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+/**
+ * RowProcessorFactory のユニットテストクラス
+ * @coversDefaultClass \App\Plugins\User\Learningtasks\Factories\RowProcessorFactory
+ */
+class RowProcessorFactoryTest extends TestCase
+{
+    /** @var RowProcessorFactory */
+    private $factory;
+
+    /** 各テスト前に Factory を準備 */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new RowProcessorFactory();
+    }
+
+    /**
+     * "report" タイプが指定された場合に LearningtaskEvaluationRowProcessor が返ることをテスト
+     * @test
+     * @covers ::make
+     * @group learningtasks
+     * @group learningtasks-factory
+     */
+    public function makeReturnsEvaluationProcessorForReportType(): void
+    {
+        // Arrange: コンテナが Processor を解決できるように準備 (任意だが確実性のため)
+        // ServiceProvider で bind されていれば不要な場合も多いが、テスト内で明示的に bind しても良い。
+        // Auto-wiring が効くはずなので、ここでは bind しないで試す。
+        // $this->app->bind(LearningtaskEvaluationRowProcessor::class);
+
+        $import_type = 'report';
+
+        // Act: Factory の make メソッドを実行 (内部で app() が呼ばれる)
+        $processor = $this->factory->make($import_type);
+
+        // Assert: 返されたインスタンスが期待した型であること、およびインターフェースを実装していることを確認
+        $this->assertInstanceOf(LearningtaskEvaluationRowProcessor::class, $processor, 'report タイプは LearningtaskEvaluationRowProcessor を返す');
+        $this->assertInstanceOf(RowProcessorInterface::class, $processor, '返されたオブジェクトはインターフェースを実装している');
+    }
+
+    /**
+     * 未知のタイプが指定された場合に InvalidArgumentException がスローされることをテスト
+     * @test
+     * @covers ::make
+     * @group learningtasks
+     * @group learningtasks-factory
+     */
+    public function makeThrowsExceptionForUnknownType(): void
+    {
+        // Arrange
+        $unknown_type = 'unknown_type_string';
+
+        // Assert: 例外がスローされることを期待
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/未知の行処理タイプ.*{$unknown_type}/");
+
+        // Act: Factory の make メソッドを実行
+        $this->factory->make($unknown_type);
+    }
+
+    // 将来 'exam' タイプが追加された際のテストケース例
+    // public function testMakeReturnsExamProcessorForExamType(): void
+    // {
+    //     // Arrange
+    //     // $this->app->bind(LearningtaskExamRowProcessor::class); // 必要なら bind
+    //     $import_type = 'exam';
+    //     // Act
+    //     $processor = $this->factory->make($import_type);
+    //     // Assert
+    //     $this->assertInstanceOf(LearningtaskExamRowProcessor::class, $processor);
+    //     $this->assertInstanceOf(RowProcessorInterface::class, $processor);
+    // }
+}

--- a/tests/Unit/Plugins/User/Learningtasks/Handlers/ReportExceptionHandlerTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Handlers/ReportExceptionHandlerTest.php
@@ -20,7 +20,6 @@ use Illuminate\Support\MessageBag;
 use Mockery; // Validator モック用
 use Tests\TestCase;
 
-
 /**
  * ReportExceptionHandler のユニットテストクラス
  * @coversDefaultClass \App\Plugins\User\Learningtasks\Handlers\ReportExceptionHandler
@@ -37,12 +36,12 @@ class ReportExceptionHandlerTest extends TestCase
         $this->handler = new ReportExceptionHandler();
     }
 
-     /** 各テスト後に Mockery コンテナをクリーンアップ (Validator モック用) */
-     protected function tearDown(): void
-     {
-         parent::tearDown();
-         Mockery::close();
-     }
+    /** 各テスト後に Mockery コンテナをクリーンアップ (Validator モック用) */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
 
     /**
      * handle メソッドが各種例外に対して正しい設定配列または null を返すことをテスト

--- a/tests/Unit/Plugins/User/Learningtasks/Handlers/ReportExceptionHandlerTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Handlers/ReportExceptionHandlerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks\Handlers;
+
+// --- テスト対象クラス ---
+use App\Plugins\User\Learningtasks\Handlers\ReportExceptionHandler;
+// --- テストで使用する例外クラス ---
+use App\Plugins\User\Learningtasks\Exceptions\AlreadyEvaluatedException;
+use App\Plugins\User\Learningtasks\Exceptions\InvalidStudentException;
+use App\Plugins\User\Learningtasks\Exceptions\SubmissionNotFoundException;
+use Exception; // Generic Exception
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Validation\ValidationException; // Laravel Validation Exception
+use InvalidArgumentException; // その他の汎用例外の例
+use Error; // PHP Error (Throwable)
+use Throwable; // Type hint 用
+// --- Testing ---
+use Illuminate\Contracts\Validation\Validator as ValidatorContract; // Validator モック用
+use Illuminate\Support\MessageBag;
+use Mockery; // Validator モック用
+use Tests\TestCase;
+
+
+/**
+ * ReportExceptionHandler のユニットテストクラス
+ * @coversDefaultClass \App\Plugins\User\Learningtasks\Handlers\ReportExceptionHandler
+ */
+class ReportExceptionHandlerTest extends TestCase
+{
+    /** @var ReportExceptionHandler */
+    private $handler;
+
+    /** 各テスト前にハンドラを準備 */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->handler = new ReportExceptionHandler();
+    }
+
+     /** 各テスト後に Mockery コンテナをクリーンアップ (Validator モック用) */
+     protected function tearDown(): void
+     {
+         parent::tearDown();
+         Mockery::close();
+     }
+
+    /**
+     * handle メソッドが各種例外に対して正しい設定配列または null を返すことをテスト
+     *
+     * @test
+     * @covers ::handle
+     * @dataProvider exceptionDataProvider
+     * @group learningtasks
+     * @group learningtasks-handler
+     */
+    public function handleReturnsCorrectConfigForExceptions(Throwable $exception, ?array $expected_config): void
+    {
+        // Act: ハンドラの handle メソッドを実行
+        $actual_config = $this->handler->handle($exception);
+
+        // Assert: 戻り値が期待通りか検証
+        $this->assertEquals($expected_config, $actual_config);
+    }
+
+    /**
+     * handle メソッドテスト用のデータプロバイダ
+     *
+     * @return array<string, array{exception: Throwable, expected_config: ?array}>
+     */
+    public function exceptionDataProvider(): array
+    {
+        // ValidationException のインスタンス化には Validator が必要。
+        // instanceof の型チェックだけが目的なら、単純なモックで代用する。
+        /** @var \Illuminate\Contracts\Validation\Validator|MockInterface $validatorMock */
+        $validatorMock = Mockery::mock(ValidatorContract::class);
+        // errors() が MessageBag を返すように設定 (ValidationException のコンストラクタで必要)
+        $validatorMock->shouldReceive('errors')->andReturn(new MessageBag());
+        $validationException = new ValidationException($validatorMock);
+
+        // テストケース名 => [渡す例外オブジェクト, 期待される戻り値] の配列
+        return [
+            'ValidationExceptionの場合' => [
+                'exception' => $validationException, // モックを使う
+                'expected_config' => ['outcome' => 'error', 'type' => 'validation_error', 'log_level' => 'warning']
+            ],
+            'InvalidStudentExceptionの場合' => [
+                'exception' => new InvalidStudentException(),
+                'expected_config' => ['outcome' => 'skip', 'type' => 'invalid_student', 'log_level' => 'info']
+            ],
+            'AlreadyEvaluatedExceptionの場合' => [
+                'exception' => new AlreadyEvaluatedException(),
+                'expected_config' => ['outcome' => 'skip', 'type' => 'already_evaluated', 'log_level' => 'info']
+            ],
+            'SubmissionNotFoundExceptionの場合' => [
+                'exception' => new SubmissionNotFoundException(),
+                'expected_config' => ['outcome' => 'error', 'type' => 'submission_not_found', 'log_level' => 'error']
+            ],
+            'ModelNotFoundExceptionの場合' => [
+                'exception' => new ModelNotFoundException("Test model not found"), // メッセージは任意
+                'expected_config' => ['outcome' => 'error', 'type' => 'processing_error_user_not_found', 'log_level' => 'error']
+            ],
+            'その他の汎用Exceptionの場合' => [
+                'exception' => new Exception("Generic error"), // マップにない Exception
+                'expected_config' => null // ハンドルできないので null を期待
+            ],
+            'PHP Errorの場合' => [
+                'exception' => new Error("Generic PHP error"), // マップにない Throwable (Error)
+                'expected_config' => null // ハンドルできないので null を期待
+             ],
+             'マップにない他のExceptionの場合' => [
+                 'exception' => new InvalidArgumentException("Other type"),
+                 'expected_config' => null
+             ],
+        ];
+    }
+}

--- a/tests/Unit/Plugins/User/Learningtasks/Repositories/LearningtaskUserRepositoryTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Repositories/LearningtaskUserRepositoryTest.php
@@ -134,7 +134,8 @@ class LearningtaskUserRepositoryTest extends TestCase
             ['learningtasks_id' => $learningtask->id, 'student_join_flag' => 3]
         );
         LearningtasksUsers::factory()->create(
-            ['post_id' => $post->id, 'user_id' => $user1->id, 'role_name' => RoleName::student]);
+            ['post_id' => $post->id, 'user_id' => $user1->id, 'role_name' => RoleName::student]
+        );
         // not_selected_userはメンバーシップユーザだが、選択されていない
 
         // Act: メソッドの実行
@@ -271,7 +272,8 @@ class LearningtaskUserRepositoryTest extends TestCase
             ['learningtasks_id' => $learningtask->id, 'teacher_join_flag' => 3]
         );
         LearningtasksUsers::factory()->create(
-            ['post_id' => $post->id, 'user_id' => $user1->id, 'role_name' => RoleName::teacher]);
+            ['post_id' => $post->id, 'user_id' => $user1->id, 'role_name' => RoleName::teacher]
+        );
         // not_selected_userはメンバーシップユーザだが、選択されていない
 
         // Act: メソッドの実行

--- a/tests/Unit/Plugins/User/Learningtasks/Repositories/LearningtaskUserRepositoryTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Repositories/LearningtaskUserRepositoryTest.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks\Repositories;
+
+use App\Enums\RoleName;
+use App\Models\Common\Group;
+use App\Models\Common\GroupUser;
+use App\Models\Common\Page;
+use App\Models\Common\PageRole;
+use App\Models\Core\UsersRoles;
+use App\Models\User\Learningtasks\Learningtasks;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Models\User\Learningtasks\LearningtasksUsers;
+use App\Plugins\User\Learningtasks\Repositories\LearningtaskUserRepository;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class LearningtaskUserRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * テスト対象のリポジトリインスタンス
+     * @var LearningtaskUserRepository
+     */
+    private $repository;
+
+    /**
+     * 各テスト前のセットアップ
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new LearningtaskUserRepository();
+    }
+
+    /**
+     * 配置ページのメンバーシップユーザ全員の学生を取得するテスト
+     *
+     * @test
+     * @group learningtasks
+     * @group learningtasks-repository
+     */
+    public function getStudentsReturnsPageMembers()
+    {
+        // Arrange: テストデータの準備 (student_join_flag = 2 のシナリオ)
+        // メンバーシップページを作成する
+        $page = Page::factory()->create(['membership_flag' => 1]);
+        // グループを作成し、ページロールを作成する
+        $group = Group::factory()->create();
+        $page_role = PageRole::factory()->create(['page_id' => $page->id, 'group_id' => $group->id]);
+
+        // 期待されるユーザ
+        // user1, user2は学生のロールかつ、グループに所属する（=メンバーシップユーザとなる）
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        // 除外されるユーザ
+        // other_role_userはグループに所属するが、教員のロール
+        // not_in_group_userはグループに所属しない学生
+        $other_role_user = User::factory()->create();
+        $not_in_group_user = User::factory()->create();
+
+        // ロール設定
+        UsersRoles::factory()->create(['users_id' => $user1->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        UsersRoles::factory()->create(['users_id' => $user2->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        UsersRoles::factory()->create(['users_id' => $other_role_user->id, 'target' => 'original_role', 'role_name' => RoleName::teacher]);
+        UsersRoles::factory()->create(['users_id' => $not_in_group_user->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        // グループにユーザを追加する
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $user1->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $user2->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $other_role_user->id]);
+
+        $learningtask = Learningtasks::factory()->create();
+        // 配置ページのメンバーシップユーザ全員 student_join_flag = 2
+        $post = LearningtasksPosts::factory()->create(
+            ['learningtasks_id' => $learningtask->id, 'student_join_flag' => 2]
+        );
+
+        // Act: メソッドの実行
+        $result_students = $this->repository->getStudents($post, $page);
+
+        // Assert: 結果の検証
+        $this->assertCount(2, $result_students, '対象グループの受講生が2人だけ取得されるべき');
+        $this->assertEquals($user1->id, $result_students[0]->id, '期待される受講生1が含まれていること');
+        $this->assertEquals($user2->id, $result_students[1]->id, '期待される受講生2が含まれていること');
+        $this->assertFalse($result_students->contains('id', $other_role_user->id), '教員は含まれないこと');
+        $this->assertFalse($result_students->contains('id', $not_in_group_user->id), 'グループ外の受講生は含まれないこと');
+    }
+
+    /**
+     * 配置ページのメンバーシップユーザから選んだ学生を取得するテスト
+     *
+     * @test
+     * @group learningtasks
+     * @group learningtasks-repository
+     */
+    public function getStudentsReturnsSelectedMembers()
+    {
+        // Arrange: テストデータの準備 (student_join_flag = 3 のシナリオ)
+        // メンバーシップページを作成する
+        $page = Page::factory()->create(['membership_flag' => 1]);
+        // グループを作成し、ページロールを作成する
+        $group = Group::factory()->create();
+        $page_role = PageRole::factory()->create(['page_id' => $page->id, 'group_id' => $group->id]);
+
+        // 期待されるユーザ
+        // user1, user2は学生のロールかつ、グループに所属する（=メンバーシップユーザとなる）
+        $user1 = User::factory()->create();
+
+        // 除外されるユーザ
+        // not_selected_userはグループに所属するが、選択されていない学生
+        // other_role_userはグループに所属するが、教員のロール
+        // not_in_group_userはグループに所属しない学生
+        $not_selected_user = User::factory()->create();
+        $other_role_user = User::factory()->create();
+        $not_in_group_user = User::factory()->create();
+
+        // ロール設定
+        UsersRoles::factory()->create(['users_id' => $user1->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        UsersRoles::factory()->create(['users_id' => $not_selected_user->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        UsersRoles::factory()->create(['users_id' => $other_role_user->id, 'target' => 'original_role', 'role_name' => RoleName::teacher]);
+        UsersRoles::factory()->create(['users_id' => $not_in_group_user->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        // グループにユーザを追加する
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $user1->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $not_selected_user->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $other_role_user->id]);
+
+        $learningtask = Learningtasks::factory()->create();
+        // 配置ページのメンバーシップユーザから選ぶ
+        $post = LearningtasksPosts::factory()->create(
+            ['learningtasks_id' => $learningtask->id, 'student_join_flag' => 3]
+        );
+        LearningtasksUsers::factory()->create(
+            ['post_id' => $post->id, 'user_id' => $user1->id, 'role_name' => RoleName::student]);
+        // not_selected_userはメンバーシップユーザだが、選択されていない
+
+        // Act: メソッドの実行
+        $result_students = $this->repository->getStudents($post, $page);
+
+        // Assert: 結果の検証
+        $this->assertCount(1, $result_students, '選ばれた学生が1人だけ取得されるべき');
+        $this->assertEquals($user1->id, $result_students[0]->id, '期待される受講生1が含まれていること');
+        $this->assertFalse($result_students->contains('id', $not_selected_user->id), 'メンバーシップユーザだが選ばれていない学生が含まれないこと');
+        $this->assertFalse($result_students->contains('id', $other_role_user->id), '教員は含まれないこと');
+        $this->assertFalse($result_students->contains('id', $not_in_group_user->id), 'グループ外の受講生は含まれないこと');
+    }
+
+    /**
+     * getStudents メソッド, 該当する学生がいない場合に空のコレクションを返すことを確認するテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-repository
+     */
+    public function getStudentsReturnsEmptyWhenNoMatchingStudents(): void
+    {
+        // Arrange: 該当する学生がいない状況を作る
+        $page = Page::factory()->create();
+        $post_flag2 = LearningtasksPosts::factory()->create(['student_join_flag' => 2]);
+        $post_flag3 = LearningtasksPosts::factory()->create(['student_join_flag' => 3]);
+        User::factory()->create(); // ユーザーを作成するが、グループやロール、直接リンクは設定しない
+
+        // Act & Assert for flag = 2
+        $result_flag2 = $this->repository->getStudents($post_flag2, $page);
+        $this->assertCount(0, $result_flag2, 'Flag=2で該当者がいない場合、空のコレクションが返るべき');
+        $this->assertInstanceOf(Collection::class, $result_flag2);
+
+        // Act & Assert for flag = 3
+        $result_flag3 = $this->repository->getStudents($post_flag3, $page);
+        $this->assertCount(0, $result_flag3, 'Flag=3で該当者がいない場合、空のコレクションが返るべき');
+        $this->assertInstanceOf(Collection::class, $result_flag3);
+    }
+
+    /**
+     * 配置ページのメンバーシップユーザ全員の教員を取得するテスト
+     *
+     * @test
+     * @group learningtasks
+     * @group learningtasks-repository
+     */
+    public function getTeachersReturnsPageMembers()
+    {
+        // Arrange: テストデータの準備 (teacher_join_flag = 2 のシナリオ)
+        // メンバーシップページを作成する
+        $page = Page::factory()->create(['membership_flag' => 1]);
+        // グループを作成し、ページロールを作成する
+        $group = Group::factory()->create();
+        $page_role = PageRole::factory()->create(['page_id' => $page->id, 'group_id' => $group->id]);
+
+        // 期待されるユーザ
+        // user1, user2は教員のロールかつ、グループに所属する（=メンバーシップユーザとなる）
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        // 除外されるユーザ
+        // other_role_userはグループに所属するが、学生のロール
+        // not_in_group_userはグループに所属しない教員
+        $other_role_user = User::factory()->create();
+        $not_in_group_user = User::factory()->create();
+
+        // ロール設定
+        UsersRoles::factory()->create(['users_id' => $user1->id, 'target' => 'original_role', 'role_name' => RoleName::teacher]);
+        UsersRoles::factory()->create(['users_id' => $user2->id, 'target' => 'original_role', 'role_name' => RoleName::teacher]);
+        UsersRoles::factory()->create(['users_id' => $other_role_user->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        UsersRoles::factory()->create(['users_id' => $not_in_group_user->id, 'target' => 'original_role', 'role_name' => RoleName::teacher]);
+        // グループにユーザを追加する
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $user1->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $user2->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $other_role_user->id]);
+
+        $learningtask = Learningtasks::factory()->create();
+        // 配置ページのメンバーシップユーザ全員 teacher_join_flag = 2
+        $post = LearningtasksPosts::factory()->create(
+            ['learningtasks_id' => $learningtask->id, 'teacher_join_flag' => 2]
+        );
+
+        // Act: メソッドの実行
+        $result_students = $this->repository->getTeachers($post, $page);
+
+        // Assert: 結果の検証
+        $this->assertCount(2, $result_students, '対象グループの教員が2人だけ取得されるべき');
+        $this->assertEquals($user1->id, $result_students[0]->id, '期待される教員1が含まれていること');
+        $this->assertEquals($user2->id, $result_students[1]->id, '期待される教員2が含まれていること');
+        $this->assertFalse($result_students->contains('id', $other_role_user->id), '学生は含まれないこと');
+        $this->assertFalse($result_students->contains('id', $not_in_group_user->id), 'グループ外の教員は含まれないこと');
+    }
+
+    /**
+     * 配置ページのメンバーシップユーザから選んだ教員を取得するテスト
+     *
+     * @test
+     * @group learningtasks
+     * @group learningtasks-repository
+     */
+    public function getTeachersReturnsSelectedMembers()
+    {
+        // Arrange: テストデータの準備 (teacher_join_flag = 3 のシナリオ)
+        // メンバーシップページを作成する
+        $page = Page::factory()->create(['membership_flag' => 1]);
+        // グループを作成し、ページロールを作成する
+        $group = Group::factory()->create();
+        $page_role = PageRole::factory()->create(['page_id' => $page->id, 'group_id' => $group->id]);
+
+        // 期待されるユーザ
+        // user1は教員のロールかつ、グループに所属する（=メンバーシップユーザとなる）
+        $user1 = User::factory()->create();
+
+        // 除外されるユーザ
+        // not_selected_userはグループに所属するが、選択されていない教員
+        // other_role_userはグループに所属するが、教員のロール
+        // not_in_group_userはグループに所属しない教員
+        $not_selected_user = User::factory()->create();
+        $other_role_user = User::factory()->create();
+        $not_in_group_user = User::factory()->create();
+
+        // ロール設定
+        UsersRoles::factory()->create(['users_id' => $user1->id, 'target' => 'original_role', 'role_name' => RoleName::teacher]);
+        UsersRoles::factory()->create(['users_id' => $not_selected_user->id, 'target' => 'original_role', 'role_name' => RoleName::teacher]);
+        UsersRoles::factory()->create(['users_id' => $other_role_user->id, 'target' => 'original_role', 'role_name' => RoleName::student]);
+        UsersRoles::factory()->create(['users_id' => $not_in_group_user->id, 'target' => 'original_role', 'role_name' => RoleName::teacher]);
+        // グループにユーザを追加する
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $user1->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $not_selected_user->id]);
+        GroupUser::factory()->create(['group_id' => $group->id, 'user_id' => $other_role_user->id]);
+
+        $learningtask = Learningtasks::factory()->create();
+        // 配置ページのメンバーシップユーザから選ぶ
+        $post = LearningtasksPosts::factory()->create(
+            ['learningtasks_id' => $learningtask->id, 'teacher_join_flag' => 3]
+        );
+        LearningtasksUsers::factory()->create(
+            ['post_id' => $post->id, 'user_id' => $user1->id, 'role_name' => RoleName::teacher]);
+        // not_selected_userはメンバーシップユーザだが、選択されていない
+
+        // Act: メソッドの実行
+        $result_students = $this->repository->getTeachers($post, $page);
+
+        // Assert: 結果の検証
+        $this->assertCount(1, $result_students, '選ばれた学生が1人だけ取得されるべき');
+        $this->assertEquals($user1->id, $result_students[0]->id, '期待される受講生1が含まれていること');
+        $this->assertFalse($result_students->contains('id', $not_selected_user->id), 'メンバーシップユーザだが選ばれていない学生が含まれないこと');
+        $this->assertFalse($result_students->contains('id', $other_role_user->id), '教員は含まれないこと');
+        $this->assertFalse($result_students->contains('id', $not_in_group_user->id), 'グループ外の受講生は含まれないこと');
+    }
+
+    /**
+     * getTeachers メソッド, 該当する教員がいない場合に空のコレクションを返すことを確認するテスト
+     * @test
+     * @group learningtasks
+     * @group learningtasks-repository
+     */
+    public function getTeachersReturnsEmptyWhenNoMatchingTeacher(): void
+    {
+        // Arrange: 該当する教員がいない状況を作る
+        $page = Page::factory()->create();
+        $post_flag2 = LearningtasksPosts::factory()->create(['teacher_join_flag' => 2]);
+        $post_flag3 = LearningtasksPosts::factory()->create(['teacher_join_flag' => 3]);
+        User::factory()->create(); // ユーザーを作成するが、グループやロール、直接リンクは設定しない
+
+        // Act & Assert for flag = 2
+        $result_flag2 = $this->repository->getTeachers($post_flag2, $page);
+        $this->assertCount(0, $result_flag2, 'Flag=2で該当者がいない場合、空のコレクションが返るべき');
+        $this->assertInstanceOf(Collection::class, $result_flag2);
+
+        // Act & Assert for flag = 3
+        $result_flag3 = $this->repository->getTeachers($post_flag3, $page);
+        $this->assertCount(0, $result_flag3, 'Flag=3で該当者がいない場合、空のコレクションが返るべき');
+        $this->assertInstanceOf(Collection::class, $result_flag3);
+    }
+}

--- a/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskEvaluationRowProcessorTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskEvaluationRowProcessorTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks\Services;
+
+use App\Plugins\User\Learningtasks\Exceptions\AlreadyEvaluatedException;
+use App\Plugins\User\Learningtasks\Exceptions\InvalidStudentException;
+use App\Models\Common\Page;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Models\User\Learningtasks\LearningtasksUsersStatuses;
+use App\Plugins\User\Learningtasks\Repositories\LearningtaskUserRepository;
+use App\Plugins\User\Learningtasks\Services\LearningtaskEvaluationRowProcessor;
+use App\User;
+use Exception;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+/**
+ * LearningtaskEvaluationRowProcessor のテストクラス (DB利用)
+ * @coversDefaultClass \App\Plugins\User\Learningtasks\Services\LearningtaskEvaluationRowProcessor
+ */
+class LearningtaskEvaluationRowProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var LearningtaskUserRepository|MockInterface */
+    private $mock_user_repository; // UserRepository はモック化する
+
+    /** @var LearningtaskEvaluationRowProcessor */
+    private $processor; // テスト対象
+
+    /**
+     * 各テスト前にモック準備とテスト対象を生成
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // UserRepository のモックを作成
+        $this->mock_user_repository = Mockery::mock(LearningtaskUserRepository::class);
+        // モックを注入して Processor をインスタンス化
+        $this->processor = new LearningtaskEvaluationRowProcessor($this->mock_user_repository);
+    }
+
+    /**
+     * 正常系: 有効なデータで評価レコードが作成されることをテスト
+     * @test
+     * @covers ::process
+     * @group learningtasks
+     * @group learningtasks-processor
+     */
+    public function processCreatesEvaluationRecordSuccessfully(): void
+    {
+        // Arrange: データ準備
+        $page = Page::factory()->create();
+        $post = LearningtasksPosts::factory()->create();
+        $student = User::factory()->create(['userid' => 'student01']); // ログインID指定
+        $importer = User::factory()->create(); // インポート実行者
+        // 最新の提出レコードを作成
+        $latest_submission = LearningtasksUsersStatuses::factory()->create([
+            'post_id' => $post->id,
+            'user_id' => $student->id,
+            'task_status' => 1, // 提出ステータス
+        ]);
+        // UserRepository のモック設定: この学生が有効であると返す
+        $this->mock_user_repository
+            ->shouldReceive('getStudents')
+            ->withArgs(fn ($p, $pg) => $p->id === $post->id && $pg->id === $page->id) // 引数チェック
+            ->once() // キャッシュ機能のテストも兼ねる。初回のみ呼ばれるはず。
+            ->andReturn(new EloquentCollection([$student])); // 学生を含む Collection を返す
+
+        // インポートする評価データ
+        $validated_data = [
+            'userid' => $student->userid, // 'student01'
+            'grade' => 'A',
+            'comment' => 'よくできています',
+        ];
+
+        $this->actingAs($importer);
+
+        // Act: process メソッドを実行
+        $this->processor->process($validated_data, $post, $page, $importer);
+
+        // Assert: DB アサーション
+        $this->assertDatabaseHas('learningtasks_users_statuses', [
+            'post_id' => $post->id,
+            'user_id' => $student->id,
+            'task_status' => 2, // 評価ステータス
+            'grade' => 'A',
+            'comment' => 'よくできています',
+            'created_id' => $importer->id, // 作成者(評価者)ID
+        ]);
+        // 念のため、評価レコードが1件だけ作成されたことを確認
+        $this->assertDatabaseCount('learningtasks_users_statuses', 2); // 提出 + 評価
+    }
+
+    /**
+     * 異常系: 既に評価済みの場合に AlreadyEvaluatedException がスローされるテスト
+     * @test
+     * @covers ::process
+     * @group learningtasks
+     * @group learningtasks-processor
+     */
+    public function processThrowsExceptionWhenAlreadyEvaluated(): void
+    {
+         // Arrange
+         $page = Page::factory()->create();
+         $post = LearningtasksPosts::factory()->create();
+         $student = User::factory()->create(['userid' => 'student02']);
+         $importer = User::factory()->create();
+         $latest_submission = LearningtasksUsersStatuses::factory()->create([
+             'post_id' => $post->id, 'user_id' => $student->id, 'task_status' => 1,
+         ]);
+         // 既存の評価レコードを作成 (ID > 提出ID になるように)
+         $existing_evaluation = LearningtasksUsersStatuses::factory()->create([
+             'post_id' => $post->id, 'user_id' => $student->id, 'task_status' => 2,
+             'id' => $latest_submission->id + 1, // IDを調整 (Factoryでできない場合は手動更新)
+             'created_id' => $importer->id,
+         ]);
+         $this->mock_user_repository->shouldReceive('getStudents')->once()->andReturn(new EloquentCollection([$student]));
+         $validated_data = ['userid' => $student->userid, 'grade' => 'B'];
+
+         // Assert: 例外のスローを期待
+         $this->expectException(AlreadyEvaluatedException::class);
+
+         // Act
+         try {
+              $this->processor->process($validated_data, $post, $page, $importer);
+         } catch (Exception $e) {
+             // 例外発生後、DBに追加の評価レコードがないことを確認
+             $this->assertDatabaseCount('learningtasks_users_statuses', 2); // 提出 + 既存評価 のままのはず
+             throw $e; // 例外を再スローして PHPUnit に検知させる
+         }
+    }
+
+    /**
+     * 異常系: ユーザーが受講生でない場合に InvalidStudentException がスローされるテスト
+     * @test
+     * @covers ::process
+     * @group learningtasks
+     * @group learningtasks-processor
+     */
+    public function processThrowsExceptionWhenUserIsNotStudent(): void
+    {
+         // Arrange
+         $page = Page::factory()->create();
+         $post = LearningtasksPosts::factory()->create();
+         $not_a_student = User::factory()->create(['userid' => 'notstudent']);
+         $importer = User::factory()->create();
+         LearningtasksUsersStatuses::factory()->create(['post_id' => $post->id, 'user_id' => $not_a_student->id, 'task_status' => 1]);
+         // UserRepository が空のコレクションを返すようにモック
+         $this->mock_user_repository->shouldReceive('getStudents')->once()->andReturn(new EloquentCollection([]));
+         $validated_data = ['userid' => $not_a_student->userid, 'grade' => 'C'];
+
+         // Assert: 例外を期待
+         $this->expectException(InvalidStudentException::class);
+
+         // Act
+         try {
+             $this->processor->process($validated_data, $post, $page, $importer);
+         } catch(Exception $e) {
+             // DBに評価が追加されていないことを確認
+             $this->assertDatabaseMissing('learningtasks_users_statuses', [
+                 'post_id' => $post->id, 'user_id' => $not_a_student->id, 'task_status' => 2
+             ]);
+             throw $e;
+         }
+    }
+
+    /**
+     * 異常系: 提出記録がない場合に Exception がスローされるテスト
+     * @test
+     * @covers ::process
+     * @group learningtasks
+     * @group learningtasks-processor
+     */
+    public function processThrowsExceptionWhenNoSubmissionExists(): void
+    {
+        // Arrange
+        $page = Page::factory()->create();
+        $post = LearningtasksPosts::factory()->create();
+        $student = User::factory()->create(['userid' => 'student03']);
+        $importer = User::factory()->create();
+        // 提出記録 (task_status=1) は作成しない
+        $this->mock_user_repository->shouldReceive('getStudents')->once()->andReturn(new EloquentCollection([$student]));
+        $validated_data = ['userid' => $student->userid, 'grade' => 'D'];
+
+        // Assert: 汎用 Exception を期待 (メッセージも確認)
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/提出記録がユーザー .* に見つかりません/');
+
+        // Act
+        try {
+            $this->processor->process($validated_data, $post, $page, $importer);
+        } catch(Exception $e) {
+             // DBに評価が追加されていないことを確認
+            $this->assertDatabaseMissing('learningtasks_users_statuses', [
+                'post_id' => $post->id, 'user_id' => $student->id, 'task_status' => 2
+            ]);
+            throw $e;
+        }
+    }
+
+     /**
+     * 異常系: ユーザーIDが存在しない場合に ModelNotFoundException がスローされるテスト
+     * @test
+     * @covers ::process
+     * @group learningtasks
+     * @group learningtasks-processor
+     */
+    public function processThrowsModelNotFoundExceptionWhenUserDoesNotExist(): void
+    {
+        // Arrange
+        $page = Page::factory()->create();
+        $post = LearningtasksPosts::factory()->create();
+        $importer = User::factory()->create();
+        $validated_data = ['userid' => 'nonexistentuser', 'grade' => 'A'];
+        // UserRepository は呼ばれる前に例外発生するのでモック不要
+
+        // Assert: ModelNotFoundException を期待
+        $this->expectException(ModelNotFoundException::class);
+
+        // Act
+        $this->processor->process($validated_data, $post, $page, $importer);
+    }
+
+}

--- a/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskEvaluationRowProcessorTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskEvaluationRowProcessorTest.php
@@ -127,13 +127,13 @@ class LearningtaskEvaluationRowProcessorTest extends TestCase
          $this->expectException(AlreadyEvaluatedException::class);
 
          // Act
-         try {
-              $this->processor->process($validated_data, $post, $page, $importer);
-         } catch (Exception $e) {
-             // 例外発生後、DBに追加の評価レコードがないことを確認
-             $this->assertDatabaseCount('learningtasks_users_statuses', 2); // 提出 + 既存評価 のままのはず
-             throw $e; // 例外を再スローして PHPUnit に検知させる
-         }
+        try {
+             $this->processor->process($validated_data, $post, $page, $importer);
+        } catch (Exception $e) {
+            // 例外発生後、DBに追加の評価レコードがないことを確認
+            $this->assertDatabaseCount('learningtasks_users_statuses', 2); // 提出 + 既存評価 のままのはず
+            throw $e; // 例外を再スローして PHPUnit に検知させる
+        }
     }
 
     /**
@@ -159,15 +159,15 @@ class LearningtaskEvaluationRowProcessorTest extends TestCase
          $this->expectException(InvalidStudentException::class);
 
          // Act
-         try {
-             $this->processor->process($validated_data, $post, $page, $importer);
-         } catch(Exception $e) {
-             // DBに評価が追加されていないことを確認
-             $this->assertDatabaseMissing('learningtasks_users_statuses', [
-                 'post_id' => $post->id, 'user_id' => $not_a_student->id, 'task_status' => 2
-             ]);
-             throw $e;
-         }
+        try {
+            $this->processor->process($validated_data, $post, $page, $importer);
+        } catch (Exception $e) {
+            // DBに評価が追加されていないことを確認
+            $this->assertDatabaseMissing('learningtasks_users_statuses', [
+                'post_id' => $post->id, 'user_id' => $not_a_student->id, 'task_status' => 2
+            ]);
+            throw $e;
+        }
     }
 
     /**
@@ -195,7 +195,7 @@ class LearningtaskEvaluationRowProcessorTest extends TestCase
         // Act
         try {
             $this->processor->process($validated_data, $post, $page, $importer);
-        } catch(Exception $e) {
+        } catch (Exception $e) {
              // DBに評価が追加されていないことを確認
             $this->assertDatabaseMissing('learningtasks_users_statuses', [
                 'post_id' => $post->id, 'user_id' => $student->id, 'task_status' => 2
@@ -226,5 +226,4 @@ class LearningtaskEvaluationRowProcessorTest extends TestCase
         // Act
         $this->processor->process($validated_data, $post, $page, $importer);
     }
-
 }

--- a/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinitionTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinitionTest.php
@@ -128,13 +128,13 @@ class LearningtaskReportColumnDefinitionTest extends TestCase
          $expected_headers = [
             'ログインID', 'ユーザ名', '提出日時', '提出回数', // Base
             '評価', '評価コメント' // Enabled optional
-        ];
+         ];
 
         // Act
-        $headers = $definition->getHeaders();
+         $headers = $definition->getHeaders();
 
         // Assert
-        $this->assertEquals($expected_headers, $headers);
+         $this->assertEquals($expected_headers, $headers);
     }
 
     /**
@@ -267,22 +267,22 @@ class LearningtaskReportColumnDefinitionTest extends TestCase
      * @group learningtasks
      * @group learningtasks-coldef
      */
-     public function getValidationRulesBaseReturnsCorrectRulesWhenEvaluateOnCommentOff(): void
-     {
-         // Arrange: 評価ON, コメントOFF
-         $definition = $this->createInstance([
-             LearningtaskUseFunction::use_report_evaluate => true,
-             LearningtaskUseFunction::use_report_evaluate_comment => false,
-         ]);
-         // Act
-         $rules = $definition->getValidationRulesBase();
-         // Assert
-         $this->assertArrayHasKey('grade', $rules);
-         $this->assertIsObject($rules['grade'][2]); // Check Rule::in is object
-         $this->assertContains('nullable', $rules['grade']);
-         $this->assertArrayHasKey('comment', $rules);
-         $this->assertEquals(['prohibited'], $rules['comment']); // コメントは禁止される
-     }
+    public function getValidationRulesBaseReturnsCorrectRulesWhenEvaluateOnCommentOff(): void
+    {
+        // Arrange: 評価ON, コメントOFF
+        $definition = $this->createInstance([
+            LearningtaskUseFunction::use_report_evaluate => true,
+            LearningtaskUseFunction::use_report_evaluate_comment => false,
+        ]);
+        // Act
+        $rules = $definition->getValidationRulesBase();
+        // Assert
+        $this->assertArrayHasKey('grade', $rules);
+        $this->assertIsObject($rules['grade'][2]); // Check Rule::in is object
+        $this->assertContains('nullable', $rules['grade']);
+        $this->assertArrayHasKey('comment', $rules);
+        $this->assertEquals(['prohibited'], $rules['comment']); // コメントは禁止される
+    }
 
     /**
      * getValidationRulesBase が評価OFF/コメントON時に正しいルールを返すことをテスト
@@ -291,22 +291,22 @@ class LearningtaskReportColumnDefinitionTest extends TestCase
      * @group learningtasks
      * @group learningtasks-coldef
      */
-     public function getValidationRulesBaseReturnsCorrectRulesWhenEvaluateOffCommentOn(): void
-     {
-          // Arrange: 評価OFF, コメントON
-         $definition = $this->createInstance([
-             LearningtaskUseFunction::use_report_evaluate => false,
-             LearningtaskUseFunction::use_report_evaluate_comment => true,
-         ]);
-          // Act
-         $rules = $definition->getValidationRulesBase();
-          // Assert
-         $this->assertArrayHasKey('grade', $rules);
-         $this->assertEquals(['prohibited'], $rules['grade']); // 評価は禁止
-         $this->assertArrayHasKey('comment', $rules);
-         // コメントは有効だが、依存する grade が prohibited なので required_with は影響小
-         $this->assertEquals(['nullable', 'string', 'max:65535', 'required_with:grade'], $rules['comment']);
-     }
+    public function getValidationRulesBaseReturnsCorrectRulesWhenEvaluateOffCommentOn(): void
+    {
+         // Arrange: 評価OFF, コメントON
+        $definition = $this->createInstance([
+            LearningtaskUseFunction::use_report_evaluate => false,
+            LearningtaskUseFunction::use_report_evaluate_comment => true,
+        ]);
+         // Act
+        $rules = $definition->getValidationRulesBase();
+         // Assert
+        $this->assertArrayHasKey('grade', $rules);
+        $this->assertEquals(['prohibited'], $rules['grade']); // 評価は禁止
+        $this->assertArrayHasKey('comment', $rules);
+        // コメントは有効だが、依存する grade が prohibited なので required_with は影響小
+        $this->assertEquals(['nullable', 'string', 'max:65535', 'required_with:grade'], $rules['comment']);
+    }
 
      /**
      * getValidationMessages が期待されるメッセージ配列を返すことをテスト
@@ -330,5 +330,4 @@ class LearningtaskReportColumnDefinitionTest extends TestCase
         $this->assertEquals('評価コメント機能が無効なため、評価コメント列は入力できません（空にしてください）。', $messages['comment.prohibited']);
         // 全てのメッセージを網羅的にテストしても良い
     }
-
 }

--- a/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinitionTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinitionTest.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks\Services;
+
+use App\Enums\LearningtaskUseFunction;
+use App\Plugins\User\Learningtasks\Services\LearningtaskReportColumnDefinition;
+use App\Plugins\User\Learningtasks\Services\LearningtaskSettingChecker;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+/**
+ * LearningtaskReportColumnDefinition のユニットテストクラス
+ * @coversDefaultClass \App\Plugins\User\Learningtasks\Services\LearningtaskReportColumnDefinition
+ */
+class LearningtaskReportColumnDefinitionTest extends TestCase
+{
+    /**
+     * 設定チェッカーのモックインスタンス
+     * @var LearningtaskSettingChecker|MockInterface
+     */
+    private $mock_setting_checker;
+
+    /**
+     * 各テスト前にモックを準備
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // テストごとに SettingChecker のモックを生成
+        $this->mock_setting_checker = Mockery::mock(LearningtaskSettingChecker::class);
+    }
+
+    /**
+     * テスト対象クラスのインスタンスを生成するヘルパー
+     * 指定された設定の isEnabled の振る舞いをモックに設定する
+     *
+     * @param array $settings ['setting_name' => bool, ...] 形式で設定の有効/無効を指定
+     * @return LearningtaskReportColumnDefinition
+     */
+    private function createInstance(array $settings = []): LearningtaskReportColumnDefinition
+    {
+        // 指定された設定に基づいて isEnabled の戻り値を設定
+        foreach ($settings as $setting_name => $is_enabled) {
+            $this->mock_setting_checker
+                ->shouldReceive('isEnabled')
+                ->with($setting_name) // 特定の設定名に対する呼び出しを期待
+                ->andReturn($is_enabled); // 指定された bool 値を返す
+        }
+        // 指定されなかった設定名に対して isEnabled が呼ばれた場合のデフォルト動作
+        // 指定外は false を返すように設定しておく
+        $this->mock_setting_checker->shouldReceive('isEnabled')->zeroOrMoreTimes()->andReturn(false);
+
+        // モックを注入してテスト対象クラスのインスタンスを生成
+        return new LearningtaskReportColumnDefinition($this->mock_setting_checker);
+    }
+
+    /**
+     * isEnabled が全て無効の場合に基本ヘッダーのみを返すことをテスト
+     * @test
+     * @covers ::getHeaders
+     * @group learningtasks
+     * @group learningtasks-coldef
+     */
+    public function getHeadersReturnsBaseHeadersWhenNoSettingsEnabled(): void
+    {
+        // Arrange: 全ての設定を無効にした状態でインスタンス生成
+        $definition = $this->createInstance([
+            LearningtaskUseFunction::use_report_comment => false,
+            LearningtaskUseFunction::use_report_file => false,
+            LearningtaskUseFunction::use_report_evaluate => false,
+            LearningtaskUseFunction::use_report_evaluate_comment => false,
+        ]);
+        $expected_base_headers = ['ログインID', 'ユーザ名', '提出日時', '提出回数'];
+
+        // Act: ヘッダーを取得
+        $headers = $definition->getHeaders();
+
+        // Assert: 基本ヘッダーのみが返されることを確認
+        $this->assertEquals($expected_base_headers, $headers);
+    }
+
+    /**
+     * isEnabled が全て有効の場合に全てのヘッダーを返すことをテスト
+     * @test
+     * @covers ::getHeaders
+     * @group learningtasks
+     * @group learningtasks-coldef
+     */
+    public function getHeadersReturnsCorrectHeadersWhenAllSettingsEnabled(): void
+    {
+        // Arrange: 全ての設定を有効にした状態でインスタンス生成
+        $definition = $this->createInstance([
+            LearningtaskUseFunction::use_report_comment => true,
+            LearningtaskUseFunction::use_report_file => true,
+            LearningtaskUseFunction::use_report_evaluate => true,
+            LearningtaskUseFunction::use_report_evaluate_comment => true,
+        ]);
+        // 期待されるヘッダー（基本＋オプション全て）
+        $expected_headers = [
+            'ログインID', 'ユーザ名', '提出日時', '提出回数',
+            '本文', 'ファイルURL', '評価', '評価コメント'
+        ];
+
+        // Act
+        $headers = $definition->getHeaders();
+
+        // Assert
+        $this->assertEquals($expected_headers, $headers);
+    }
+
+    /**
+     * isEnabled が一部有効の場合に正しいヘッダーを返すことをテスト
+     * @test
+     * @covers ::getHeaders
+     * @group learningtasks
+     * @group learningtasks-coldef
+     */
+    public function getHeadersReturnsCorrectHeadersWhenSomeSettingsEnabled(): void
+    {
+         // Arrange: 一部の設定のみ有効 (評価と評価コメントのみ有効)
+         $definition = $this->createInstance([
+            LearningtaskUseFunction::use_report_evaluate => true,
+            LearningtaskUseFunction::use_report_evaluate_comment => true,
+            // 他はデフォルト(false)になるはず
+         ]);
+         // 期待されるヘッダー
+         $expected_headers = [
+            'ログインID', 'ユーザ名', '提出日時', '提出回数', // Base
+            '評価', '評価コメント' // Enabled optional
+        ];
+
+        // Act
+        $headers = $definition->getHeaders();
+
+        // Assert
+        $this->assertEquals($expected_headers, $headers);
+    }
+
+    /**
+     * getColumnMap が期待される完全なマップ配列を返すことをテスト
+     * @test
+     * @covers ::getColumnMap
+     * @group learningtasks
+     * @group learningtasks-coldef
+     */
+    public function getColumnMapReturnsExpectedArray(): void
+    {
+        // Arrange
+        $definition = $this->createInstance(); // 設定内容は getColumnMap に影響しない
+        // クラス内の COLUMN_MAP 定数と同じものが返るはず
+        $expected_map = [
+            'ログインID' => 'userid', 'ユーザ名' => 'username', '提出日時' => 'submitted_at',
+            '提出回数' => 'submit_count', '本文' => 'report_comment', 'ファイルURL' => 'file_url',
+            '評価' => 'grade', '評価コメント' => 'comment',
+        ];
+
+        // Act
+        $map = $definition->getColumnMap();
+
+        // Assert
+        $this->assertEquals($expected_map, $map);
+    }
+
+    /**
+     * getInternalKey がヘッダー名に対して正しい内部キーまたはnullを返すことをテスト
+     * @test
+     * @covers ::getInternalKey
+     * @group learningtasks
+     * @group learningtasks-coldef
+     * @dataProvider internalKeyDataProvider
+     */
+    public function getInternalKeyReturnsCorrectKeyOrNull(string $header_name, ?string $expected_key): void
+    {
+        // Arrange
+        $definition = $this->createInstance(); // 設定内容は影響しない
+
+        // Act
+        $key = $definition->getInternalKey($header_name);
+
+        // Assert
+        $this->assertEquals($expected_key, $key);
+    }
+
+    /**
+     * getInternalKey テスト用のデータプロバイダ
+     * @return array<string, array{header_name: string, expected_key: ?string}>
+     */
+    public function internalKeyDataProvider(): array
+    {
+        // テストケース名 => [引数, 期待値]
+        return [
+            'ログインID' => ['header_name' => 'ログインID', 'expected_key' => 'userid'],
+            '評価コメント' => ['header_name' => '評価コメント', 'expected_key' => 'comment'],
+            '存在しないヘッダー' => ['header_name' => '存在しない', 'expected_key' => null],
+            '空文字ヘッダー' => ['header_name' => '', 'expected_key' => null],
+        ];
+    }
+
+     /**
+     * getValidationRulesBase が設定有効時に正しいルールを返すことをテスト
+     * @test
+     * @covers ::getValidationRulesBase
+     * @group learningtasks
+     * @group learningtasks-coldef
+     */
+    public function getValidationRulesBaseReturnsCorrectRulesWhenSettingsEnabled(): void
+    {
+        // Arrange: 評価・評価コメントの両方が有効な設定
+        $definition = $this->createInstance([
+            LearningtaskUseFunction::use_report_evaluate => true,
+            LearningtaskUseFunction::use_report_evaluate_comment => true,
+        ]);
+
+        // Act
+        $rules = $definition->getValidationRulesBase();
+
+        // Assert
+        // userid ルールの確認
+        $this->assertArrayHasKey('userid', $rules);
+        $this->assertEquals(['required', 'string', 'exists:users,userid'], $rules['userid']);
+
+        // grade ルールの確認 (有効時)
+        $this->assertArrayHasKey('grade', $rules);
+        // Rule::in はオブジェクトなので、単純比較ではなく内容を確認
+        $this->assertContains('nullable', $rules['grade']);
+        $this->assertContains('string', $rules['grade']);
+        $this->assertInstanceOf(\Illuminate\Validation\Rules\In::class, $rules['grade'][2]); // Rule::in(...) が Rule オブジェクトであることを確認
+
+        // comment ルールの確認 (有効時)
+        $this->assertArrayHasKey('comment', $rules);
+        $this->assertEquals(['nullable', 'string', 'max:65535', 'required_with:grade'], $rules['comment']);
+    }
+
+    /**
+     * getValidationRulesBase が設定無効時に正しい(prohibited)ルールを返すことをテスト
+     * @test
+     * @covers ::getValidationRulesBase
+     * @group learningtasks
+     * @group learningtasks-coldef
+     */
+    public function getValidationRulesBaseReturnsCorrectRulesWhenSettingsDisabled(): void
+    {
+         // Arrange: 評価・評価コメントの両方が無効な設定
+         $definition = $this->createInstance([
+             LearningtaskUseFunction::use_report_evaluate => false,
+             LearningtaskUseFunction::use_report_evaluate_comment => false,
+         ]);
+
+         // Act
+         $rules = $definition->getValidationRulesBase();
+
+         // Assert
+         $this->assertArrayHasKey('userid', $rules); // userid は常に存在
+         // grade ルール (無効時)
+         $this->assertArrayHasKey('grade', $rules);
+         $this->assertEquals(['prohibited'], $rules['grade']);
+         // comment ルール (無効時)
+         $this->assertArrayHasKey('comment', $rules);
+         $this->assertEquals(['prohibited'], $rules['comment']);
+    }
+
+    /**
+     * getValidationRulesBase が評価ON/コメントOFF時に正しいルールを返すことをテスト
+     * @test
+     * @covers ::getValidationRulesBase
+     * @group learningtasks
+     * @group learningtasks-coldef
+     */
+     public function getValidationRulesBaseReturnsCorrectRulesWhenEvaluateOnCommentOff(): void
+     {
+         // Arrange: 評価ON, コメントOFF
+         $definition = $this->createInstance([
+             LearningtaskUseFunction::use_report_evaluate => true,
+             LearningtaskUseFunction::use_report_evaluate_comment => false,
+         ]);
+         // Act
+         $rules = $definition->getValidationRulesBase();
+         // Assert
+         $this->assertArrayHasKey('grade', $rules);
+         $this->assertIsObject($rules['grade'][2]); // Check Rule::in is object
+         $this->assertContains('nullable', $rules['grade']);
+         $this->assertArrayHasKey('comment', $rules);
+         $this->assertEquals(['prohibited'], $rules['comment']); // コメントは禁止される
+     }
+
+    /**
+     * getValidationRulesBase が評価OFF/コメントON時に正しいルールを返すことをテスト
+     * @test
+     * @covers ::getValidationRulesBase
+     * @group learningtasks
+     * @group learningtasks-coldef
+     */
+     public function getValidationRulesBaseReturnsCorrectRulesWhenEvaluateOffCommentOn(): void
+     {
+          // Arrange: 評価OFF, コメントON
+         $definition = $this->createInstance([
+             LearningtaskUseFunction::use_report_evaluate => false,
+             LearningtaskUseFunction::use_report_evaluate_comment => true,
+         ]);
+          // Act
+         $rules = $definition->getValidationRulesBase();
+          // Assert
+         $this->assertArrayHasKey('grade', $rules);
+         $this->assertEquals(['prohibited'], $rules['grade']); // 評価は禁止
+         $this->assertArrayHasKey('comment', $rules);
+         // コメントは有効だが、依存する grade が prohibited なので required_with は影響小
+         $this->assertEquals(['nullable', 'string', 'max:65535', 'required_with:grade'], $rules['comment']);
+     }
+
+     /**
+     * getValidationMessages が期待されるメッセージ配列を返すことをテスト
+     * @test
+     * @covers ::getValidationMessages
+     * @group learningtasks
+     * @group learningtasks-coldef
+     */
+    public function getValidationMessagesReturnsExpectedMessages(): void
+    {
+        // Arrange
+        $definition = $this->createInstance(); // 設定はメッセージに影響しないと仮定
+        // Act
+        $messages = $definition->getValidationMessages();
+        // Assert: 代表的なメッセージが存在し、内容が期待通りかを確認
+        $this->assertArrayHasKey('userid.required', $messages);
+        $this->assertEquals('ログインID列は必須です。', $messages['userid.required']);
+        $this->assertArrayHasKey('grade.in', $messages);
+        $this->assertEquals('評価列の値は A, B, C, D のいずれかである必要があります。', $messages['grade.in']);
+        $this->assertArrayHasKey('comment.prohibited', $messages);
+        $this->assertEquals('評価コメント機能が無効なため、評価コメント列は入力できません（空にしてください）。', $messages['comment.prohibited']);
+        // 全てのメッセージを網羅的にテストしても良い
+    }
+
+}

--- a/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskSettingCheckerTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/Services/LearningtaskSettingCheckerTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Learningtasks\Services; // 実装に合わせた名前空間
+
+use App\Models\User\Learningtasks\Learningtasks;
+use App\Models\User\Learningtasks\LearningtasksPosts;
+use App\Plugins\User\Learningtasks\Services\LearningtaskSettingChecker;
+use Illuminate\Support\Collection;
+use Mockery;
+use Mockery\MockInterface;
+use stdClass;
+use Tests\TestCase;
+
+/**
+ * LearningtaskSettingChecker のユニットテストクラス
+ *
+ * @coversDefaultClass \App\Plugins\User\Learningtasks\Services\LearningtaskSettingChecker
+ */
+class LearningtaskSettingCheckerTest extends TestCase
+{
+    /**
+     * テスト用の設定オブジェクト(stdClass)を生成するヘルパー
+     */
+    private function createMockSetting(string $use_function, string $value): object
+    {
+        $setting = new stdClass(); // 実際のモデルでなくても、プロパティがあればOK
+        $setting->use_function = $use_function;
+        $setting->value = $value;
+        return $setting;
+    }
+
+    /**
+     * ->where()->first() をシミュレートする Collection のモックを生成するヘルパー
+     *
+     * @param object|null $setting_to_return first() で返すべき設定オブジェクト、または null
+     * @param string $expected_setting_name where() で期待される設定名
+     * @return MockInterface Collection のモック
+     */
+    private function mockSettingCollection(?object $setting_to_return, string $expected_setting_name): MockInterface
+    {
+        $mock_collection = Mockery::mock(Collection::class);
+        // where('use_function', $name) が呼ばれたら自分自身を返す (->first() をチェーンするため)
+        $mock_collection->shouldReceive('where')
+            ->with('use_function', $expected_setting_name)
+            ->andReturnSelf();
+        // first() が呼ばれたら、指定された設定オブジェクトまたは null を返す
+        $mock_collection->shouldReceive('first')
+            ->andReturn($setting_to_return);
+        return $mock_collection;
+    }
+
+    /**
+     * 投稿設定がonならtrueを返す
+     * @test
+     * @covers ::isEnabled
+     * @group learningtasks
+     */
+    public function isEnabledReturnsTrueWhenPostSettingIsOn(): void
+    {
+        // Arrange
+        $setting_name = 'test_setting_on';
+        // 模擬する設定データ ('on')
+        $target_setting = $this->createMockSetting($setting_name, 'on');
+        // post_settings コレクションのモック (指定の設定名を where したら $target_setting を返す)
+        $mock_post_settings = $this->mockSettingCollection($target_setting, $setting_name);
+        // LearningtasksPosts モデルのモック
+        /** @var LearningtasksPosts|MockInterface $mock_post */
+        $mock_post = Mockery::mock(LearningtasksPosts::class);
+        // ->post_settings が呼ばれたら $mock_post_settings を返すように設定
+        $mock_post->shouldReceive('getAttribute')->with('post_settings')->andReturn($mock_post_settings);
+        // ->learningtask は呼ばれないはず
+
+        // Act
+        // テスト対象クラスをモックオブジェクトで初期化
+        $checker = new LearningtaskSettingChecker($mock_post);
+        $result = $checker->isEnabled($setting_name);
+
+        // Assert
+        $this->assertTrue($result, '投稿設定が on なら true が返るべき');
+    }
+
+    /**
+     * 投稿設定がoffならfalseを返す
+     * @test
+     * @covers ::isEnabled
+     * @group learningtasks
+     */
+    public function isEnabledReturnsFalseWhenPostSettingIsOff(): void
+    {
+        // Arrange
+        $setting_name = 'test_setting_off';
+        // 模擬する設定データ ('off')
+        $target_setting = $this->createMockSetting($setting_name, 'off');
+        $mock_post_settings = $this->mockSettingCollection($target_setting, $setting_name);
+        /** @var LearningtasksPosts|MockInterface $mock_post */
+        $mock_post = Mockery::mock(LearningtasksPosts::class);
+        $mock_post->shouldReceive('getAttribute')->with('post_settings')->andReturn($mock_post_settings);
+
+        // Act
+        $checker = new LearningtaskSettingChecker($mock_post);
+        $result = $checker->isEnabled($setting_name);
+
+        // Assert
+        $this->assertFalse($result, '投稿設定が off なら false が返るべき');
+    }
+
+    /**
+     * 投稿設定がなく課題設定がonならtrueを返す
+     * @test
+     * @covers ::isEnabled
+     * @group learningtasks
+     */
+    public function isEnabledReturnsTrueWhenPostSettingAbsentAndTaskSettingIsOn(): void
+    {
+        // Arrange
+        $setting_name = 'test_setting_fallback_on';
+        $task_setting = $this->createMockSetting($setting_name, 'on');
+        $mock_post_settings = $this->mockSettingCollection(null, $setting_name);
+        $mock_task_settings = $this->mockSettingCollection($task_setting, $setting_name);
+        /** @var Learningtasks|MockInterface $mock_learningtask */
+        $mock_learningtask = Mockery::mock(Learningtasks::class);
+        $mock_learningtask->shouldReceive('getAttribute')->with('learningtask_settings')->andReturn($mock_task_settings);
+        /** @var LearningtasksPosts|MockInterface $mock_post */
+        $mock_post = Mockery::mock(LearningtasksPosts::class);
+        $mock_post->shouldReceive('getAttribute')->with('post_settings')->andReturn($mock_post_settings);
+        $mock_post->shouldReceive('getAttribute')->with('learningtask')->andReturn($mock_learningtask);
+
+        // Act
+        $checker = new LearningtaskSettingChecker($mock_post);
+        $result = $checker->isEnabled($setting_name);
+
+        // Assert
+        $this->assertTrue($result, '投稿設定がなく課題設定が on なら true が返るべき');
+    }
+    /**
+     * 投稿設定がなく課題設定がoffならfalseを返す
+     * @test
+     * @covers ::isEnabled
+     * @group learningtasks
+     */
+    public function isEnabledReturnsFalseWhenPostSettingAbsentAndTaskSettingIsOff(): void
+    {
+        // Arrange
+        $setting_name = 'test_setting_fallback_off';
+        $task_setting = $this->createMockSetting($setting_name, 'off');
+        $mock_post_settings = $this->mockSettingCollection(null, $setting_name);
+        $mock_task_settings = $this->mockSettingCollection($task_setting, $setting_name);
+         /** @var Learningtasks|MockInterface $mock_learningtask */
+        $mock_learningtask = Mockery::mock(Learningtasks::class);
+        $mock_learningtask->shouldReceive('getAttribute')->with('learningtask_settings')->andReturn($mock_task_settings);
+        // $mock_learningtask->shouldReceive('__get')->with('learningtask_settings')->andReturn($mock_task_settings);
+         /** @var LearningtasksPosts|MockInterface $mock_post */
+        $mock_post = Mockery::mock(LearningtasksPosts::class);
+        $mock_post->shouldReceive('getAttribute')->with('post_settings')->andReturn($mock_post_settings);
+        $mock_post->shouldReceive('getAttribute')->with('learningtask')->andReturn($mock_learningtask);
+
+        // Act
+        $checker = new LearningtaskSettingChecker($mock_post);
+        $result = $checker->isEnabled($setting_name);
+
+        // Assert
+        $this->assertFalse($result, '投稿設定がなく課題設定が off なら false が返るべき');
+    }
+
+    /**
+     * 投稿設定も課題設定もなければfalseを返す
+     * @test
+     * @covers ::isEnabled
+     * @group learningtasks
+     */
+    public function isEnabledReturnsFalseWhenBothSettingsAreAbsent(): void
+    {
+        // Arrange
+        $setting_name = 'test_setting_absent';
+        $mock_post_settings = $this->mockSettingCollection(null, $setting_name);
+        $mock_task_settings = $this->mockSettingCollection(null, $setting_name);
+        /** @var Learningtasks|MockInterface $mock_learningtask */
+        $mock_learningtask = Mockery::mock(Learningtasks::class);
+        $mock_learningtask->shouldReceive('getAttribute')->with('learningtask_settings')->andReturn($mock_task_settings);
+        /** @var LearningtasksPosts|MockInterface $mock_post */
+        $mock_post = Mockery::mock(LearningtasksPosts::class);
+        $mock_post->shouldReceive('getAttribute')->with('post_settings')->andReturn($mock_post_settings);
+        $mock_post->shouldReceive('getAttribute')->with('learningtask')->andReturn($mock_learningtask);
+
+        // Act
+        $checker = new LearningtaskSettingChecker($mock_post);
+        $result = $checker->isEnabled($setting_name);
+
+        // Assert
+        $this->assertFalse($result, '両方の設定がなければ false が返るべき');
+    }
+    /**
+     * リレーションがnullなら課題設定を見ずにfalseを返す
+     * @test
+     * @covers ::isEnabled
+     * @group learningtasks
+     */
+    public function isEnabledReturnsFalseWhenLearningtaskRelationIsNull(): void
+    {
+        // Arrange
+        $setting_name = 'test_setting_null_relation';
+
+        $mock_post_settings = $this->mockSettingCollection(null, $setting_name); // 投稿設定なし
+         /** @var LearningtasksPosts|MockInterface $mock_post */
+        $mock_post = Mockery::mock(LearningtasksPosts::class);
+        $mock_post->shouldReceive('getAttribute')->with('post_settings')->andReturn($mock_post_settings);
+        $mock_post->shouldReceive('getAttribute')->with('learningtask')->andReturnNull();
+
+        // Act
+        $checker = new LearningtaskSettingChecker($mock_post);
+        $result = $checker->isEnabled($setting_name);
+
+        // Assert
+        $this->assertFalse($result, 'learningtask 関係が null なら false が返るべき'); // 課題設定を読みに行かずに false になるはず
+    }
+}


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

課題管理プラグインにおいて、レポート課題の評価結果（評価・評価コメント）をCSVファイルで一括インポートする機能を追加しました。

## 変更の目的

従来、レポート課題の評価は個々の提出画面を開いて行う必要があり、手間がかかっていました。
本機能により、CSVファイルを用いて評価結果を一括で登録できるようにし、教員の評価作業の負担を軽減します。

## 変更内容

- **機能:**
    - 指定された課題投稿に対し、特定のフォーマットのCSVファイルをアップロードすることで、複数ユーザーのレポート評価を一括で登録します。（現在は新規登録のみ）
    - 対象の課題投稿設定で「評価」機能 (`App\Enums\LearningtaskUseFunction::use_report_evaluate`) が有効になっている場合に利用可能です。
    - 実行ユーザーは対象課題の「担当教員」 (`App\Enums\RoleName::teacher`) または「サイト管理者」 (`role_article_admin` 権限) である必要があります。
- **対象:**
    - プラグイン: `LearningtasksPlugin` (課題管理プラグイン)
    - アクション: `importCsv` (HTTP POST, Route: `/plugin/learningtasks/importCsv/{page_id}/{frame_id}/{id}`)
- **CSVフォーマット:**
    - 必須ヘッダー: `ログインID`
    - オプションヘッダー: `評価`, `評価コメント` (課題設定 `use_report_evaluate`, `use_report_evaluate_comment` に依存) など。(`LearningtaskReportColumnDefinition` で定義)
    - CSV1行目のヘッダーが定義と一致するか検証します（定義された必須・オプションヘッダーが全て存在するか。順不同、余分な列は許容）。不一致の場合 `CsvInvalidHeaderException` でエラー。
    - 文字コードは UTF-8 (BOM有無), SJIS-win を自動判定します。
- **処理結果の振り分け:**
    - **成功 (Success):** CSVの各行がバリデーションを通過し、対象ユーザー/提出が存在し、未評価であり、評価(`grade`)または評価コメント(`comment`)のいずれかに有効なデータがあれば、評価データが登録されます。評価・コメントが両方空の場合、DB登録はスキップされますが、成功としてカウントされます。
    - **スキップ (Skip):** 以下の場合、処理がスキップされ DB 登録は行われず、スキップとしてカウント・詳細が記録されます（トランザクションはコミットされます）。
        - CSV行が空行の場合。
        - 対象ユーザーが課題の受講生ではない場合 (`InvalidStudentException`)。
        - 対象ユーザーの提出が既に評価済みの場合 (`AlreadyEvaluatedException`)。
    - **エラー (Error):** 以下の場合、エラーとして扱われ、エラー詳細が記録されます。エラーが1件でも発生した場合、インポート処理全体が**ロールバック**され、DBへの変更は一切反映されません。
        - CSVファイルのヘッダーが無効な場合 (`CsvInvalidHeaderException`, `CsvHeaderReadException` など)。
        - CSV行のデータがバリデーションルールを満たさない場合 (`ValidationException`)。
        - CSVに記載されたログインIDのユーザーが存在しない場合 (`ModelNotFoundException`)。
        - 対象ユーザーの有効な提出が見つからない場合 (`SubmissionNotFoundException`)。
        - その他の予期せぬエラーが発生した場合 (`Exception`, `Throwable`)。
    - 処理完了後、結果（成功/スキップ/エラー件数）の要約メッセージが `'flash_message'` キーでセッションに格納されリダイレクトします。エラーまたはスキップがあった場合は、その詳細がそれぞれ `'csv_import_errors'`, `'csv_import_skipped_details'` キーでセッションに格納されます。
- **画面（UI）変更:**
    - 課題管理記事詳細画面 (`learningtasks_show.blade.php`) を修正しました。
    - CSVファイル選択用のファイル入力 (`<input type="file" name="csv_file">`) と、「レポート評価インポート」ボタン (`<button type="submit">`) を含むフォームを追加しました。
    - このフォームは、課題設定で「評価」機能 (`$tool->checkFunction(LearningtaskUseFunction::use_report_evaluate)`) が有効であり、かつ表示ユーザーが担当教員 (`$tool->isTeacher()`) または課題管理者 (`$tool->isLearningtaskAdmin()`) である場合にのみ画面に表示されます。（フォーム送信後のサーバーサイドでも改めて権限チェック (`canImport`) が行われます。）
    - インポート処理後のリダイレクト時に、セッションに格納された `'flash_message'`, `'csv_import_errors'`, `'csv_import_skipped_details'` の内容を画面上部に Bootstrap 4 の Alert を用いて表示するようにしました。

## テスト

- **ユニットテスト:**
    - 以下の各コンポーネントに対してユニットテストを実装済みです。
    - `LearningtaskSettingChecker`, `LearningtaskUserRepository`, `LearningtaskReportColumnDefinition`, `LearningtaskEvaluationRowProcessor`, `ColumnDefinitionFactory`, `RowProcessorFactory`, `ExceptionHandlerFactory`, `ReportExceptionHandler`
    - 各クラスのロジックを Mockery を利用して隔離し、検証しています。
- **フィーチャーテスト:**
    - `LearningtasksPlugin` の `importCsv` アクションに対して、Laravel HTTP Testing を用いてテストを実装済みです。
    * `actingAs`, `post`, `UploadedFile::fake` を使用し、以下のシナリオをカバーしています。
        * 正常なCSVファイルによるインポート成功（リダイレクト、フラッシュメッセージ（要約・詳細）、DB状態）。
        * ファイル未選択、不正なMIMEタイプ時のバリデーションエラー。
        * 権限のないユーザー（ゲスト、ログイン済み非権限者）によるアクセス拒否（403）。
        * 課題設定で機能が無効な場合のエラー。
        * 不正なCSVヘッダーによるエラー（メッセージと詳細確認）。
        * スキップが発生した場合の適切なフィードバック（メッセージとスキップ詳細確認）とDBコミット。
        * エラー（バリデーションor処理中）が発生した場合の適切なフィードバック（メッセージとエラー詳細確認）とDBロールバックの確認 (`assertDatabaseMissing`)。

## 特記事項

- **処理フロー:**
    - Controller -> Factory -> Importer -> Definition/Processor/Handler の依存関係と処理の流れを構築しました。
- **実装:**
    - 依存性の注入 (DI) を積極的に利用しました (特に Importer)。
    - 例外処理に Strategy パターンを適用し、Importer と例外分類ロジックを分離しました。
    - 処理固有のカスタム例外 (`FeatureDisabledException`, `SubmissionNotFoundException` など) を定義しました。
    - マジックストリングを排除するため、Enum (`LearningtaskImportType`, `LearningtaskUseFunction`, `RoleName`) 及びクラス定数を使用しました。
    - DB 操作は `DB::transaction` でラップし、エラー時の原子性を保証します。
    - `UserableNohistory` Trait による `created_id` 等の自動設定に対応しています。
    - CSV の文字コードは `StreamFilter` により自動判定・UTF-8変換されます。
    - **ロールバックメッセージ:** エラーによるロールバックが発生した場合、`'csv_import_errors'` に記録される `fatal_error_rollback` タイプの詳細メッセージには、ロールバックをトリガーした**汎用例外のメッセージ**が含まれます。ロールバックの根本原因となった元の例外（例: 提出なしエラー）のメッセージは、別途記録される処理エラーの詳細で確認できます。
    - **N+1 対策:** 行処理(`RowProcessor`) 内での受講生リスト取得は、N+1 問題を避けるためにインスタンス内で結果をキャッシュする機構を導入済みです。
    - **エラー/スキップ詳細表示:** セッションに格納された `'csv_import_errors'` および `'csv_import_skipped_details'` の内容は、`learningtasks_show.blade.php` にて Bootstrap 4 の Alert (danger と info/warning) を利用して表示することを想定しています。
- **DB スキーマ変更:**
    - 本機能追加に伴うデータベーススキーマの変更は**ありません**。

## 保留事項・TODO

- エクスポート機能のリファクタリング（当PRのコンポーネントを利用する）
- 試験結果 (`exam`) のインポート機能。
- 巨大なCSVファイルに対するパフォーマンス/メモリ使用量のテストと最適化。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

OW-2532
