### PR TITLE
[FAQ] Q&A全表示テンプレートを追加しました

### DIFF
--- a/resources/views/plugins/user/faqs/full_display/faq_item.blade.php
+++ b/resources/views/plugins/user/faqs/full_display/faq_item.blade.php
@@ -6,9 +6,9 @@
  * @category FAQプラグイン
  * @param boolean $show_category カテゴリを表示するか
 --}}
-<article class="faq-item mb-4 border-bottom pb-3">
+<article class="faq-list-item mb-4 border-bottom pb-3">
     {{-- 質問部分 --}}
-    <div class="faq-question mb-3">
+    <div class="faq-list-question mb-3">
         <div class="d-flex align-items-start">
             <span class="mr-2 mt-1"><span class="h5"><span class="badge badge-primary">Q</span></span></span>
             <div class="flex-grow-1">
@@ -35,12 +35,12 @@
     </div>
 
     {{-- 回答部分 --}}
-    <div class="faq-answer">
+    <div class="faq-list-answer">
         <div class="d-flex align-items-start">
             <span class="mr-2 mt-1"><span class="h5"><span class="badge badge-secondary">A</span></span></span>
             <div class="flex-grow-1">
                 {{-- 記事本文 --}}
-                <div class="faq-answer-content">
+                <div class="faq-list-answer-content">
                     {!! $post->post_text !!}
                 </div>
             </div>
@@ -49,7 +49,7 @@
         {{-- フッター情報 --}}
         <footer class="mt-3">
             <div class="d-flex flex-wrap align-items-center justify-content-between">
-                <div class="faq-meta">
+                <div class="faq-list-meta">
                     @if ($faq_frame->display_posted_at_flag)
                         {{-- 投稿日時 --}}
                         <small class="text-muted mr-3">公開日時：{{$post->posted_at->format('Y年n月j日 H時i分')}}</small>
@@ -74,7 +74,7 @@
                 </div>
 
                 {{-- 操作ボタン --}}
-                <div class="faq-actions">
+                <div class="faq-list-actions">
                     @if ($post->status == 2)
                         @can('role_update_or_approval',[[$post, 'faqs', $buckets]])
                             <span class="badge badge-warning align-bottom mr-1">承認待ち</span>

--- a/resources/views/plugins/user/faqs/full_display/faq_item.blade.php
+++ b/resources/views/plugins/user/faqs/full_display/faq_item.blade.php
@@ -4,7 +4,7 @@
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category FAQプラグイン
- * @param boolean $hide_category カテゴリを隠すか
+ * @param boolean $show_category カテゴリを表示するか
 --}}
 <article class="faq-item mb-4 border-bottom pb-3">
     {{-- 質問部分 --}}
@@ -15,7 +15,7 @@
                 <h5 class="mb-2 font-weight-bold">{{$post->getNobrPostTitle()}}</h5>
                 
                 {{-- カテゴリ --}}
-                @if($post->category_view_flag && !$hide_category)
+                @if($post->category_view_flag && $show_category)
                     <span class="badge mb-1" style="color:{{$post->category_color}};background-color:{{$post->category_background_color}};">{{$post->category}}</span>
                 @endif
 

