### PR TITLE
[データベース]詳細閲覧時にデータの更新日が更新される不具合を修正しました

### DIFF
--- a/app/Models/User/Databases/DatabasesInputCols.php
+++ b/app/Models/User/Databases/DatabasesInputCols.php
@@ -13,4 +13,16 @@ class DatabasesInputCols extends Model
 
     // 更新する項目の定義
     protected $fillable = ['databases_inputs_id', 'databases_columns_id', 'value'];
+
+    // リレーション
+    /**
+     * データベース入力
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @phpcsSuppress
+     */
+    public function databases_input()
+    {
+        return $this->belongsTo(DatabasesInputs::class, 'databases_inputs_id');
+    }
+
 }

--- a/app/Models/User/Databases/DatabasesInputCols.php
+++ b/app/Models/User/Databases/DatabasesInputCols.php
@@ -20,9 +20,8 @@ class DatabasesInputCols extends Model
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      * @phpcsSuppress
      */
-    public function databases_input()
+    public function databases_input() // phpcs:ignore
     {
         return $this->belongsTo(DatabasesInputs::class, 'databases_inputs_id');
     }
-
 }

--- a/app/Models/User/Databases/DatabasesInputs.php
+++ b/app/Models/User/Databases/DatabasesInputs.php
@@ -30,6 +30,7 @@ class DatabasesInputs extends Model
         'first_committed_at',
         'categories_id',
         'views',
+        'last_col_updated_at',
         'created_at',
         'updated_at'
     ];

