### PR TITLE
[キャビネット] フォルダ間の移動機能を追加しました

### DIFF
--- a/app/Plugins/User/Cabinets/CabinetsPlugin.php
+++ b/app/Plugins/User/Cabinets/CabinetsPlugin.php
@@ -620,6 +620,7 @@ class CabinetsPlugin extends UserPluginBase
         $cabinet = $this->getPluginBucket($this->frame->bucket_id);
         $destination = CabinetContent::find($request->destination_id);
 
+        $moved_count = 0;
         foreach ((array) $request->cabinet_content_id as $cabinet_content_id) {
             $node = CabinetContent::find($cabinet_content_id);
             if (empty($node)) {
@@ -629,10 +630,13 @@ class CabinetsPlugin extends UserPluginBase
             // 移動実施
             $node->parent_id = $destination->id;
             $node->save();
+            $moved_count++;
         }
 
-        // フレーム用フラッシュメッセージ
-        session()->flash("flash_message_for_frame{$frame_id}", '移動しました。');
+        // フレーム用フラッシュメッセージ（件数と移動先を案内）
+        $dest_name = e($destination->name);
+        $message = "選択した{$moved_count}件の項目を「{$dest_name}」へ移動しました。";
+        session()->flash("flash_message_for_frame{$frame_id}", $message);
 
         // リダイレクトはビューからの redirect_path を使用するため、ここでは指定しない
         return;

--- a/app/Rules/CabinetNoDuplicateNameInDestination.php
+++ b/app/Rules/CabinetNoDuplicateNameInDestination.php
@@ -45,4 +45,3 @@ class CabinetNoDuplicateNameInDestination implements Rule
         return $this->message ?: '移動先に同名があります。';
     }
 }
-

--- a/app/Rules/CabinetNoDuplicateNameInDestination.php
+++ b/app/Rules/CabinetNoDuplicateNameInDestination.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use App\Models\User\Cabinets\CabinetContent;
+
+class CabinetNoDuplicateNameInDestination implements Rule
+{
+    /** @var int|null */
+    private $destinationId;
+
+    /** @var string */
+    private $message = '';
+
+    public function __construct($destinationId)
+    {
+        $this->destinationId = $destinationId;
+    }
+
+    public function passes($attribute, $value)
+    {
+        if (empty($this->destinationId)) {
+            return true;
+        }
+        $node = CabinetContent::find($value);
+        $destination = CabinetContent::find($this->destinationId);
+        if (empty($node) || empty($destination)) {
+            return true;
+        }
+
+        $exists = CabinetContent::where('parent_id', $destination->id)
+            ->where('name', $node->name)
+            ->where('id', '!=', $node->id)
+            ->exists();
+        if ($exists) {
+            $this->message = '移動先に同名のアイテムが存在します。';
+            return false;
+        }
+        return true;
+    }
+
+    public function message()
+    {
+        return $this->message ?: '移動先に同名があります。';
+    }
+}
+

--- a/app/Rules/CabinetNotIntoDescendant.php
+++ b/app/Rules/CabinetNotIntoDescendant.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use App\Models\User\Cabinets\CabinetContent;
+
+class CabinetNotIntoDescendant implements Rule
+{
+    /** @var int|null */
+    private $destinationId;
+
+    /** @var string */
+    private $message = '';
+
+    public function __construct($destinationId)
+    {
+        $this->destinationId = $destinationId;
+    }
+
+    public function passes($attribute, $value)
+    {
+        // 宛先未指定や不正は他のルールで検出するため、ここではスキップ
+        if (empty($this->destinationId)) {
+            return true;
+        }
+        $node = CabinetContent::find($value);
+        $destination = CabinetContent::find($this->destinationId);
+        if (empty($node) || empty($destination)) {
+            return true;
+        }
+
+        // 自身および配下へは移動不可
+        $ngIds = CabinetContent::descendantsAndSelf($node->id)->pluck('id')->all();
+        if (in_array($destination->id, $ngIds, true)) {
+            $this->message = '自身または配下へは移動できません。';
+            return false;
+        }
+        return true;
+    }
+
+    public function message()
+    {
+        return $this->message ?: '不正な移動先です。';
+    }
+}
+

--- a/app/Rules/CabinetNotIntoDescendant.php
+++ b/app/Rules/CabinetNotIntoDescendant.php
@@ -44,4 +44,3 @@ class CabinetNotIntoDescendant implements Rule
         return $this->message ?: '不正な移動先です。';
     }
 }
-

--- a/app/Rules/CabinetSameCabinet.php
+++ b/app/Rules/CabinetSameCabinet.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use App\Models\User\Cabinets\CabinetContent;
+
+class CabinetSameCabinet implements Rule
+{
+    /** @var int */
+    private $expectedCabinetId;
+
+    /** @var string */
+    private $message = '';
+
+    public function __construct($expectedCabinetId)
+    {
+        $this->expectedCabinetId = $expectedCabinetId;
+    }
+
+    public function passes($attribute, $value)
+    {
+        $node = CabinetContent::find($value);
+        if (empty($node)) {
+            // 別ルール（exists）で捕捉される想定
+            $this->message = '移動対象が不正です。';
+            return false;
+        }
+
+        if ($node->cabinet_id != $this->expectedCabinetId) {
+            $this->message = '移動対象とキャビネットが一致しません。';
+            return false;
+        }
+        return true;
+    }
+
+    public function message()
+    {
+        return $this->message ?: '移動対象が不正です。';
+    }
+}

