### PR TITLE
[モデル] モデルの$dates → $castsに切替（Laravel10.xで$date廃止に対応）

### DIFF
--- a/app/Models/Common/Frame.php
+++ b/app/Models/Common/Frame.php
@@ -13,10 +13,12 @@ class Frame extends Model
 {
     use HasFactory;
 
-    // 日付型
-    protected $dates = [
-        'content_open_date_from',
-        'content_open_date_to'
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'content_open_date_from' => 'datetime',
+        'content_open_date_to' => 'datetime',
     ];
 
     /**

--- a/app/Models/Common/Group.php
+++ b/app/Models/Common/Group.php
@@ -32,9 +32,11 @@ class Group extends Model
     protected $fillable = ['name', 'initial_group_flag', 'display_sequence'];
 
     /**
-     * 日付型の場合、$dates にカラムを指定しておく。
+     * キャストする必要のある属性
      */
-    protected $dates = ['created_at', 'updated_at', 'deleted_at'];
+    protected $casts = [
+        'deleted_at' => 'datetime',
+    ];
 
     /**
      * 特定のページが指定されたときのグループに対する権限。ページ管理で使用。

--- a/app/Models/Common/GroupUser.php
+++ b/app/Models/Common/GroupUser.php
@@ -24,9 +24,11 @@ class GroupUser extends Model
     protected $fillable = ['group_id', 'user_id', 'group_role'];
 
     /**
-     * 日付型の場合、$dates にカラムを指定しておく。
+     * キャストする必要のある属性
      */
-    protected $dates = ['created_at', 'updated_at', 'deleted_at'];
+    protected $casts = [
+        'deleted_at' => 'datetime',
+    ];
 
     /**
      * belongsTo 設定

--- a/app/Models/Common/PageRole.php
+++ b/app/Models/Common/PageRole.php
@@ -29,9 +29,11 @@ class PageRole extends Model
     protected $fillable = ['page_id', 'group_id', 'target', 'role_name', 'role_value'];
 
     /**
-     * 日付型の場合、$dates にカラムを指定しておく。
+     * キャストする必要のある属性
      */
-    protected $dates = ['created_at', 'updated_at', 'deleted_at'];
+    protected $casts = [
+        'deleted_at' => 'datetime',
+    ];
 
     /**
      * ページの系統取得

--- a/app/Models/Core/UsersLoginHistories.php
+++ b/app/Models/Core/UsersLoginHistories.php
@@ -11,9 +11,11 @@ class UsersLoginHistories extends Model
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
 
-    // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = [
-        'logged_in_at',
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'logged_in_at' => 'datetime',
     ];
 
     // 更新する項目の定義

--- a/app/Models/Migration/Nc3/Nc3Announcement.php
+++ b/app/Models/Migration/Nc3/Nc3Announcement.php
@@ -16,6 +16,11 @@ class Nc3Announcement extends Model
      */
     protected $table = 'announcements';
 
-    // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = ['created', 'modified'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'created' => 'datetime',
+        'modified' => 'datetime',
+    ];
 }

--- a/app/Models/Migration/Nc3/Nc3AuthorizationKey.php
+++ b/app/Models/Migration/Nc3/Nc3AuthorizationKey.php
@@ -16,6 +16,11 @@ class Nc3AuthorizationKey extends Model
      */
     protected $table = 'authorization_keys';
 
-    /** Carbonインスタンス（日付）に自動的に変換 */
-    protected $dates = ['created', 'modified'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'created' => 'datetime',
+        'modified' => 'datetime',
+    ];
 }

--- a/app/Models/Migration/Nc3/Nc3Frame.php
+++ b/app/Models/Migration/Nc3/Nc3Frame.php
@@ -16,8 +16,13 @@ class Nc3Frame extends Model
      */
     protected $table = 'frames';
 
