### PR TITLE
[RSS]XMLパースエラー発生時にシステムエラーとなる問題を修正しました

### DIFF
--- a/app/Plugins/User/Rsses/RssesPlugin.php
+++ b/app/Plugins/User/Rsses/RssesPlugin.php
@@ -257,6 +257,10 @@ class RssesPlugin extends UserPluginBase
         return false;
     }
 
+    /**
+     * XMLをパースする
+     * @throws \Exception XMLパースエラー時
+     */
     private function xmlParse($response)
     {
         // SimpleXMLを使用してXMLデータをオブジェクトに変換

--- a/resources/views/plugins/user/rsses/default/rsses_error_messages.blade.php
+++ b/resources/views/plugins/user/rsses/default/rsses_error_messages.blade.php
@@ -4,13 +4,31 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
-@can('frames.edit',[[null, null, null, $frame]])
-<div class="card border-danger">
-    <div class="card-body">
-        @foreach ($error_messages as $error_message)
-            <p class="text-center cc_margin_bottom_0">{!! nl2br(e($error_message)) !!}</p>
-        @endforeach
+{{-- xmlのパースエラー --}}
+@isset($parse_errors)
+    <div class="alert alert-danger" role="alert">
+        {{ $parse_errors['message'] }}
+        @can('frames.edit',[[null, null, null, $frame]])
+            @isset($parse_errors['url'])
+                <ul>
+                    @foreach ($parse_errors['url'] as $url)
+                        <li>{{ $url }}</li>
+                    @endforeach
+                </ul>
+            @endisset
+        @endcan
     </div>
-</div>
+@endisset
+{{-- 管理者専用のエラーメッセージ --}}
+@can('frames.edit',[[null, null, null, $frame]])
+    @isset($error_messages)
+        <div class="card border-danger">
+            <div class="card-body">
+                @foreach ($error_messages as $error_message)
+                    <p class="text-center cc_margin_bottom_0">{!! nl2br(e($error_message)) !!}</p>
+                @endforeach
+            </div>
+        </div>
+    @endisset
 @endcan
 @endsection


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
RSSフィードの取得時に、XMLのパースエラーが原因でシステムエラーが発生する問題を修正しました。

## 変更の目的
RSSフィードの提供元URLがリンク切れになっている場合や、不正な形式のXMLが返された場合に、フレーム内にシステムエラーが表示される問題がありました。これを防ぎ、安定した運用ができるようにすることが目的です。

## 変更内容
XMLのパース処理に例外処理を追加しました。パースエラーが発生した際にはシステムエラーとせず、エラー内容をログに出力します。

また、エラー発生時に表示するメッセージを権限に応じて変更しました。
- **管理者向け：** 原因調査のヒントとなるよう「RSSフィードの取得に失敗しました。URLが正しいか、またはフィードが有効であるかご確認ください。」というメッセージを表示します。
- **一般ユーザー向け：** シンプルに「RSSフィードの読み込みに失敗しました。しばらくしてから再度お試しください。」というメッセージを表示します。

## テスト
- 意図的にリンク切れのURLを設定し、システムエラーが発生しないことを確認しました。
- 不正な形式のXMLを返すURLを設定し、システムエラーが発生しないことを確認しました。
- 管理者アカウントでログイン時、専用のエラーメッセージが表示されることを確認しました。
- 一般ユーザー（非ログイン含む）で、専用のエラーメッセージが表示されることを確認しました。

## 特記事項
- エラー発生時、管理者には原因の調査に役立つメッセージを、一般ユーザーにはシンプルなメッセージを表示するように制御しています。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
