### PR TITLE
[開発ツール] sync_option_private_2_dev.shのrsyncのオプション指定見直し

### DIFF
--- a/sync_option_private_2_dev.sh.example
+++ b/sync_option_private_2_dev.sh.example
@@ -35,17 +35,17 @@ rsync -arvz --delete "${src_root_dir}${option_plugin}/resources/views/plugins_op
 # バッチ
 rsync -arvz --delete "${src_root_dir}${option_plugin}/app/Console/CommandsOption/${option_plugin_command_dir}" "${dist_root_dir}app/Console/CommandsOption/"
 # マイグレーション
-rsync -arvz --delete --exclude '_readme.txt' "${src_root_dir}${option_plugin}/database/migrations_option" "${dist_root_dir}database/"
+rsync -arvz --exclude '_readme.txt' "${src_root_dir}${option_plugin}/database/migrations_option" "${dist_root_dir}database/"
 # シーダー
 rsync -arvz "${src_root_dir}${option_plugin}/database/seeders/Options/${option_plugin}" "${dist_root_dir}database/seeders/Options/"
 # Enum
-rsync -arvz --delete "${src_root_dir}${option_plugin}/app/EnumsOption" "${dist_root_dir}app/"
+rsync -arvz "${src_root_dir}${option_plugin}/app/EnumsOption" "${dist_root_dir}app/"
 # 画像
 rsync -arvz --delete "${src_root_dir}${option_plugin}/public/images/plugins/${option_plugin_resources_dir}" "${dist_root_dir}public/images/plugins/"
 # メールテンプレート
 rsync -arvz --delete "${src_root_dir}${option_plugin}/resources/views/mail_option/${option_plugin_resources_dir}" "${dist_root_dir}resources/views/mail_option/"
 # バリデーション
-rsync -arvz --delete "${src_root_dir}${option_plugin}/app/RulesOption/${option_plugin}" "${dist_root_dir}${option_plugin}/app/RulesOption/"
+rsync -arvz --delete "${src_root_dir}${option_plugin}/app/RulesOption/${option_plugin}" "${dist_root_dir}app/RulesOption/"
 # Composer Option
 cp -f "${src_root_dir}composer-option.json" "${dist_root_dir}"
 cp -f "${src_root_dir}composer-option.lock" "${dist_root_dir}"


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* マイグレーションとEnum同期時に、他オプションのファイルを消してしまうrsyncオプション(--delete)を消しました。
* バリデーションの同期フォルダが違っていたため、修正しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
