### PR TITLE
[フォーム] 本登録後のメッセージを必須項目に設定しました

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -1651,6 +1651,9 @@ class FormsPlugin extends UserPluginBase
         $validator_values['forms_name'] = ['required'];
         $validator_attributes['forms_name'] = 'フォーム名';
 
+        $validator_values['after_message'] = ['required'];
+        $validator_attributes['after_message'] = '本登録後のメッセージ';
+
         $validator_values['entry_limit'] = ['nullable', 'numeric', 'min:0'];
         $validator_attributes['entry_limit'] = '登録制限数';
 

--- a/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
+++ b/resources/views/plugins/user/forms/default/forms_edit_form.blade.php
@@ -435,9 +435,10 @@
     </div>
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass()}}">本登録後のメッセージ</label>
+        <label class="{{$frame->getSettingLabelClass()}}">本登録後のメッセージ <span class="badge badge-danger">必須</span></label>
         <div class="{{$frame->getSettingInputClass()}}">
             <textarea name="after_message" class="form-control" rows=5 placeholder="（例）お申込みありがとうございます。&#13;&#10;受付番号は[[number]]になります。">{{old('after_message', $form->after_message)}}</textarea>
+            @include('plugins.common.errors_inline', ['name' => 'after_message'])
             <small class="text-muted">
                 ※ HTMLでも記述できます。<br />
                 ※ [[number]] を記述すると該当部分に採番した番号が入ります。（採番機能の使用時）


### PR DESCRIPTION
## 概要
フォーム設定画面において、「本登録後のメッセージ」フィールドを必須項目に変更しました。
これにより、フォーム作成時の設定漏れを防ぎ、ユーザーに適切な完了メッセージを表示することができます。

### 変更内容
- バリデーションルールに`after_message`の必須チェックを追加
- 設定画面のラベルに「必須」バッジを表示
- エラーメッセージの表示処理を追加

### 動作確認
- [x] フォーム新規作成時に「本登録後のメッセージ」未入力でバリデーションエラーが表示される
- [x] フォーム編集時に「本登録後のメッセージ」を空にしてバリデーションエラーが表示される
- [x] 「本登録後のメッセージ」入力時に正常に保存できる

## レビュー完了希望日
特になし

## 関連PR/Issues
なし

## 参考情報
なし

## DB変更
- [ ] あり
- [x] なし

## チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました
- [x] コードスタイルチェック（phpcs）を実行しました
- [x] 動作テストを実施しました