-    // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = ['created', 'modified'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'created' => 'datetime',
+        'modified' => 'datetime',
+    ];
 
     /**
      * NC3 header_type -> Connect-CMS frame_design 変換用テーブル

--- a/app/Models/User/Blogs/BlogsPosts.php
+++ b/app/Models/User/Blogs/BlogsPosts.php
@@ -20,8 +20,12 @@ class BlogsPosts extends Model
     const read_more_button_default = '続きを読む';
     const close_more_button_default = '閉じる';
 
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = ['posted_at'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'posted_at' => 'datetime',
+    ];
 
     // 更新する項目の定義
     protected $fillable = [

--- a/app/Models/User/Blogs/BlogsPostsTags.php
+++ b/app/Models/User/Blogs/BlogsPostsTags.php
@@ -15,8 +15,12 @@ class BlogsPostsTags extends Model
     // 保存時のユーザー関連データの保持
     use Userable;
 
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = ['posted_at'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'posted_at' => 'datetime',
+    ];
 
     /**
      * タグデータをポストデータに紐づけ

--- a/app/Models/User/Calendars/CalendarPost.php
+++ b/app/Models/User/Calendars/CalendarPost.php
@@ -38,8 +38,13 @@ class CalendarPost extends Model
         'contact',
     ];
 
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = ['start_date', 'end_date'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'start_date' => 'datetime',
+        'end_date' => 'datetime',
+    ];
 
     /**
      * 新しいEloqunetコレクションインスタンスの生成

--- a/app/Models/User/Contents/Contents.php
+++ b/app/Models/User/Contents/Contents.php
@@ -32,6 +32,10 @@ class Contents extends Model
         'status',
     ];
 
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = ['deleted_at'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'deleted_at' => 'datetime',
+    ];
 }

--- a/app/Models/User/Counters/CounterCount.php
+++ b/app/Models/User/Counters/CounterCount.php
@@ -25,9 +25,11 @@ class CounterCount extends Model
         'total_count',
     ];
 
-    // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = [
-        'counted_at',
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'counted_at' => 'datetime',
     ];
 
     /**

--- a/app/Models/User/Databases/DatabasesInputs.php
+++ b/app/Models/User/Databases/DatabasesInputs.php
@@ -12,8 +12,13 @@ class DatabasesInputs extends Model
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
 
-    // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = ['posted_at', 'expires_at'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'posted_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
 
     // 更新する項目の定義
     protected $fillable = [

--- a/app/Models/User/Faqs/FaqsPosts.php
+++ b/app/Models/User/Faqs/FaqsPosts.php
@@ -15,8 +15,12 @@ class FaqsPosts extends Model
     // 保存時のユーザー関連データの保持
     use Userable;
 
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = ['posted_at'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'posted_at' => 'datetime',
+    ];
 
     // 更新する項目の定義
     protected $fillable = ['contents_id', 'faqs_id', 'post_title', 'post_text', 'categories_id', 'posted_at', 'display_sequence', 'status'];

--- a/app/Models/User/Faqs/FaqsPostsTags.php
+++ b/app/Models/User/Faqs/FaqsPostsTags.php
@@ -15,6 +15,10 @@ class FaqsPostsTags extends Model
     // 保存時のユーザー関連データの保持
     use Userable;
 
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = ['posted_at'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'posted_at' => 'datetime',
+    ];
 }

--- a/app/Models/User/Forms/Forms.php
+++ b/app/Models/User/Forms/Forms.php
@@ -11,12 +11,14 @@ class Forms extends Model
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
 
-    // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = [
-        'display_from',
-        'display_to',
-        'regist_from',
-        'regist_to',
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'display_from' => 'datetime',
+        'display_to' => 'datetime',
+        'regist_from' => 'datetime',
+        'regist_to' => 'datetime',
     ];
 
     // 更新する項目の定義

--- a/app/Models/User/Learningtasks/LearningtasksExaminations.php
+++ b/app/Models/User/Learningtasks/LearningtasksExaminations.php
@@ -17,11 +17,13 @@ class LearningtasksExaminations extends Model
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
 
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = [
-        'start_at',
-        'end_at',
-        'entry_end_at',
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'start_at' => 'datetime',
+        'end_at' => 'datetime',
+        'entry_end_at' => 'datetime',
     ];
 
     /**

--- a/app/Models/User/Learningtasks/LearningtasksPosts.php
+++ b/app/Models/User/Learningtasks/LearningtasksPosts.php
@@ -18,8 +18,12 @@ class LearningtasksPosts extends Model
     use UserableNohistory;
     use HasFactory;
 
-    // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = ['posted_at'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'posted_at' => 'datetime',
+    ];
 
     /**
      * 課題管理を取得

--- a/app/Models/User/Learningtasks/LearningtasksPostsFiles.php
+++ b/app/Models/User/Learningtasks/LearningtasksPostsFiles.php
@@ -20,8 +20,12 @@ class LearningtasksPostsFiles extends Model
     // 保存時のユーザー関連データの保持（履歴なしUserable）
     use UserableNohistory;
 
-    // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = ['posted_at'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'posted_at' => 'datetime',
+    ];
 
     /**
      * create()やupdate()で入力を受け付ける ホワイトリスト

--- a/app/Models/User/Learningtasks/LearningtasksUseSettings.php
+++ b/app/Models/User/Learningtasks/LearningtasksUseSettings.php
@@ -27,9 +27,11 @@ class LearningtasksUseSettings extends Model
         'datetime_value',
     ];
 
-    // Carbonインスタンス（日付）に自動的に変換
-    protected $dates = [
-        'datetime_value',
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'datetime_value' => 'datetime',
     ];
 
     /**

--- a/app/Models/User/Opacs/OpacsBooks.php
+++ b/app/Models/User/Opacs/OpacsBooks.php
@@ -6,8 +6,16 @@ use Illuminate\Database\Eloquent\Model;
 
 class OpacsBooks extends Model
 {
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = ['accept_date', 'storage_life', 'remove_date', 'last_lending_date', 'posted_at'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'accept_date' => 'datetime',
+        'storage_life' => 'datetime',
+        'remove_date' => 'datetime',
+        'last_lending_date' => 'datetime',
+        'posted_at' => 'datetime',
+    ];
 
     // 更新する項目の定義
     protected $fillable = [

--- a/app/Models/User/Opacs/OpacsBooksLents.php
+++ b/app/Models/User/Opacs/OpacsBooksLents.php
@@ -21,8 +21,14 @@ class OpacsBooksLents extends Model
         'delivery_request_time',
     ];
 
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = ['lent_at', 'scheduled_return', 'delivery_request_date'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'lent_at' => 'datetime',
+        'scheduled_return' => 'datetime',
+        'delivery_request_date' => 'datetime',
+    ];
 
     /**
      *  フォーマット付きの返却予定日を返却

--- a/app/Models/User/Reservations/ReservationsInput.php
+++ b/app/Models/User/Reservations/ReservationsInput.php
@@ -24,7 +24,13 @@ class ReservationsInput extends Model
         'status',
     ];
 
-    protected $dates = ['start_datetime', 'end_datetime'];
+    /**
+     * キャストする必要のある属性
+     */
+    protected $casts = [
+        'start_datetime' => 'datetime',
+        'end_datetime' => 'datetime',
+    ];
 
     /**
      * 表示する予約日付

--- a/app/User.php
+++ b/app/User.php
@@ -19,9 +19,6 @@ class User extends Authenticatable
 {
     use HasFactory, Notifiable;
 
-    // 日付型の場合、$dates にカラムを指定しておく。
-    protected $dates = ['created_at', 'updated_at'];
-
     // ユーザーの権限セット
     public $user_roles = null;
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/pull/2191
* 上記対応時に気付きました。
* モデルの$dates → $castsに切替えて、Laravel 8.x(Connect 1.x系)で動作する事を確認しました。

# 簡易テスト

* github actionsで簡易テストを実施しました。
  * https://github.com/opensource-workshop/connect-cms/actions/runs/14871924142

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
