### PR TITLE
[フォーム] フォーム送信時に画像認証する機能を追加しました

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,3 +133,31 @@ PRを作成する際は以下のルールに従ってください：
 - チェックリスト
 
 詳細: https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
+
+## 記録すべき内容
+
+- 現在のプロジェクトの状態や、今後の開発で注意すべき点を随時メモする
+- 特に、複雑な実装や重要な設計判断の背景を記録する
+- **プラグイン固有の知識**: 各プラグインの実装パターンや特殊な仕様は積極的に記録し、今後の開発効率化に活用する
+
+## 効率的な開発のためのベストプラクティス
+
+### 検索とファイル読み込み
+- 複数回にわたる検索が必要な場合は、Taskツールを使用してトークン消費を削減
+- 複数ファイルの同時読み込みには、並行してReadツールを実行
+- 特定のファイルパスが分かっている場合は、GrepやGlobよりもReadツールを直接使用
+
+### コード共通化
+- 重複するコードパターンを発見した場合は、DRY原則に従って共通テンプレートやヘルパー関数を作成
+- 特にビューファイルでは、includeを活用した部分テンプレート化を推奨
+
+### フォームプラグイン固有の知識
+- フォームモードは `form`（通常）と `questionnaire`（アンケート）の2種類
+- アンケートモードでは `index_tandem.blade.php` と `forms_confirm_tandem.blade.php` を使用
+- Captcha機能は `mews/captcha` ライブラリを使用、APIエンドポイント: `/captcha/api/flat`
+- 共通エラー表示は `@include('plugins.common.errors_inline', ['name' => 'field_name'])` を使用
+
+## 注意点
+
+- git comment や PR本文にはclaudeで生成した内容の文章は残さない
+- git commentにはprefixを付ける

--- a/app/Enums/FormAccessLimitType.php
+++ b/app/Enums/FormAccessLimitType.php
@@ -16,12 +16,15 @@ final class FormAccessLimitType extends EnumsBase
     const password = 1;
     /** 画像認証で閲覧制限する */
     const captcha = 2;
