### PR TITLE
[ブログ] デザインベーステンプレートで年月絞り込み機能が表示されない問題を修正しました

### DIFF
--- a/resources/views/plugins/user/blogs/designbase/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs.blade.php
@@ -50,6 +50,10 @@
     {{-- 絞り込み機能 --}}
     @include('plugins.user.blogs.default.include_narrowing_down')
 </div>
+<div class="float-right ml-2">
+    {{-- 年月絞り込み機能 --}}
+    @include('plugins.user.blogs.default.include_narrowing_down_for_posted_month')
+</div>
 <div class="float-right">
     {{-- 投稿者絞り込み機能 --}}
     @include('plugins.user.blogs.default.include_narrowing_down_for_created_id')


### PR DESCRIPTION
## 概要
ブログプラグインのデザインベーステンプレートにおいて、年月絞り込み機能のUIが表示されない問題を修正しました。

### 問題
- ブログ一覧画面で「デザインベース」テンプレートを選択した場合、年月絞り込み機能が表示されない
- 通常テンプレート（default）では正常に表示されている
- バックエンド機能は実装済みだが、フロントエンドのUI部分が欠落していた

### 修正内容
`resources/views/plugins/user/blogs/designbase/blogs.blade.php` に以下を追加：
```php
<div class="float-right ml-2">
    {{-- 年月絞り込み機能 --}}
    @include('plugins.user.blogs.default.include_narrowing_down_for_posted_month')
</div>
```

### 確認事項
- デザインベーステンプレートで年月絞り込み機能が正常に表示されること
- 既存の絞り込み機能（カテゴリ、投稿者）に影響がないこと
- レイアウトが適切に表示されること

## レビュー完了希望日
特になし

## 関連PR/Issues
なし

## 参考情報
- 年月絞り込み機能は他のテンプレート（default、titleindex、sidetitleindex）では実装済み
- datefirstテンプレートでも同様の対応漏れがある可能性

## DB変更
なし

## チェックリスト
- [x] 修正内容の動作確認
- [x] 既存機能への影響確認
- [x] コーディング規約の遵守

🤖 Generated with [Claude Code](https://claude.ai/code)