### PR TITLE
[ユーザ管理] ユーザ管理＞項目設定, 一覧のレイアウトが崩れるケースがある不具合（HTML有りのキャプション時）に対応

### DIFF
--- a/resources/views/plugins/manage/user/include_edit_column_row.blade.php
+++ b/resources/views/plugins/manage/user/include_edit_column_row.blade.php
@@ -133,7 +133,7 @@ use App\Models\Core\UsersColumns;
             {{-- キャプションが設定されている場合、キャプションを表示する --}}
             <div class="small {{ $column->caption_color }}">
                 <i class="fas fa-pen" data-toggle="tooltip" title="キャプション"></i>
-                {!! mb_strimwidth($column->caption, 0, 60, '...', 'UTF-8') !!}
+                {{ mb_strimwidth($column->caption, 0, 60, '...', 'UTF-8') }}
             </div>
         @endif
 
@@ -141,7 +141,7 @@ use App\Models\Core\UsersColumns;
             {{-- プレースホルダが設定されている場合、プレースホルダを表示する --}}
             <div class="small">
                 <i class="fas fa-pen-square" data-toggle="tooltip" title="プレースホルダ"></i>
-                {!! mb_strimwidth($column->place_holder, 0, 60, '...', 'UTF-8') !!}
+                {{ mb_strimwidth($column->place_holder, 0, 60, '...', 'UTF-8') }}
             </div>
         @endif
 
@@ -149,7 +149,7 @@ use App\Models\Core\UsersColumns;
             {{-- 変数名を使用する場合、変数名を表示する --}}
             <div class="small">
                 <i class="fas fa-box" data-toggle="tooltip" title="変数名"></i>
-                {!! mb_strimwidth($column->variable_name, 0, 60, '...', 'UTF-8') !!}
+                {{ mb_strimwidth($column->variable_name, 0, 60, '...', 'UTF-8') }}
             </div>
         @endif
     </td>


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/2013

上記不具合の修正です。
同様の不具合が「プレースホルダ」「変数名」にもあったため、対応しました。

## 対応詳細

* 一覧で表示するキャプションは、60文字以下で表示するようになっており、今回のHTML入りのキャプションでは、ちょうどAタグの開始のみ記載されて、HTMLを有効にして表示するようになっていたため、レイアウトが崩れていました。
* 上記不具合を回避するため、一覧でのキャプションのHTML表示は無効（サニタイジング対応）をしました。

# 修正後画面
## ユーザ管理＞項目設定

HTML有りのキャプションを設定した時に、一覧のレイアウトが崩れない事を確認しました。

![image](https://github.com/user-attachments/assets/f7624e7e-952e-4363-87a3-7e48317a12c2)

# 簡易テスト

* github actionsで簡易テストを実施しました。
  * https://github.com/opensource-workshop/connect-cms/actions/runs/15310891675

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

概要に記載しました。

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
