### PR TITLE
[ユーザ管理] デフォルト項目で正規表現バリデーション設定を可能にしました

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -109,14 +109,8 @@ class RegisterController extends Controller
             }
         }
 
-        foreach ($users_columns as $users_column) {
-            if (UsersColumns::isLoopNotShowColumnType($users_column->column_type)) {
-                // 既に入力チェックセット済みのため、ここではチェックしない
-                continue;
-            }
-            // バリデータールールをセット
-            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $columns_set_id, null);
-        }
+        // デフォルト項目とカスタム項目のバリデーション配列構築
+        $validator_array = UsersTool::buildValidatorArray($validator_array, $users_columns, $columns_set_id, null);
 
         // 入力値チェック
         $validator = Validator::make($data, $validator_array['column']);

--- a/app/Plugins/Manage/UserManage/UserManage.php
+++ b/app/Plugins/Manage/UserManage/UserManage.php
@@ -872,14 +872,8 @@ class UserManage extends ManagePluginBase
             ]
         ];
 
-        foreach ($users_columns as $users_column) {
-            if (UsersColumns::isLoopNotShowColumnType($users_column->column_type)) {
-                // 既に入力チェックセット済みのため、ここではチェックしない
-                continue;
-            }
-            // バリデータールールをセット
-            $validator_array = UsersTool::getValidatorRule($validator_array, $users_column, $request->columns_set_id, $id);
-        }
+        // デフォルト項目とカスタム項目のバリデーション配列構築
+        $validator_array = UsersTool::buildValidatorArray($validator_array, $users_columns, $request->columns_set_id, $id);
 
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), $validator_array['column']);