--- a/app/Rules/CabinetSameCabinet.php
+++ b/app/Rules/CabinetSameCabinet.php
@@ -8,14 +8,14 @@ use App\Models\User\Cabinets\CabinetContent;
 class CabinetSameCabinet implements Rule
 {
     /** @var int */
-    private $expectedCabinetId;
+    private $expected_cabinet_id;
 
     /** @var string */
     private $message = '';
 
-    public function __construct($expectedCabinetId)
+    public function __construct($expected_cabinet_id)
     {
-        $this->expectedCabinetId = $expectedCabinetId;
+        $this->expected_cabinet_id = $expected_cabinet_id;
     }
 
     public function passes($attribute, $value)
@@ -27,7 +27,7 @@ class CabinetSameCabinet implements Rule
             return false;
         }
 
-        if ($node->cabinet_id != $this->expectedCabinetId) {
+        if ($node->cabinet_id != $this->expected_cabinet_id) {
             $this->message = '移動対象とキャビネットが一致しません。';
             return false;
         }

--- a/app/Rules/CabinetValidDestinationFolder.php
+++ b/app/Rules/CabinetValidDestinationFolder.php
@@ -8,17 +8,17 @@ use App\Models\User\Cabinets\CabinetContent;
 class CabinetValidDestinationFolder implements Rule
 {
     /** @var int|null */
-    private $expectedCabinetId;
+    private $expected_cabinet_id;
 
     /** @var string */
     private $message = '';
 
     /**
-     * @param int|null $expectedCabinetId 同一であるべきキャビネットID
+     * @param int|null $expected_cabinet_id 同一であるべきキャビネットID
      */
-    public function __construct($expectedCabinetId)
+    public function __construct($expected_cabinet_id)
     {
-        $this->expectedCabinetId = $expectedCabinetId;
+        $this->expected_cabinet_id = $expected_cabinet_id;
     }
 
     /**
@@ -38,7 +38,7 @@ class CabinetValidDestinationFolder implements Rule
         }
 
         // キャビネット一致チェック
-        if ($this->expectedCabinetId !== null && $destination->cabinet_id != $this->expectedCabinetId) {
+        if ($this->expected_cabinet_id !== null && $destination->cabinet_id != $this->expected_cabinet_id) {
             $this->message = '移動先フォルダのキャビネットが一致しません。';
             return false;
         }

--- a/app/Rules/CabinetValidDestinationFolder.php
+++ b/app/Rules/CabinetValidDestinationFolder.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use App\Models\User\Cabinets\CabinetContent;
+
+class CabinetValidDestinationFolder implements Rule
+{
+    /** @var int|null */
+    private $expectedCabinetId;
+
+    /** @var string */
+    private $message = '';
+
+    /**
+     * @param int|null $expectedCabinetId 同一であるべきキャビネットID
+     */
+    public function __construct($expectedCabinetId)
+    {
+        $this->expectedCabinetId = $expectedCabinetId;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        // destination_id がフォルダか
+        $destination = CabinetContent::find($value);
+        if (empty($destination) || $destination->is_folder !== CabinetContent::is_folder_on) {
+            $this->message = '移動先フォルダが不正です。';
+            return false;
+        }
+
+        // キャビネット一致チェック
+        if ($this->expectedCabinetId !== null && $destination->cabinet_id != $this->expectedCabinetId) {
+            $this->message = '移動先フォルダのキャビネットが一致しません。';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return $this->message ?: '移動先が不正です。';
+    }
+}
+

--- a/app/Rules/CabinetValidDestinationFolder.php
+++ b/app/Rules/CabinetValidDestinationFolder.php
@@ -56,4 +56,3 @@ class CabinetValidDestinationFolder implements Rule
         return $this->message ?: '移動先が不正です。';
     }
 }
-

--- a/resources/views/plugins/user/cabinets/default/folder_options.blade.php
+++ b/resources/views/plugins/user/cabinets/default/folder_options.blade.php
@@ -1,0 +1,13 @@
+@php
+// $nodes: Illuminate\Support\Collection (toTree() した結果)
+// $depth: int インデントレベル
+// インデント記号
+$prefix = str_repeat('— ', $depth ?? 0);
+@endphp
+@foreach($nodes as $node)
+    <option value="{{$node->id}}">{{$prefix}}{{$node->name}}</option>
+    @if ($node->children && $node->children->count())
+        @include('plugins.user.cabinets.default.folder_options', ['nodes' => $node->children, 'depth' => ($depth ?? 0) + 1])
+    @endif
+@endforeach
+

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -93,7 +93,7 @@
 <div class="bg-light p-2 text-right">
     <span class="mr-2">チェックした項目を</span>
     @can('posts.update', [[null, $frame->plugin_name, $buckets]])
-    <button class="btn btn-secondary btn-sm btn-move" type="button" disabled><i class="fas fa-arrows-alt"></i><span class="d-none d-sm-inline"> 移動</span></button>
+    <button class="btn btn-secondary btn-sm btn-move" type="button" disabled><i class="fa-solid fa-folder-tree"></i><span class="d-none d-sm-inline"> 移動</span></button>
     @endcan
     @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
     <button class="btn btn-danger btn-sm btn-delete" type="button" data-toggle="modal" data-target="#delete-confirm{{$frame->id}}" disabled><i class="fas fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span></button>
@@ -196,7 +196,7 @@
 <div class="bg-light p-2 text-right">
     <span class="mr-2">チェックした項目を</span>
     @can('posts.update', [[null, $frame->plugin_name, $buckets]])
-    <button class="btn btn-secondary btn-sm btn-move" type="button" disabled><i class="fas fa-arrows-alt"></i><span class="d-none d-sm-inline"> 移動</span></button>
+    <button class="btn btn-secondary btn-sm btn-move" type="button" disabled><i class="fa-solid fa-folder-tree"></i><span class="d-none d-sm-inline"> 移動</span></button>
     @endcan
     @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
     <button class="btn btn-danger btn-sm btn-delete" type="button" data-toggle="modal" data-target="#delete-confirm{{$frame_id}}" disabled><i class="fas fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span></button>
