### PR TITLE
[アップロードファイル管理] プラン容量表示と使用量警告機能を追加しました

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,16 @@ DB_PASSWORD=
 # Cookie Secure setting. Set to true for https.
 #SESSION_SECURE_COOKIE=true
 
+# Storage Plan Limit (MB) - For Service Providers
+# Set the storage limit for the service plan (in MB). Leave empty to disable plan capacity display.
+# Example: STORAGE_LIMIT_MB=1000 (for 1GB limit)
+#STORAGE_LIMIT_MB=
+
+# Storage Usage Warning Threshold (0.0-1.0) - For Service Providers
+# Set the threshold for displaying warning messages when storage usage reaches this percentage.
+# Example: STORAGE_USAGE_WARNING_THRESHOLD=0.8 (for 80% warning)
+#STORAGE_USAGE_WARNING_THRESHOLD=
+
 # Cache-Control default value.
 CACHE_CONTROL="max-age=604800"
 

--- a/app/Plugins/Manage/IndexManage/IndexManage.php
+++ b/app/Plugins/Manage/IndexManage/IndexManage.php
@@ -2,7 +2,6 @@
 
 namespace app\Plugins\Manage\IndexManage;
 
-
 use App\Plugins\Manage\ManagePluginBase;
 use App\Utilities\Storage\StorageUsageCalculator;
 

--- a/app/Plugins/Manage/IndexManage/IndexManage.php
+++ b/app/Plugins/Manage/IndexManage/IndexManage.php
@@ -2,12 +2,9 @@
 
 namespace app\Plugins\Manage\IndexManage;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
-
-use DB;
 
 use App\Plugins\Manage\ManagePluginBase;
+use App\Utilities\Storage\StorageUsageCalculator;
 
 /**
  * 管理画面インデックスクラス
@@ -83,6 +80,10 @@ class IndexManage extends ManagePluginBase
             }
         }
 
+        // ストレージ使用量の取得
+        $storage_usage = StorageUsageCalculator::getDataUsage();
+        $is_storage_warning_enabled = StorageUsageCalculator::shouldShowWarning($storage_usage['usage_percentage']);
+
         // 管理画面プラグインの戻り値の返し方
         // view 関数の第一引数に画面ファイルのパス、第二引数に画面に渡したいデータを名前付き配列で渡し、その結果のHTML。
         return view('plugins.manage.index.index', [
@@ -90,6 +91,8 @@ class IndexManage extends ManagePluginBase
             "rss_xml"      => $rss_xml,
             "errors"       => $errors,
             "is_writable_storage" => is_writable(storage_path()),
+            "storage_usage" => $storage_usage,
+            "is_storage_warning_enabled" => $is_storage_warning_enabled,
         ]);
     }
 

--- a/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
+++ b/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
@@ -410,6 +410,4 @@ class UploadfileManage extends ManagePluginBase
 
         return redirect('/manage/uploadfile/')->with('flash_message', $message);
     }
-
-
 }

--- a/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
+++ b/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
@@ -125,8 +125,8 @@ class UploadfileManage extends ManagePluginBase
         // データ取得
         $uploads = $uploads_query->paginate($per_page, null, 'page', $page);
 
-        // 使用量の計算
-        $storage_usage = $this->getStorageUsage();
+        // アップロードファイル使用量の計算
+        $storage_usage = $this->getUploadsUsage();
 
         // 入力値をsessionへ保存（検索用）
         $request->flash();
@@ -412,23 +412,13 @@ class UploadfileManage extends ManagePluginBase
     }
 
     /**
-     * ストレージ使用量を取得
+     * アップロードファイル使用量を取得
      *
      * @return array
      */
-    private function getStorageUsage() : array
+    private function getUploadsUsage() : array
     {
         $usage = [];
-
-        // 総使用量（アプリケーションルート配下）
-        $startTime = microtime(true);
-        $usage['total'] = FileUtils::getTotalUsageFormatted(base_path());
-        $totalElapsed = microtime(true) - $startTime;
-        Log::info('UploadfileManage: Total usage calculation completed', [
-            'path' => base_path(),
-            'size' => $usage['total'],
-            'elapsed_time' => number_format($totalElapsed, 3) . 's'
-        ]);
 
         // ファイル使用量（storage/app/uploads配下）
         $startTime = microtime(true);

--- a/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
+++ b/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
@@ -6,11 +6,10 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\DB;
 
 use App\Models\Common\Uploads;
 use App\Models\Core\Configs;
-use App\Utilities\File\FileUtils;
+use App\Utilities\Storage\StorageUsageCalculator;
 
 use App\Plugins\Manage\ManagePluginBase;
 use App\Traits\ConnectCommonTrait;
@@ -127,7 +126,7 @@ class UploadfileManage extends ManagePluginBase
         $uploads = $uploads_query->paginate($per_page, null, 'page', $page);
 
         // データ使用量の計算
-        $storage_usage = $this->getDataUsage();
+        $storage_usage = StorageUsageCalculator::getDataUsage();
 
         // 入力値をsessionへ保存（検索用）
         $request->flash();
@@ -412,169 +411,5 @@ class UploadfileManage extends ManagePluginBase
         return redirect('/manage/uploadfile/')->with('flash_message', $message);
     }
 
