### PR TITLE
[メニュー] モデレータがメニューを編集できるようにしました

### DIFF
--- a/app/Enums/MenuFrameConfig.php
+++ b/app/Enums/MenuFrameConfig.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * メニューのフレーム設定項目
+ */
+final class MenuFrameConfig extends EnumsBase
+{
+    // 定数メンバ
+    const menu_allow_moderator_edit = 'menu_allow_moderator_edit';
+
+    // key/valueの連想配列
+    const enum = [
+        self::menu_allow_moderator_edit => 'モデレータ編集許可',
+    ];
+}

--- a/app/Plugins/User/Menus/MenusPlugin.php
+++ b/app/Plugins/User/Menus/MenusPlugin.php
@@ -2,10 +2,12 @@
 
 namespace App\Plugins\User\Menus;
 
+use App\Enums\MenuFrameConfig;
 use Illuminate\Support\Facades\Log;
 
 use App\Models\Common\Page;
 use App\Models\Common\PageRole;
+use App\Models\Core\FrameConfig;
 use App\Models\User\Menus\Menu;
 
 use App\Plugins\User\UserPluginBase;
@@ -43,8 +45,14 @@ class MenusPlugin extends UserPluginBase
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
         $functions = array();
-        $functions['get']  = ['select'];
-        $functions['post'] = ['saveSelect'];
+        $functions['get']  = [
+            'select',
+            'editFrameRoles'
+        ];
+        $functions['post'] = [
+            'saveSelect',
+            'saveFrameRoles'
+        ];
         return $functions;
     }
 
@@ -55,11 +63,12 @@ class MenusPlugin extends UserPluginBase
     {
         // 標準権限以外で設定画面などから呼ばれる権限の定義
         // 標準権限は右記で定義 config/cc_role.php
-        //
-        // 権限チェックテーブル
+
+        // selectとsaveSelectはアクション内で権限チェックを行う
+        // →プラグイン管理者とモデレータの組み合わせで権限を付与する、特殊な組み合わせなため
         $role_check_table = [];
-        $role_check_table["select"]            = ['frames.edit'];
-        $role_check_table["saveSelect"]        = ['frames.create'];
+        $role_check_table["editFrameRoles"] = ['frames.edit'];
+        $role_check_table["saveFrameRoles"] = ['frames.create'];
 
         return $role_check_table;
     }
@@ -120,6 +129,7 @@ class MenusPlugin extends UserPluginBase
             'current_page' => $this->page,
             'menu'         => $menu,
             'page_roles'   => $page_roles,
+            'can_edit_menu' => $this->canEditMenu(),
             // 'ancestors_page_roles' => $ancestors_page_roles,
             // 'page'      => $this->page,
         ]);
@@ -134,6 +144,11 @@ class MenusPlugin extends UserPluginBase
      */
     public function select($request, $page_id, $frame_id)
     {
+        // 権限チェック
+        if (!$this->canEditMenu()) {
+            return $this->viewError('403_inframe', '権限がありません。');
+        }
+
         // ページデータ＆深さを全て取得
         // 表示順は入れ子集合モデルの順番
         $format = null;
@@ -160,6 +175,11 @@ class MenusPlugin extends UserPluginBase
      */
     public function saveSelect($request, $page_id, $frame_id)
     {
+        // 権限チェック
+        if (!$this->canEditMenu()) {
+            return $this->viewError('403_inframe', '権限がありません。');
+        }
+
         // メニューデータ作成 or 更新
         Menu::updateOrCreate(
             ['frame_id'          => $frame_id],
@@ -175,5 +195,56 @@ class MenusPlugin extends UserPluginBase
 
         // 画面へ
         return $this->select($request, $page_id, $frame_id);
+    }
+
+    /**
+     * 権限設定 変更画面
+     * メニューは、バケツを持たないので、editBucketsRoles は利用しない。
+     *
+     */
+    public function editFrameRoles($request, $page_id, $frame_id, $id = null, $use_approval = true)
+    {
+        return $this->view('menus_edit_roles', [
+            'frame_configs' => $this->frame_configs,
+        ]);
+    }
+
+    /**
+     * 権限設定 保存処理
+     * メニューは、バケツを持たないので、saveBucketsRoles は利用しない。
+     */
+    public function saveFrameRoles($request, $page_id, $frame_id, $id = null, $use_approval = true)
+    {
+        FrameConfig::saveFrameConfigs(
+            $request,
+            $frame_id,
+            MenuFrameConfig::getMemberKeys()
+        );
+
+        session()->flash("flash_message_for_frame{$frame_id}", '更新しました。');
+    }
+
+    /**
+     * モデレータ編集許可設定の取得
+     */
+    private function isModeratorEditAllowed(): bool
+    {
+        return (bool) FrameConfig::getConfigValue($this->frame_configs, MenuFrameConfig::menu_allow_moderator_edit, 0);
+    }
+
+    /**
+     * メニュー編集権限の判定
+     */
+    private function canEditMenu(): bool
+    {
+        if ($this->isCan('frames.edit', null, null, null, $this->frame)) {
+            return true;
+        }
+
+        if ($this->isModeratorEditAllowed() && $this->isCan('role_article')) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/app/Plugins/User/Menus/MenusPlugin.php
+++ b/app/Plugins/User/Menus/MenusPlugin.php
@@ -167,6 +167,7 @@ class MenusPlugin extends UserPluginBase
             'current_pages' => $this->page,
             'frame'         => $this->frame,
             'menu'          => $menu,
+            'can_use_setting_menu' => $this->isCan('frames.edit', null, null, null, $this->frame),
         ]);
     }
 

--- a/config/app.php
+++ b/config/app.php
@@ -335,6 +335,7 @@ $app_array = [
         'FormAccessLimitType' => \App\Enums\FormAccessLimitType::class,
         'EditType' => \App\Enums\EditType::class,
         'SmartphoneMenuTemplateType' => \App\Enums\SmartphoneMenuTemplateType::class,
+        'MenuFrameConfig' => \App\Enums\MenuFrameConfig::class,
 
         // utils
         'DateUtils' => \App\Utilities\Date\DateUtils::class,

--- a/resources/views/plugins/user/menus/ancestor_descendant_sibling/menus.blade.php
+++ b/resources/views/plugins/user/menus/ancestor_descendant_sibling/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 <div class="list-group mb-0" role="navigation" aria-label="メニュー">
 

--- a/resources/views/plugins/user/menus/breadcrumbs/menus.blade.php
+++ b/resources/views/plugins/user/menus/breadcrumbs/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($ancestors_breadcrumbs)
     <nav aria-label="パンくずリスト">
         <ol class="breadcrumb">

--- a/resources/views/plugins/user/menus/common/edit_button.blade.php
+++ b/resources/views/plugins/user/menus/common/edit_button.blade.php
@@ -1,0 +1,14 @@
+{{--
+ * メニュー編集ボタン
+ *
+ * モデレータまたは管理者に対して、設定メニュー外に編集ボタンを表示する。
+ *
+ * @category メニュープラグイン
+ --}}
+@if ($can_edit_menu)
+    <div class="text-right mb-2 menu-edit-button">
+        <a href="{{ url('/') }}/plugin/menus/select/{{ $page->id }}/{{ $frame->id }}#frame-{{ $frame->id }}" class="btn btn-sm btn-outline-success">
+            <i class="fas fa-edit"></i> メニューを編集
+        </a>
+    </div>
+@endif

--- a/resources/views/plugins/user/menus/default/menus.blade.php
+++ b/resources/views/plugins/user/menus/default/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 
     <div class="list-group mb-0" role="navigation" aria-label="メニュー">

--- a/resources/views/plugins/user/menus/default/menus_edit_roles.blade.php
+++ b/resources/views/plugins/user/menus/default/menus_edit_roles.blade.php
@@ -1,0 +1,37 @@
+{{--
+ * メニュー権限設定画面
+ *
+ * @category メニュープラグイン
+ --}}
+@extends('core.cms_frame_base_setting')
+
+@section("core.cms_frame_edit_tab_$frame->id")
+    @include('plugins.user.menus.menus_frame_edit_tab')
+@endsection
+
+@section("plugin_setting_$frame->id")
+@include('plugins.common.flash_message_for_frame')
+
+@php
+    $allow_moderator_edit = (bool) FrameConfig::getConfigValue($frame_configs, MenuFrameConfig::menu_allow_moderator_edit, 0);
+@endphp
+
+<form action="{{ url('/') }}/redirect/plugin/menus/saveFrameRoles/{{ $page->id }}/{{ $frame_id }}#frame-{{ $frame->id }}" method="POST" class="mt-3">
+    {{ csrf_field() }}
+    <input type="hidden" name="redirect_path" value="{{ url('/') }}/plugin/menus/editFrameRoles/{{ $page->id }}/{{ $frame_id }}#frame-{{ $frame->id }}">
+
+    <div class="form-group">
+        <div class="custom-control custom-checkbox">
+            <input type="hidden" name="{{MenuFrameConfig::menu_allow_moderator_edit}}" value="0">
+            <input type="checkbox" class="custom-control-input" id="{{MenuFrameConfig::menu_allow_moderator_edit}}" name="{{MenuFrameConfig::menu_allow_moderator_edit}}" value="1" @if ($allow_moderator_edit) checked @endif>
+            <label class="custom-control-label" for="{{MenuFrameConfig::menu_allow_moderator_edit}}">モデレータにメニュー項目の編集を許可する</label>
+        </div>
+        <small class="form-text text-muted">有効にすると、モデレータおよびプラグイン管理者にメニューの編集ボタンが表示されます。</small>
+    </div>
+
+    <div class="form-group text-center">
+        <button type="button" class="btn btn-secondary mr-2" onclick="location.href='{{URL::to($page->permanent_link)}}#frame-{{$frame->id}}'"><i class="fas fa-times"></i><span class="d-none d-md-inline"> キャンセル</span></button>
+        <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i> 更新</button>
+    </div>
+</form>
+@endsection

--- a/resources/views/plugins/user/menus/default/menus_select.blade.php
+++ b/resources/views/plugins/user/menus/default/menus_select.blade.php
@@ -5,14 +5,8 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category メニュープラグイン
  --}}