@@ -310,7 +310,7 @@
                     <i class="mr-2"></i>
                     <span class="message-text"></span>
                 </div>
-                
+
                 <div class="form-group">
                     <label for="newItemName{{$frame_id}}">新しい名前</label>
                     <input type="text" class="form-control" id="newItemName{{$frame_id}}" v-model="newItemName" maxlength="100" @keyup.enter="!isRenameInProgress && confirmRename()" :disabled="isRenameInProgress">

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -78,18 +78,16 @@
 <input type="hidden" name="parent_id" value="{{$parent_id}}">
 @include('plugins.common.errors_inline', ['name' => 'cabinet_content_id'])
 @include('plugins.common.errors_inline', ['name' => 'destination_id'])
-@php
-    // cabinet_content_id.* のエラー（個別要素に紐づくバリデーション）も一覧の上でまとめて表示
-    if ($errors) {
-        foreach ($errors->getMessages() as $key => $messages) {
-            if (strpos($key, 'cabinet_content_id.') === 0) {
-                foreach ($messages as $msg) {
-                    echo '<div class="text-danger"><i class="fas fa-exclamation-triangle"></i> ' . e($msg) . '</div>';
-                }
-            }
-        }
-    }
-@endphp
+{{-- cabinet_content_id.* のエラー（個別要素に紐づくバリデーション）も一覧の上でまとめて表示 --}}
+@if ($errors)
+    @foreach ($errors->getMessages() as $key => $messages)
+        @if (strpos($key, 'cabinet_content_id.') === 0)
+            @foreach ($messages as $msg)
+                <div class="text-danger"><i class="fas fa-exclamation-triangle"></i> {{ $msg }}</div>
+            @endforeach
+        @endif
+    @endforeach
+@endif
 <div class="bg-light p-2 text-right">
     <span class="mr-2">チェックした項目を</span>
     @can('posts.update', [[null, $frame->plugin_name, $buckets]])

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -9,6 +9,7 @@
 
 @section("plugin_contents_$frame->id")
 <div id="app_{{$frame_id}}">
+@include('plugins.common.flash_message_for_frame')
 @can('posts.create', [[null, $frame->plugin_name, $buckets]])
 <div class="p-2 text-right mb-2">
     <button class="btn btn-primary" data-toggle="collapse" data-target="#collapse_mkdir{{$frame->id}}"><i class="fas fa-folder-plus"></i><span class="d-none d-sm-inline"> フォルダ作成</span></button>
@@ -76,6 +77,19 @@
 {{csrf_field()}}
 <input type="hidden" name="parent_id" value="{{$parent_id}}">
 @include('plugins.common.errors_inline', ['name' => 'cabinet_content_id'])
+@include('plugins.common.errors_inline', ['name' => 'destination_id'])
+@php
+    // cabinet_content_id.* のエラー（個別要素に紐づくバリデーション）も一覧の上でまとめて表示
+    if ($errors) {
+        foreach ($errors->getMessages() as $key => $messages) {
+            if (strpos($key, 'cabinet_content_id.') === 0) {
+                foreach ($messages as $msg) {
+                    echo '<div class="text-danger"><i class="fas fa-exclamation-triangle"></i> ' . e($msg) . '</div>';
+                }
+            }
+        }
+    }
+@endphp
 <div class="bg-light p-2 text-right">
     <span class="mr-2">チェックした項目を</span>
     @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
@@ -178,6 +192,9 @@
 </table>
 <div class="bg-light p-2 text-right">
     <span class="mr-2">チェックした項目を</span>
+    @can('posts.update', [[null, $frame->plugin_name, $buckets]])
+    <button class="btn btn-secondary btn-sm btn-move" type="button" disabled><i class="fas fa-arrows-alt"></i><span class="d-none d-sm-inline"> 移動</span></button>
+    @endcan
     @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
     <button class="btn btn-danger btn-sm btn-delete" type="button" data-toggle="modal" data-target="#delete-confirm{{$frame_id}}" disabled><i class="fas fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span></button>
     @endcan
@@ -216,6 +233,35 @@
         </div>
     </div>
 </div>
+@endcan
+
+@can('posts.update', [[null, $frame->plugin_name, $buckets]])
+{{-- 移動モーダル --}}
+<div class="modal" id="moveModal{{$frame_id}}" tabindex="-1" role="dialog" aria-labelledby="move-title" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="move-title">移動先フォルダの選択</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="move_destination_{{$frame_id}}">移動先</label>
+                    <select id="move_destination_{{$frame_id}}" class="form-control" name="destination_id">
+                        @include('plugins.user.cabinets.default.folder_options', ['nodes' => $folders_tree, 'depth' => 0])
+                    </select>
+                    @include('plugins.common.errors_inline', ['name' => 'destination_id'])
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">キャンセル</button>
+                <button type="button" class="btn btn-primary" id="btn-confirm-move-{{$frame_id}}" @click="confirmMove">移動</button>
+            </div>
+        </div>
+    </div>
+    </div>
 @endcan
 
 {{-- ケバブメニューモーダル for frame {{$frame_id}} --}}
@@ -550,6 +596,11 @@
                 if (deleteBtns) deleteBtns.forEach(delbtn => delbtn.disabled = !hasSelection);
                 @endcan
 
+                @can('posts.update', [[null, $frame->plugin_name, $buckets]])
+                const moveBtns = document.querySelectorAll('#app_{{$frame_id}} .btn-move');
+                if (moveBtns) moveBtns.forEach(mvbtn => mvbtn.disabled = !hasSelection);
+                @endcan
+
                 // 選択リストの更新
                 const selectedList = document.getElementById('selected-contents{{$frame_id}}');
                 if (selectedList) {
@@ -636,10 +687,72 @@
                 }
             }
             @endcan
