### PR TITLE
[WYSIWYG] TinyMCEのiframe埋め込みセキュリティ設定を追加しました

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -269,6 +269,21 @@
 </script>
 <script type="text/javascript">
     tinymce.init({
+        // see) https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#sandbox-iframes-exclusions
+        sandbox_iframes: true,
+        // ホワイトリストにはTinyMCEのデフォルト値を設定
+        sandbox_iframes_exclusions: [
+            'youtube.com',
+            'youtu.be',
+            'vimeo.com',
+            'player.vimeo.com',
+            'dailymotion.com',
+            'embed.music.apple.com',
+            'open.spotify.com',
+            'giphy.com',
+            'dai.ly',
+            'codepen.io'
+        ],
         @if(isset($target_class) && $target_class)
             selector : 'textarea.{{$target_class}}',
         @else

--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -279,6 +279,7 @@
             'player.vimeo.com',
             'dailymotion.com',
             'embed.music.apple.com',
+            'google.com',
             'open.spotify.com',
             'giphy.com',
             'dai.ly',


### PR DESCRIPTION
## 概要
WYSIWYGエディタ（TinyMCE）でのiframe埋め込み機能のセキュリティ設定を改善しました。

### 変更内容
- `sandbox_iframes: true` を設定し、iframeのサンドボックス機能を有効化
- `sandbox_iframes_exclusions` でホワイトリストを設定し、以下の外部サービスからの埋め込みを許可：
  - YouTube (youtube.com, youtu.be)
  - Vimeo (vimeo.com, player.vimeo.com)
  - Dailymotion (dailymotion.com, dai.ly)
  - Apple Music (embed.music.apple.com)
  - Spotify (open.spotify.com)
  - Giphy (giphy.com)
  - CodePen (codepen.io)

### 目的
セキュリティを向上させながら、主要な動画・音楽配信サービスのコンテンツ埋め込みを可能にする

## レビュー完了希望日
超特急

## 関連PR/Issues
なし

## 参考情報
- [TinyMCE Content Filtering Documentation](https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#sandbox-iframes-exclusions)

## DB変更の有無
- [ ] DB変更あり
- [x] DB変更なし

## チェックリスト
- [x] コードレビューを実施済み
- [x] 動作確認済み
- [x] セキュリティ観点での確認済み
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule