### PR TITLE
#2213 登録データのユーザをダウンロードできるようにしました。

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -2512,6 +2512,7 @@ class FormsPlugin extends UserPluginBase
                     'forms_inputs.status as inputs_status',
                     'forms_inputs.number_with_prefix as number_with_prefix',
                     'forms_inputs.created_at as inputs_created_at',
+                    'forms_inputs.created_name as inputs_created_name',
                     'forms_input_cols.*'
                 )
                 ->leftjoin('forms_input_cols', 'forms_inputs.id', '=', 'forms_input_cols.forms_inputs_id')
@@ -2575,6 +2576,8 @@ ORDER BY forms_inputs_id, forms_columns_id
             $copy_base['number_with_prefix'] = '';
         }
         // 見出し行-行末（固定項目）
+        $csv_array[0]['created_name'] = '登録ユーザ';
+        $copy_base['created_name'] = '';
         $csv_array[0]['created_at'] = '登録日時';
         $copy_base['created_at'] = '';
 
@@ -2590,6 +2593,7 @@ ORDER BY forms_inputs_id, forms_columns_id
                     // 採番項目
                     $csv_array[$input_col->inputs_id]['number_with_prefix'] = $input_col->number_with_prefix;
                 }
+                $csv_array[$input_col->inputs_id]['created_name'] = $input_col->inputs_created_name;
                 $csv_array[$input_col->inputs_id]['created_at'] = $input_col->inputs_created_at;
             }
             $csv_array[$input_col->inputs_id][$input_col->forms_columns_id] = $input_col->value;

--- a/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_list_inputs.blade.php
@@ -98,6 +98,7 @@
             @if ($form->numbering_use_flag)
                 <th nowrap>採番</th>
             @endif
+            <th nowrap>登録ユーザ</th>
             <th nowrap>登録日時</th>
         </tr>
     </thead>
@@ -141,6 +142,10 @@
                     {{$input->number_with_prefix}}
                 </td>
             @endif
+
+            <td nowrap>
+                {{$input->created_name}}
+            </td>
 
             <td nowrap>
                 {{$input->created_at}}


### PR DESCRIPTION
登録一覧画面、ダウンロードデータに登録ユーザを含むようにしました。
ログインしていないゲストでの登録時は空になります。
GithubのIssueは以下です。
https://github.com/opensource-workshop/connect-cms/issues/2213

# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
ログイン前提のサイトで、フォームに登録したデータが誰が登録したかわからなかったため。

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->
https://github.com/opensource-workshop/connect-cms/issues/2213

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->
無し

# チェックリスト
- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