-@extends('core.cms_frame_base_setting')
-
-@section("core.cms_frame_edit_tab_$frame->id")
-    {{-- プラグイン側のフレームメニュー --}}
-    @include('plugins.user.menus.menus_frame_edit_tab')
-@endsection
-
-@section("plugin_setting_$frame->id")
+@extends('core.cms_frame_base')
+@section("plugin_contents_$frame->id")
 <form action="{{url('/')}}/plugin/menus/saveSelect/{{$page->id}}/{{$frame->frame_id}}#frame-{{$frame->id}}" name="contents_buckets_form" method="POST" class="mt-3">
     {{ csrf_field() }}
 

--- a/resources/views/plugins/user/menus/default/menus_select.blade.php
+++ b/resources/views/plugins/user/menus/default/menus_select.blade.php
@@ -5,8 +5,21 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category メニュープラグイン
  --}}
-@extends('core.cms_frame_base')
-@section("plugin_contents_$frame->id")
+@php
+    $can_use_setting_menu = $can_use_setting_menu ?? false;
+    $layout = $can_use_setting_menu ? 'core.cms_frame_base_setting' : 'core.cms_frame_base';
+    $section = $can_use_setting_menu ? "plugin_setting_{$frame->id}" : "plugin_contents_{$frame->id}";
+@endphp
+
+@extends($layout)
+
+@if ($can_use_setting_menu)
+    @section("core.cms_frame_edit_tab_$frame->id")
+        @include('plugins.user.menus.menus_frame_edit_tab')
+    @endsection
+@endif
+
+@section($section)
 <form action="{{url('/')}}/plugin/menus/saveSelect/{{$page->id}}/{{$frame->frame_id}}#frame-{{$frame->id}}" name="contents_buckets_form" method="POST" class="mt-3">
     {{ csrf_field() }}
 

