### PR TITLE
[FAQ] キーワード検索機能を追加しました

### DIFF
--- a/app/Enums/FaqFrameConfig.php
+++ b/app/Enums/FaqFrameConfig.php
@@ -12,10 +12,12 @@ final class FaqFrameConfig extends EnumsBase
     // 定数メンバ
     const faq_display_created_name = 'faq_display_created_name';
     const faq_narrowing_down_type = 'faq_narrowing_down_type';
+    const faq_keyword_search_display = 'faq_keyword_search_display';
 
     // key/valueの連想配列
     const enum = [
         self::faq_display_created_name => '投稿者名',
         self::faq_narrowing_down_type => '絞り込み機能',
+        self::faq_keyword_search_display => 'キーワード検索機能',
     ];
 }

--- a/resources/views/plugins/user/faqs/category/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/category/faqs.blade.php
@@ -2,6 +2,7 @@
  * FAQ画面テンプレート（カテゴリー別表示）
  *
  * @author 石垣 佑樹 <ishigaki@opensource-workshop.jp>
+ * @author 井上 雅人 <inoue@opensource-workshop.co.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category FAQプラグイン
 --}}
@@ -41,6 +42,12 @@
 
 {{-- FAQ表示 --}}
 @if (isset($faqs_posts))
+    {{-- 検索フォーム --}}
+    @include('plugins.user.faqs.search_form')
+    
+    {{-- 条件クリア --}}
+    @include('plugins.user.faqs.clear_conditions')
+    
     @php
         $sorted_posts = $faqs_posts;
         if ($faq_frame->sequence_conditions != 3) {

--- a/resources/views/plugins/user/faqs/category/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/category/faqs.blade.php
@@ -48,6 +48,9 @@
     {{-- 条件クリア --}}
     @include('plugins.user.faqs.clear_conditions')
     
+    {{-- 件数表示 --}}
+    @include('plugins.user.faqs.count_display')
+    
     @php
         $sorted_posts = $faqs_posts;
         if ($faq_frame->sequence_conditions != 3) {

--- a/resources/views/plugins/user/faqs/clear_conditions.blade.php
+++ b/resources/views/plugins/user/faqs/clear_conditions.blade.php
@@ -1,0 +1,18 @@
+{{--
+ * FAQ条件クリア共通部品
+ *
+ * @author 井上 雅人 <inoue@opensource-workshop.co.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category FAQプラグイン
+--}}
+
+{{-- 条件クリアボタン --}}
+@if(session('search_keyword_'. $frame_id) || session('categories_id_'. $frame_id))
+<div class="mb-3">
+    <form action="{{url('/')}}/plugin/faqs/search/{{$page->id}}/{{$frame_id}}/#frame-{{$frame_id}}" method="GET" style="display: inline;">
+        <button type="submit" name="clear_search" value="1" class="btn btn-secondary btn-sm">
+            <i class="fas fa-times" role="presentation"></i> 条件クリア
+        </button>
+    </form>
+</div>
+@endif

--- a/resources/views/plugins/user/faqs/count_display.blade.php
+++ b/resources/views/plugins/user/faqs/count_display.blade.php
@@ -1,0 +1,17 @@
+{{--
+ * FAQ件数表示共通部品
+ *
+ * @author 井上 雅人 <inoue@opensource-workshop.co.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category FAQプラグイン
+--}}
+
+{{-- 件数表示 --}}
+<div class="row mb-3">
+    <div class="col-md-9 d-flex align-items-center">
+        <div>
+            表示件数 {{ $faqs_posts->total() }} 件
+            {{ $faqs_posts->total() > 0 ? ' (' . $faqs_posts->firstItem() . '-' . $faqs_posts->lastItem() . ')' : '' }}
+        </div>
+    </div>
+</div>

--- a/resources/views/plugins/user/faqs/default/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/default/faqs.blade.php
@@ -51,6 +51,8 @@
     {{-- 条件クリア --}}
     @include('plugins.user.faqs.clear_conditions')
 
+    {{-- 件数表示 --}}
+    @include('plugins.user.faqs.count_display')
 
     <div class="accordion" id="accordionFaq{{$frame_id}}">
     @foreach($faqs_posts as $post)

--- a/resources/views/plugins/user/faqs/default/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/default/faqs.blade.php
@@ -2,6 +2,7 @@
  * FAQ画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 井上 雅人 <inoue@opensource-workshop.co.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category FAQプラグイン
 --}}