-    /**
-     * 各種の使用量（テーブル使用量、アップロードファイル使用量、総使用量）を配列に詰めて返す
-     *
-     * @return array
-     */
-    private function getDataUsage() : array
-    {
-        $usage = [];
 
-        // テーブル使用量
-        $usage['tables'] = $this->getTableUsageFormatted();
-
-        // アップロードファイル使用量（storage/app/uploads配下）
-        $usage['uploads'] = FileUtils::getTotalUsageFormatted(storage_path('app/uploads'));
-
-        // 総使用量（テーブル使用量 + アップロードファイル使用量）
-        $usage['total'] = $this->calculateTotalUsage($usage['tables'], $usage['uploads']);
-
-        // プラン容量（env設定がある場合のみ）
-        $usage['plan_limit'] = $this->getPlanLimitFormatted();
-
-        // 使用率（プラン容量が設定されている場合のみ）
-        $usage['usage_percentage'] = $this->getUsagePercentage($usage['total'], $usage['plan_limit']);
-
-        return $usage;
-    }
-
-    /**
-     * information_schema.tablesからテーブル使用量を算出してフォーマット済みの使用量を返す
-     *
-     * @return string
-     */
-    private function getTableUsageFormatted() : string
-    {
-        try {
-            $database_name = env('DB_DATABASE');
-            
-            // システムスキーマからテーブルの使用量を取得
-            $result = DB::select("
-                SELECT COALESCE(SUM(data_length + index_length), 0) as total_size 
-                FROM information_schema.tables 
-                WHERE table_schema = ? AND table_name NOT IN ('app_logs', 'migrations', 'migration_mappings', 'dusks', 'api_secrets')
-            ", [$database_name]);
-            
-            $total_bytes = $result[0]->total_size ?? 0;
-
-            return FileUtils::getFormatSizeDecimalPoint((int)$total_bytes);
-        } catch (\Exception $e) {
-            Log::error('UploadfileManage: Table usage calculation failed', ['error' => $e->getMessage()]);
-            return '-';
-        }
-    }
-
-    /**
-     * 総使用量（データ使用量＋アップロードファイル使用量）を算出してフォーマット済みの総使用量を返す
-     *
-     * @param string $tables_size
-     * @param string $uploads_size
-     * @return string
-     */
-    private function calculateTotalUsage(string $tables_size, string $uploads_size) : string
-    {
-        try {
-            $tables_bytes = $this->parseFormattedSize($tables_size);
-            $uploads_bytes = $this->parseFormattedSize($uploads_size);
-            
-            $total_bytes = $tables_bytes + $uploads_bytes;
-            
-            // デバッグログ
-            Log::info('UploadfileManage: Total usage calculation details', [
-                'tables_size' => $tables_size,
-                'uploads_size' => $uploads_size,
-                'tables_bytes' => $tables_bytes,
-                'uploads_bytes' => $uploads_bytes,
-                'total_bytes' => $total_bytes
-            ]);
-
-            return FileUtils::getFormatSizeDecimalPoint((int)$total_bytes);
-        } catch (\Exception $e) {
-            Log::error('UploadfileManage: Total usage calculation failed', ['error' => $e->getMessage()]);
-            return '-';
-        }
-    }
-
-    /**
-     * 後続処理の計算用にフォーマット済みサイズ文字列をバイト数に変換して返す
-     *
-     * @param string $formatted_size
-     * @return int
-     */
-    private function parseFormattedSize(string $formatted_size) : int
-    {
-        $formatted_size = trim($formatted_size);
-        
-        // 単位とその倍数を定義（長い単位から順番に処理するため降順で配列を構成）※「MB」→「B」の順でチェックしないと「177.50MB」が「B」として誤認識される
-        $units = ['TB' => 1024*1024*1024*1024, 'GB' => 1024*1024*1024, 'MB' => 1024*1024, 'KB' => 1024, 'B' => 1];
-        
-        // 各単位をチェックして該当する単位を見つける
-        foreach ($units as $unit => $multiplier) {
-            // 文字列の末尾が単位文字列と一致するかチェック ※例：「177.50MB」の末尾2文字が「MB」と一致するか
-            if (substr($formatted_size, -strlen($unit)) === $unit) {
-                // 単位部分を除去して数値部分のみを取得 ※例：「177.50MB」→「177.50」
-                $number = floatval(str_replace($unit, '', $formatted_size));
-                // 数値に倍数を掛けてバイト数に変換（例：177.50 * 1048576 = 186122240バイト）
-                return intval($number * $multiplier);
-            }
-        }
-        
-        // どの単位にも一致しなかった場合は0バイトを返す
-        return 0;
-    }
-
-    /**
-     * フォーマット済みのプラン容量を返す ※env設定がない場合、数値以外の設定はnullを返す
-     *
-     * @return string|null
-     */
-    private function getPlanLimitFormatted() : ?string
-    {
-        $storage_limit_mb = env('STORAGE_LIMIT_MB');
-        
-        // env設定がない場合はnullを返す
-        if (empty($storage_limit_mb) || !is_numeric($storage_limit_mb)) {
-            return null;
-        }
-        
-        // MB→バイトに変換してからフォーマット
-        $storage_limit_bytes = intval($storage_limit_mb) * 1024 * 1024;
-        
-        return FileUtils::getFormatSizeDecimalPoint($storage_limit_bytes);
-    }
-
-    /**
-     * 使用率を計算して返す ※プラン容量が設定されていない場合はnullを返す
-     *
-     * @param string $total_usage フォーマット済み総使用量
-     * @param string|null $plan_limit フォーマット済みプラン容量
-     * @return float|null 使用率（パーセンテージではない）
-     */
-    private function getUsagePercentage(string $total_usage, ?string $plan_limit) : ?float
-    {
-        // プラン容量が設定されていない場合はnullを返す
-        if (empty($plan_limit)) {
-            return null;
-        }
-        
-        try {
-            $total_bytes = $this->parseFormattedSize($total_usage);
-            $limit_bytes = $this->parseFormattedSize($plan_limit);
-            
-            // プラン容量が0の場合は0%として扱う
-            if ($limit_bytes <= 0) {
-                return 0.0;
-            }
-            
-            // 使用率を計算（0.0以上の値、どのぐらい超過しているかも緊急度の判断基準になる為、100%超過も表示）
-            $percentage = $total_bytes / $limit_bytes;
-            
-            return $percentage;
-            
-        } catch (\Exception $e) {
-            Log::error('UploadfileManage: Usage percentage calculation failed', ['error' => $e->getMessage()]);
-            return null;
-        }
-    }
 }