--- a/resources/views/plugins/user/menus/dropdown/menus.blade.php
+++ b/resources/views/plugins/user/menus/dropdown/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
     <nav aria-label="タブメニュー">
     <ul class="nav nav-tabs nav-justified d-none d-md-flex">

--- a/resources/views/plugins/user/menus/dropdown_hamburger/menus.blade.php
+++ b/resources/views/plugins/user/menus/dropdown_hamburger/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 
 {{-- スマホのときだけ表示させる --}}

--- a/resources/views/plugins/user/menus/footersitemap/menus.blade.php
+++ b/resources/views/plugins/user/menus/footersitemap/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 <div class="footersitemap" role="navigation" aria-label="サイトマップ">
     <ul class="nav nav-justified">

--- a/resources/views/plugins/user/menus/footersitemap_no_rootrink/menus.blade.php
+++ b/resources/views/plugins/user/menus/footersitemap_no_rootrink/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 <div class="footersitemap" role="navigation" aria-label="サイトマップ">
     <ul class="nav nav-justified">

--- a/resources/views/plugins/user/menus/hamburger/menus.blade.php
+++ b/resources/views/plugins/user/menus/hamburger/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 {{-- スマホのときだけ表示させる --}}
 <div class="hamburger-menu d-md-none">

--- a/resources/views/plugins/user/menus/hamburger_button/menus.blade.php
+++ b/resources/views/plugins/user/menus/hamburger_button/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 
 {{-- ハンバーガーメニュー用script&CSS読み込み --}}

--- a/resources/views/plugins/user/menus/menus_frame_edit_tab.blade.php
+++ b/resources/views/plugins/user/menus/menus_frame_edit_tab.blade.php
@@ -14,3 +14,13 @@
         <a href="{{url('/')}}/plugin/menus/select/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">ページ選択</a>
     </li>
 @endif
+
+@if ($action == 'editFrameRoles' || $action == 'saveFrameRoles')
+    <li role="presentation" class="nav-item">
+        <span class="nav-link"><span class="active">権限設定</span></span>
+    </li>
+@else
+    <li role="presentation" class="nav-item">
+        <a href="{{url('/')}}/plugin/menus/editFrameRoles/{{$page->id}}/{{$frame->id}}#frame-{{$frame->id}}" class="nav-link">権限設定</a>
+    </li>
+@endif

--- a/resources/views/plugins/user/menus/mouseover_dropdown/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
     <nav aria-label="タブメニュー">
     <ul class="nav nav-tabs nav-justified d-none d-md-flex">

--- a/resources/views/plugins/user/menus/mouseover_dropdown_hamburger/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_hamburger/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 
 {{-- スマホのときだけ表示させる --}}

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
     <nav aria-label="タブメニュー">
     <ul class="nav nav-tabs nav-justified d-none d-md-flex">

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_design/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_design/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
     <nav aria-label="タブメニュー">
     <ul class="nav nav-tabs nav-justified d-none d-md-flex">

--- a/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
+++ b/resources/views/plugins/user/menus/mouseover_dropdown_no_rootlink_for_icon/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
     <nav aria-label="アイコンメニュー">
     <ul class="nav nav-justified d-none d-md-flex">

--- a/resources/views/plugins/user/menus/opencurrenttree/menus.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
     <div class="list-group mb-0" role="navigation" aria-label="メニュー">
         @include('plugins.user.menus.opencurrenttree.menu_parent')

--- a/resources/views/plugins/user/menus/opencurrenttree_for_design/menus.blade.php
+++ b/resources/views/plugins/user/menus/opencurrenttree_for_design/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 
     <div class="list-group mb-0" role="navigation" aria-label="メニュー">

--- a/resources/views/plugins/user/menus/parentsandchild/menus.blade.php
+++ b/resources/views/plugins/user/menus/parentsandchild/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 <div class="list-group mb-0" role="navigation" aria-label="メニュー">
     @foreach($pages as $key => $page)

--- a/resources/views/plugins/user/menus/sitemap/menus.blade.php
+++ b/resources/views/plugins/user/menus/sitemap/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 <nav aria-label="サイトマップ">
 

