### PR TITLE
[プラグイン共通] 投稿通知の件名が未設定の場合に500エラーが発生する問題を修正しました

### DIFF
--- a/app/Models/Common/BucketsMail.php
+++ b/app/Models/Common/BucketsMail.php
@@ -106,9 +106,20 @@ class BucketsMail extends Model
 
     /**
      * フォーマット済みの件名を取得
+     *
+     * @param string|null $subject
+     * @param array $notice_embedded_tags
+     * @return void
      */
-    public function getFormattedSubject(string $subject, array $notice_embedded_tags)
+    public function getFormattedSubject(string|null $subject, array $notice_embedded_tags)
     {
+        if ($subject === null || $subject === '') {
+            /**
+             * 件名が未設定の場合、Laravelのデフォルト値（「Post Notice」等）が設定されてわかりづらい為、【件名未設定】を設定する。
+             * ※別途、画面側でバリデーションを追加する為、件名が空の状態は今後、基本的にはありえないが、既存運用で件名が空のデータがある場合の対策として実装する。
+             */
+            return '【件名未設定】';
+        }
         return $this->replaceEmbeddedTags($subject, $notice_embedded_tags);
     }
 

--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -818,16 +818,43 @@ class UserPluginBase extends PluginBase
             $rules['approved_groups']      = [new CustomValiRequiredWithoutAllSupportsArrayInput([$request->approved_author, $request->approved_addresses], $name)];
         }
 
+        // 使用するメール送信メソッドを取得
+        $use_bucket_mail_methods = ['notice', 'relate', 'approval', 'approved']; // デフォルト値
+        if (method_exists($this, 'useBucketMailMethods')) {
+            $use_bucket_mail_methods = $this->useBucketMailMethods();
+        }
+
+        // 有効なメール機能に対してのみ件名フィールドのバリデーションを追加
+        if (in_array('notice', $use_bucket_mail_methods) && $request->notice_on) {
+            $rules['notice_subject'] = ['required', 'max:255'];
+        }
+
+        if (in_array('relate', $use_bucket_mail_methods) && $request->relate_on) {
+            $rules['relate_subject'] = ['required', 'max:255'];
+        }
+
+        if (in_array('approval', $use_bucket_mail_methods) && $request->approval_on) {
+            $rules['approval_subject'] = ['required', 'max:255'];
+        }
+
+        if (in_array('approved', $use_bucket_mail_methods) && $request->approved_on) {
+            $rules['approved_subject'] = ['required', 'max:255'];
+        }
+
         $validator = Validator::make($request->all(), $rules);
         $validator->setAttributeNames([
             'notice_addresses' => '送信先メールアドレス',
             'notice_groups' => '送信先グループ',
             'notice_everyone' => '全ユーザに通知',
+            'notice_subject' => '投稿通知の件名',
             'approval_addresses' => '送信先メールアドレス',
             'approval_groups' => '送信先グループ',
+            'approval_subject' => '承認通知の件名',
             'approved_author' => '投稿者へ通知する',
             'approved_addresses' => '送信先メールアドレス',
             'approved_groups' => '送信先グループ',
+            'approved_subject' => '承認済み通知の件名',
+            'relate_subject' => '関連記事通知の件名',
         ]);
 
         // エラーがあった場合は入力画面に戻る。

--- a/resources/views/plugins/common/frame_edit_mails.blade.php
+++ b/resources/views/plugins/common/frame_edit_mails.blade.php
@@ -136,6 +136,7 @@
                     </small>
 
                     <span class="badge badge-secondary mt-3 mb-1">投稿通知の件名</span>
+                    <span class="badge badge-danger">必須</span>
                     <div class="pl-0">
                         <input type="text" name="notice_subject" value="{{old('notice_subject', $bucket_mail->notice_subject)}}" class="form-control @if ($errors && $errors->has('notice_subject')) border-danger @endif">
                         @include('plugins.common.errors_inline', ['name' => 'notice_subject'])
@@ -166,6 +167,7 @@
                 </div>
                 <div class="collapse" id="collapse_relate">
                     <span class="badge badge-secondary mt-3 mb-1">関連記事通知の件名</span>
+                    <span class="badge badge-danger">必須</span>
                     <div class="pl-0">
                         <input type="text" name="relate_subject" value="{{old('relate_subject', $bucket_mail->relate_subject)}}" class="form-control @if ($errors && $errors->has('relate_subject')) border-danger @endif">
                         @include('plugins.common.errors_inline', ['name' => 'relate_subject'])
@@ -222,6 +224,7 @@
                     </small>
 
                     <span class="badge badge-secondary mt-3 mb-1">承認通知の件名</span>
+                    <span class="badge badge-danger">必須</span>
                     <div class="pl-0">
                         <input type="text" name="approval_subject" value="{{old('approval_subject', $bucket_mail->approval_subject)}}" class="form-control @if ($errors && $errors->has('approval_subject')) border-danger @endif">
                         @include('plugins.common.errors_inline', ['name' => 'approval_subject'])
@@ -290,6 +293,7 @@
                     </small>
 
                     <span class="badge badge-secondary mt-3 mb-1">承認済み通知の件名</span>
+                    <span class="badge badge-danger">必須</span>
                     <div class="pl-0">
                         <input type="text" name="approved_subject" value="{{old('approved_subject', $bucket_mail->approved_subject)}}" class="form-control @if ($errors && $errors->has('approved_subject')) border-danger @endif">
                         @include('plugins.common.errors_inline', ['name' => 'approved_subject'])

