### PR TITLE
[メール] PHP7系でメール通知設定のUnion型エラーを修正しました

### DIFF
--- a/app/Models/Common/BucketsMail.php
+++ b/app/Models/Common/BucketsMail.php
@@ -111,7 +111,7 @@ class BucketsMail extends Model
      * @param array $notice_embedded_tags
      * @return void
      */
-    public function getFormattedSubject(string|null $subject, array $notice_embedded_tags)
+    public function getFormattedSubject(?string $subject, array $notice_embedded_tags)
     {
         if ($subject === null || $subject === '') {
             /**


### PR DESCRIPTION
# 概要
PHP8のUnion型記法（`string|null`）がPHP7系で動作しないため、Nullable型記法（`?string`）に修正し、PHP7系との互換性を確保しました。

### 変更背景
  - Connect-CMSはPHP7.4以上をサポートしているが、PHP8のUnion型記法がPHP7系でエラーとなっていた
  - メール通知機能（ブログ等）でPHP7系環境において Fatal Error が発生していた

  ### 変更内容
  - `app/Models/Common/BucketsMail.php` の `getFormattedSubject` メソッドの引数型を修正
    - 変更前: `string|null $subject`（PHP8のUnion型記法）
    - 変更後: `?string $subject`（PHP7互換のNullable型記法）

# レビュー完了希望日
特になし

# 関連Pull requests/Issues
https://github.com/opensource-workshop/connect-cms/pull/2225

# 参考
  - PHP8.0のUnion型仕様: https://www.php.net/manual/ja/language.types.declarations.php#language.types.declarations.union
  - 社内チケットID：OW-2613

# DB変更の有無
なし

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