@@ -41,8 +42,15 @@
 
 {{-- FAQ表示 --}}
 @if (isset($faqs_posts))
+    {{-- 検索フォーム --}}
+    @include('plugins.user.faqs.search_form')
+    
     {{-- 絞り込み機能 --}}
     @include('plugins.user.faqs.default.faqs_narrowing_down')
+
+    {{-- 条件クリア --}}
+    @include('plugins.user.faqs.clear_conditions')
+
 
     <div class="accordion" id="accordionFaq{{$frame_id}}">
     @foreach($faqs_posts as $post)

--- a/resources/views/plugins/user/faqs/default/faqs_edit_faq.blade.php
+++ b/resources/views/plugins/user/faqs/default/faqs_edit_faq.blade.php
@@ -2,6 +2,7 @@
  * FAQ編集画面テンプレート。
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 井上 雅人 <inoue@opensource-workshop.co.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category FAQプラグイン
 --}}
@@ -199,6 +200,30 @@
                 <label class="custom-control-label" for="narrowing_down_type_{{$key}}" id="label_narrowing_down_type_{{$key}}">{{$type}}</label>
             </div>
             @endforeach
+        </div>
+    </div>
+
+    {{-- キーワード検索機能の表示 --}}
+    <div class="form-group row">
+        <label class="{{$frame->getSettingLabelClass(true)}}">{{FaqFrameConfig::getDescription('faq_keyword_search_display')}}</label>
+        <div class="{{$frame->getSettingInputClass(true)}}">
+            <div class="custom-control custom-radio custom-control-inline">
+                @if (FrameConfig::getConfigValueAndOld($frame_configs, FaqFrameConfig::faq_keyword_search_display) === '' ||
+                    FrameConfig::getConfigValueAndOld($frame_configs, FaqFrameConfig::faq_keyword_search_display) == ShowType::not_show)
+                    <input type="radio" value="{{ShowType::not_show}}" id="{{FaqFrameConfig::faq_keyword_search_display}}_0" name="{{FaqFrameConfig::faq_keyword_search_display}}" class="custom-control-input" checked="checked">
+                @else
+                    <input type="radio" value="{{ShowType::not_show}}" id="{{FaqFrameConfig::faq_keyword_search_display}}_0" name="{{FaqFrameConfig::faq_keyword_search_display}}" class="custom-control-input">
+                @endif
+                <label class="custom-control-label text-nowrap" for="{{FaqFrameConfig::faq_keyword_search_display}}_0" id="label_{{FaqFrameConfig::faq_keyword_search_display}}_0">{{ShowType::getDescription(ShowType::not_show)}}</label>
+            </div>
+            <div class="custom-control custom-radio custom-control-inline">
+                @if (FrameConfig::getConfigValueAndOld($frame_configs, FaqFrameConfig::faq_keyword_search_display) == ShowType::show)
+                    <input type="radio" value="{{ShowType::show}}" id="{{FaqFrameConfig::faq_keyword_search_display}}_1" name="{{FaqFrameConfig::faq_keyword_search_display}}" class="custom-control-input" checked="checked">
+                @else
+                    <input type="radio" value="{{ShowType::show}}" id="{{FaqFrameConfig::faq_keyword_search_display}}_1" name="{{FaqFrameConfig::faq_keyword_search_display}}" class="custom-control-input">
+                @endif
+                <label class="custom-control-label text-nowrap" for="{{FaqFrameConfig::faq_keyword_search_display}}_1" id="label_{{FaqFrameConfig::faq_keyword_search_display}}_1">{{ShowType::getDescription(ShowType::show)}}</label>
+            </div>
         </div>
     </div>
 