--- a/resources/views/plugins/user/faqs/full_display/faq_item.blade.php
+++ b/resources/views/plugins/user/faqs/full_display/faq_item.blade.php
@@ -1,0 +1,108 @@
+{{--
+ * FAQの1レコード部（Q&A全表示用）
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category FAQプラグイン
+ * @param boolean $hide_category カテゴリを隠すか
+--}}
+<article class="faq-item mb-4 border-bottom pb-3">
+    {{-- 質問部分 --}}
+    <div class="faq-question mb-3">
+        <div class="d-flex align-items-start">
+            <span class="mr-2 mt-1"><span class="h5"><span class="badge badge-primary">Q</span></span></span>
+            <div class="flex-grow-1">
+                <h5 class="mb-2 font-weight-bold">{{$post->getNobrPostTitle()}}</h5>
+                
+                {{-- カテゴリ --}}
+                @if($post->category_view_flag && !$hide_category)
+                    <span class="badge mb-1" style="color:{{$post->category_color}};background-color:{{$post->category_background_color}};">{{$post->category}}</span>
+                @endif
+
+                {{-- 状態表示 --}}
+                @if ($post->status == 2)
+                    @can('role_update_or_approval',[[$post, 'faqs', $buckets]])
+                        <span class="badge badge-warning mb-1">承認待ち</span>
+                    @endcan
+                @endif
+                @can('posts.update',[[$post, 'faqs', $buckets]])
+                    @if ($post->status == 1)
+                        <span class="badge badge-warning mb-1">一時保存</span>
+                    @endif
+                @endcan
+            </div>
+        </div>
+    </div>
+
+    {{-- 回答部分 --}}
+    <div class="faq-answer">
+        <div class="d-flex align-items-start">
+            <span class="mr-2 mt-1"><span class="h5"><span class="badge badge-secondary">A</span></span></span>
+            <div class="flex-grow-1">
+                {{-- 記事本文 --}}
+                <div class="faq-answer-content">
+                    {!! $post->post_text !!}
+                </div>
+            </div>
+        </div>
+
+        {{-- フッター情報 --}}
+        <footer class="mt-3">
+            <div class="d-flex flex-wrap align-items-center justify-content-between">
+                <div class="faq-meta">
+                    @if ($faq_frame->display_posted_at_flag)
+                        {{-- 投稿日時 --}}
+                        <small class="text-muted mr-3">公開日時：{{$post->posted_at->format('Y年n月j日 H時i分')}}</small>
+                    @endif
+
+                    @if (FrameConfig::getConfigValueAndOld($frame_configs, FaqFrameConfig::faq_display_created_name) == ShowType::show)
+                        {{-- 投稿者 --}}
+                        <small class="text-muted mr-3">[{{$post->created_name}}]</small>
+                    @endif
+
+                    {{-- 重要記事 --}}
+                    @if ($post->important == 1)
+                        <span class="badge badge-danger mr-1">重要</span>
+                    @endif
+
+                    {{-- タグ --}}
+                    @isset($post->tags)
+                        @foreach($post->tags as $tag)
+                            <span class="badge badge-secondary mr-1">{{$tag}}</span>
+                        @endforeach
+                    @endisset
+                </div>
+
+                {{-- 操作ボタン --}}
+                <div class="faq-actions">
+                    @if ($post->status == 2)
+                        @can('role_update_or_approval',[[$post, 'faqs', $buckets]])
+                            <span class="badge badge-warning align-bottom mr-1">承認待ち</span>
+                        @endcan
+                        @can('posts.approval',[[$post, 'faqs', $buckets]])
+                            <form action="{{url('/')}}/plugin/faqs/approval/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}" method="post" name="form_approval" class="d-inline">
+                                {{ csrf_field() }}
+                                <button type="submit" class="btn btn-primary btn-sm mr-1" onclick="javascript:return confirm('承認します。\nよろしいですか？');">
+                                    <i class="fas fa-check"></i> <span class="d-none d-sm-inline">承認</span>
+                                </button>
+                            </form>
+                        @endcan
+                    @endif
+                    @can('posts.update',[[$post, 'faqs', $buckets]])
+                        @if ($post->status == 1)
+                            <span class="badge badge-warning align-bottom mr-1">一時保存</span>
+                        @endif
+                        <a class="btn btn-success btn-sm mr-1" href="{{url('/')}}/plugin/faqs/edit/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}">
+                            <i class="far fa-edit"></i> <span class="d-none d-sm-inline">編集</span>
+                        </a>
+                    @endcan
+
+                    {{-- 詳細画面 --}}
+                    <a class="btn btn-success btn-sm" href="{{url('/')}}/plugin/faqs/show/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}" title="{{$post->getNobrPostTitle()}}の詳細">
+                        詳細 <i class="fas fa-angle-right"></i>
+                    </a>
+                </div>
+            </div>
+        </footer>
+    </div>
+</article>

