### PR TITLE
[課題管理] レポートのコメントに単語数と文字数を表示する機能を追加しました

### DIFF
--- a/app/Enums/LearningtaskUseFunction.php
+++ b/app/Enums/LearningtaskUseFunction.php
@@ -43,6 +43,8 @@ final class LearningtaskUseFunction extends EnumsBase
     const use_report_reference_mail = 'use_'.self::report.'_reference_mail';
     // [表示方法]
     const use_report_status_collapse = 'use_'.self::report.'_status_collapse';
+    const use_report_show_word_count = 'use_'.self::report.'_show_word_count';
+    const use_report_show_char_count = 'use_'.self::report.'_show_char_count';
 
     // --- 試験設定
     // [利用する試験提出機能]
@@ -110,6 +112,8 @@ final class LearningtaskUseFunction extends EnumsBase
         self::use_report_reference_mail => 'メール送信（受講者宛）',
         // 表示方法
         self::use_report_status_collapse => '履歴を開閉する',
+        self::use_report_show_word_count => '文字数を表示する',
+        self::use_report_show_char_count => '字数を表示する',
         // --- 試験設定
         // 利用する試験提出機能
         self::use_examination => '提出',

--- a/app/Models/User/Learningtasks/LearningtasksUsersStatuses.php
+++ b/app/Models/User/Learningtasks/LearningtasksUsersStatuses.php
@@ -192,4 +192,23 @@ class LearningtasksUsersStatuses extends Model
         // withDefault() を指定しておくことで、Uploads がないときに空のオブジェクトが返ってくるので、null po 防止。
         return $this->hasOne(Uploads::class, 'id', 'upload_id')->withDefault();
     }
+
+    /**
+     * 単語数を取得する
+     */
+    public function getWordCountAttribute()
+    {
+        // マルチバイト文字などは適切な値を取得できない
+        // 必要になれば形態素解析などを行う必要がある
+        return $this->comment ? str_word_count($this->comment) : 0;
+    }
+
+    /**
+     * 字数を取得する
+     * 文字数は、全角文字も半角文字も1文字としてカウントする。
+     */
+    public function getCharCountAttribute()
+    {
+        return $this->comment ? mb_strlen($this->comment) : 0;
+    }
 }

--- a/app/Plugins/User/Learningtasks/DataProviders/ReportCsvDataProvider.php
+++ b/app/Plugins/User/Learningtasks/DataProviders/ReportCsvDataProvider.php
@@ -171,6 +171,8 @@ class ReportCsvDataProvider implements CsvDataProviderInterface
             },
             '評価' => fn() => optional($last_evaluation)->grade,
             '評価コメント' => fn() => optional($last_evaluation)->comment,
+            '単語数' => fn() => optional($last_submission)->word_count,
+            '字数' => fn() => optional($last_submission)->char_count,
         ];
     }
 }

--- a/app/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinition.php
+++ b/app/Plugins/User/Learningtasks/Services/LearningtaskReportColumnDefinition.php
@@ -28,6 +28,8 @@ class LearningtaskReportColumnDefinition implements ColumnDefinitionInterface //
         'ファイルURL' => 'file_url',
         '評価' => 'grade',
         '評価コメント' => 'comment',