--- a/app/Utilities/Storage/StorageUsageCalculator.php
+++ b/app/Utilities/Storage/StorageUsageCalculator.php
@@ -95,8 +95,9 @@ class StorageUsageCalculator
     {
         $storage_limit_mb = env('STORAGE_LIMIT_MB');
         
-        // env設定がない場合はnullを返す
-        if (empty($storage_limit_mb) || !is_numeric($storage_limit_mb)) {
+        // env設定がない場合や無効な値の場合はnullを返す
+        if (empty($storage_limit_mb) || !is_numeric($storage_limit_mb) || $storage_limit_mb <= 0) {
+            Log::warning('Invalid STORAGE_LIMIT_MB configuration: ' . $storage_limit_mb);
             return null;
         }
         

--- a/app/Utilities/Storage/StorageUsageCalculator.php
+++ b/app/Utilities/Storage/StorageUsageCalculator.php
@@ -12,6 +12,18 @@ use App\Utilities\File\FileUtils;
 class StorageUsageCalculator
 {
     /**
+     * バイト変換の定数
+     */
+    private const BYTES_PER_KB = 1024;
+    private const BYTES_PER_MB = self::BYTES_PER_KB * 1024;
+    private const BYTES_PER_GB = self::BYTES_PER_MB * 1024;
+    private const BYTES_PER_TB = self::BYTES_PER_GB * 1024;
+    
+    /**
+     * デフォルト警告閾値（80%）
+     */
+    private const DEFAULT_WARNING_THRESHOLD = 0.8;
+    /**
      * 各種の使用量を配列に詰めて返す
      *
      * @return array
@@ -102,7 +114,7 @@ class StorageUsageCalculator
         }
         
         // MB→バイトに変換してからフォーマット
-        $storage_limit_bytes = intval($storage_limit_mb) * 1024 * 1024;
+        $storage_limit_bytes = intval($storage_limit_mb) * self::BYTES_PER_MB;
         
         return FileUtils::getFormatSizeDecimalPoint($storage_limit_bytes);
     }
@@ -155,7 +167,7 @@ class StorageUsageCalculator
         }
         
         // 警告閾値を取得（デフォルト80%）
-        $warning_threshold = env('STORAGE_USAGE_WARNING_THRESHOLD', 0.8);
+        $warning_threshold = env('STORAGE_USAGE_WARNING_THRESHOLD', self::DEFAULT_WARNING_THRESHOLD);
         
         // 使用率が閾値以上の場合は警告表示
         return $usage_percentage >= $warning_threshold;
@@ -173,7 +185,13 @@ class StorageUsageCalculator
         $formatted_size = trim($formatted_size);
         
         // 単位とその倍数を定義（長い単位から順番に処理するため降順で配列を構成）※「MB」→「B」の順でチェックしないと「177.50MB」が「B」として誤認識される
-        $units = ['TB' => 1024*1024*1024*1024, 'GB' => 1024*1024*1024, 'MB' => 1024*1024, 'KB' => 1024, 'B' => 1];
+        $units = [
+            'TB' => self::BYTES_PER_TB,
+            'GB' => self::BYTES_PER_GB,
+            'MB' => self::BYTES_PER_MB,
+            'KB' => self::BYTES_PER_KB,
+            'B' => 1
+        ];
         
         // 各単位をチェックして該当する単位を見つける
         foreach ($units as $unit => $multiplier) {

--- a/app/Utilities/Storage/StorageUsageCalculator.php
+++ b/app/Utilities/Storage/StorageUsageCalculator.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Utilities\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use App\Utilities\File\FileUtils;
+
+/**
+ * ストレージ使用量計算ユーティリティ
+ */
+class StorageUsageCalculator
+{
+    /**
+     * 各種の使用量を配列に詰めて返す
+     *
+     * @return array
+     */
+    public static function getDataUsage(): array
+    {
+        $usage = [];
+
+        // テーブル使用量
+        $usage['tables'] = self::getTableUsageFormatted();
+
+        // データファイル使用量（storage/app/uploads配下）
+        $usage['uploads'] = FileUtils::getTotalUsageFormatted(storage_path('app/uploads'));
+
+        // 総使用量（テーブル使用量 + アップロードファイル使用量）
+        $usage['total'] = self::calculateTotalUsage($usage['tables'], $usage['uploads']);
+
+        // プラン容量（env設定がある場合のみ）
+        $usage['plan_limit'] = self::getPlanLimitFormatted();
+
+        // 使用率（プラン容量が設定されている場合のみ）
+        $usage['usage_percentage'] = self::getUsagePercentage($usage['total'], $usage['plan_limit']);
+
+        return $usage;
+    }
+
+    /**
+     * information_schema.tablesからテーブル使用量を算出してフォーマット済みの使用量を返す
+     *
+     * @return string
+     */
+    private static function getTableUsageFormatted(): string
+    {
+        try {
+            $database_name = env('DB_DATABASE');
+            
+            // システムスキーマからテーブルの使用量を取得
+            $result = DB::select("
+                SELECT COALESCE(SUM(data_length + index_length), 0) as total_size 
+                FROM information_schema.tables 
+                WHERE table_schema = ? AND table_name NOT IN ('app_logs', 'migrations', 'migration_mappings', 'dusks', 'api_secrets')
+            ", [$database_name]);
+            
+            $total_bytes = $result[0]->total_size ?? 0;
+            
+            return FileUtils::getFormatSizeDecimalPoint((int)$total_bytes);
+        } catch (\Exception $e) {
+            Log::error('StorageUsageCalculator: Table usage calculation failed', ['error' => $e->getMessage()]);
+            return '0B';
+        }
+    }
+
+    /**
+     * 総使用量（データ使用量＋アップロードファイル使用量）を算出してフォーマット済みの総使用量を返す
+     *
+     * @param string $tables_size
+     * @param string $uploads_size
+     * @return string
+     */
+    private static function calculateTotalUsage(string $tables_size, string $uploads_size): string
+    {
+        try {
+            $tables_bytes = self::parseFormattedSize($tables_size);
+            $uploads_bytes = self::parseFormattedSize($uploads_size);
+            
+            $total_bytes = $tables_bytes + $uploads_bytes;
+            
+            return FileUtils::getFormatSizeDecimalPoint((int)$total_bytes);
+        } catch (\Exception $e) {
+            Log::error('StorageUsageCalculator: Total usage calculation failed', ['error' => $e->getMessage()]);
+            return '0B';
+        }
+    }
+
+    /**
+     * フォーマット済みのプラン容量を返す ※env設定がない場合、数値以外の設定はnullを返す
+     *
+     * @return string|null
+     */
+    private static function getPlanLimitFormatted(): ?string
+    {
+        $storage_limit_mb = env('STORAGE_LIMIT_MB');
+        
+        // env設定がない場合はnullを返す
+        if (empty($storage_limit_mb) || !is_numeric($storage_limit_mb)) {
+            return null;
+        }
+        
+        // MB→バイトに変換してからフォーマット
+        $storage_limit_bytes = intval($storage_limit_mb) * 1024 * 1024;
+        
+        return FileUtils::getFormatSizeDecimalPoint($storage_limit_bytes);
+    }
+
+    /**
+     * 使用率を計算して返す ※プラン容量が設定されていない場合はnullを返す
+     *
+     * @param string $total_usage フォーマット済み総使用量
+     * @param string|null $plan_limit フォーマット済みプラン容量
+     * @return float|null 使用率（パーセンテージではない）
+     */
+    private static function getUsagePercentage(string $total_usage, ?string $plan_limit): ?float
+    {
+        // プラン容量が設定されていない場合はnullを返す
+        if (empty($plan_limit)) {
+            return null;
+        }
+        
+        try {
+            $total_bytes = self::parseFormattedSize($total_usage);
+            $limit_bytes = self::parseFormattedSize($plan_limit);
+            
+            // プラン容量が0の場合は0%として扱う
+            if ($limit_bytes <= 0) {
+                return 0.0;
+            }
+            
+            // 使用率を計算（0.0以上の値、どのぐらい超過しているかも緊急度の判断基準になる為、100%超過も表示）
+            $percentage = $total_bytes / $limit_bytes;
+            
+            return $percentage;
+            
+        } catch (\Exception $e) {
+            Log::error('StorageUsageCalculator: Usage percentage calculation failed', ['error' => $e->getMessage()]);
+            return null;
+        }
+    }
+
+    /**
+     * 警告表示が必要かどうかを判定
+     *
+     * @param float|null $usage_percentage 使用率
+     * @return bool 警告表示が必要な場合true
+     */
+    public static function shouldShowWarning(?float $usage_percentage): bool
+    {
+        // 使用率が取得できない場合は警告しない
+        if ($usage_percentage === null) {
+            return false;
+        }
+        
+        // 警告閾値を取得（デフォルト80%）
+        $warning_threshold = env('STORAGE_USAGE_WARNING_THRESHOLD', 0.8);
+        
+        // 使用率が閾値以上の場合は警告表示
+        return $usage_percentage >= $warning_threshold;
+    }
+
+    /**
+     * 後続処理の計算用にフォーマット済みサイズ文字列をバイト数に変換して返す
+     *
+     * @param string $formatted_size
+     * @return int
+     */
+    private static function parseFormattedSize(string $formatted_size): int
+    {
+        // 前後の空白を除去（例：" 177.50MB " → "177.50MB"）
+        $formatted_size = trim($formatted_size);
+        
+        // 単位とその倍数を定義（長い単位から順番に処理するため降順で配列を構成）※「MB」→「B」の順でチェックしないと「177.50MB」が「B」として誤認識される
+        $units = ['TB' => 1024*1024*1024*1024, 'GB' => 1024*1024*1024, 'MB' => 1024*1024, 'KB' => 1024, 'B' => 1];
+        
+        // 各単位をチェックして該当する単位を見つける
+        foreach ($units as $unit => $multiplier) {
+            // 文字列の末尾が単位文字列と一致するかチェック ※例：「177.50MB」の末尾2文字が「MB」と一致するか
+            if (substr($formatted_size, -strlen($unit)) === $unit) {
+                // 単位部分を除去して数値部分のみを取得 ※例：「177.50MB」→「177.50」
+                $number = floatval(str_replace($unit, '', $formatted_size));
+                // 数値に倍数を掛けてバイト数に変換（例：177.50 * 1048576 = 186122240バイト）
+                return intval($number * $multiplier);
+            }
+        }
+        
+        // どの単位にも一致しなかった場合は0バイトを返す
+        return 0;
+    }
+}

--- a/resources/views/plugins/manage/index/index.blade.php
+++ b/resources/views/plugins/manage/index/index.blade.php
@@ -17,6 +17,29 @@
     </div>
 @endif
 
+{{-- ストレージ使用量警告メッセージ --}}
+@if ($is_storage_warning_enabled)
+<div class="card mb-3 border-warning">
+    <div class="card-header bg-warning text-dark">
+        <i class="fas fa-exclamation-triangle"></i> ストレージ容量警告
+    </div>
+    <div class="card-body">
+        <p class="card-text mb-2">
+            <strong>空き容量が残りわずかです（使用率{{ number_format($storage_usage['usage_percentage'] * 100, 1) }}%）。</strong>
+        </p>
+        <p class="card-text mb-2">
+            容量上限に達すると、ファイルのアップロードができなくなります。
+        </p>
+        <p class="card-text mb-0">
+            <a href="{{ url('/manage/uploadfile') }}" class="btn btn-primary btn-sm">
+                <i class="fas fa-folder-open"></i> アップロードファイル管理
+            </a>
+            より不要なファイルを削除してください。
+        </p>
+    </div>
+</div>
+@endif
+
 {{-- バージョン情報 --}}
 @if (config('version.show_cc_version'))
 <div class="card mb-2">

--- a/resources/views/plugins/manage/index/index.blade.php
+++ b/resources/views/plugins/manage/index/index.blade.php
@@ -28,7 +28,7 @@
             <strong>空き容量が残りわずかです（使用率{{ number_format($storage_usage['usage_percentage'] * 100, 1) }}%）。</strong>
         </p>
         <p class="card-text mb-2">
-            容量上限に達すると、ファイルのアップロードができなくなります。
+            データ容量が上限に近づいています。不要なファイルを削除して容量を確保してください。
         </p>
         <p class="card-text mb-0">
             <a href="{{ url('/manage/uploadfile') }}" class="btn btn-primary btn-sm">

--- a/resources/views/plugins/manage/uploadfile/index.blade.php
+++ b/resources/views/plugins/manage/uploadfile/index.blade.php
@@ -52,7 +52,7 @@
                             </div>
                             <p class="text-muted small mt-1 mb-0">
                                 <i class="fas fa-info-circle mr-1"></i>
-                                使用率100%を超えるとファイルアップロードができなくなります。
+                                使用率が高い場合は、不要なファイルを削除してください。
                             </p>
                         </div>
                         @endif

--- a/resources/views/plugins/manage/uploadfile/index.blade.php
+++ b/resources/views/plugins/manage/uploadfile/index.blade.php
@@ -23,11 +23,51 @@
 
         {{-- 使用量表示 --}}
         <div class="row mb-3">
+            @if($storage_usage['plan_limit'])
+            {{-- プラン容量表示（env設定がある場合のみ） --}}
             <div class="col-md-6">
                 <div class="card h-100">
                     <div class="card-body p-3">
                         <h6 class="card-title mb-2">
+                            <i class="fas fa-server text-danger"></i> プラン容量
+                            <i class="fas fa-question-circle text-muted ml-1" data-toggle="tooltip" data-placement="top" title="ご契約プランの上限容量です。"></i>
+                        </h6>
+                        <p class="card-text h5 mb-0 text-danger">{{ $storage_usage['plan_limit'] }}</p>
+                        @if($storage_usage['usage_percentage'] !== null)
+                        <div class="mt-2">
+                            <div class="d-flex justify-content-between align-items-center mb-1">
+                                <span class="text-muted small">使用率</span>
+                                <span class="small font-weight-bold @if($storage_usage['usage_percentage'] >= 0.9) text-danger @elseif($storage_usage['usage_percentage'] >= 0.7) text-dark @else text-success @endif">
+                                    {{ number_format($storage_usage['usage_percentage'] * 100, 1) }}%
+                                </span>
+                            </div>
+                            <div class="progress" style="height: 6px;">
+                                <div class="progress-bar @if($storage_usage['usage_percentage'] >= 0.9) bg-danger @elseif($storage_usage['usage_percentage'] >= 0.7) bg-warning @else bg-success @endif" 
+                                     role="progressbar" 
+                                     style="width: {{ min($storage_usage['usage_percentage'] * 100, 100) }}%"
+                                     aria-valuenow="{{ $storage_usage['usage_percentage'] * 100 }}" 
+                                     aria-valuemin="0" 
+                                     aria-valuemax="100">
+                                </div>
+                            </div>
+                            <p class="text-muted small mt-1 mb-0">
+                                <i class="fas fa-info-circle mr-1"></i>
+                                使用率100%を超えるとファイルアップロードができなくなります。
+                            </p>
+                        </div>
+                        @endif
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+            @else
+            <div class="col-md-6">
+            @endif
+                <div class="card h-100">
+                    <div class="card-body p-3">
+                        <h6 class="card-title mb-2">
                             <i class="fas fa-chart-pie text-primary"></i> 総使用量
+                            <i class="fas fa-question-circle text-muted ml-1" data-toggle="tooltip" data-placement="top" title="データ使用量とアップロードファイル使用量を合計した総容量です。"></i>
                         </h6>
                         <p class="card-text h5 mb-2 text-primary">{{ $storage_usage['total'] }}</p>
                         <div class="row text-sm">
@@ -35,6 +75,7 @@
                                 <div class="mb-1">
                                     <i class="fas fa-database text-info mr-1"></i>
                                     <span class="text-muted">データ使用量</span>
+                                    <i class="fas fa-question-circle text-muted ml-1" data-toggle="tooltip" data-placement="top" title="データベースに保存されているコンテンツデータの使用量です。"></i>
                                 </div>
                                 <div class="text-info font-weight-bold">{{ $storage_usage['tables'] }}</div>
                             </div>
@@ -42,6 +83,7 @@
                                 <div class="mb-1">
                                     <i class="fas fa-folder-open text-success mr-1"></i>
                                     <span class="text-muted">アップロードファイル使用量</span>
+                                    <i class="fas fa-question-circle text-muted ml-1" data-toggle="tooltip" data-placement="top" title="サーバーにアップロードされたファイルの使用量です。"></i>
                                 </div>
                                 <div class="text-success font-weight-bold">{{ $storage_usage['uploads'] }}</div>
                             </div>
@@ -288,6 +330,9 @@
         // 初期状態の設定
         updateSelectAllCheckbox();
         updateBulkDeleteButton();
+
+        // ツールチップの初期化
+        $('[data-toggle="tooltip"]').tooltip();
     });
 </script>
 @endsection

--- a/resources/views/plugins/manage/uploadfile/index.blade.php
+++ b/resources/views/plugins/manage/uploadfile/index.blade.php
@@ -21,16 +21,31 @@
         {{-- メッセージ表示 --}}
         @include('plugins.common.flash_message')
 
-        {{-- アップロードファイル使用量表示 --}}
+        {{-- 使用量表示 --}}
         <div class="row mb-3">
             <div class="col-md-6">
                 <div class="card h-100">
                     <div class="card-body p-3">
                         <h6 class="card-title mb-2">
-                            <i class="fas fa-folder-open text-success"></i> アップロードファイル使用量
+                            <i class="fas fa-chart-pie text-primary"></i> 総使用量
                         </h6>
-                        <p class="card-text h5 mb-0 text-success">{{ $storage_usage['uploads'] }}</p>
-                        <small class="text-muted">アップロードファイルの使用量</small>
+                        <p class="card-text h5 mb-2 text-primary">{{ $storage_usage['total'] }}</p>
+                        <div class="row text-sm">
+                            <div class="col-md-6">
+                                <div class="mb-1">
+                                    <i class="fas fa-database text-info mr-1"></i>
+                                    <span class="text-muted">データ使用量</span>
+                                </div>
+                                <div class="text-info font-weight-bold">{{ $storage_usage['tables'] }}</div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="mb-1">
+                                    <i class="fas fa-folder-open text-success mr-1"></i>
+                                    <span class="text-muted">アップロードファイル使用量</span>
+                                </div>
+                                <div class="text-success font-weight-bold">{{ $storage_usage['uploads'] }}</div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/views/plugins/manage/uploadfile/index.blade.php
+++ b/resources/views/plugins/manage/uploadfile/index.blade.php
@@ -21,19 +21,8 @@
         {{-- メッセージ表示 --}}
         @include('plugins.common.flash_message')
 
-        {{-- 使用量表示 --}}
+        {{-- アップロードファイル使用量表示 --}}
         <div class="row mb-3">
-            <div class="col-md-6">
-                <div class="card h-100">
-                    <div class="card-body p-3">
-                        <h6 class="card-title mb-2">
-                            <i class="fas fa-folder-open text-primary"></i> 総使用量
-                        </h6>
-                        <p class="card-text h5 mb-0 text-primary">{{ $storage_usage['total'] }}</p>
-                        <small class="text-muted">サイト全体の使用量</small>
-                    </div>
-                </div>
-            </div>
             <div class="col-md-6">
                 <div class="card h-100">
                     <div class="card-body p-3">

--- a/tests/Unit/Utilities/Storage/StorageUsageCalculatorTest.php
+++ b/tests/Unit/Utilities/Storage/StorageUsageCalculatorTest.php
@@ -1,0 +1,386 @@
+<?php
+
+namespace Tests\Unit\Utilities\Storage;
+
+use Tests\TestCase;
+use App\Utilities\Storage\StorageUsageCalculator;
+
+class StorageUsageCalculatorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        // 環境変数を削除
+        if (function_exists('putenv')) {
+            putenv('STORAGE_LIMIT_MB');
+            putenv('STORAGE_USAGE_WARNING_THRESHOLD');
+        }
+    }
+    
+    protected function tearDown(): void
+    {
+        // 環境変数を削除
+        if (function_exists('putenv')) {
+            putenv('STORAGE_LIMIT_MB');
+            putenv('STORAGE_USAGE_WARNING_THRESHOLD');
+            putenv('DB_DATABASE');
+        }
+        
+        parent::tearDown();
+    }
+
+    /**
+     * getDataUsage メソッドの基本動作テスト
+     * 
+     * このメソッドは StorageUsageCalculator の中核機能である getDataUsage() の動作を検証します。
+     * 戻り値の構造と型が正しいかを確認し、各種の使用量データが適切に取得できることを保証します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::getDataUsage
+     */
+    public function testGetDataUsageReturnsExpectedStructure()
+    {
+        // テスト環境の設定 - 実際のDBとの接続を確保
+        config(['database.default' => 'testing']);
+        putenv('DB_DATABASE=testing');
+        putenv('STORAGE_LIMIT_MB=100');
+        
+        // メソッド実行
+        $result = StorageUsageCalculator::getDataUsage();
+        
+        // 戻り値の構造確認 - 必須キーが全て存在することを検証
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('tables', $result);        // DBテーブル使用量
+        $this->assertArrayHasKey('uploads', $result);       // アップロードファイル使用量
+        $this->assertArrayHasKey('total', $result);         // 総使用量
+        $this->assertArrayHasKey('plan_limit', $result);    // プラン容量制限
+        $this->assertArrayHasKey('usage_percentage', $result); // 使用率
+        
+        // 各値の型確認 - データの整合性を保証
+        $this->assertIsString($result['tables']);           // フォーマット済み文字列
+        $this->assertIsString($result['uploads']);          // フォーマット済み文字列
+        $this->assertIsString($result['total']);            // フォーマット済み文字列
+        $this->assertTrue(is_string($result['plan_limit']) || is_null($result['plan_limit'])); // 設定次第でnull
+        $this->assertTrue(is_float($result['usage_percentage']) || is_null($result['usage_percentage'])); // 計算結果
+    }
+
+    /**
+     * shouldShowWarning メソッドのテスト - 使用率が閾値以上の場合
+     * 
+     * 管理者にストレージ警告を表示すべき状況での動作を検証します。
+     * デフォルト閾値（80%）とカスタム閾値の両方でテストし、
+     * 適切に警告判定が行われることを確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::shouldShowWarning
+     */
+    public function testShouldShowWarningReturnsTrueWhenUsageExceedsThreshold()
+    {
+        // テストケース1: デフォルト閾値（80%）を超える使用率での警告表示確認
+        $this->assertTrue(StorageUsageCalculator::shouldShowWarning(0.85)); // 85% > 80%
+        
+        // テストケース2: カスタム閾値を設定した場合の動作確認
+        putenv('STORAGE_USAGE_WARNING_THRESHOLD=0.9'); // 90%に変更
+        $this->assertTrue(StorageUsageCalculator::shouldShowWarning(0.95)); // 95% > 90%
+        
+        // テストケース3: 閾値ちょうどの境界値テスト（以上の条件なので警告表示）
+        $this->assertTrue(StorageUsageCalculator::shouldShowWarning(0.9)); // 90% >= 90%
+    }
+
+    /**
+     * shouldShowWarning メソッドのテスト - 使用率が閾値未満の場合
+     * 
+     * 警告を表示しない正常範囲での使用率における動作を検証します。
+     * デフォルト閾値未満と0%での境界値テストを実施し、
+     * 不必要な警告が表示されないことを確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::shouldShowWarning
+     */
+    public function testShouldShowWarningReturnsFalseWhenUsageIsBelowThreshold()
+    {
+        // 環境変数をクリアしてデフォルト閾値（80%）を使用
+        putenv('STORAGE_USAGE_WARNING_THRESHOLD');
+        
+        // テストケース1: デフォルト閾値（80%）未満の使用率では警告なし
+        $this->assertFalse(StorageUsageCalculator::shouldShowWarning(0.75)); // 75% < 80%
+        
+        // テストケース2: 最小値（0%）での境界値テスト
+        $this->assertFalse(StorageUsageCalculator::shouldShowWarning(0.0)); // 0% < 80%
+    }
+
+    /**
+     * shouldShowWarning メソッドのテスト - 使用率がnullの場合
+     * 
+     * 使用率が取得できない（null）場合の安全な動作を検証します。
+     * プラン容量が未設定の場合など、使用率が計算できない状況で
+     * 適切にfalseを返すことを確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::shouldShowWarning
+     */
+    public function testShouldShowWarningReturnsFalseWhenUsageIsNull()
+    {
+        // テストケース: 使用率がnullの場合は警告表示しない（安全な動作）
+        $this->assertFalse(StorageUsageCalculator::shouldShowWarning(null));
+    }
+
+    /**
+     * getPlanLimitFormatted メソッドのテスト - 有効な設定値
+     * 
+     * 有効な環境変数設定でのプラン容量フォーマット処理を検証します。
+     * MBからバイトへの変換とフォーマット済み文字列への変換が
+     * 正しく行われることを確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::getPlanLimitFormatted
+     */
+    public function testGetPlanLimitFormattedWithValidConfiguration()
+    {
+        // テスト用環境変数設定（100MB）
+        putenv('STORAGE_LIMIT_MB=100');
+        
+        // privateメソッドへのアクセス準備
+        $method = new \ReflectionMethod(StorageUsageCalculator::class, 'getPlanLimitFormatted');
+        $method->setAccessible(true);
+        
+        // メソッド実行
+        $result = $method->invoke(null);
+        
+        // フォーマット結果の検証
+        $this->assertIsString($result);  // 文字列型であること
+        $this->assertMatchesRegularExpression('/^\d+\.\d{2}[KMGTB]+$/', $result); // 正規表現でフォーマット確認
+    }
+
+    /**
+     * getPlanLimitFormatted メソッドのテスト - 無効な設定値
+     */
+    public function testGetPlanLimitFormattedWithInvalidConfiguration()
+    {
+        $method = new \ReflectionMethod(StorageUsageCalculator::class, 'getPlanLimitFormatted');
+        $method->setAccessible(true);
+        
+        // 現在の環境で設定されている値でのテスト
+        $result = $method->invoke(null);
+        
+        // 結果が文字列またはnullであることを確認
+        $this->assertTrue(is_string($result) || is_null($result));
+        
+        // 文字列の場合は適切なフォーマットであることを確認
+        if (is_string($result)) {
+            $this->assertMatchesRegularExpression('/^\d+(\.\d{2})?[KMGTB]+$/', $result);
+        }
+    }
+
+    /**
+     * getPlanLimitFormatted メソッドのテスト - 小数値は有効
+     * 
+     * 環境変数に小数値が設定された場合の動作を検証します。
+     * PHPのintval()関数により整数部分のみが使用されることを確認し、
+     * エラーとならずに適切なフォーマット済み文字列が返されることを検証します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::getPlanLimitFormatted
+     */
+    public function testGetPlanLimitFormattedWithDecimalValue()
+    {
+        // 小数値を含む環境変数設定（10.5MB）
+        putenv("STORAGE_LIMIT_MB=10.5");
+        
+        // privateメソッドへのアクセス準備
+        $method = new \ReflectionMethod(StorageUsageCalculator::class, 'getPlanLimitFormatted');
+        $method->setAccessible(true);
+        
+        // メソッド実行
+        $result = $method->invoke(null);
+        
+        // 検証: 小数値は有効（intval で整数部分の10として処理される）
+        $this->assertIsString($result); // エラーにならず文字列が返される
+    }
+
+    /**
+     * parseFormattedSize メソッドのテスト
+     * 
+     * フォーマット済みサイズ文字列（例："1.5MB"）をバイト数に変換する機能を検証します。
+     * 異なる単位（B, KB, MB, GB, TB）や小数点、無効値などの様々な
+     * 入力パターンに対する適切な変換を確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::parseFormattedSize
+     * @dataProvider formattedSizeProvider
+     */
+    public function testParseFormattedSize($input, $expected)
+    {
+        // privateメソッドへのアクセス準備
+        $method = new \ReflectionMethod(StorageUsageCalculator::class, 'parseFormattedSize');
+        $method->setAccessible(true);
+        
+        // 変換処理実行
+        $result = $method->invoke(null, $input);
+        
+        // 期待値との比較検証
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * フォーマット済みサイズのテストデータプロバイダ
+     * 
+     * parseFormattedSizeメソッドのテスト用データセットを提供します。
+     * 様々なサイズ単位、小数点、無効値などのパターンを網羅しています。
+     * 
+     * @return array[] テストケースの配列 [入力値, 期待されるバイト数]
+     */
+    public function formattedSizeProvider()
+    {
+        return [
+            // 基本的な単位変換テスト
+            ['1B', 1],                    // 1バイト
+            ['1KB', 1024],                // 1KB = 1024バイト
+            ['1MB', 1048576],             // 1MB = 1024^2バイト
+            ['1GB', 1073741824],          // 1GB = 1024^3バイト
+            ['1TB', 1099511627776],       // 1TB = 1024^4バイト
+            
+            // 小数点を含む値の変換テスト
+            ['1.5KB', 1536],              // 1.5KB = 1536バイト
+            ['2.5MB', 2621440],           // 2.5MB = 2621440バイト
+            
+            // 空白文字の処理テスト
+            [' 1MB ', 1048576],           // 前後の空白を除去して処理
+            
+            // 無効値のエラーハンドリングテスト
+            ['invalid', 0],               // 無効な文字列
+            ['', 0],                      // 空文字
+        ];
+    }
+
+    /**
+     * calculateTotalUsage メソッドのテスト
+     * 
+     * テーブル使用量とアップロードファイル使用量を合計し、
+     * フォーマット済みの総使用量文字列を生成する機能を検証します。
+     * 異なる単位のサイズを正しく合計し、適切なフォーマットで出力することを確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::calculateTotalUsage
+     */
+    public function testCalculateTotalUsage()
+    {
+        // privateメソッドへのアクセス準備
+        $method = new \ReflectionMethod(StorageUsageCalculator::class, 'calculateTotalUsage');
+        $method->setAccessible(true);
+        
+        // 異なる単位のサイズを合計（1MB + 512KB = 1.5MB相当）
+        $result = $method->invoke(null, '1MB', '512KB');
+        
+        // 結果が適切なフォーマットの文字列であることを確認
+        $this->assertIsString($result);                                              // 文字列型であること
+        $this->assertMatchesRegularExpression('/^\d+\.\d{2}[KMGTB]+$/', $result);  // 正規表現でフォーマット確認
+    }
+
+    /**
+     * getUsagePercentage メソッドのテスト - 正常ケース
+     * 
+     * 総使用量とプラン容量から使用率（0.0-1.0以上）を計算する機能を検証します。
+     * 正常な範囲（50%）と100%を超えるケース（150%）の両方でテストし、
+     * 適切な使用率が計算されることを確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::getUsagePercentage
+     */
+    public function testGetUsagePercentageWithValidData()
+    {
+        // privateメソッドへのアクセス準備
+        $method = new \ReflectionMethod(StorageUsageCalculator::class, 'getUsagePercentage');
+        $method->setAccessible(true);
+        
+        // テストケース1: 正常範囲の使用率計算（50MB / 100MB = 0.5（50%））
+        $result = $method->invoke(null, '50MB', '100MB');
+        $this->assertEquals(0.5, $result);
+        
+        // テストケース2: 100%を超える場合の計算（150MB / 100MB = 1.5（150%））
+        $result = $method->invoke(null, '150MB', '100MB');
+        $this->assertEquals(1.5, $result);
+    }
+
+    /**
+     * getUsagePercentage メソッドのテスト - プラン容量がnullの場合
+     * 
+     * プラン容量が未設定（null）の場合の安全な動作を検証します。
+     * 使用率が計算できない状況では適切にnullを返し、
+     * エラーを発生させないことを確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::getUsagePercentage
+     */
+    public function testGetUsagePercentageWithNullPlanLimit()
+    {
+        // privateメソッドへのアクセス準備
+        $method = new \ReflectionMethod(StorageUsageCalculator::class, 'getUsagePercentage');
+        $method->setAccessible(true);
+        
+        // テストケース: プラン容量がnullの場合はnullを返す（エラーなし）
+        $result = $method->invoke(null, '50MB', null);
+        $this->assertNull($result);
+    }
+
+    /**
+     * getUsagePercentage メソッドのテスト - プラン容量が0の場合
+     * 
+     * プラン容量が0の異常ケースでの安全な動作を検証します。
+     * 0除算を回避し、0.0を返してエラーを防ぐことを確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::getUsagePercentage
+     */
+    public function testGetUsagePercentageWithZeroPlanLimit()
+    {
+        // privateメソッドへのアクセス準備
+        $method = new \ReflectionMethod(StorageUsageCalculator::class, 'getUsagePercentage');
+        $method->setAccessible(true);
+        
+        // テストケース: プラン容量が0の場合は0.0を返す（0除算回避）
+        $result = $method->invoke(null, '50MB', '0B');
+        $this->assertEquals(0.0, $result);
+    }
+
+    /**
+     * getTableUsageFormatted メソッドのテスト - 正常ケース
+     * 
+     * データベーステーブルの使用量を information_schema.tables から取得し、
+     * フォーマット済み文字列として返す機能を検証します。
+     * 実際のDBに接続してテーブル情報を取得し、適切な形式で結果が返されることを確認します。
+     * 
+     * @test
+     * @group StorageUsageCalculator
+     * @covers \App\Utilities\Storage\StorageUsageCalculator::getTableUsageFormatted
+     */
+    public function testGetTableUsageFormattedSuccess()
+    {
+        // テストDB環境の設定
+        config(['database.default' => 'testing']);
+        putenv('DB_DATABASE=testing');
+        
+        // privateメソッドへのアクセス準備
+        $method = new \ReflectionMethod(StorageUsageCalculator::class, 'getTableUsageFormatted');
+        $method->setAccessible(true);
+        
+        // DBテーブル使用量取得処理の実行
+        $result = $method->invoke(null);
+        
+        // 結果の検証 - フォーマット済み文字列として適切な形式であることを確認
+        $this->assertIsString($result);                                                  // 文字列型であること
+        $this->assertMatchesRegularExpression('/^\d+(\.\d{2})?[KMGTB]+$/', $result);    // 正規表現でフォーマット確認
+    }
+}


### PR DESCRIPTION
## 概要
サービス提供者向けに、ストレージ使用量の監視とプラン容量管理機能を追加しました。

### 主な変更内容
- **プラン容量表示機能**: アップロードファイル管理画面にプラン容量と使用率を表示
- **容量警告機能**: 管理者お知らせ画面に使用率が閾値に達した際の警告メッセージを表示
- **使用量詳細表示**: データ使用量とアップロードファイル使用量の内訳表示
- **共通化**: ストレージ使用量計算ロジックを共通クラス化

### 新機能の詳細
1. **プラン容量表示**
   - env設定（`STORAGE_LIMIT_MB`）によりプラン容量を設定可能
   - 使用率をパーセンテージとプログレスバーで視覚的に表示
   - 100%超過時も実際の使用率を表示（緊急度判断のため）

#### 画面イメージ
<img width="1877" height="247" alt="image" src="https://github.com/user-attachments/assets/97c25027-aab4-4b0f-8e62-c8acfdb740ef" />

---

2. **容量警告機能**
   - 管理者お知らせ画面に警告カードを表示
   - 閾値（`STORAGE_USAGE_WARNING_THRESHOLD`、デフォルト80%）で警告表示
   - アップロードファイル管理への直接リンク提供

#### 画面イメージ
<img width="1897" height="365" alt="image" src="https://github.com/user-attachments/assets/87e95be1-909a-429a-a883-7fa716892b75" />

---

3. **使用量内訳表示**
   - データ使用量：データベーステーブルの使用量
   - アップロードファイル使用量：storage/app/uploads配下の使用量
   - 各項目にツールチップで詳細説明を追加

### 環境変数追加
```bash
--- 設定例
# サービス提供者用：プランの容量制限（MB単位）
STORAGE_LIMIT_MB=20480
 - 設定あり：
   - アップロードファイル画面にプラン容量を表示
   - お知らせ画面にストレージ容量警告を表示（使用量警告閾値に応じて。使用量警告閾値未設定の場合は80%超えで表示）

# サービス提供者用：使用量警告閾値（0.0-1.0）
STORAGE_USAGE_WARNING_THRESHOLD=0.8
   - 初期値：0.8
```

### 技術的な改善
- `StorageUsageCalculator`クラス新規作成により使用量計算ロジックを共通化
- システム管理用テーブル（app_logs、migrations等）を使用量計算から除外
- テーブル使用量はinformation_schema.tablesのDATA_LENGTH + INDEX_LENGTHで算出

## テスト計画
- [x] 機能テスト完了
- [x] 環境変数設定テスト完了（設定あり/なし両方）
- [x] プラン容量表示テスト完了
- [x] 警告メッセージ表示テスト完了
- [x] 使用率計算テスト完了（100%超過含む）
- [x] ツールチップ表示テスト完了
- [x] レスポンシブデザイン確認完了