### PR TITLE
[共通] form-dataパッケージのセキュリティ脆弱性を修正しました

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6133,15 +6133,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -10062,21 +10063,6 @@
             },
             "engines": {
                 "node": ">=0.8"
-            }
-        },
-        "node_modules/request/node_modules/form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 0.12"
             }
         },
         "node_modules/request/node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
         "tui-image-editor": "^3.15.3",
         "vue": "^3.5.13",
         "vue-loader": "^17.3.0"
+    },
+    "overrides": {
+        "form-data": "^4.0.4"
     }
 }


### PR DESCRIPTION
## 概要
tui-image-editor経由で使用されているform-dataパッケージのCritical脆弱性（CVE-2025-7783, CVSS 9.4）を修正しました。

## 変更内容
- `package.json`にnpm overridesを追加し、form-data@^4.0.4を強制適用
- tui-image-editor → fabric → jsdom → request → form-data の依存チェーンで発生していた脆弱性を解決

## 技術的詳細
- **脆弱性**: form-data@2.3.3のunsafe random function使用によるboundary値の予測可能性
- **影響範囲**: Node.js環境でのfabric.js使用時のみ（ブラウザでの画像編集機能には影響なし）
- **解決方法**: npm overridesでform-data@4.0.4以上を強制

## テスト結果
- `npm ls form-data`で全ての依存関係が4.0.4に更新されることを確認
- ウィジウィグ上の画像エディタで一通りの画像編集でモンキー打鍵を実施、問題ないことを確認

## DB変更
なし

## 関連Issue/PR
Dependabot security alert #111