+
+            @can('posts.update', [[null, $frame->plugin_name, $buckets]])
+            ,
+            /**
+             * 移動確定
+             */
+            confirmMove() {
+                const destSelect = document.getElementById('move_destination_{{$frame_id}}');
+                const destId = destSelect ? destSelect.value : '';
+                if (!destId) {
+                    alert('移動先フォルダを選択してください。');
+                    return;
+                }
+                const form = document.getElementById('form-cabinet-contents{{$frame_id}}');
+                form.action = '{{url('/')}}/redirect/plugin/cabinets/move/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}';
+                form.method = 'POST';
+
+                // redirect_path を設定
+                let redirectInput = form.querySelector('input[name="redirect_path"][data-for="move"]');
+                if (!redirectInput) {
+                    redirectInput = document.createElement('input');
+                    redirectInput.type = 'hidden';
+                    redirectInput.name = 'redirect_path';
+                    redirectInput.setAttribute('data-for', 'move');
+                    form.appendChild(redirectInput);
+                }
+                redirectInput.value = '{{url('/')}}/plugin/cabinets/changeDirectory/{{$page->id}}/{{$frame_id}}/{{$parent_id}}/#frame-{{$frame->id}}';
+
+                // destination_id を設定
+                let destInput = form.querySelector('input[name="destination_id"]');
+                if (!destInput) {
+                    destInput = document.createElement('input');
+                    destInput.type = 'hidden';
+                    destInput.name = 'destination_id';
+                    form.appendChild(destInput);
+                }
+                destInput.value = destId;
+
+                form.submit();
+            }
+            @endcan
         }
     });
 
     cabinetApp{{$frame_id}}.mount('#app_{{$frame_id}}');
+
+    // 非Vueイベント: 移動ボタンクリック、モーダル内ボタン
+    @can('posts.update', [[null, $frame->plugin_name, $buckets]])
+    (function() {
+        const appRoot = document.getElementById('app_{{$frame_id}}');
+        if (!appRoot) return;
+        const moveBtn = appRoot.querySelector('.btn-move');
+        if (moveBtn) {
+            moveBtn.addEventListener('click', () => {
+                const select = document.getElementById('move_destination_{{$frame_id}}');
+                if (select) {
+                    // 現在のディレクトリをデフォルト選択
+                    const currentId = '{{$parent_id}}';
+                    if (currentId) select.value = currentId;
+                }
+                $('#moveModal{{$frame_id}}').modal('show');
+            });
+        }
+        // confirm は Vue メソッドにバインド済み (@click="confirmMove")
+    })();
+    @endcan
 </script>
 
 

--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -92,6 +92,9 @@
 @endphp
 <div class="bg-light p-2 text-right">
     <span class="mr-2">チェックした項目を</span>
+    @can('posts.update', [[null, $frame->plugin_name, $buckets]])
+    <button class="btn btn-secondary btn-sm btn-move" type="button" disabled><i class="fas fa-arrows-alt"></i><span class="d-none d-sm-inline"> 移動</span></button>
+    @endcan
     @can('posts.delete', [[null, $frame->plugin_name, $buckets]])
     <button class="btn btn-danger btn-sm btn-delete" type="button" data-toggle="modal" data-target="#delete-confirm{{$frame->id}}" disabled><i class="fas fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span></button>
     @endcan
