### PR TITLE
[ページ管理]固定リンクを空で登録するとシステムエラーとなる問題を修正しました

### DIFF
--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -221,7 +221,7 @@ class PageManage extends ManagePluginBase
     public function store($request)
     {
         // 固定リンクの先頭に / がない場合、追加する。
-        if (strncmp($request->permanent_link, '/', 1) !== 0) {
+        if (strncmp($request->permanent_link ?? '', '/', 1) !== 0) {
             $request->merge([
                 "permanent_link" => '/' . $request->permanent_link,
             ]);
@@ -264,7 +264,7 @@ class PageManage extends ManagePluginBase
     public function update($request, $page_id)
     {
         // 固定リンクの先頭に / がない場合、追加する。
-        if (strncmp($request->permanent_link, '/', 1) !== 0) {
+        if (strncmp($request->permanent_link ?? '', '/', 1) !== 0) {
             $request->merge([
                 "permanent_link" => '/' . $request->permanent_link,
             ]);


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

ページ管理機能において、ページ登録または更新時に固定リンクを空のまま保存しようとするとシステムエラーが発生する問題を修正しました。

## 変更の目的

固定リンクが未入力の状態で保存操作が行われた際に、予期せぬシステムエラー（`strncmp()` 関数の型エラー）が発生するのを防ぎ、アプリケーションの安定性を向上させます。

## 変更内容

`app/Plugins/Manage/PageManage/PageManage.php` の 224 行目付近にある `strncmp()` 関数において、第一引数 `$request->permanent_link` が `null` となる可能性がありました。

`null` 合体演算子 (`??`) を使用し、`$request->permanent_link` が `null` の場合に空文字列 (`''`) を `strncmp()` 関数に渡すよう修正しました。

```php
// 修正前
// if (strncmp($request->permanent_link, '/', 1) !== 0) {

// 修正後
if (strncmp($request->permanent_link ?? '', '/', 1) !== 0) {
```

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
#2183

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

<!-- （オンラインマニュアルの更新が可能な方で、画面変更があった場合。なければ下記は消す） -->
- [x] (DB変更有りの場合) 移行プログラムに影響がない事を確認しました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-check-list---Migration
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
