### PR TITLE
[施設予約] 「重複予約を許可しない」設定にしていても、予約の終了時間を「24:00」にすると重複して予約ができてしまう不具合対応

### DIFF
--- a/app/Rules/CustomValiDuplicateBookings.php
+++ b/app/Rules/CustomValiDuplicateBookings.php
@@ -2,11 +2,10 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
-
-use Illuminate\Support\Collection;
-
 use App\Models\User\Reservations\ReservationsInput;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Collection;
+use Carbon\Carbon;
 
 /**
  * 施設予約重複チェック
@@ -33,6 +32,16 @@ class CustomValiDuplicateBookings implements Rule
 
         $this->start_datetime = $start_datetime;
         $this->end_datetime = $end_datetime;
+
+        // 終了日時を日付と時間に分割
+        [$end_date, $end_time] = explode(' ', $this->end_datetime);
+        if ($end_time == '24:00') {
+            // 予約重複できない設定＋2025-05-30 14:00-17:00予定あり時、2025-05-30 12:00-24:00の予約が重複登録できてしまう不具合対応。end_datatimeの'2025-05-30 24:00'は不正な値でチェックできないため、'2025-05-31 00:00'に変換する
+            $end_carbon = new Carbon($end_datetime);
+            $this->end_datetime = $end_carbon->format('Y-m-d H:i');
+        } else {
+            $this->end_datetime = $end_datetime;
+        }
 
         $this->message = $message;
     }


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

施設予約で「重複予約を許可しない」設定にしていても、予約の終了時間を「24:00」にすると重複して予約ができてしまう不具合がありましたので、重複予約チェックを修正しました。

## 不具合詳細

* 施設管理
  * 「重複予約を許可しない」設定にする
* 施設予約
  * 2025-05-30 14:00-17:00予定あり
  * 2025-05-30 12:00-24:00予定を登録すると、登録できてしまう

※ 終了時間の24:00表示は、施設予約特有の表示で、変換して表示しています。
　システム上では`2025-05-30 24:00`はイレギュラーな値で、CarbonやDBのdatetime型ですと、正しい値は 翌日の0時 `2025-05-31 00:00` になります。
　`2025-05-30 24:00`のイレギュラーな値で、予約重複チェックを行ったため、うまくチェックが働きませんでした。

## 対応

* 重複チェックで`2025-05-30 24:00`等の24:00がきた場合、正しい値の 翌日の0時 `2025-05-31 00:00` に変換してチェックするよう対応しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

5/30(金)

# 修正後画面
## (参考) 施設管理＞施設変更（重複予約＝許可しない）

![image](https://github.com/user-attachments/assets/fef5a5c4-239b-46c6-a614-2664238d4c99)

## (参考) 施設予約＞初期表示（05-30 14:00-17:00予定あり）

![image](https://github.com/user-attachments/assets/b1ef94cb-6827-4a4c-ad34-d8f5a3a72de7)

## 施設予約＞予約（05-30 12:00-24:00予定を登録で、重複予約エラーが出ることを確認しました）

![image](https://github.com/user-attachments/assets/e6228fff-112b-4206-ae7a-3e5938b5460f)


# 簡易テスト

* github actionsで簡易テストを実施しました。
  * https://github.com/opensource-workshop/connect-cms/actions/runs/15311849492

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
