### PR TITLE
[ブラウザテスト] .envからDUSK_NO_MANUAL_ALL／DUSK_NO_API_TEST_ALLを設定できるように対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,10 +171,10 @@ FACE_AI_API_KEY="${COMMON_API_KEY}"
 #DUSK_DRIVER_URL=
 
 # Do not create manuals in Dusk.
-#DUSK_NO_MANUAL=true
+#DUSK_NO_MANUAL_ALL=true
 
 # Do not run API tests in Dusk.
-#DUSK_NO_API_TEST=true
+#DUSK_NO_API_TEST_ALL=true
 
 # dusk use uploads dir.
 #UPLOADS_DIRECTORY_BASE=uploads_dusk/

--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,12 @@ FACE_AI_API_KEY="${COMMON_API_KEY}"
 
 #DUSK_DRIVER_URL=
 
+# Do not create manuals in Dusk.
+#DUSK_NO_MANUAL=true
+
+# Do not run API tests in Dusk.
+#DUSK_NO_API_TEST=true
+
 # dusk use uploads dir.
 #UPLOADS_DIRECTORY_BASE=uploads_dusk/
 

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -108,6 +108,7 @@ abstract class DuskTestCase extends BaseTestCase
             });
         }
 
+        // Laravel9以前
         // コマンドライン引数 第5（配列インデックス4）に no_manual が指定されていた場合は、マニュアル作成しない。
         if ($_SERVER && count($_SERVER['argv']) > 4) {
             if ($_SERVER['argv'][4] == 'no_manual') {
@@ -117,6 +118,17 @@ abstract class DuskTestCase extends BaseTestCase
             if ($_SERVER['argv'][4] == 'no_api_test') {
                 $this->no_api_test = true;
             }
+        }
+
+        // Laravel 10対応(phpunit 10.x) dusk実行時のコマンドライン引数はテストクラスのパスと認識されるため、envで対応
+        // .envの DUSK_NO_MANUAL に何か値が指定されていた場合は、マニュアル作成しない。
+        if (env('DUSK_NO_MANUAL')) {
+            $this->no_manual = true;
+        }
+
+        // .envの DUSK_NO_API_TEST に何か値が指定されていた場合は、APIテストを実行しない。
+        if (env('DUSK_NO_API_TEST')) {
+            $this->no_api_test = true;
         }
 
 /* 一旦コメントアウト。データのクリアは、意識して行いたいかもしれないので。

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -121,13 +121,13 @@ abstract class DuskTestCase extends BaseTestCase
         }
 
         // Laravel 10対応(phpunit 10.x) dusk実行時のコマンドライン引数はテストクラスのパスと認識されるため、envで対応
-        // .envの DUSK_NO_MANUAL に何か値が指定されていた場合は、マニュアル作成しない。
-        if (env('DUSK_NO_MANUAL')) {
+        // .envの DUSK_NO_MANUAL_ALL に何か値が指定されていた場合は、マニュアル作成しない。
+        if (env('DUSK_NO_MANUAL_ALL')) {
             $this->no_manual = true;
         }
 
-        // .envの DUSK_NO_API_TEST に何か値が指定されていた場合は、APIテストを実行しない。
-        if (env('DUSK_NO_API_TEST')) {
+        // .envの DUSK_NO_API_TEST_ALL に何か値が指定されていた場合は、APIテストを実行しない。
+        if (env('DUSK_NO_API_TEST_ALL')) {
             $this->no_api_test = true;
         }
 
@@ -569,6 +569,11 @@ abstract class DuskTestCase extends BaseTestCase
      */
     public function putManualTemplateData($frame, $category, $test_path, $plugin, $templates)
     {
+        // マニュアル用データ出力がOFF の場合は、出力せずに戻る。
+        if ($this->no_manual) {
+            return;
+        }
+
         // 画像関係パス
         $img_args = "";
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

Connect-CMS 1.x（Laravel8.x）ではdusk実行時の引数を指定しても、テスト実行できていましたが、
Laravel10.xでdusk実行時の引数は、テストケースのパスとして認識されるようになり、no_manual, no_api_test の引数がテストケースのパスとして誤認され、そんなテストケースはないのでエラーが出るようになりました。

そのため、現在のdusk実行時の引数を指定に加えて、.envからもDUSK_NO_MANUAL_ALL／DUSK_NO_API_TEST_ALLを設定できるよう修正しました。

# 簡易テスト

* github actionsで簡易テストを実施しました。
  * https://github.com/opensource-workshop/connect-cms/actions/runs/14953975329

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms/pull/2191

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