--- a/resources/views/plugins/user/menus/sitemap_no_rootlink/menus.blade.php
+++ b/resources/views/plugins/user/menus/sitemap_no_rootlink/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 <nav aria-label="サイトマップ">
 

--- a/resources/views/plugins/user/menus/tab/menus.blade.php
+++ b/resources/views/plugins/user/menus/tab/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 
 <nav aria-label="タブメニュー">

--- a/resources/views/plugins/user/menus/tab_flat/menus.blade.php
+++ b/resources/views/plugins/user/menus/tab_flat/menus.blade.php
@@ -9,6 +9,7 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
+@include('plugins.user.menus.common.edit_button')
 @if ($pages)
 
     @php $active_page_id = \App\Models\Common\Page::getTabFlatActivePageId($pages, $ancestors, $page_roles); @endphp

--- a/tests/Feature/Plugins/User/Menus/MenusModeratorEditFeatureTest.php
+++ b/tests/Feature/Plugins/User/Menus/MenusModeratorEditFeatureTest.php
@@ -149,6 +149,7 @@ class MenusModeratorEditFeatureTest extends TestCase
         $response->assertStatus(200);
         // ページ選択の画面が表示されることを確認
         $response->assertSee('ページの表示');
+        $response->assertDontSee('設定メニュー');
 
         $payload = [
             'select_flag' => 1,
@@ -182,6 +183,7 @@ class MenusModeratorEditFeatureTest extends TestCase
         $response->assertStatus(200);
         // ページ選択の画面が表示されることを確認
         $response->assertSee('ページの表示');
+        $response->assertSee('設定メニュー');
     }
 
     /**
@@ -266,5 +268,6 @@ class MenusModeratorEditFeatureTest extends TestCase
         $permitted_response = $this->actingAs($moderator)->get('/');
         $permitted_response->assertStatus(200);
         $permitted_response->assertSee('menu-edit-button');
+        $permitted_response->assertDontSee('設定メニュー');
     }
 }

--- a/tests/Feature/Plugins/User/Menus/MenusModeratorEditFeatureTest.php
+++ b/tests/Feature/Plugins/User/Menus/MenusModeratorEditFeatureTest.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Menus;
+
+use App\Enums\MenuFrameConfig;
+use App\Models\Common\Frame;
+use App\Models\Common\Page;
+use App\Models\Core\UsersRoles;
+use App\Models\User\Menus\Menu;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MenusModeratorEditFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var \App\Models\Common\Page */
+    private $page;
+
+    /** @var \App\Models\Common\Frame */
+    private $frame;
+
+    /** @var string */
+    private $select_url;
+
+    /** @var string */
+    private $save_select_url;
+
+    /** @var string */
+    private $index_url;
+
+    /** @var string */
+    private $save_frame_roles_url;
+
+    /** @var string */
+    private $edit_frame_roles_url;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+
+        $this->page = Page::where('permanent_link', '/')->first();
+        if (!$this->page) {
+            $this->page = Page::factory()->create([
+                'permanent_link' => '/',
+                'page_name' => 'home',
+            ]);
+        }
+
+        $this->frame = Frame::factory()->create([
+            'page_id' => $this->page->id,
+            'area_id' => 2,
+            'plugin_name' => 'menus',
+            'bucket_id' => null,
+            'template' => 'default',
+            'display_sequence' => 1,
+        ]);
+
+        $this->frame->frame_id = $this->frame->id;
+
+        $this->select_url = "/plugin/menus/select/{$this->page->id}/{$this->frame->id}";
+        $this->save_select_url = "/plugin/menus/saveSelect/{$this->page->id}/{$this->frame->id}";
+        $this->index_url = "/plugin/menus/index/{$this->page->id}/{$this->frame->id}";
+        $this->save_frame_roles_url = "/redirect/plugin/menus/saveFrameRoles/{$this->page->id}/{$this->frame->id}";
+        $this->edit_frame_roles_url = "/plugin/menus/editFrameRoles/{$this->page->id}/{$this->frame->id}";
+    }
+
+    /**
+     * モデレーターロールのユーザーを作成する。
+     */
+    private function createModeratorUser(): User
+    {
+        return $this->createUserWithRole('role_article');
+    }
+
+    /**
+     * コンテンツ管理者ロールのユーザーを作成する。
+     */
+    private function createAdminUser(): User
+    {
+        return $this->createUserWithRole('role_article_admin');
+    }
+
+    private function createUserWithRole(string $role): User
+    {
+        $user = User::factory()->create();
+
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => $role,
+            'role_value' => 1,
+        ]);
+
+        return $user;
+    }
+
+    private function enableModeratorEdit(): void
+    {
+        $admin = $this->createAdminUser();
+        $redirect_path = url($this->edit_frame_roles_url . "#frame-{$this->frame->id}");
+
+        $response = $this->actingAs($admin)->post($this->save_frame_roles_url, [
+            'redirect_path' => $redirect_path,
+            MenuFrameConfig::menu_allow_moderator_edit => 1,
+        ]);
+
+        $response->assertStatus(302);
+    }
+
+    /**
+     * モデレータは許可が無い場合、ページ選択画面にアクセスできない。
+     */
+    public function testModeratorCannotAccessSelectionWhenNotAllowed(): void
+    {
+        $user = $this->createModeratorUser();
+
+        $response = $this->actingAs($user)->get($this->select_url);
+
+        $response->assertStatus(200);
+        $response->assertSee('権限がありません');
+        $this->assertEquals(0, Menu::count());
+
+        $post_response = $this->actingAs($user)->post($this->save_select_url, [
+            'select_flag' => 1,
+            'page_select' => [$this->page->id],
+            'folder_close_font' => 0,
+            'folder_open_font' => 0,
+            'indent_font' => 0,
+        ]);
+
+        $post_response->assertStatus(200);
+        $post_response->assertSee('権限がありません');
+        $this->assertEquals(0, Menu::count());
+    }
+
+    /**
+     * モデレータは許可設定が有効であれば編集できる。
+     */
+    public function testModeratorCanEditWhenAllowed(): void
+    {
+        $this->enableModeratorEdit();
+        $user = $this->createModeratorUser();
+
+        $response = $this->actingAs($user)->get($this->select_url);
+        $response->assertStatus(200);
+        // ページ選択の画面が表示されることを確認
+        $response->assertSee('ページの表示');
+
+        $payload = [
+            'select_flag' => 1,
+            'page_select' => [$this->page->id],
+            'folder_close_font' => 0,
+            'folder_open_font' => 0,
+            'indent_font' => 0,
+        ];
+
+        $post_response = $this->actingAs($user)->post($this->save_select_url, $payload);
+
+        $post_response->assertStatus(200);
+
+        $menu = Menu::where('frame_id', $this->frame->id)->first();
+        $this->assertNotNull($menu);
+        $this->assertEquals(1, $menu->select_flag);
+        $this->assertEquals((string) $this->page->id, $menu->page_ids);
+        $this->assertEquals(0, $menu->folder_close_font);
+        $this->assertEquals(0, $menu->folder_open_font);
+        $this->assertEquals(0, $menu->indent_font);
+    }
+
+    /**
+     * 管理者は設定に関係なく編集できる。
+     */
+    public function testAdminCanEditWithoutModeratorSetting(): void
+    {
+        $user = $this->createAdminUser();
+
+        $response = $this->actingAs($user)->get($this->select_url);
+        $response->assertStatus(200);
+        // ページ選択の画面が表示されることを確認
+        $response->assertSee('ページの表示');
+    }
+
+    /**
+     * 権限設定保存がフレーム設定を更新し、フラッシュメッセージを残す。
+     */
+    public function testSaveFrameRolesPersistsSettingAndFlashesMessage(): void
+    {
+        $user = $this->createAdminUser();
+        $redirect_path = url($this->edit_frame_roles_url . "#frame-{$this->frame->id}");
+
+        $response = $this->actingAs($user)->post($this->save_frame_roles_url, [
+            'redirect_path' => $redirect_path,
+            MenuFrameConfig::menu_allow_moderator_edit => 1,
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertRedirect($redirect_path);
+        $response->assertSessionHas("flash_message_for_frame{$this->frame->id}", '更新しました。');
+
+        $this->assertDatabaseHas('frame_configs', [
+            'frame_id' => $this->frame->id,
+            'name' => MenuFrameConfig::menu_allow_moderator_edit,
+            'value' => '1',
+        ]);
+
+        $second_response = $this->actingAs($user)->post($this->save_frame_roles_url, [
+            'redirect_path' => $redirect_path,
+            MenuFrameConfig::menu_allow_moderator_edit => 0,
+        ]);
+
+        $second_response->assertStatus(302);
+        $second_response->assertRedirect($redirect_path);
+        $this->assertDatabaseHas('frame_configs', [
+            'frame_id' => $this->frame->id,
+            'name' => MenuFrameConfig::menu_allow_moderator_edit,
+            'value' => '0',
+        ]);
+    }
+
+    /**
+     * モデレータは権限設定保存を実行できない。
+     */
+    public function testModeratorCannotSaveFrameRoles(): void
+    {
+        $user = $this->createModeratorUser();
+        $redirect_path = url($this->edit_frame_roles_url . "#frame-{$this->frame->id}");
+
+        $response = $this->actingAs($user)->post($this->save_frame_roles_url, [
+            'redirect_path' => $redirect_path,
+            MenuFrameConfig::menu_allow_moderator_edit => 1,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertSee('権限がありません');
+
+        $this->assertDatabaseMissing('frame_configs', [
+            'frame_id' => $this->frame->id,
+            'name' => MenuFrameConfig::menu_allow_moderator_edit,
+        ]);
+    }
+
+    /**
+     * 編集ボタンは権限に応じて表示が切り替わる。
+     */
+    public function testEditButtonVisibilityReflectsPermissions(): void
+    {
+        $moderator = $this->createModeratorUser();
+        $admin = $this->createAdminUser();
+
+        // 権限なしではモデレータに表示されない
+        $response_for_moderator = $this->actingAs($moderator)->get('/');
+        $response_for_moderator->assertStatus(200);
+        $response_for_moderator->assertDontSee('menu-edit-button');
+
+        // 管理者は設定が無くても表示される
+        $response_for_admin = $this->actingAs($admin)->get('/');
+        $response_for_admin->assertStatus(200);
+        $response_for_admin->assertSee('menu-edit-button');
+
+        // 権限を付与するとモデレータにも表示される
+        $this->enableModeratorEdit();
+        $permitted_response = $this->actingAs($moderator)->get('/');
+        $permitted_response->assertStatus(200);
+        $permitted_response->assertSee('menu-edit-button');
+    }
+}


### PR DESCRIPTION
# 概要
メニュープラグインでモデレータが「メニューを編集」操作を行えるようにしました。
従来はプラグイン管理者のみメニューの編集が可能でした。
モデレータへ編集許可の設定をすることで、プラグイン管理者でなくてもメニューを編集することができるようにしました。

- フレーム設定メニューにあったページ選択画面について、メニューの初期表示ページから遷移できるように変更
  - ログインユーザーに編集権限がある場合に限り、各メニューテンプレートで編集ボタンを表示
- フレーム設定メニューに権限設定タブを追加し、設定画面を通じて「モデレータ編集許可」を設定できるように整備

## 特記事項

### リリース後すぐにモデレータが編集できるようになるか？

なりません。
管理者が権限設定画面でモデレータに権限を付与しない限り、モデレータはメニューを編集できません。

### 権限チェック処理

メニュープラグインはバケツを持たないプラグインであるため、Connect-CMSのBucketsRolesを利用した権限チェック処理を利用していません。
その代わりに、FrameConfigを利用した権限チェックをプラグイン内に実装しました。

# レビュー完了希望日
なし

# 関連Pull requests/Issues
#2271

# 参考
なし

# DB変更の有無
無し

# チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。