--- a/tests/Unit/Models/Common/BucketsMailTest.php
+++ b/tests/Unit/Models/Common/BucketsMailTest.php
@@ -52,4 +52,40 @@ class BucketsMailTest extends TestCase
         // $this->assertStringContainsString('[[delete_comment]]', $subject, '件名の[[delete_comment]]は置換されない事');
         $this->assertStringContainsString('【サンプルサイト】', $subject, '件名の[[site_name]]は置換される事');
     }
+
+    /**
+     * getFormattedSubject()でnull値を渡した場合のテスト
+     */
+    public function testGetFormattedSubjectWithNull(): void
+    {
+        $notice_embedded_tags = [
+            NoticeEmbeddedTag::site_name => 'サンプルサイト',
+            NoticeEmbeddedTag::title => 'テストタイトル',
+            NoticeEmbeddedTag::body => 'HTMLを除いた本文',
+            NoticeEmbeddedTag::url => 'http://localhost/plugin/xxxx',
+        ];
+
+        $mail = new BucketsMail();
+        $result = $mail->getFormattedSubject(null, $notice_embedded_tags);
+
+        $this->assertEquals('【件名未設定】', $result, 'null値の場合はデフォルトメッセージが返される事');
+    }
+
+    /**
+     * getFormattedSubject()で空文字列を渡した場合のテスト
+     */
+    public function testGetFormattedSubjectWithEmptyString(): void
+    {
+        $notice_embedded_tags = [
+            NoticeEmbeddedTag::site_name => 'サンプルサイト',
+            NoticeEmbeddedTag::title => 'テストタイトル',
+            NoticeEmbeddedTag::body => 'HTMLを除いた本文',
+            NoticeEmbeddedTag::url => 'http://localhost/plugin/xxxx',
+        ];
+
+        $mail = new BucketsMail();
+        $result = $mail->getFormattedSubject('', $notice_embedded_tags);
+
+        $this->assertEquals('【件名未設定】', $result, '空文字列の場合はデフォルトメッセージが返される事');
+    }
 }


### PR DESCRIPTION
## 概要
ブログプラグインなどで、メール設定において「投稿通知の件名」を空の状態で記事を新規登録すると500エラーが発生する問題を修正しました。

## 修正内容

### 1. BucketsMail::getFormattedSubject()メソッドの修正
- null/空文字列を許容するよう型定義を変更（`string < /dev/null | null`）
- 件名が未設定の場合に「【件名未設定】」をデフォルト値として返すよう修正
- 既存データへの対応も考慮したコメントを追加

### 2. UserPluginBase::saveBucketsMailsメソッドの修正
- `useBucketMailMethods()`で有効なメール機能を動的に判定
- 通知機能がONの場合のみ件名フィールドを必須とするバリデーションを追加
- 適切な日本語エラーメッセージを設定

### 3. メール設定画面の改善
- 全ての件名フィールドに赤い「必須」バッジを追加
- ユーザーに必須項目であることを視覚的に伝達

### 4. テストケースの追加
- `BucketsMailTest::testGetFormattedSubjectWithNull()`: null値処理のテスト
- `BucketsMailTest::testGetFormattedSubjectWithEmptyString()`: 空文字列処理のテスト
- 既存テストでカバーされていなかったエッジケースを追加

## 検討事項

### 本文の必須化について
メール通知の本文についても必須にすることを検討しましたが、以下の理由により実装を見送りました：

- **シンプル通知の要求**: 件名のみで十分な情報を伝える通知の需要（例：「【ブログ更新】新しい記事が投稿されました」）
- **運用の柔軟性**: 組織によって通知の詳細度要求が異なる
- **モバイル対応**: スマートフォンでの通知表示を重視し、URLアクセスを促進する運用
- **既存設計**: Connect-CMSは本文を`nullable`として設計されており、設計思想との整合性

件名に`[[title]]`や`[[url]]`の埋め込みタグを活用することで、本文なしでも十分な通知が可能と判断しました。

## 影響範囲
- Connect-CMSの**ほぼ全てのプラグイン（30プラグイン）**が対象
- 投稿通知、承認通知、承認済み通知、関連記事通知の全てで同様の問題が解決

## テスト手順
1. ブログプラグインを配置
2. フレーム編集 → メール設定を開く
3. 投稿通知をONにして件名を空白にして保存
4. バリデーションエラーが表示されることを確認
5. 適切な件名を入力して保存が成功することを確認

## テスト実行
```bash
# 今回追加したテストの実行
./vendor/bin/phpunit tests/Unit/Models/Common/BucketsMailTest.php

# 特定のテストメソッドのみ実行
./vendor/bin/phpunit tests/Unit/Models/Common/BucketsMailTest.php --filter testGetFormattedSubjectWith
```

## 関連Issue
Closes #2224

## レビュー観点
- バリデーションロジックが各プラグインの`useBucketMailMethods()`に応じて適切に動作するか
- 既存データ（件名が空のデータ）に対する後方互換性が保たれているか
- エラーメッセージが適切に日本語で表示されるか
- 新しく追加したテストケースが適切にエッジケースをカバーしているか
- テスト実行時に全てのテストが成功するか