@@ -738,16 +741,18 @@
     (function() {
         const appRoot = document.getElementById('app_{{$frame_id}}');
         if (!appRoot) return;
-        const moveBtn = appRoot.querySelector('.btn-move');
-        if (moveBtn) {
-            moveBtn.addEventListener('click', () => {
-                const select = document.getElementById('move_destination_{{$frame_id}}');
-                if (select) {
-                    // 現在のディレクトリをデフォルト選択
-                    const currentId = '{{$parent_id}}';
-                    if (currentId) select.value = currentId;
-                }
-                $('#moveModal{{$frame_id}}').modal('show');
+        const moveBtnsTopBottom = document.querySelectorAll('#app_{{$frame_id}} .btn-move');
+        if (moveBtnsTopBottom && moveBtnsTopBottom.length) {
+            moveBtnsTopBottom.forEach((btn) => {
+                btn.addEventListener('click', () => {
+                    const select = document.getElementById('move_destination_{{$frame_id}}');
+                    if (select) {
+                        // 現在のディレクトリをデフォルト選択
+                        const currentId = '{{$parent_id}}';
+                        if (currentId) select.value = currentId;
+                    }
+                    $('#moveModal{{$frame_id}}').modal('show');
+                });
             });
         }
         // confirm は Vue メソッドにバインド済み (@click="confirmMove")

--- a/tests/Feature/Plugins/User/Cabinets/CabinetMoveFeatureTest.php
+++ b/tests/Feature/Plugins/User/Cabinets/CabinetMoveFeatureTest.php
@@ -1,0 +1,423 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Cabinets;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\Models\Common\Buckets;
+use App\Models\Common\Frame;
+use App\Models\Common\Page;
+use App\Models\User\Cabinets\Cabinet;
+use App\Models\User\Cabinets\CabinetContent;
+use App\Models\Core\UsersRoles;
+use App\User;
+
+class CabinetMoveFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Featureテスト概要
+     *
+     * - URL経由で CabinetsPlugin の move アクションにPOSTし、
+     *   リダイレクトやフラッシュメッセージ、セッションエラー内容を検証する。
+     * - 成功ケースと主要な失敗ケース（移動先がファイル／別キャビネット／自身・子孫／同名重複）をカバー。
+     */
+
+    /**
+     * 各テスト前のセットアップ
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // DB Seeder を実行して初期データ(configs等)を投入
+        $this->seed();
+    }
+
+    /**
+     * ルートキャビネットを持つページ、バケツ、フレーム、キャビネット、ルートフォルダを作成して返す。
+     *
+     * @return array [$page, $bucket, $frame, $cabinet, $root]
+     */
+    private function makeRootCabinetWithFrame(): array
+    {
+        // Page / Buckets / Frame / Cabinet 準備
+        $page = Page::factory()->create([
+            'permanent_link' => 'test',
+        ]);
+
+        $bucket = Buckets::factory()->create([
+            'bucket_name' => 'Test Cabinet',
+            'plugin_name' => 'cabinets',
+        ]);
+
+        $frame = Frame::factory()->create([
+            'page_id' => $page->id,
+            'frame_title' => 'CabinetFrame',
+            'plug_name' => 'cabinets',
+            'bucket_id' => $bucket->id,
+        ]);
+
+        $cabinet = Cabinet::create([
+            'bucket_id' => $bucket->id,
+            'name' => 'Test Cabinet',
+            'upload_max_size' => 1024,
+        ]);
+
+        // ルート
+        $root = CabinetContent::create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => $cabinet->name,
+            'is_folder' => CabinetContent::is_folder_on,
+            'parent_id' => null,
+        ]);
+
+        return [$page, $bucket, $frame, $cabinet, $root];
+    }
+
+    /**
+     * 正常系: ファイルをA→Bへ移動でき、件数と移動先名のフラッシュが出る。
+     *
+     * 前提:
+     * - 同一キャビネット内にフォルダA/BとA配下のファイルを用意
+     * - コンテンツ管理者権限のユーザーとしてPOST
+     * 検証:
+     * - 302リダイレクト（redirect_path）
+     * - 対象ファイルの親IDがBへ更新
+     * - フレーム用フラッシュメッセージに件数とBの名称を含む
+     */
+    public function testMoveFileToAnotherFolderSuccessAndFlashMessage()
+    {
+        [$page, $bucket, $frame, $cabinet, $root] = $this->makeRootCabinetWithFrame();
+
+        // フォルダA/B と A配下のファイル
+        $folderA = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'A',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+        $folderB = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'B',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+        $fileInA = $folderA->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => 1,
+            'name' => 'sample.txt',
+            'is_folder' => CabinetContent::is_folder_off,
+        ]);
+
+        // 権限のあるユーザー（コンテンツ管理者）を作成
+        $user = User::factory()->create();
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin',
+        ]);
+
+        // URL を叩く形式で移動実行
+        $url = "/redirect/plugin/cabinets/move/{$page->id}/{$frame->id}";
+        $redirect_path = "/plugin/cabinets/changeDirectory/{$page->id}/{$frame->id}/{$folderA->id}/#frame-{$frame->id}";
+        $post_data = [
+            'cabinet_content_id' => [$fileInA->id],
+            'destination_id' => $folderB->id,
+            'parent_id' => $folderA->id,
+            'redirect_path' => $redirect_path,
+        ];
+
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        // リダイレクト先
+        $response->assertStatus(302);
+        $response->assertRedirect($redirect_path);
+
+        // 検証: 親がBに変わる
+        $fileInA->refresh();
+        $this->assertEquals($folderB->id, $fileInA->parent_id);
+
+        // フラッシュメッセージが設定されている（件数と移動先名を含む）
+        $expected_message = "選択した1件の項目を「{$folderB->name}」へ移動しました。";
+        $response->assertSessionHas('flash_message_for_frame' . $frame->id, $expected_message);
+    }
+
+    /**
+     * 失敗系: 移動先にファイルを指定した場合はバリデーションエラー。
+     *
+     * 検証:
+     * - 302リダイレクト（redirect_path経由の戻り）
+     * - destination_id に『移動先フォルダが不正です。』が格納される
+     */
+    public function testMoveFailsWhenDestinationIsFile(): void
+    {
+        [$page, $bucket, $frame, $cabinet, $root] = $this->makeRootCabinetWithFrame();
+
+        $folderA = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'A',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+        $fileDest = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => 1,
+            'name' => 'not_folder.txt',
+            'is_folder' => CabinetContent::is_folder_off,
+        ]);
+        $fileInA = $folderA->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => 2,
+            'name' => 'sample.txt',
+            'is_folder' => CabinetContent::is_folder_off,
+        ]);
+
+        $user = User::factory()->create();
+        UsersRoles::factory()->create(['users_id' => $user->id, 'target' => 'base', 'role_name' => 'role_article_admin']);
+
+        $url = "/redirect/plugin/cabinets/move/{$page->id}/{$frame->id}";
+        $redirect_path = "/plugin/cabinets/changeDirectory/{$page->id}/{$frame->id}/{$folderA->id}/#frame-{$frame->id}";
+        $post_data = [
+            'cabinet_content_id' => [$fileInA->id],
+            'destination_id' => $fileDest->id, // ファイルを指定（不正）
+            'parent_id' => $folderA->id,
+            'redirect_path' => $redirect_path,
+        ];
+
+        $response = $this->actingAs($user)->post($url, $post_data);
+
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors(['destination_id' => '移動先フォルダが不正です。']);
+    }
+
+    /**
+     * 失敗系: 別キャビネットのフォルダを移動先にした場合はバリデーションエラー。
+     *
+     * 検証:
+     * - 302リダイレクト
+     * - destination_id に『移動先フォルダのキャビネットが一致しません。』
+     */
+    public function testMoveFailsWhenDestinationInDifferentCabinet(): void
+    {
+        [$page, $bucket, $frame, $cabinet, $root] = $this->makeRootCabinetWithFrame();
+
+        // 同一キャビネット側
+        $folderA = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'A',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+        $fileInA = $folderA->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => 1,
+            'name' => 'sample.txt',
+            'is_folder' => CabinetContent::is_folder_off,
+        ]);
+
+        // 別キャビネットを用意（同一ページ/フレームに紐づける必要はない）
+        $otherBucket = Buckets::factory()->create(['bucket_name' => 'Other', 'plugin_name' => 'cabinets']);
+        $otherCabinet = Cabinet::create(['bucket_id' => $otherBucket->id, 'name' => 'OtherCab', 'upload_max_size' => 0]);
+        $otherRoot = CabinetContent::create([
+            'cabinet_id' => $otherCabinet->id,
+            'upload_id' => null,
+            'name' => $otherCabinet->name,
+            'is_folder' => CabinetContent::is_folder_on,
+            'parent_id' => null,
+        ]);
+        $destInOther = $otherRoot->children()->create([
+            'cabinet_id' => $otherCabinet->id,
+            'upload_id' => null,
+            'name' => 'Dest',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+
+        $user = User::factory()->create();
+        UsersRoles::factory()->create(['users_id' => $user->id, 'target' => 'base', 'role_name' => 'role_article_admin']);
+
+        $url = "/redirect/plugin/cabinets/move/{$page->id}/{$frame->id}";
+        $redirect_path = "/plugin/cabinets/changeDirectory/{$page->id}/{$frame->id}/{$folderA->id}/#frame-{$frame->id}";
+        $post_data = [
+            'cabinet_content_id' => [$fileInA->id],
+            'destination_id' => $destInOther->id, // 別キャビネット
+            'parent_id' => $folderA->id,
+            'redirect_path' => $redirect_path,
+        ];
+
+        $response = $this->actingAs($user)->post($url, $post_data);
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors(['destination_id' => '移動先フォルダのキャビネットが一致しません。']);
+    }
+
+    /**
+     * 失敗系: 自身／子孫フォルダを移動先にした場合はバリデーションエラー。
+     *
+     * 検証:
+     * - cabinet_content_id.0 に『自身または配下へは移動できません。』
+     *   （子孫を指定したケース／自身を指定したケースの両方）
+     */
+    public function testMoveFailsWhenMovingIntoSelfOrDescendant(): void
+    {
+        [$page, $bucket, $frame, $cabinet, $root] = $this->makeRootCabinetWithFrame();
+
+        $folderA = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'A',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+        $child = $folderA->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'child',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+
+        $user = User::factory()->create();
+        UsersRoles::factory()->create(['users_id' => $user->id, 'target' => 'base', 'role_name' => 'role_article_admin']);
+
+        $url = "/redirect/plugin/cabinets/move/{$page->id}/{$frame->id}";
+        $redirect_path = "/plugin/cabinets/changeDirectory/{$page->id}/{$frame->id}/{$folderA->id}/#frame-{$frame->id}";
+
+        // 子孫へ（NG）
+        $response1 = $this->actingAs($user)->post($url, [
+            'cabinet_content_id' => [$folderA->id],
+            'destination_id' => $child->id,
+            'parent_id' => $root->id,
+            'redirect_path' => $redirect_path,
+        ]);
+        $response1->assertStatus(302);
+        $response1->assertSessionHasErrors(['cabinet_content_id.0' => '自身または配下へは移動できません。']);
+
+        // 自身へ（NG）
+        $response2 = $this->actingAs($user)->post($url, [
+            'cabinet_content_id' => [$folderA->id],
+            'destination_id' => $folderA->id,
+            'parent_id' => $root->id,
+            'redirect_path' => $redirect_path,
+        ]);
+        $response2->assertStatus(302);
+        $response2->assertSessionHasErrors(['cabinet_content_id.0' => '自身または配下へは移動できません。']);
+    }
+
+    /**
+     * 失敗系: 移動先に同名のアイテムが既に存在する場合はバリデーションエラー。
+     *
+     * 検証:
+     * - cabinet_content_id.0 に『移動先に同名のアイテムが存在します。』
+     */
+    public function testMoveFailsWhenDuplicateNameExistsInDestination(): void
+    {
+        [$page, $bucket, $frame, $cabinet, $root] = $this->makeRootCabinetWithFrame();
+
+        $folderA = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'A',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+        $folderB = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'B',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+        // B側に同名ファイルを先に用意
+        $folderB->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => 10,
+            'name' => 'dup.txt',
+            'is_folder' => CabinetContent::is_folder_off,
+        ]);
+        // A側から同名ファイルを移動しようとする
+        $fileInA = $folderA->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => 11,
+            'name' => 'dup.txt',
+            'is_folder' => CabinetContent::is_folder_off,
+        ]);
+
+        $user = User::factory()->create();
+        UsersRoles::factory()->create(['users_id' => $user->id, 'target' => 'base', 'role_name' => 'role_article_admin']);
+
+        $url = "/redirect/plugin/cabinets/move/{$page->id}/{$frame->id}";
+        $redirect_path = "/plugin/cabinets/changeDirectory/{$page->id}/{$frame->id}/{$folderA->id}/#frame-{$frame->id}";
+
+        $response = $this->actingAs($user)->post($url, [
+            'cabinet_content_id' => [$fileInA->id],
+            'destination_id' => $folderB->id,
+            'parent_id' => $folderA->id,
+            'redirect_path' => $redirect_path,
+        ]);
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors(['cabinet_content_id.0' => '移動先に同名のアイテムが存在します。']);
+    }
+
+    /**
+     * 正常系: 複数選択（ファイル＋フォルダ）を一度に移動できる。
+     *
+     * 検証:
+     * - 302リダイレクト
+     * - 選択した2件がともに移動先フォルダ配下になる
+     * - フレーム用フラッシュに「2件」と移動先名が含まれる
+     */
+    public function testMoveMultipleItemsSuccess(): void
+    {
+        [$page, $bucket, $frame, $cabinet, $root] = $this->makeRootCabinetWithFrame();
+
+        // A, B フォルダと A配下の ファイル＋サブフォルダ を用意
+        $folderA = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'A',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+        $folderB = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'B',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+        $file1 = $folderA->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => 21,
+            'name' => 'multi1.txt',
+            'is_folder' => CabinetContent::is_folder_off,
+        ]);
+        $subFolder = $folderA->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => 'SubA',
+            'is_folder' => CabinetContent::is_folder_on,
+        ]);
+
+        // 権限ユーザー
+        $user = User::factory()->create();
+        UsersRoles::factory()->create(['users_id' => $user->id, 'target' => 'base', 'role_name' => 'role_article_admin']);
+
+        $url = "/redirect/plugin/cabinets/move/{$page->id}/{$frame->id}";
+        $redirect_path = "/plugin/cabinets/changeDirectory/{$page->id}/{$frame->id}/{$folderA->id}/#frame-{$frame->id}";
+
+        $response = $this->actingAs($user)->post($url, [
+            'cabinet_content_id' => [$file1->id, $subFolder->id],
+            'destination_id' => $folderB->id,
+            'parent_id' => $folderA->id,
+            'redirect_path' => $redirect_path,
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertRedirect($redirect_path);
+
+        $file1->refresh();
+        $subFolder->refresh();
+        $this->assertEquals($folderB->id, $file1->parent_id);
+        $this->assertEquals($folderB->id, $subFolder->parent_id);
+
+        $expected = "選択した2件の項目を「{$folderB->name}」へ移動しました。";
+        $response->assertSessionHas('flash_message_for_frame' . $frame->id, $expected);
+    }
+}