+    /** フォーム送信時に画像認証する */
+    const captcha_form_submit = 3;
 
     /** key/valueの連想配列 */
     const enum = [
         self::none => '制限しない',
         self::password => 'パスワードで閲覧制限する',
         self::captcha => '画像認証で閲覧制限する',
+        self::captcha_form_submit => 'フォーム送信時に画像認証する',
     ];
 
     /**

--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -815,6 +815,12 @@ class FormsPlugin extends UserPluginBase
             }
         }
 
+        // フォーム送信時Captcha認証の場合、Captchaバリデーションを追加
+        if ($form->access_limit_type == FormAccessLimitType::captcha_form_submit) {
+            $validator_array['column']['captcha'] = ['required', 'captcha'];
+            $validator_array['message']['captcha'] = '画像認証';
+        }
+
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), $validator_array['column']);
         $validator->setAttributeNames($validator_array['message']);
@@ -901,6 +907,19 @@ class FormsPlugin extends UserPluginBase
     {
         // Forms、Frame データ
         $form = $this->getForms($frame_id);
+
+        // フォーム送信時Captcha認証の場合、Captcha検証
+        if ($form->access_limit_type == FormAccessLimitType::captcha_form_submit) {
+            $validator = Validator::make($request->all(), [
+                'captcha' => ['required', 'captcha'],
+            ]);
+            $validator->setAttributeNames([
+                'captcha' => '画像認証',
+            ]);
+            if ($validator->fails()) {
+                return redirect()->back()->withErrors($validator)->withInput();
+            }
+        }
 
         // 表示期間外か
         if ($this->isOutOfTermDisplay($form)) {

--- a/resources/views/plugins/user/forms/default/forms.blade.php
+++ b/resources/views/plugins/user/forms/default/forms.blade.php
@@ -148,10 +148,15 @@
                 @endswitch
             </div>
         @endforeach
+
+        {{-- Captcha フィールド --}}
+        @include('plugins.user.forms.default.forms_captcha_field')
+
         {{-- ボタンエリア --}}
         <div class="form-group text-center">
             <button class="btn btn-primary"><i class="fa-solid fa-comment"></i> {{__('messages.to_confirm')}}</button>
         </div>
     </fieldset>
 </form>
+@include('plugins.user.forms.default.forms_captcha_script')
 @endsection

--- a/resources/views/plugins/user/forms/default/forms_captcha_field.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_captcha_field.blade.php
@@ -1,0 +1,41 @@
+{{--
+ * Captcha入力フィールド共通テンプレート
+ *
+ * @author Claude
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォーム・プラグイン
+--}}
+
+{{-- Captcha フィールド（フォーム送信時認証の場合） --}}
+@if ($form->access_limit_type == App\Enums\FormAccessLimitType::captcha_form_submit)
+    <div class="form-group row">
+        @if (isset($is_template_label_sm_4))
+            <label class="col-sm-4 control-label" for="captcha-{{$frame_id}}">画像認証 <strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger lead' }}">{{__('messages.required')}}</strong></label>
+        @elseif (isset($is_template_label_sm_6))
+            <label class="col-sm-6 control-label" for="captcha-{{$frame_id}}">画像認証 <strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong></label>
+        @elseif (isset($is_tandem_template))
+            <label class="col-12 control-label" for="captcha-{{$frame_id}}">画像認証 <strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong></label>
+        @else
+            <label class="col-sm-2 control-label" for="captcha-{{$frame_id}}">画像認証 <strong class="{{ App::getLocale() == ConnectLocale::ja ? 'badge badge-danger' : 'text-danger' }}">{{__('messages.required')}}</strong></label>
+        @endif
+        
+        @if (isset($is_tandem_template))
+            <div class="col-12">
+        @else
+            <div class="col-sm">
+        @endif
+            <div class="d-flex align-items-center mb-2">
+                {!! captcha_img('flat') !!}
+                <button type="button" class="btn btn-outline-secondary btn-sm ml-2" onclick="refreshCaptcha()" title="画像を更新">
+                    <i class="fas fa-sync-alt"></i>
+                </button>
+            </div>
+            <input type="text" id="captcha-{{$frame_id}}" name="captcha" class="form-control @if($errors && $errors->has('captcha')) is-invalid @endif" placeholder="画像に表示されている文字を入力してください" autocomplete="off" value="{{ old('captcha') }}">
+            @include('plugins.common.errors_inline', ['name' => 'captcha'])
+            <div class="small text-muted mt-1">
+                <i class="fas fa-info-circle"></i>
+                文字が読みづらい場合は、右側の更新ボタンで新しい画像に変更できます。
+            </div>
+        </div>
+    </div>
+@endif

--- a/resources/views/plugins/user/forms/default/forms_captcha_hidden.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_captcha_hidden.blade.php
@@ -1,0 +1,12 @@
+{{--
+ * Captcha隠しフィールド共通テンプレート（確認画面用）
+ *
+ * @author Claude
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォーム・プラグイン
+--}}
+
+{{-- フォーム送信時Captcha認証の場合、Captcha値を保持 --}}
+@if ($form->access_limit_type == App\Enums\FormAccessLimitType::captcha_form_submit)
+    <input type="hidden" name="captcha" value="{{ old('captcha') }}">
+@endif

--- a/resources/views/plugins/user/forms/default/forms_captcha_script.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_captcha_script.blade.php
@@ -1,0 +1,39 @@
+{{--
+ * Captcha JavaScript機能共通テンプレート
+ *
+ * @author Claude
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォーム・プラグイン
+--}}
+
+@if ($form->access_limit_type == App\Enums\FormAccessLimitType::captcha_form_submit)
+<script>
+function refreshCaptcha() {
+    // mews/captchaライブラリのAPIエンドポイントから新しい画像URLを取得
+    fetch('/captcha/api/flat?' + Math.random())
+        .then(response => response.json())
+        .then(data => {
+            // 新しい画像URLで更新
+            const captchaImg = document.querySelector('#captcha-{{$frame_id}}').parentElement.querySelector('img');
+            if (captchaImg && data.img) {
+                captchaImg.src = data.img;
+            }
+        })
+        .catch(error => {
+            console.error('Captcha refresh failed:', error);
+            // フォールバック: 通常のエンドポイントで画像を取得
+            const captchaImg = document.querySelector('#captcha-{{$frame_id}}').parentElement.querySelector('img');
+            if (captchaImg) {
+                captchaImg.src = '/captcha/flat?' + Math.random();
+            }
+        });
+    
+    // 入力フィールドをクリア
+    const captchaInput = document.getElementById('captcha-{{$frame_id}}');
+    if (captchaInput) {
+        captchaInput.value = '';
+        captchaInput.focus();
+    }
+}
+</script>
+@endif

--- a/resources/views/plugins/user/forms/default/forms_confirm.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm.blade.php
@@ -36,6 +36,9 @@
 <form action="" name="forms_store{{$frame_id}}" method="POST">
     {{ csrf_field() }}
     <input type="hidden" name="redirect_path" value="">
+    
+    {{-- Captcha隠しフィールド --}}
+    @include('plugins.user.forms.default.forms_captcha_hidden')
 
     @foreach($forms_columns as $form_column)
     <div class="form-group container-fluid row">

--- a/resources/views/plugins/user/forms/default/forms_confirm_tandem.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_confirm_tandem.blade.php
@@ -35,6 +35,9 @@
 <form action="" name="forms_store{{$frame_id}}" method="POST">
     {{ csrf_field() }}
     <input type="hidden" name="redirect_path" value="">
+    
+    {{-- Captcha隠しフィールド --}}
+    @include('plugins.user.forms.default.forms_captcha_hidden')
 
     @php $no = 1; @endphp
     @foreach($forms_columns as $form_column)

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -107,6 +107,7 @@
                         @switch($enum_value)
                             @case(FormAccessLimitType::none)
                             @case(FormAccessLimitType::captcha)
+                            @case(FormAccessLimitType::captcha_form_submit)
                                 <input type="radio" value="{{$enum_value}}" id="access_limit_type_{{$enum_value}}" name="access_limit_type" class="custom-control-input" {{$checked}}
                                     data-toggle="collapse" data-target="#collapse_form_password{{$frame_id}}.show">
                                 @break

--- a/resources/views/plugins/user/forms/default/index_tandem.blade.php
+++ b/resources/views/plugins/user/forms/default/index_tandem.blade.php
@@ -118,10 +118,19 @@
                 @endswitch
             </div>
         @endforeach
+
+        {{-- Captcha フィールド --}}
+        @php $is_tandem_template = true; @endphp
+        @include('plugins.user.forms.default.forms_captcha_field')
+
         {{-- ボタンエリア --}}
         <div class="form-group text-center">
             <button class="btn btn-primary"><i class="fa-solid fa-comment"></i> {{__('messages.to_confirm')}}</button>
         </div>
     </fieldset>
 </form>
+@endsection
+
+@section('plugin_contents_footer')
+@include('plugins.user.forms.default.forms_captcha_script')
 @endsection


### PR DESCRIPTION
## 概要
フォームのスパム投稿対策として、フォーム送信時の画像認証機能を追加しました。

## 変更内容
- フォーム入力項目の最下部にCaptcha入力欄を配置
- 画像認証のリフレッシュボタンを追加してユーザビリティを向上
- フォーム・アンケート両モードに対応
- DRY原則に従い共通テンプレートを作成

## テスト計画
- [ ] フォームモードでCaptcha認証が正常に動作することを確認
- [ ] アンケートモードでCaptcha認証が正常に動作することを確認
- [ ] Captchaリフレッシュボタンが正常に動作することを確認
- [ ] エラー時のメッセージ表示が適切であることを確認
- [ ] 各テンプレート（default、label-sm-4、label-sm-6）で正常に表示されることを確認