### PR TITLE
[施設予約] 繰り返し予約後、特定操作で500エラーになる

### DIFF
--- a/app/Plugins/User/Reservations/ReservationsPlugin.php
+++ b/app/Plugins/User/Reservations/ReservationsPlugin.php
@@ -1916,6 +1916,11 @@ class ReservationsPlugin extends UserPluginBase
                 ->orderBy('start_datetime', 'asc')
                 ->first();
 
+            // 親ID以外で一番若い日がいない（$input_earliest = null）場合、繰り返しも残っていないことになるので、何もしない。
+            if (is_null($input_earliest)) {
+                return;
+            }
+
             // 親ID更新
             ReservationsInput::where('id', '!=', $input_id)
                 ->where('inputs_parent_id', $input_id)


### PR DESCRIPTION
# 背景
 - 顧客より問い合わせあり、後述の再現手順により500エラーが発生する
```
[2025-05-27 09:05:02] production.ERROR: Trying to get property 'id' of non-object {"userId":1,"exception":"[object] (ErrorException(code: 0): Trying to get property 'id' of non-object at C:\\sites\\connect_cms_php_7427\\htdocs\\app\\Plugins\\User\\Reservations\\ReservationsPlugin.php:1922)
```

# 修正概要
 - 直接的な原因は$input_earliestがnullの為、reservations_inputsテーブル更新処理でエラーになっています。
 - 後続の処理は繰り返し関係を保持する為の処理になりますが、$input_earliestが存在しない場合は後続処理の必要もないと判断して、nullチェックによるアーリーリターンを追加しています。※ここの判断もし間違ってたら突っ込んでください。

# 参考（再現手順）
1. 繰り返し予約で3日間連続予約
2. 1日目と3日目の時間を「編集」-「この予定のみ編集する」で変更
3. さらに2日目の時間を「編集」-「この予定のみ編集する」で変更しようとするとシステムエラー
4. システムエラーは出るが2日目の予約自体は変更されている。

# レビュー完了希望日
6月3日（火）

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
なし

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