--- a/tests/Unit/Plugins/User/Cabinets/CabinetMoveValidationTest.php
+++ b/tests/Unit/Plugins/User/Cabinets/CabinetMoveValidationTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Cabinets;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\Models\User\Cabinets\CabinetContent;
+use App\Rules\CabinetValidDestinationFolder;
+use App\Rules\CabinetSameCabinet;
+use App\Rules\CabinetNotIntoDescendant;
+use App\Rules\CabinetNoDuplicateNameInDestination;
+
+/**
+ * Cabinet 移動バリデーション用ルールの単体テスト。
+ *
+ * 対象ルール:
+ * - CabinetValidDestinationFolder: 移動先が存在するフォルダで、同一キャビネット内であること
+ * - CabinetSameCabinet: 移動対象が指定キャビネットに属していること
+ * - CabinetNotIntoDescendant: 自身やその子孫フォルダを移動先にしないこと
+ * - CabinetNoDuplicateNameInDestination: 移動先に同名の項目が存在しないこと
+ *
+ * それぞれのルールについて、通過/失敗ケースを最小構成のツリーで検証する。
+ */
+class CabinetMoveValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * フォルダ作成ヘルパー。親未指定時はルートとして作成する。
+     */
+    private function makeFolder(int $cabinetId, string $name, ?CabinetContent $parent = null): CabinetContent
+    {
+        $data = [
+            'cabinet_id' => $cabinetId,
+            'upload_id'  => null,
+            'name'       => $name,
+            'is_folder'  => CabinetContent::is_folder_on,
+        ];
+        if ($parent) {
+            return $parent->children()->create($data);
+        }
+        return CabinetContent::create($data);
+    }
+
+    /**
+     * ファイル作成ヘルパー。upload_id はダミー値を設定する。
+     */
+    private function makeFile(int $cabinetId, string $name, CabinetContent $parent): CabinetContent
+    {
+        return $parent->children()->create([
+            'cabinet_id' => $cabinetId,
+            'upload_id'  => 1, // dummy upload id
+            'name'       => $name,
+            'is_folder'  => CabinetContent::is_folder_off,
+        ]);
+    }
+
+    /**
+     * 同一キャビネット内のフォルダを移動先に指定した場合は通過する。
+     */
+    public function testCabinetValidDestinationFolderPassesForFolderInSameCabinet()
+    {
+        $root = $this->makeFolder(1, 'root');
+        $dest = $this->makeFolder(1, 'dest', $root);
+
+        $rule = new CabinetValidDestinationFolder(1);
+        $this->assertTrue($rule->passes('destination_id', $dest->id));
+    }
+
+    /**
+     * 移動先がフォルダでない（ファイル）場合は失敗する。
+     */
+    public function testCabinetValidDestinationFolderFailsIfNotFolder()
+    {
+        $root = $this->makeFolder(1, 'root');
+        $file = $this->makeFile(1, 'file.txt', $root);
+
+        $rule = new CabinetValidDestinationFolder(1);
+        $this->assertFalse($rule->passes('destination_id', $file->id));
+    }
+
+    /**
+     * 別キャビネットのフォルダを移動先に指定した場合は失敗する。
+     */
+    public function testCabinetValidDestinationFolderFailsIfDifferentCabinet()
+    {
+        $root1 = $this->makeFolder(1, 'root1');
+        $root2 = $this->makeFolder(2, 'root2');
+        $destInOther = $this->makeFolder(2, 'dest', $root2);
+
+        $rule = new CabinetValidDestinationFolder(1);
+        $this->assertFalse($rule->passes('destination_id', $destInOther->id));
+    }
+
+    /**
+     * 移動対象が指定されたキャビネットに属していれば通過する。
+     */
+    public function testCabinetSameCabinetPasses()
+    {
+        $root = $this->makeFolder(1, 'root');
+        $folder = $this->makeFolder(1, 'a', $root);
+
+        $rule = new CabinetSameCabinet(1);
+        $this->assertTrue($rule->passes('cabinet_content_id', $folder->id));
+    }
+
+    /**
+     * 移動対象が別キャビネットに属している場合は失敗する。
+     */
+    public function testCabinetSameCabinetFails()
+    {
+        $root = $this->makeFolder(2, 'root');
+        $folder = $this->makeFolder(2, 'a', $root);
+
+        $rule = new CabinetSameCabinet(1);
+        $this->assertFalse($rule->passes('cabinet_content_id', $folder->id));
+    }
+
+    /**
+     * 自身の子孫フォルダを移動先に指定した場合は失敗する。
+     */
+    public function testCabinetNotIntoDescendantFailsForDescendant()
+    {
+        $root = $this->makeFolder(1, 'root');
+        $parent = $this->makeFolder(1, 'parent', $root);
+        $child = $this->makeFolder(1, 'child', $parent);
+
+        $rule = new CabinetNotIntoDescendant($child->id);
+        $this->assertFalse($rule->passes('cabinet_content_id', $parent->id));
+    }
+
+    /**
+     * 自身を移動先に指定した場合は失敗する。
+     */
+    public function testCabinetNotIntoDescendantFailsForSelf()
+    {
+        $root = $this->makeFolder(1, 'root');
+        $folder = $this->makeFolder(1, 'folder', $root);
+
+        // 自身を移動先に指定した場合もNG
+        $rule = new CabinetNotIntoDescendant($folder->id);
+        $this->assertFalse($rule->passes('cabinet_content_id', $folder->id));
+    }
+
+    /**
+     * 兄弟フォルダ間の移動であれば通過する。
+     */
+    public function testCabinetNotIntoDescendantPassesForSibling()
+    {
+        $root = $this->makeFolder(1, 'root');
+        $a = $this->makeFolder(1, 'a', $root);
+        $b = $this->makeFolder(1, 'b', $root);
+
+        $rule = new CabinetNotIntoDescendant($b->id);
+        $this->assertTrue($rule->passes('cabinet_content_id', $a->id));
+    }
+
+    /**
+     * 移動先に同名のフォルダが既に存在する場合は失敗する。
+     */
+    public function testCabinetNoDuplicateNameInDestinationFailsWhenDuplicate()
+    {
+        $root = $this->makeFolder(1, 'root');
+        $dest = $this->makeFolder(1, 'dest', $root);
+        // duplicate exists in destination
+        $this->makeFolder(1, 'same', $dest);
+        $node = $this->makeFolder(1, 'same', $root);
+
+        $rule = new CabinetNoDuplicateNameInDestination($dest->id);
+        $this->assertFalse($rule->passes('cabinet_content_id', $node->id));
+    }
+
+    /**
+     * 移動先に同名の項目が存在しなければ通過する。
+     */
+    public function testCabinetNoDuplicateNameInDestinationPassesWhenUnique()
+    {
+        $root = $this->makeFolder(1, 'root');
+        $dest = $this->makeFolder(1, 'dest', $root);
+        $node = $this->makeFolder(1, 'unique', $root);
+
+        $rule = new CabinetNoDuplicateNameInDestination($dest->id);
+        $this->assertTrue($rule->passes('cabinet_content_id', $node->id));
+    }
+
+    /**
+     * 移動先に同名のファイルが存在する場合は失敗する。
+     */
+    public function testCabinetNoDuplicateNameInDestinationFailsWhenDuplicateFileName()
+    {
+        $root = $this->makeFolder(1, 'root');
+        $dest = $this->makeFolder(1, 'dest', $root);
+        // 既に同名ファイルが存在
+        $this->makeFile(1, 'same.txt', $dest);
+        // 移動対象（ファイル）
+        $file = $this->makeFile(1, 'same.txt', $root);
+
+        $rule = new CabinetNoDuplicateNameInDestination($dest->id);
+        $this->assertFalse($rule->passes('cabinet_content_id', $file->id));
+    }
+}