--- a/resources/views/plugins/user/faqs/full_display/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/full_display/faqs.blade.php
@@ -1,0 +1,58 @@
+{{--
+ * FAQ画面テンプレート（Q&A全表示）
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category FAQプラグイン
+--}}
+@extends('core.cms_frame_base')
+
+@section("plugin_contents_$frame->id")
+
+{{-- RSS --}}
+@if (isset($faq_frame->rss) && $faq_frame->rss == 1)
+<div class="row">
+    <p class="text-left col-6">
+        <a href="{{url('/')}}/redirect/plugin/faqs/rss/{{$page->id}}/{{$frame_id}}/"><span class="badge badge-info">RSS2.0</span></a>
+    </p>
+</div>
+@endif
+
+@if (isset($frame) && $frame->bucket_id)
+    {{-- 新規登録 --}}
+    @can('posts.create',[[null, 'faqs', $buckets]])
+        <div class="row">
+            <p class="text-right col-12">
+                {{-- 新規登録ボタン --}}
+                <button type="button" class="btn btn-success" onclick="location.href='{{url('/')}}/plugin/faqs/create/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}'"><i class="far fa-edit"></i> 新規登録</button>
+            </p>
+        </div>
+    @endcan
+@else
+    {{-- 新規登録 --}}
+    @can('frames.edit',[[null, null, null, $frame]])
+        <div class="card border-danger">
+            <div class="card-body">
+                <p class="text-center cc_margin_bottom_0">フレームの設定画面から、使用するFAQを選択するか、作成してください。</p>
+            </div>
+        </div>
+    @endcan
+@endif
+
+{{-- FAQ表示 --}}
+@if (isset($faqs_posts))
+    {{-- 絞り込み機能 --}}
+    @include('plugins.user.faqs.default.faqs_narrowing_down')
+
+    <div class="faq-full-display">
+    @foreach($faqs_posts as $post)
+        {{-- FAQの要素呼び出し --}}
+        @include('plugins.user.faqs.full_display.faq_item', ['post' => $post, 'hide_category' => false])
+    @endforeach
+    </div>
+
+    {{-- ページング処理 --}}
+    @include('plugins.common.user_paginate', ['posts' => $faqs_posts, 'frame' => $frame, 'aria_label_name' => $faq_frame->faq_name, 'class' => 'mt-3'])
+
+@endif
+@endsection

--- a/resources/views/plugins/user/faqs/full_display/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/full_display/faqs.blade.php
@@ -47,7 +47,7 @@
     <div class="faq-full-display">
     @foreach($faqs_posts as $post)
         {{-- FAQの要素呼び出し --}}
-        @include('plugins.user.faqs.full_display.faq_item', ['post' => $post, 'hide_category' => false])
+        @include('plugins.user.faqs.full_display.faq_item', ['post' => $post, 'show_category' => true])
     @endforeach
     </div>
 

--- a/resources/views/plugins/user/faqs/full_display/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/full_display/faqs.blade.php
@@ -44,7 +44,7 @@
     {{-- 絞り込み機能 --}}
     @include('plugins.user.faqs.default.faqs_narrowing_down')
 
-    <div class="faq-full-display">
+    <div class="faq-list-full-display">
     @foreach($faqs_posts as $post)
         {{-- FAQの要素呼び出し --}}
         @include('plugins.user.faqs.full_display.faq_item', ['post' => $post, 'show_category' => true])

--- a/resources/views/plugins/user/faqs/full_display/template.ini
+++ b/resources/views/plugins/user/faqs/full_display/template.ini
@@ -1,0 +1,3 @@
+[base]
+template_name = Ｑ＆Ａ全表示
+display_sequence = 3


### PR DESCRIPTION
## 概要
FAQプラグインに新しいテンプレート「Q&A全表示」を追加しました。
従来のアコーディオン形式とは異なり、全てのQ&Aを常時表示するテンプレートです。

### 変更の背景・目的
- 一覧性の向上（スクロールで全FAQ確認可能）
- 印刷対応の改善
- アクセシビリティの向上
- 検索エンジン最適化対応

### 変更内容
- `resources/views/plugins/user/faqs/full_display/` ディレクトリ作成
- `template.ini` - テンプレート設定ファイル
- `faqs.blade.php` - メインテンプレート
- `faq_item.blade.php` - Q&A表示コンポーネント
- template.iniの文字エンコーディング問題（`&`文字）対応

## レビュー完了希望日
お時間のある時で構いません

## 関連PR/Issues
なし

## 参考情報
- 既存テンプレート: default（アコーディオン）、category（カテゴリ別アコーディオン）
- 新テンプレート: full_display（Q&A全表示）

## DB変更の有無
- [ ] あり
- [x] なし

## チェックリスト
- [x] 既存機能に影響がないことを確認
- [x] テンプレート選択画面での表示確認
- [x] レスポンシブ対応
- [x] 権限・承認機能の継承
- [x] 絞り込み・RSS・ページング機能の継承