### PR TITLE
[アップロードファイル][ユーザ管理] 一覧のページャ指定が、別ページ遷移後でも残っている不具合対応

### DIFF
--- a/resources/views/plugins/manage/menus_list.blade.php
+++ b/resources/views/plugins/manage/menus_list.blade.php
@@ -94,9 +94,9 @@
         <div class="list-group-item bg-light">データ管理系</div>
         @if (Auth::user()->can('admin_site'))
             @if (isset($plugin_name) && $plugin_name == 'uploadfile')
-                <a href="{{url('/')}}/manage/uploadfile" class="list-group-item active">アップロードファイル</a>
+                <a href="{{url('/')}}/manage/uploadfile?page=1" class="list-group-item active">アップロードファイル</a>
             @else
-                <a href="{{url('/')}}/manage/uploadfile" class="list-group-item">アップロードファイル</a>
+                <a href="{{url('/')}}/manage/uploadfile?page=1" class="list-group-item">アップロードファイル</a>
             @endif
         @endif
         @if (Auth::user()->can('admin_site'))

--- a/resources/views/plugins/manage/menus_list.blade.php
+++ b/resources/views/plugins/manage/menus_list.blade.php
@@ -26,9 +26,9 @@
     @endif
     @if (Auth::user()->can('admin_user'))
         @if (isset($plugin_name) && $plugin_name == 'user')
-            <a href="{{url('/')}}/manage/user" class="list-group-item active">ユーザ管理</a>
+            <a href="{{url('/')}}/manage/user?page=1" class="list-group-item active">ユーザ管理</a>
         @else
-            <a href="{{url('/')}}/manage/user" class="list-group-item">ユーザ管理</a>
+            <a href="{{url('/')}}/manage/user?page=1" class="list-group-item">ユーザ管理</a>
         @endif
     @endif
     @if (Auth::user()->can('admin_user'))

--- a/resources/views/plugins/manage/uploadfile/uploadfile_manage_tab.blade.php
+++ b/resources/views/plugins/manage/uploadfile/uploadfile_manage_tab.blade.php
@@ -17,7 +17,7 @@
                 @if ($function == "index")
                     <span class="nav-link"><span class="active">アップロードファイル一覧</span></span>
                 @else
-                    <a href="{{url('/manage/uploadfile')}}" class="nav-link">アップロードファイル一覧</a></li>
+                    <a href="{{url('/manage/uploadfile?page=1')}}" class="nav-link">アップロードファイル一覧</a></li>
                 @endif
                 </li>
                 <li role="presentation" class="nav-item">

--- a/resources/views/plugins/manage/user/user_manage_tab.blade.php
+++ b/resources/views/plugins/manage/user/user_manage_tab.blade.php
@@ -18,7 +18,7 @@
                 @if ($function == "index")
                     <span class="nav-link"><span class="active">ユーザ一覧</span></span>
                 @else
-                    <a href="{{url('/manage/user')}}" class="nav-link">ユーザ一覧</a></li>
+                    <a href="{{url('/manage/user?page=1')}}" class="nav-link">ユーザ一覧</a></li>
                 @endif
                 </li>
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/issues/1717
* 上記の不具合修正です。
* アップロードファイル／ユーザ管理 を対応しました。

# 対応

* ユーザ管理の例に話をすると、２ページ目のユーザ編集後に２ページを表示して欲しいので、ページ保持機能はそのままにしました。
* 左メニュー／上部メニュー押下時のみ、1ページ目表示のクエリストリング `?page=1` を追加して、必ず１ページ目を表示するように対応しました。

# 修正後画面

画面表示に変更はないため、ありません。

# 簡易テスト

* github actionsで簡易テストを実施しました。
  * https://github.com/opensource-workshop/connect-cms/actions/runs/15312356653

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
なし

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
概要に記載しました。

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