### PR DESCRIPTION
# 概要
キャビネットのフォルダ間移動機能を追加しました（複数選択対応）。

- UI: 一覧のアクションバーに「移動」ボタン追加、移動先選択モーダル、フォルダツリーの再帰セレクト
- API: `move` アクションを追加し、権限（`posts.update`）とフレーム内フラッシュ表示に対応
- バリデーション: ルール化して整理
  - `CabinetValidDestinationFolder`: 移動先がフォルダであること／同一キャビネットであること
  - `CabinetSameCabinet`: 各移動対象が同一キャビネットであること
  - `CabinetNotIntoDescendant`: 自身／配下への移動を禁止
  - `CabinetNoDuplicateNameInDestination`: 移動先での同名重複を禁止
- リダイレクト: `redirect_path` はビュー側で指定、コントローラでは指定しない方針に統一

## 画面キャプチャ

- 移動ボタンを追加
<img width="500" height="684" alt="image" src="https://github.com/user-attachments/assets/fa0be308-4cd2-4858-b57d-7a70fa116613" />

- 移動先選択ダイアログ
<img width="500" height="397" alt="image" src="https://github.com/user-attachments/assets/6a03a39b-8d66-4bf9-b98a-82c2c259b1d8" />


# レビュー完了希望日
特になし（通常レビューで問題ありません）。

# 関連Pull requests/Issues
- #2262 fix(cabinets): cabinet_id 誤設定の修正＋既存データ修復マイグレーション

# 参考
（なし）

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

