### PR TITLE
[データベース] 表示設定＞急上昇ワードの下部に説明メッセージ追加

### DIFF
--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -163,6 +163,13 @@
                     <input type="text" name="database_trend_words_caption" value="{{$database_trend_words_caption}}" class="form-control">
                 </div>
             </div>
+            <small class="form-text text-muted">
+                ※ 検索されたキーワードを、急上昇ワード(再検索できるキーワード)として手動で設定できます。<br>
+                ※ 設定するには事前に下記を設定します。<br>
+                　※ <a href="{{ url("/plugin/databases/editBuckets/{$page->id}/{$frame_id}#frame-{$frame_id}") }}" target="_blank">DB設定</a>の「検索キーワードを記録」を「使用する」に設定する。<br>
+                　※ 当表示設定の「検索機能の表示」を「表示する」に設定する。<br>
+                　※ 上記を設定後にデータベースが検索されると、当表示設定の「急上昇ワードの表示＞更新する値」の「最新化」ボタン押下で、急上昇ワードを設定できます。<br>
+            </small>
         </div>
     </div>
 

--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -166,9 +166,9 @@
             <small class="form-text text-muted">
                 ※ 検索されたキーワードを、急上昇ワード(再検索できるキーワード)として手動で設定できます。<br>
                 ※ 設定するには事前に下記を設定します。<br>
-                　※ <a href="{{ url("/plugin/databases/editBuckets/{$page->id}/{$frame_id}#frame-{$frame_id}") }}" target="_blank">DB設定</a>の「検索キーワードを記録」を「使用する」に設定する。<br>
-                　※ 当表示設定の「検索機能の表示」を「表示する」に設定する。<br>
-                　※ 上記を設定後にデータベースが検索されると、当表示設定の「急上昇ワードの表示＞更新する値」の「最新化」ボタン押下で、急上昇ワードを設定できます。<br>
+                　・<a href="{{ url("/plugin/databases/editBuckets/{$page->id}/{$frame_id}#frame-{$frame_id}") }}" target="_blank">DB設定</a>の「検索キーワードを記録」を「使用する」に設定する。<br>
+                　・当表示設定の「検索機能の表示」を「表示する」に設定する。<br>
+                　・(上記２点を設定後)にデータベースが検索されると、当表示設定の「急上昇ワードの表示＞更新する値」の「最新化」ボタン押下で、急上昇ワードを設定できます。<br>
             </small>
         </div>
     </div>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

データベース＞表示設定＞急上昇ワード の設定方法に迷ったため、その項目の下部に、急上昇ワードの説明と設定方法の説明メッセージを追加しました。

# 修正後画面
## データベース＞表示設定＞急上昇ワードの表示

![image](https://github.com/user-attachments/assets/66c953ae-ffa6-4d96-b4d7-8169521630be)

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/1838

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし
# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
