### PR TITLE
[サイト管理] Laravel DuskテストのCSSセレクターエラーを修正しました

### DIFF
--- a/resources/views/plugins/manage/site/meta.blade.php
+++ b/resources/views/plugins/manage/site/meta.blade.php
@@ -45,7 +45,7 @@
 
         {{-- OGP設定 --}}
         <hr class="mt-4 mb-3">
-        <h5>OGP設定</h5>
+        <h5 id="ogp_settings">OGP設定</h5>
         <div class="alert alert-info mb-3">
             <small>
                 <strong><i class="fas fa-info-circle"></i> OGP（Open Graph Protocol）とは</strong><br>

--- a/tests/Browser/Manage/SiteManageTest.php
+++ b/tests/Browser/Manage/SiteManageTest.php
@@ -136,7 +136,7 @@ class SiteManageTest extends DuskTestCase
 
         // OGP設定セクションのスクロール表示
         $this->browse(function (Browser $browser) {
-            $browser->scrollIntoView('h5:contains("OGP設定")')
+            $browser->scrollIntoView('//h5[contains(text(), "OGP設定")]')
                     ->screenshot('manage/site/meta/images/meta_ogp');
         });
 

--- a/tests/Browser/Manage/SiteManageTest.php
+++ b/tests/Browser/Manage/SiteManageTest.php
@@ -136,7 +136,7 @@ class SiteManageTest extends DuskTestCase
 
         // OGP設定セクションのスクロール表示
         $this->browse(function (Browser $browser) {
-            $browser->scrollIntoView('//h5[contains(text(), "OGP設定")]')
+            $browser->_executeScript('document.evaluate("//h5[contains(text(), \"OGP設定\")]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.scrollIntoView();')
                     ->screenshot('manage/site/meta/images/meta_ogp');
         });
 

--- a/tests/Browser/Manage/SiteManageTest.php
+++ b/tests/Browser/Manage/SiteManageTest.php
@@ -136,7 +136,7 @@ class SiteManageTest extends DuskTestCase
 
         // OGP設定セクションのスクロール表示
         $this->browse(function (Browser $browser) {
-            $browser->_executeScript('document.evaluate("//h5[contains(text(), \"OGP設定\")]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.scrollIntoView();')
+            $browser->script('document.evaluate("//h5[contains(text(), \'OGP設定\')]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.scrollIntoView();')
                     ->screenshot('manage/site/meta/images/meta_ogp');
         });
 

--- a/tests/Browser/Manage/SiteManageTest.php
+++ b/tests/Browser/Manage/SiteManageTest.php
@@ -136,7 +136,7 @@ class SiteManageTest extends DuskTestCase
 
         // OGP設定セクションのスクロール表示
         $this->browse(function (Browser $browser) {
-            $browser->script('document.evaluate("//h5[contains(text(), \'OGP設定\')]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.scrollIntoView();')
+            $browser->scrollIntoView('#ogp_settings')
                     ->screenshot('manage/site/meta/images/meta_ogp');
         });
 


### PR DESCRIPTION
## 概要
SiteManageTestのmeta()メソッドでLaravel DuskのCSSセレクターエラーが発生していた問題を修正しました。

### 変更内容
- meta.blade.phpのOGP設定h5タグにid属性 `ogp_settings` を追加
- SiteManageTest.phpでCSSセレクター `#ogp_settings` を使用してスクロール対象を特定

### 修正理由
- `:contains()` 擬似クラスはCSS標準ではなく、Laravel Duskでサポートされていない
- テスト実行時に「invalid element state: Failed to execute 'querySelector'」エラーが発生していた
- idセレクターを使用することで確実で保守性の高いテストコードに改善

### テスト結果
- Duskテストが正常に動作することを確認済み

## レビュー完了希望日
本日中

## 関連PR/Issues
なし

## 参考情報
- Laravel Dusk公式ドキュメント
- Connect-CMS CLAUDE.md開発ガイドライン

## DB変更の有無
なし

## チェックリスト
- [x] コードスタイルチェック（phpcs）をパスしている
- [x] 既存のテストが動作することを確認している
- [x] 修正内容が要件を満たしている
- [x] セキュリティ上の問題がないことを確認している
- [x] Duskテストが正常に動作することを確認している