--- a/app/Plugins/Mypage/ProfileMypage/ProfileMypage.php
+++ b/app/Plugins/Mypage/ProfileMypage/ProfileMypage.php
@@ -97,12 +97,15 @@ class ProfileMypage extends MypagePluginBase
 
         foreach ($users_columns as $users_column) {
             if ($users_column->column_type == UserColumnType::user_name) {
-                $validator_array['column']['name'] = 'required|string|max:255';
+                $base_rules = ['required', 'string', 'max:255'];
+                $validator_array['column']['name'] = UsersTool::getDefaultColumnAdditionalRules($base_rules, $users_column, $user->columns_set_id, $id);
             } elseif ($users_column->column_type == UserColumnType::login_id) {
-                $validator_array['column']['userid'] = ['required', 'max:255', Rule::unique('users', 'userid')->ignore($id)];
+                $base_rules = ['required', 'max:255', Rule::unique('users', 'userid')->ignore($id)];
+                $validator_array['column']['userid'] = UsersTool::getDefaultColumnAdditionalRules($base_rules, $users_column, $user->columns_set_id, $id);
             } elseif ($users_column->column_type == UserColumnType::user_email) {
                 // $validator_array['column']['email'] = ['nullable', 'email', 'max:255', Rule::unique('users')->ignore($id)];
-                $validator_array['column']['email'] = ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($request->columns_set_id, $id)];
+                $base_rules = ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($request->columns_set_id, $id)];
+                $validator_array['column']['email'] = UsersTool::getDefaultColumnAdditionalRules($base_rules, $users_column, $user->columns_set_id, $id);
             } elseif ($users_column->column_type == UserColumnType::user_password) {
                 // 入力があったら、ここで現在のパスワードチェック
                 $validator_array['column']['now_password'] = [

--- a/resources/views/plugins/manage/user/edit_column_detail.blade.php
+++ b/resources/views/plugins/manage/user/edit_column_detail.blade.php
@@ -306,7 +306,13 @@ use App\Models\Core\UsersColumns;
                 <br>
             @endif
 
-            @if ($column->column_type == UserColumnType::text || $column->column_type == UserColumnType::textarea || $column->column_type == UserColumnType::mail)
+            @if ($column->column_type == UserColumnType::text || 
+                $column->column_type == UserColumnType::textarea || 
+                $column->column_type == UserColumnType::mail || 
+                $column->column_type == UserColumnType::user_name || 
+                $column->column_type == UserColumnType::login_id || 
+                $column->column_type == UserColumnType::user_email
+            )
                 {{-- チェック処理の設定 --}}
                 <div class="card form-group" id="div_rule">
                     <h5 class="card-header">チェック処理の設定</h5>
@@ -393,7 +399,13 @@ use App\Models\Core\UsersColumns;
                             </div>
                         @endif
 
-                        @if ($column->column_type == UserColumnType::text || $column->column_type == UserColumnType::textarea || $column->column_type == UserColumnType::mail)
+                        @if ($column->column_type == UserColumnType::text || 
+                            $column->column_type == UserColumnType::textarea || 
+                            $column->column_type == UserColumnType::mail || 
+                            $column->column_type == UserColumnType::user_name || 
+                            $column->column_type == UserColumnType::login_id || 
+                            $column->column_type == UserColumnType::user_email
+                        )
                             {{-- 正規表現設定 --}}
                             <div class="form-group row">
                                 <label class="col-md-3 col-form-label text-md-right">正規表現</label>


### PR DESCRIPTION
## 概要
ユーザ管理の項目設定において、デフォルト項目（ユーザ名、ログインID、メールアドレス）でも正規表現による入力制限設定ができるようになりました。

## 変更内容

### 🎯 主な機能追加
- **デフォルト項目のバリデーション設定対応**
  - ログインID、ユーザ名、メールアドレスの詳細編集画面で「チェック処理の設定」エリアを表示
  - 正規表現による柔軟な入力制限設定が可能
  - 既存の基本バリデーション（必須、重複チェック等）は完全に維持

### 🔧 技術的改善
- **コード共通化とリファクタリング**
  - RegisterController、UserManage、ProfileMypageの重複バリデーション処理を統合
  - `UsersTool::buildValidatorArray()`メソッドを新規作成
  - `UsersTool::getDefaultColumnAdditionalRules()`メソッドを追加（正規表現専用）
  - DRY原則に従った保守性の向上

### 📝 修正ファイル
- `resources/views/plugins/manage/user/edit_column_detail.blade.php`
- `app/Http/Controllers/Auth/RegisterController.php`
- `app/Plugins/Manage/UserManage/UserManage.php`
- `app/Plugins/Mypage/ProfileMypage/ProfileMypage.php`
- `app/Plugins/Manage/UserManage/UsersTool.php`

## 解決する課題
顧客からの要望「ログインIDで電話番号やメールアドレスの入力を防止したい」に対応。これまでデフォルト項目では管理画面からのバリデーション設定ができませんでした。

## 使用方法
1. 管理画面 → ユーザ管理 → 項目設定 → 詳細編集
2. ログインID等のデフォルト項目を選択
3. 「チェック処理の設定」→「正規表現」欄で入力制限を設定

### 設定例
- **メールアドレス形式を排除**: `/^(?\!.*@).*$/`
- **英数字とアンダースコアのみ**: `/^[a-zA-Z0-9_]+$/`
- **特定文字を禁止**: `/^(?\!.*[-.])[a-zA-Z0-9_]+$/`

## 影響範囲
- ✅ 既存のバリデーション機能は完全に維持
- ✅ 新規・既存ユーザーデータへの影響なし
- ✅ 後方互換性を保持
- ✅ 自動ユーザ登録、管理者ユーザ登録、マイページ更新で一貫した動作

## テスト確認項目
- [ ] デフォルト項目の詳細編集画面に「チェック処理の設定」エリアが表示される
- [ ] 正規表現バリデーションが正常に動作する
- [ ] 既存のユーザ登録機能（RegisterController）が正常動作する
- [ ] 既存のユーザ更新機能（UserManage）が正常動作する
- [ ] マイページでのプロフィール更新が正常動作する
- [ ] エラーメッセージが適切に表示される

## レビュー完了希望日
[日付を記入]

## 関連PR/Issues
[関連するIssue番号があれば記入]

## 参考情報
- 正規表現による入力制限により、電話番号（数字の連続）やメールアドレス（@マーク含む）の入力を効果的に防止できます
- バリデーション処理の共通化により、今後の保守性が向上しました

## DB変更の有無
なし

🤖 Generated with [Claude Code](https://claude.ai/code)