+        '単語数' => 'word_count',
+        '字数' => 'char_count',
     ];
 
     /**
@@ -57,6 +59,12 @@ class LearningtaskReportColumnDefinition implements ColumnDefinitionInterface //
         $header_columns = ['ログインID', 'ユーザ名', '提出日時', '提出回数'];
         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_comment)) {
             $header_columns[] = '本文';
+        }
+        if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_show_word_count)) {
+            $header_columns[] = '単語数';
+        }
+        if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_show_char_count)) {
+            $header_columns[] = '字数';
         }
         if ($this->setting_checker->isEnabled(LearningtaskUseFunction::use_report_file)) {
             $header_columns[] = 'ファイルURL';

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_edit_learningtasks.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_edit_learningtasks.blade.php
@@ -340,11 +340,20 @@
 
         <div class="form-group row mb-0">
             <label class="{{$frame->getSettingLabelClass()}}">表示方法</label>
-            <div class="{{$frame->getSettingInputClass(true)}}">
-                <div class="custom-control custom-checkbox mr-3">
+            <div class="{{$frame->getSettingInputClass()}}">
+                <div class="custom-control custom-checkbox custom-control-inline">
                     <input type="checkbox" name="base_settings[use_report_status_collapse]" value="on" class="custom-control-input" id="use_report_status_collapse" @if(old("base_settings.use_report_status_collapse", $tool->getFunction('use_report_status_collapse')) == 'on') checked=checked @endif>
                     <label class="custom-control-label" for="use_report_status_collapse">履歴を開閉する</label>
                 </div>
+                <div class="custom-control custom-checkbox custom-control-inline">
+                    <input type="checkbox" name="base_settings[use_report_show_word_count]" value="on" class="custom-control-input" id="use_report_show_word_count" @if(old("base_settings.use_report_show_word_count", $tool->getFunction('use_report_show_word_count')) == 'on') checked=checked @endif>
+                    <label class="custom-control-label" for="use_report_show_word_count">単語数を表示する</label>
+                </div>
+                <div class="custom-control custom-checkbox custom-control-inline">
+                    <input type="checkbox" name="base_settings[use_report_show_char_count]" value="on" class="custom-control-input" id="use_report_show_char_count" @if(old("base_settings.use_report_show_char_count", $tool->getFunction('use_report_show_char_count')) == 'on') checked=checked @endif>
+                    <label class="custom-control-label" for="use_report_show_char_count">文字数を表示する</label>
+                </div>
+                <small class="form-text text-muted">単語数の表示は、日本語などのマルチバイト文字に対応していません。</small>
             </div>
         </div>
 

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_edit_report.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_edit_report.blade.php
@@ -231,11 +231,20 @@
 
                 <div class="form-group row">
                     <label class="col-md-3 text-md-right">表示方法</label>
-                    <div class="col-md-9 d-md-flex">
-                        <div class="custom-control custom-checkbox mr-3">
+                    <div class="col-md-9">
+                        <div class="custom-control custom-checkbox custom-control-inline">
                             <input type="checkbox" name="post_settings[use_report_status_collapse]" value="on" class="custom-control-input" id="use_report_status_collapse" @if(old("post_settings.use_report_status_collapse", $tool->getFunction('use_report_status_collapse', true)) == 'on') checked=checked @endif>
                             <label class="custom-control-label" for="use_report_status_collapse">履歴を開閉する</label>
                         </div>
+                        <div class="custom-control custom-checkbox custom-control-inline">
+                            <input type="checkbox" name="post_settings[use_report_show_word_count]" value="on" class="custom-control-input" id="use_report_show_word_count" @if(old("post_settings.use_report_show_word_count", $tool->getFunction('use_report_show_word_count', true)) == 'on') checked=checked @endif>
+                            <label class="custom-control-label" for="use_report_show_word_count">単語数を表示する</label>
+                        </div>
+                        <div class="custom-control custom-checkbox custom-control-inline">
+                            <input type="checkbox" name="post_settings[use_report_show_char_count]" value="on" class="custom-control-input" id="use_report_show_char_count" @if(old("post_settings.use_report_show_char_count", $tool->getFunction('use_report_show_char_count', true)) == 'on') checked=checked @endif>
+                            <label class="custom-control-label" for="use_report_show_char_count">文字数を表示する</label>
+                        </div>
+                        <small class="form-text text-muted">単語数の表示は、日本語などのマルチバイト文字に対応していません。</small>
                     </div>
                 </div>
             </div>

--- a/resources/views/plugins/user/learningtasks/default/learningtasks_show_report_status.blade.php
+++ b/resources/views/plugins/user/learningtasks/default/learningtasks_show_report_status.blade.php
@@ -31,7 +31,28 @@
             @if ($tool->isUseFunction($user_status->task_status, 'comment'))
             <tr>
                 <th>コメント</th>
-                <td>{!!nl2br(e($user_status->comment))!!}</td>
+                <td>{!!nl2br(e($user_status->comment))!!}
+                {{-- 文字数、単語数の表示 --}}
+                @php
+                    $should_show_word_count = $tool->isUseFunction($user_status->task_status, 'show_word_count');
+                    $should_show_char_count = $tool->isUseFunction($user_status->task_status, 'show_char_count');
+                    $word_count = $user_status->word_count;
+                    $char_count = $user_status->char_count;
+                @endphp
+                @if ($should_show_word_count || $should_show_char_count)
+                    <div><small class="text-muted">
+                        @if ($should_show_word_count)
+                            {{ $word_count }}単語
+                        @endif
+                        @if ($should_show_word_count && $should_show_char_count)
+                            /
+                        @endif
+                        @if ($should_show_char_count)
+                            {{ $char_count }}文字
+                        @endif
+                    </small></div>
+                @endif
+                </td>
             </tr>
         @endif
     </tbody>

--- a/tests/Unit/Models/User/Learningtasks/LearningtasksUsersStatusesTest.php
+++ b/tests/Unit/Models/User/Learningtasks/LearningtasksUsersStatusesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Models\User\Learningtasks;
+
+use App\Models\User\Learningtasks\LearningtasksUsersStatuses;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LearningtasksUsersStatusesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * commentがnullまたは空文字の場合、word_countは0を返すことをテスト
+     */
+    public function testWordCountIsZeroWhenCommentIsNullOrEmpty(): void
+    {
+        $model = new LearningtasksUsersStatuses(['comment' => null]);
+        $this->assertSame(0, $model->word_count);
+        $model = new LearningtasksUsersStatuses(['comment' => '']);
+        $this->assertSame(0, $model->word_count);
+    }
+
+    /**
+     * commentの内容に応じてword_countが正しい値を返すことをテスト
+     */
+    public function testWordCountReturnsExpectedValue(): void
+    {
+        $model = new LearningtasksUsersStatuses(['comment' => 'This is a test']);
+        $this->assertSame(4, $model->word_count);
+    }
+
+    /**
+     * commentがnullまたは空文字の場合、char_countは0を返すことをテスト
+     */
+    public function testCharCountIsZeroWhenCommentIsNullOrEmpty(): void
+    {
+        $model = new LearningtasksUsersStatuses(['comment' => null]);
+        $this->assertSame(0, $model->char_count);
+        $model = new LearningtasksUsersStatuses(['comment' => '']);
+        $this->assertSame(0, $model->char_count);
+    }
+
+    /**
+     * commentの内容に応じてchar_countが正しい値を返すことをテスト
+     */
+    public function testCharCountReturnsExpectedValue(): void
+    {
+        $model = new LearningtasksUsersStatuses(['comment' => 'abc']);
+        $this->assertSame(3, $model->char_count);
+        $model = new LearningtasksUsersStatuses(['comment' => 'テストword']);
+        $this->assertSame(7, $model->char_count);
+    }
+}