--- a/resources/views/plugins/user/faqs/full_display/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/full_display/faqs.blade.php
@@ -51,6 +51,8 @@
     {{-- 条件クリア --}}
     @include('plugins.user.faqs.clear_conditions')
 
+    {{-- 件数表示 --}}
+    @include('plugins.user.faqs.count_display')
 
     <div class="faq-list-full-display">
     @foreach($faqs_posts as $post)

--- a/resources/views/plugins/user/faqs/full_display/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/full_display/faqs.blade.php
@@ -2,6 +2,7 @@
  * FAQ画面テンプレート（Q&A全表示）
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 井上 雅人 <inoue@opensource-workshop.co.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category FAQプラグイン
 --}}
@@ -41,8 +42,15 @@
 
 {{-- FAQ表示 --}}
 @if (isset($faqs_posts))
+    {{-- 検索フォーム --}}
+    @include('plugins.user.faqs.search_form')
+    
     {{-- 絞り込み機能 --}}
     @include('plugins.user.faqs.default.faqs_narrowing_down')
+
+    {{-- 条件クリア --}}
+    @include('plugins.user.faqs.clear_conditions')
+
 
     <div class="faq-list-full-display">
     @foreach($faqs_posts as $post)

--- a/resources/views/plugins/user/faqs/search_form.blade.php
+++ b/resources/views/plugins/user/faqs/search_form.blade.php
@@ -1,0 +1,28 @@
+{{--
+ * FAQ検索フォーム共通部品
+ *
+ * @author 井上 雅人 <inoue@opensource-workshop.co.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category FAQプラグイン
+--}}
+
+@if (FrameConfig::getConfigValue($frame_configs, FaqFrameConfig::faq_keyword_search_display) == ShowType::show)
+<div class="faq-search-form mb-3">
+    <form action="{{url('/')}}/plugin/faqs/search/{{$page->id}}/{{$frame_id}}/#frame-{{$frame_id}}" method="GET" name="search_form{{$frame_id}}" role="search" aria-label="FAQ検索">
+        <div class="input-group mb-2">
+            <input type="text" 
+                   class="form-control" 
+                   name="search_keyword" 
+                   value="{{session('search_keyword_'. $frame_id)}}" 
+                   placeholder="検索はキーワードを入力してください。"
+                   title="検索キーワード"
+                   id="search_keyword_{{$frame_id}}">
+            <div class="input-group-append">
+                <button type="submit" class="btn btn-primary" title="検索">
+                    <i class="fas fa-search" role="presentation"></i>
+                </button>
+            </div>
+        </div>
+    </form>
+</div>
+@endif


### PR DESCRIPTION
## 概要
FAQプラグインにキーワード検索機能を追加し、ユーザーがキーワードでFAQを検索できるようにしました。

### 主な変更内容
- **キーワード検索機能の実装**
  - タイトル・本文・カテゴリ・タグを対象とした包括的な検索

- **設定機能の追加**
  - フレーム設定でキーワード検索機能の表示/非表示を切り替え可能
  - デフォルトは「表示しない」設定

- **UI・UX改善**
  - 件数表示機能を追加（「表示件数 X 件 (開始-終了)」形式）

- **コード整理**
  - 検索フォーム、件数表示、条件クリアを共通部品化

## レビュー完了希望日
特になし

## 関連PR/Issues
なし

## 参考情報
- データベースプラグインの検索UIを参考に実装
- 既存の絞り込み機能との整合性を保持

## DB変更の有無
- [ ] あり
- [x] なし

## チェックリスト
- [x] コードスタイルに準拠している
- [x] 既存機能への影響がないことを確認
- [x] 全テンプレート（default, full_display, category）で動作確認
- [x] 検索条件の組み合わせ（キーワード+カテゴリ）で動作確認
- [x] 設定画面での表示/非表示切り替えを確認