### PR TITLE
[テーマ管理] ディレクトリ名のバリデーション不備による文字化けや重複の問題を修正しました

### DIFF
--- a/app/Plugins/Manage/ThemeManage/ThemeManage.php
+++ b/app/Plugins/Manage/ThemeManage/ThemeManage.php
@@ -290,13 +290,12 @@ class ThemeManage extends ManagePluginBase
         // セッション初期化などのLaravel 処理
         $request->flash();
 
-        // copy by resources/lang/ja/validation.php - alpha_dash
-        $messages['dir_name.regex'] = ':attributeには英数字・ハイフン・アンダースコアのみからなる文字列を指定してください。';
+        $messages['dir_name.regex'] = '入力された:attributeは使用できません。半角の英数字、アンダースコア(_)、ハイフン(-)のみを使い、先頭がハイフンにならないように入力してください。';
 
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
             /* regex：英数字_- OK */
-            'dir_name'   => ['required', 'regex:/\w+|[-]+/'],
+            'dir_name'   => ['required', 'regex:/^\w[\w-]*$/'],
             'theme_name' => ['required'],
         ], $messages);
         $validator->setAttributeNames([
@@ -870,11 +869,14 @@ class ThemeManage extends ManagePluginBase
         // セッション初期化などのLaravel 処理
         $request->flash();
 
+        $messages['dir_name.regex'] = '入力された:attributeは使用できません。半角の英数字、アンダースコア(_)、ハイフン(-)のみを使い、先頭がハイフンにならないように入力してください。';
+
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
-            'dir_name'   => ['required'],
+            // regex：英数字_- OK
+            'dir_name'   => ['required', 'regex:/^\w[\w-]*$/'],
             'theme_name' => ['required'],
-        ]);
+        ], $messages);
         $validator->setAttributeNames([
             'dir_name'   => 'ディレクトリ名',
             'theme_name' => 'テーマ名',
@@ -884,13 +886,12 @@ class ThemeManage extends ManagePluginBase
         if ($validator->fails()) {
             return $this->generateIndex($request, $id, $validator->errors());
         }
-/* TODO 上書きさせるか否か決める
+
         // ディレクトリの存在チェック
-        if (File::isDirectory(public_path() . '/themes/Users/' . $request->dir_name)) {
+        if (File::isDirectory(public_path() . '/themes/Users/' . basename($request->dir_name))) {
             $validator->errors()->add('dir_name', 'このディレクトリは存在します。');
             return $this->generateIndex($request, $id, $validator->errors());
         }
-*/
 
         // 確認ボタンの場合は入力画面に戻る。
         $themes_css = $this->getSelectStyle($request);


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
テーマ管理の「ユーザ・テーマ機能」および「カスタムテーマ生成機能」において、ディレクトリ名のバリデーションルールを修正・統一しました。

## 変更の目的

サーバーの文字コード設定によっては、ディレクトリ名に日本語などのマルチバイト文字を使用すると文字化けが発生し、テーマが正常に参照できなくなる問題がありました。
また、同名のテーマディレクトリが存在すると意図しない上書きが発生する可能性があるため、これらの問題を未然に防ぐ目的でバリデーションを強化します。

## 変更内容

**対象機能**
- ユーザ・テーマ機能
- カスタムテーマ生成機能

**修正内容**
- **ユーザ・テーマ機能**：正しく機能していなかったディレクトリ名の正規表現(regex)を修正しました。
- **カスタムテーマ生成機能**：ディレクトリ名のバリデーションを追加し、さらに同名のディレクトリが存在しないかチェックする処理も追加しました。

**新しいバリデーションルール**
- **使用可能な文字**：半角の英数字、アンダースコア(\_)、ハイフン(-)。
- **先頭の文字**：半角の英数字、またはアンダースコア(\_)。
- **使用不可能な文字**：スペース、スラッシュ(/)、その他の記号。

## テスト
両機能の画面にて、以下の項目を確認しました。
- 許可されていない文字（全角文字、スペース、記号など）を入力した場合に、エラーメッセージが正しく表示されること。
- カスタムテーマ生成機能で、既に存在するディレクトリ名を入力した場合にエラーメッセージが表示されること。
- 許可されている形式のディレクトリ名で、正常に登録・作成できること。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