--- a/tests/Unit/Plugins/User/Learningtasks/DataProviders/ReportCsvDataProviderTest.php
+++ b/tests/Unit/Plugins/User/Learningtasks/DataProviders/ReportCsvDataProviderTest.php
@@ -279,7 +279,7 @@ class ReportCsvDataProviderTest extends TestCase
     }
 
     /**
-     * 単語数・字数カラムが有効な場合に正しい値が出力されるテスト（カスタムアクセサ対応）
+     * 単語数・字数カラムが有効な場合に正しい値が出力されるテスト
      * @test
      * @covers ::getRows
      * @group learningtasks


### PR DESCRIPTION
# 概要
レポートのコメント欄の下に、入力されたテキストの単語数と文字数を表示する機能を追加しました。
この表示は、設定画面から個別にON/OFFを切り替えることが可能です。

## 変更の目的
教員が学生のレポートを評価する際、その記述量を参考情報の一つとして活用できるようにするため。

## 変更内容

- **レポート設定の変更**
    - 「表示方法」の項目に、「単語数を表示する」および「文字数を表示する」チェックボックスを追加しました。
- **画面表示の変更**
    - 上記設定が有効な場合、レポート提出履歴画面のコメント欄の下に「X単語 / Y文字」の形式でそれぞれの数を表示します。
- **CSVエクスポートの変更**
    - レポート提出履歴をCSVファイルとしてエクスポートする際に、「単語数」と「字数」の列を追加し、それぞれの値が出力されるようにしました。

## テスト
以下の項目について、動作確認を行いました。
- [x] レポート設定画面で、単語数・文字数表示のON/OFFが正しく保存・反映されること。
- [x] 設定を有効にした際、レポート提出履歴画面に単語数と文字数が正しく表示されること。
- [x] 設定を無効にした際、単語数と文字数が表示されないこと。
- [x] レポート提出履歴のCSVエクスポートで、単語数と文字数が正しく出力されること。

## 特記事項

- レポート設定画面に記載の通り、単語数のカウントは日本語などのマルチバイト文字に対応していません。主にスペースで区切られる言語（英語など）を想定した機能となります。

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