--- a/app/Observers/User/Databases/DatabasesInputColsObserver.php
+++ b/app/Observers/User/Databases/DatabasesInputColsObserver.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Observers\User\Databases;
+
+use App\Models\User\Databases\DatabasesInputCols;
+use Carbon\Carbon;
+
+class DatabasesInputColsObserver
+{
+    /**
+     * Handle the DatabasesInputCols "created" event.
+     *
+     * @param  App\Models\User\Databases\DatabasesInputCols  $databases_input_cols
+     * @return void
+     */
+    public function created(DatabasesInputCols $databases_input_cols)
+    {
+        $databases_input_cols->databases_input->update([
+            'last_col_updated_at' => Carbon::now(),
+        ]);
+    }
+
+    /**
+     * Handle the DatabasesInputCols "updated" event.
+     *
+     * @param  App\Models\User\Databases\DatabasesInputCols  $databases_input_cols
+     * @return void
+     */
+    public function updated(DatabasesInputCols $databases_input_cols)
+    {
+        $databases_input_cols->databases_input->update([
+            'last_col_updated_at' => Carbon::now(),
+        ]);
+    }
+
+    /**
+     * Handle the DatabasesInputCols "deleted" event.
+     *
+     * @param  App\Models\User\Databases\DatabasesInputCols  $databases_input_cols
+     * @return void
+     */
+    public function deleted(DatabasesInputCols $databases_input_cols)
+    {
+        $databases_input_cols->databases_input->update([
+            'last_col_updated_at' => Carbon::now(),
+        ]);
+    }
+
+    /**
+     * Handle the DatabasesInputCols "restored" event.
+     *
+     * @param  App\Models\User\Databases\DatabasesInputCols  $databases_input_cols
+     * @return void
+     */
+    public function restored(DatabasesInputCols $databases_input_cols)
+    {
+        //
+    }
+
+    /**
+     * Handle the DatabasesInputCols "force deleted" event.
+     *
+     * @param  App\Models\User\Databases\DatabasesInputCols  $databases_input_cols
+     * @return void
+     */
+    public function forceDeleted(DatabasesInputCols $databases_input_cols)
+    {
+        //
+    }
+}

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -1912,7 +1912,7 @@ class DatabasesPlugin extends UserPluginBase
             $value = $input->created_at;
         } elseif ($column->column_type == DatabaseColumnType::updated) {
             // 更新日型
-            $value = $input->updated_at;
+            $value = $input->last_col_updated_at;
         } elseif ($column->column_type == DatabaseColumnType::posted) {
             // 公開日型
             $value = $input->posted_at;
@@ -3139,7 +3139,7 @@ class DatabasesPlugin extends UserPluginBase
                                         select(
                                             'databases_input_cols.*',
                                             'databases_inputs.created_at as inputs_created_at',
-                                            'databases_inputs.updated_at as inputs_updated_at',
+                                            'databases_inputs.last_col_updated_at as inputs_updated_at',
                                             'databases_inputs.posted_at as inputs_posted_at',
                                             'databases_inputs.expires_at as inputs_expires_at',
                                             'databases_inputs.display_sequence as inputs_display_sequence',

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User\Databases\DatabasesInputCols;
+use App\Observers\User\Databases\DatabasesInputColsObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -33,6 +35,7 @@ class EventServiceProvider extends ServiceProvider
     {
         parent::boot();
 
-        //
+        // オブザーバーの登録
+        DatabasesInputCols::observe(DatabasesInputColsObserver::class);
     }
 }

--- a/database/migrations/2025_01_31_172824_add_last_col_updated_at_to_databases_inputs_table.php
+++ b/database/migrations/2025_01_31_172824_add_last_col_updated_at_to_databases_inputs_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLastColUpdatedAtToDatabasesInputsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->timestamp('last_col_updated_at')->nullable()->after('full_text');
+        });
+
+        // 既存データの更新
+        \DB::statement('
+            UPDATE databases_inputs di
+            SET di.last_col_updated_at = (
+                SELECT updated_at
+                FROM databases_input_cols dic
+                WHERE dic.databases_inputs_id = di.id
+                ORDER BY updated_at DESC
+                LIMIT 1
+            )
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_inputs', function (Blueprint $table) {
+            $table->dropColumn('last_col_updated_at');
+        });
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
@@ -83,7 +83,7 @@
     }
     // 更新日型
     elseif ($column->column_type == DatabaseColumnType::updated) {
-        $value = $inputs->updated_at;
+        $value = $inputs->last_col_updated_at;
     }
     // 表示件数型
     elseif ($column->column_type == DatabaseColumnType::views) {

--- a/resources/views/plugins/user/databases/default/databases_include_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_value.blade.php
@@ -85,7 +85,7 @@
     }
     // 更新日型
     elseif ($column->column_type == DatabaseColumnType::updated) {
-        $value = $input->updated_at;
+        $value = $input->last_col_updated_at;
     }
     // 表示件数型
     elseif ($column->column_type == DatabaseColumnType::views) {


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

データベースの詳細画面を閲覧した際に、意図せず最終更新日が現在の日時で上書きされてしまう不具合を修正しました。

## 変更の目的

「更新日型」として設定された項目が、データの詳細を閲覧するだけで毎回更新されてしまう問題を解決するため。本来、この項目はデータが実際に編集された際にのみ更新されるべきです。

## 変更内容

証跡用の更新日(`updated_at`)と、画面表示用の最終更新日を分離することで対応しました。

- `databases_inputs`テーブルに、最終更新日を管理するための`last_col_updated_at`カラムを追加しました。
- 項目の更新時に、Observerを利用して`last_col_updated_at`を更新するようにしました。
- 画面やCSVに出力する更新日型のデータを、従来の`updated_at`から新設した`last_col_updated_at`に変更しました。

## テスト

以下の手順で、修正が正しく反映されていることを画面上で確認しました。

1.  「更新日型」の項目を持つデータベースを用意し、データを登録します。
2.  登録したデータの詳細画面を閲覧します。
3.  一覧画面に戻り、**最終更新日が閲覧した日時に変わっていないこと**を確認します。
4.  データを編集して保存し、一覧画面で**最終更新日が正しく更新されていること**を確認します。
5. CSVを出力し、「更新日型」の項目が**画面と同様の値になっていること**を確認します。

## 特記事項

- NC2およびNC3からの移行プログラムは、今回の修正範囲外です。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
