### PR TITLE
[コア] 例外レンダリング時のnull参照を防止しました

### DIFF
--- a/app/Models/Core/Configs.php
+++ b/app/Models/Core/Configs.php
@@ -162,6 +162,10 @@ class Configs extends Model
 
         // Configs. app\Http\Middleware\ConnectInit.php でセットした全Configs
         $configs = $request->attributes->get('configs');
+        // 例外経路などでミドルウェア未実行の場合にnullのままになるため、空コレクションでフォールバック
+        if (is_null($configs)) {
+            $configs = collect();
+        }
         // dd($request->attributes->get('configs'));
 
         if ($format == 'array') {


### PR DESCRIPTION
# 概要
例外経路（例: /index.php%3F などの変則URL）で `ConnectInit` ミドルウェアが未実行のままエラービュー描画に進む場合があり、その際にレイアウトから呼ばれる `UploadController::getSiteCssTimestamp()` → `Configs::getSharedConfigs()` が `null` を返し、`firstWhere()` 実行時に「Call to a member function firstWhere() on null」で 500 となっていました。

対策として、`Configs::getSharedConfigs()` が `null` を返す状況では `collect()`（空コレクション）でフォールバックするようにし、例外レンダリング時の null 参照を防止しました。正常系の挙動に影響はありません。

変更内容:
- app/Models/Core/Configs.php
  - `getSharedConfigs()` に null ガードを追加し、`$request->attributes['configs']` が未設定の場合は `collect()` を返却

# レビュー完了希望日
軽微な修正のため急ぎません。ご都合の良いタイミングでご確認ください。

# 関連Pull requests/Issues
なし

# 参考
- エラー発生箇所（ログより）:
  - app/Http/Controllers/Core/UploadController.php: getSiteCssTimestamp() → getConfigsMaxUpdatedAt()
  - resources/views/layouts/app.blade.php: サイトCSSリンクの `?version=` 生成で `UploadController::getSiteCssTimestamp()` 呼び出し
- ミドルウェア設定:
  - app/Http/Middleware/ConnectInit.php（configs を request attributes に設定）

# DB変更の有無
無し

# チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
