### PR TITLE
[NC3移行] 多言語ページで日本語ページを優先して登録するよう修正しました

### DIFF
--- a/app/Traits/Migration/MigrationNc3ExportTrait.php
+++ b/app/Traits/Migration/MigrationNc3ExportTrait.php
@@ -611,7 +611,8 @@ trait MigrationNc3ExportTrait
                 $nc3_pages_query->whereNotIn('id', $this->getMigrationConfig('pages', 'nc3_export_ommit_page_ids'));
             }
 
-            $nc3_pages_query->orderBy('pages_languages.language_id');
+            // 日本語ページ(ID=2)を英語ページ(ID=1)より先に登録するため降順
+            $nc3_pages_query->orderBy('pages_languages.language_id', 'desc');
                 // ->orderBy('pages.sort_key')
                 // ->orderBy('rooms.sort_key')
                 // ->get();


### PR DESCRIPTION
## 概要
NetCommons3からConnect-CMSへの移行処理において、多言語ページ（日本語・英語）のインポート時に英語ページが先に登録される問題を修正しました。

### 修正内容
- `MigrationNc3ExportTrait.php` の多言語ページエクスポート処理で、言語ID順を降順（DESC）に変更
  - 日本語ページ（language_id=2）が英語ページ（language_id=1）より先に処理されるように修正

### 修正前の問題
- 英語ページ（/en）が日本語ページ（/）より小さいIDで登録されていた
  - 言語ID昇順（1→2）で処理されていたため、英語→日本語の順で登録

### 修正後の動作
- 日本語ページ（/）が英語ページ（/en）より小さいIDで登録される
  - 言語ID降順（2→1）で処理されるため、日本語→英語の順で登録

## レビュー完了希望日
なし

## 関連PR/Issues
https://opensource-workshop.atlassian.net/browse/OW-2614

## 参考情報
- NC3言語ID定数: 英語=1, 日本語=2

## DB変更の有無
- [ ] あり
- [x] なし