### PR TITLE
[スライドショー] モデレータと編集者が画像を直接編集できるようにしました

### DIFF
--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -74,11 +74,12 @@ class SlideshowsPlugin extends UserPluginBase
     {
         // 権限チェックテーブル
         $role_check_table = [];
-        $role_check_table["addItem"]            = ['buckets.addColumn'];
-        $role_check_table["editItem"]           = ['buckets.editColumn'];
-        $role_check_table["updateItems"]        = ['buckets.saveColumn'];
-        $role_check_table["deleteItem"]         = ['buckets.deleteColumn'];
-        $role_check_table["updateItemSequence"] = ['buckets.upColumnSequence', 'buckets.downColumnSequence'];
+        $role_check_table["addItem"]            = ['posts.create'];
+        $role_check_table["addPdf"]             = ['posts.create'];
+        $role_check_table["editItem"]           = ['posts.update'];
+        $role_check_table["updateItems"]        = ['posts.update'];
+        $role_check_table["updateItemSequence"] = ['posts.update'];
+        $role_check_table["deleteItem"]         = ['posts.delete'];
         return $role_check_table;
     }
 
@@ -141,11 +142,6 @@ class SlideshowsPlugin extends UserPluginBase
         } else {
             // フレームに紐づくスライドショー親データがない場合
             $setting_error_messages[] = 'フレームの設定画面から、使用するスライドショーを選択するか、作成してください。';
-        }
-
-        if ($slideshows_items->count() == 0) {
-            // フレームに紐づくスライドショー子データがない場合
-            $setting_error_messages[] = 'フレームの設定画面から、使用するスライドショーの項目を定義してください。';
         }
 
         if (empty($setting_error_messages)) {
@@ -744,11 +740,6 @@ class SlideshowsPlugin extends UserPluginBase
      */
     public function editItem($request, $page_id, $frame_id, $id = null, $message = null, $errors = null)
     {
-        // 権限チェック
-        if ($this->can('role_article_admin')) {
-            return $this->viewError(403);
-        }
-
         // フレームに紐づくスライドショーを取得
         $slideshow = $this->getSlideshows($frame_id);
 
@@ -841,5 +832,27 @@ class SlideshowsPlugin extends UserPluginBase
         ]);
 
         // リダイレクト設定はフォーム側で設定している為、return処理は省略
+    }
+
+    /**
+     * 権限設定　変更画面を表示する
+     *
+     * @see UserPluginBase::editBucketsRoles()
+     */
+    public function editBucketsRoles($request, $page_id, $frame_id, $id = null, $use_approval = false)
+    {
+        // 承認機能は使わない
+        return parent::editBucketsRoles($request, $page_id, $frame_id, $id, $use_approval);
+    }
+
+    /**
+     * 権限設定を保存する
+     *
+     * @see UserPluginBase::saveBucketsRoles()
+     */
+    public function saveBucketsRoles($request, $page_id, $frame_id, $id = null, $use_approval = false)
+    {
+        // 承認機能は使わない
+        return parent::saveBucketsRoles($request, $page_id, $frame_id, $id, $use_approval);
     }
 }

--- a/resources/views/plugins/user/slideshows/default/slideshows.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows.blade.php
@@ -12,6 +12,15 @@
     {{-- 未設定エラーメッセージの表示等 --}}
     @include('plugins.common.errors_form_line')
 
+    {{-- 編集ボタン --}}
+    @can('posts.update', [[null, $frame->plugin_name, $buckets, $frame]])
+        <div class="text-right mb-2 slideshow-edit-button">
+            <a href="{{ url('/') }}/plugin/{{ $frame->plugin_name }}/editItem/{{ $page->id }}/{{ $frame_id }}#frame-{{ $frame_id }}" class="btn btn-success btn-sm">
+                <i class="far fa-edit"></i> <span class="d-none d-sm-inline">編集</span>
+            </a>
+        </div>
+    @endcan
+
     @if ($slideshows_items->count() > 0)
         {{-- インジケータの形状は標準だとクリックしづらいので、とりあえず丸型にしておきます。後々の改修でインジケータ形状のデザイン機能も入れられるといいと考えてます。 --}}
         <style>

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
@@ -5,209 +5,200 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category スライドショー・プラグイン
 --}}
-@extends('core.cms_frame_base_setting')
+@extends('core.cms_frame_base')
 
-@section("core.cms_frame_edit_tab_$frame->id")
+@section("plugin_contents_$frame->id")
+    @if (empty($slideshows_id))
+        {{-- バケツデータ未作成の場合 --}}
+        <div class="alert alert-warning mt-2">
+            <i class="fas fa-exclamation-circle"></i>
+            スライドショー選択画面から既存のスライドショーを選択するか、新規作成してください。
+        </div>
+    @else
+        {{-- バケツデータ作成済みの場合 --}}
+        <div class="form-group" id="app_{{ $frame->id }}">
+            {{-- 項目の追加、削除等処理用の汎用フォーム --}}
+            <form action="" id="slideshow_items" name="slideshow_items" method="POST" enctype="multipart/form-data">
+                {{ csrf_field() }}
+                <input type="hidden" name="slideshows_id" value="{{$slideshows_id}}">
+                <input type="hidden" name="item_id" value="">
+                <input type="hidden" name="display_sequence" value="">
+                <input type="hidden" name="display_sequence_operation" value="">
+                <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/slideshows/editItem/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
 
-    {{-- プラグイン側のフレームメニュー --}}
-    @include('plugins.user.slideshows.slideshows_frame_edit_tab')
+                {{-- エラーメッセージエリア ※共通blade呼び出し --}}
+                @include('plugins.common.errors_form_line')
 
-@endsection
+                {{-- エラーメッセージ --}}
+                @if (session('slideshows_error_message'))
+                <div class="alert alert-danger mt-2">
+                    <i class="fas fa-exclamation-circle"></i> {{ session('slideshows_error_message') }}
+                </div>
+                @endif
 
-@section("plugin_setting_$frame->id")
-    @auth
-        @if (empty($slideshows_id))
-            {{-- バケツデータ未作成の場合 --}}
-            <div class="alert alert-warning mt-2">
-                <i class="fas fa-exclamation-circle"></i>
-                フォーム選択画面から選択するか、フォーム新規作成で作成してください。
-            </div>
-        @else
-            {{-- バケツデータ作成済みの場合 --}}
-            <div class="form-group" id="app_{{ $frame->id }}">
-                {{-- 項目の追加、削除等処理用の汎用フォーム --}}
-                <form action="" id="slideshow_items" name="slideshow_items" method="POST" enctype="multipart/form-data">
-                    {{ csrf_field() }}
-                    <input type="hidden" name="slideshows_id" value="{{$slideshows_id}}">
-                    <input type="hidden" name="item_id" value="">
-                    <input type="hidden" name="display_sequence" value="">
-                    <input type="hidden" name="display_sequence_operation" value="">
-                    <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/slideshows/editItem/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
-
-                    {{-- エラーメッセージエリア ※共通blade呼び出し --}}
-                    @include('plugins.common.errors_form_line')
-
-                    {{-- エラーメッセージ --}}
-                    @if (session('slideshows_error_message'))
-                    <div class="alert alert-danger mt-2">
-                        <i class="fas fa-exclamation-circle"></i> {{ session('slideshows_error_message') }}
-                    </div>
+                {{-- メッセージエリア --}}
+                <div class="alert alert-info mt-2">
+                    @if (session('flash_message'))
+                        <i class="fas fa-exclamation-circle"></i>{{ session('flash_message') }}
+                        <a href="https://manual.connect-cms.jp/user/slideshows/index.html" target="_brank"><i class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></i></a>
+                    @else
+                        <ul>
+                            <li>
+                                スライドショーに表示させる画像やリンクを設定します。
+                                <a href="https://manual.connect-cms.jp/user/slideshows/index.html" target="_brank"><i class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></i></a>
+                            </li>
+                            <li>PDFを選択して追加することで、PDFの内容を画像に変換して登録できます。</li>
+                        </ul>
                     @endif
+                </div>
 
-                    {{-- メッセージエリア --}}
-                    <div class="alert alert-info mt-2">
-                        @if (session('flash_message'))
-                            <i class="fas fa-exclamation-circle"></i>{{ session('flash_message') }}
-                            <a href="https://manual.connect-cms.jp/user/slideshows/index.html" target="_brank"><i class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></i></a>
-                        @else
-                            <ul>
-                                <li>
-                                    スライドショーに表示させる画像やリンクを設定します。
-                                    <a href="https://manual.connect-cms.jp/user/slideshows/index.html" target="_brank"><i class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></i></a>
-                                </li>
-                                <li>PDFを選択して追加することで、PDFの内容を画像に変換して登録できます。</li>
-                            </ul>
-                        @endif
-                    </div>
-
-                    {{-- 項目一覧 --}}
-                    <div class="table-responsive">
-                        <table class="table table-hover table-sm">
-                            <thead>
-                                <tr class="d-none d-lg-table-row">
-                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">表示順</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">表示</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">画像 <label class="badge badge-danger">必須</label></th>
-                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">リンクURL</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">キャプション</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">リンクターゲット</th>
-                                    <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">削除</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {{-- 新規登録用の行 --}}
-                                <tr>
-                                    <th colspan="7">【項目の追加行】</th>
-                                </tr>
-                                @include('plugins.user.slideshows.default.slideshows_edit_row_add')
-                                <tr>
-                                    <th colspan="7">【既存の設定行】</th>
-                                </tr>
-                                {{-- 更新用の行 --}}
-                                @foreach($items as $item)
-                                    @include('plugins.user.slideshows.default.slideshows_edit_row')
-                                @endforeach
-                            </tbody>
-                        </table>
-                    </div>
-                    {{-- ボタンエリア --}}
-                    <div class="text-center mt-3 mt-md-0">
-                        {{-- キャンセルボタン --}}
-                        <button type="button"
-                            class="btn btn-secondary mr-2"
-                            onclick="location.href='{{URL::to($page->permanent_link)}}'"
+                {{-- 項目一覧 --}}
+                <div class="table-responsive">
+                    <table class="table table-hover table-sm">
+                        <thead>
+                            <tr class="d-none d-lg-table-row">
+                                <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">表示順</th>
+                                <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">表示</th>
+                                <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">画像 <label class="badge badge-danger">必須</label></th>
+                                <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">リンクURL</th>
+                                <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">キャプション</th>
+                                <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">リンクターゲット</th>
+                                <th class="text-center text-nowrap align-middle d-block d-lg-table-cell">削除</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{-- 新規登録用の行 --}}
+                            <tr>
+                                <th colspan="7">【項目の追加行】</th>
+                            </tr>
+                            @include('plugins.user.slideshows.default.slideshows_edit_row_add')
+                            <tr>
+                                <th colspan="7">【既存の設定行】</th>
+                            </tr>
+                            {{-- 更新用の行 --}}
+                            @foreach($items as $item)
+                                @include('plugins.user.slideshows.default.slideshows_edit_row')
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                {{-- ボタンエリア --}}
+                <div class="text-center mt-3 mt-md-0">
+                    {{-- キャンセルボタン --}}
+                    <button type="button"
+                        class="btn btn-secondary mr-2"
+                        onclick="location.href='{{URL::to($page->permanent_link)}}'"
+                    >
+                        <i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass()}}"> キャンセル</span>
+                    </button>
+                    @if ($items->count() > 0)
+                        {{-- 更新ボタン --}}
+                        <button
+                            type="button"
+                            class="btn btn-primary mr-2"
+                            onclick="javascript:return submit_update_items();"
                         >
-                            <i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass()}}"> キャンセル</span>
+                            <i class="fas fa-check"></i> 更新
                         </button>
-                        @if ($items->count() > 0)
-                            {{-- 更新ボタン --}}
-                            <button
-                                type="button"
-                                class="btn btn-primary mr-2"
-                                onclick="javascript:return submit_update_items();"
-                            >
-                                <i class="fas fa-check"></i> 更新
-                            </button>
-                        @endif
-                    </div>
-                </form>
-            </div>
-        @endif
+                    @endif
+                </div>
+            </form>
+        </div>
+    @endif
 
-        <script>
-            /**
-             * 項目の追加ボタン押下
-             */
-            function submit_add_item() {
-                slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/addItem/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
-                slideshow_items.submit();
-            }
+    <script>
+        /**
+         * 項目の追加ボタン押下
+         */
+        function submit_add_item() {
+            slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/addItem/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+            slideshow_items.submit();
+        }
 
-            /**
-             * PDF選択の追加ボタン押下
-             */
-            function submit_add_pdf() {
-                slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/addPdf/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
-                slideshow_items.submit();
-            }
+        /**
+         * PDF選択の追加ボタン押下
+         */
+        function submit_add_pdf() {
+            slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/addPdf/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+            slideshow_items.submit();
+        }
 
-            /**
-             * 項目の削除ボタン押下
-             */
-            function submit_delete_item(item_id) {
-                if(confirm('項目を削除します。\nよろしいですか？')){
-                    slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/deleteItem/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
-                    slideshow_items.item_id.value = item_id;
-                    slideshow_items.submit();
-                }
-                return false;
-            }
-
-            /**
-             * 項目の更新ボタン押下
-             */
-            function submit_update_items() {
-                if(confirm('更新します。\nよろしいですか？')){
-                    slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/updateItems/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
-                    slideshow_items.submit();
-                }
-                return false;
-            }
-
-            /**
-             * 項目の表示順操作ボタン押下
-             */
-            function submit_display_sequence(item_id, display_sequence, display_sequence_operation) {
-                slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/updateItemSequence/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+        /**
+         * 項目の削除ボタン押下
+         */
+        function submit_delete_item(item_id) {
+            if(confirm('項目を削除します。\nよろしいですか？')){
+                slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/deleteItem/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
                 slideshow_items.item_id.value = item_id;
-                slideshow_items.display_sequence.value = display_sequence;
-                slideshow_items.display_sequence_operation.value = display_sequence_operation;
                 slideshow_items.submit();
             }
+            return false;
+        }
 
-            /**
-             * ツールチップ
-             */
-            $(function () {
-                // 有効化
-                $('[data-toggle="tooltip"]').tooltip()
-            })
+        /**
+         * 項目の更新ボタン押下
+         */
+        function submit_update_items() {
+            if(confirm('更新します。\nよろしいですか？')){
+                slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/updateItems/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+                slideshow_items.submit();
+            }
+            return false;
+        }
 
-            /**
-             * 新規追加行・更新行のimgのsrc、及び、モーダルのヘッダーに表示しているファイル名をイベントから抽出して動的に書き換える
-             */
-            const app_{{ $frame->id }} = createApp({
-                data: function() {
-                    return {
-                        // 更新行用の変数
-                        @foreach($items as $item)
-                            image_url_{{ $item->id }} : "{{ url('/') }}/file/{{ $item->uploads_id }}",
-                            file_name_{{ $item->id }} : "{{ $item->client_original_name }}",
-                        @endforeach
-                        // 新規追加行用の変数
-                        image_url_add:"",
-                        file_name_add:"",
-                        selected_pdf:""
-                    }
-                },
-                methods: {
-                    // 受け取ったイベントから画像オブジェクトのURL、ファイル名を生成してHTMLにセットする
-                    setImageResource(event, items_id){
-                        const file = event.target.files[0];
-                        // console.log(file);
-                        eval("this.image_url_" + items_id + " = URL.createObjectURL(file);");
-                        eval("this.file_name_" + items_id + " = file.name;");
-                    },
-                    // 選択中のPDFを表示する
-                    setPdfFile(event){
-                        let file = event.target.files[0];
-                        if (file === undefined) {
-                            this.selected_pdf = "";
-                        }
-                        this.selected_pdf = file.name;
-                    }
+        /**
+         * 項目の表示順操作ボタン押下
+         */
+        function submit_display_sequence(item_id, display_sequence, display_sequence_operation) {
+            slideshow_items.action = "{{url('/')}}/redirect/plugin/slideshows/updateItemSequence/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}";
+            slideshow_items.item_id.value = item_id;
+            slideshow_items.display_sequence.value = display_sequence;
+            slideshow_items.display_sequence_operation.value = display_sequence_operation;
+            slideshow_items.submit();
+        }
+
+        /**
+         * ツールチップ
+         */
+        $(function () {
+            // 有効化
+            $('[data-toggle="tooltip"]').tooltip()
+        })
+
+        /**
+         * 新規追加行・更新行のimgのsrc、及び、モーダルのヘッダーに表示しているファイル名をイベントから抽出して動的に書き換える
+         */
+        const app_{{ $frame->id }} = createApp({
+            data: function() {
+                return {
+                    // 更新行用の変数
+                    @foreach($items as $item)
+                        image_url_{{ $item->id }} : "{{ url('/') }}/file/{{ $item->uploads_id }}",
+                        file_name_{{ $item->id }} : "{{ $item->client_original_name }}",
+                    @endforeach
+                    // 新規追加行用の変数
+                    image_url_add:"",
+                    file_name_add:"",
+                    selected_pdf:""
                 }
-            }).mount('#app_{{ $frame->id }}');
-        </script>
-    @endauth
+            },
+            methods: {
+                // 受け取ったイベントから画像オブジェクトのURL、ファイル名を生成してHTMLにセットする
+                setImageResource(event, items_id){
+                    const file = event.target.files[0];
+                    // console.log(file);
+                    eval("this.image_url_" + items_id + " = URL.createObjectURL(file);");
+                    eval("this.file_name_" + items_id + " = file.name;");
+                },
+                // 選択中のPDFを表示する
+                setPdfFile(event){
+                    let file = event.target.files[0];
+                    if (file === undefined) {
+                        this.selected_pdf = "";
+                    }
+                    this.selected_pdf = file.name;
+                }
+            }
+        }).mount('#app_{{ $frame->id }}');
+    </script>
 @endsection

--- a/resources/views/plugins/user/slideshows/default/slideshows_error_messages.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_error_messages.blade.php
@@ -4,13 +4,22 @@
 @extends('core.cms_frame_base')
 
 @section("plugin_contents_$frame->id")
-@can('frames.edit',[[null, null, null, $frame]])
-<div class="card border-danger">
-    <div class="card-body">
-        @foreach ($error_messages as $error_message)
-            <p class="text-center cc_margin_bottom_0">{!! nl2br(e($error_message)) !!}</p>
-        @endforeach
+@php
+    $can_show_error = false;
+    if (Auth::check()) {
+        $can_show_error = Auth::user()->can('frames.edit', [[null, null, null, $frame]])
+            || Auth::user()->can('posts.update', [[null, $frame->plugin_name, $buckets, $frame]])
+            || Auth::user()->can('posts.create', [[null, $frame->plugin_name, $buckets, $frame]]);
+    }
+@endphp
+
+@if ($can_show_error)
+    <div class="card border-danger">
+        <div class="card-body">
+            @foreach ($error_messages as $error_message)
+                <p class="text-center cc_margin_bottom_0">{!! nl2br(e($error_message)) !!}</p>
+            @endforeach
+        </div>
     </div>
-</div>
-@endcan
+@endif
 @endsection

--- a/resources/views/plugins/user/slideshows/slideshows_frame_edit_tab.blade.php
+++ b/resources/views/plugins/user/slideshows/slideshows_frame_edit_tab.blade.php
@@ -6,10 +6,10 @@
  * @category スライドショー・プラグイン
 --}}
 @php
-    $arr_tab_name['editItem'] = '項目設定';
     $arr_tab_name['editBuckets'] = 'スライドショー設定';
     $arr_tab_name['createBuckets'] = 'スライドショー作成';
     $arr_tab_name['listBuckets'] = '表示コンテンツ選択';
+    $arr_tab_name['editBucketsRoles'] = '権限設定';
 @endphp
 {{-- ループしてタブを生成 --}}
 @foreach ($arr_tab_name as $url => $tab_name)

--- a/tests/Feature/Plugins/User/Slideshows/SlideshowsEditPermissionFeatureTest.php
+++ b/tests/Feature/Plugins/User/Slideshows/SlideshowsEditPermissionFeatureTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Slideshows;
+
+use App\Enums\ShowType;
+use App\Models\Common\Buckets;
+use App\Models\Common\BucketsRoles;
+use App\Models\Common\Frame;
+use App\Models\Common\Page;
+use App\Models\Common\Uploads;
+use App\Models\Core\UsersRoles;
+use App\Models\User\Slideshows\Slideshows;
+use App\Models\User\Slideshows\SlideshowsItems;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SlideshowsEditPermissionFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var \App\Models\Common\Page */
+    private $page;
+
+    /** @var \App\Models\Common\Frame */
+    private $frame;
+
+    /** @var \App\Models\Common\Buckets */
+    private $bucket;
+
+    /** @var \App\Models\User\Slideshows\Slideshows */
+    private $slideshow;
+
+    /** @var \App\Models\User\Slideshows\SlideshowsItems */
+    private $item;
+
+    /** @var string */
+    private $index_path;
+
+    /** @var string */
+    private $edit_path;
+
+    /** @var string */
+    private $edit_button_url;
+
+    /** @var string */
+    private $update_items_path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+
+        $this->page = Page::where('permanent_link', '/')->first() ?? Page::factory()->create([
+            'permanent_link' => '/',
+            'page_name' => 'home',
+        ]);
+
+        $this->bucket = Buckets::factory()->create([
+            'bucket_name' => 'テストスライド',
+            'plugin_name' => 'slideshows',
+        ]);
+
+        $this->frame = Frame::factory()->create([
+            'page_id' => $this->page->id,
+            'area_id' => 2,
+            'plugin_name' => 'slideshows',
+            'bucket_id' => $this->bucket->id,
+            'display_sequence' => 1,
+        ]);
+
+        $this->slideshow = Slideshows::create([
+            'bucket_id' => $this->bucket->id,
+            'slideshows_name' => 'テストスライド',
+            'control_display_flag' => ShowType::show,
+            'indicators_display_flag' => ShowType::show,
+            'fade_use_flag' => ShowType::not_show,
+            'image_interval' => 5000,
+            'height' => null,
+        ]);
+
+        $upload = Uploads::factory()->jpg()->create([
+            'plugin_name' => 'slideshows',
+            'page_id' => $this->page->id,
+        ]);
+
+        $this->item = SlideshowsItems::create([
+            'slideshows_id' => $this->slideshow->id,
+            'image_path' => 'dummy/path.jpg',
+            'uploads_id' => $upload->id,
+            'link_url' => null,
+            'link_target' => null,
+            'caption' => null,
+            'display_flag' => ShowType::show,
+            'display_sequence' => 1,
+        ]);
+
+        foreach (['role_article', 'role_reporter'] as $role) {
+            BucketsRoles::create([
+                'buckets_id' => $this->bucket->id,
+                'role' => $role,
+                'post_flag' => 0,
+                'approval_flag' => 0,
+            ]);
+        }
+
+        $this->index_path = "/plugin/slideshows/index/{$this->page->id}/{$this->frame->id}";
+        $this->edit_path = "/plugin/slideshows/editItem/{$this->page->id}/{$this->frame->id}";
+        $this->edit_button_url = sprintf('%s%s#frame-%d', url('/'), $this->edit_path, $this->frame->id);
+        $this->update_items_path = "/redirect/plugin/slideshows/updateItems/{$this->page->id}/{$this->frame->id}";
+    }
+
+    private function enableModeratorEdit(): void
+    {
+        BucketsRoles::where('buckets_id', $this->bucket->id)
+            ->where('role', 'role_article')
+            ->update(['post_flag' => 1]);
+    }
+
+    private function enableEditorEdit(): void
+    {
+        BucketsRoles::where('buckets_id', $this->bucket->id)
+            ->where('role', 'role_reporter')
+            ->update(['post_flag' => 1]);
+    }
+
+    private function createUserWithRole(string $role): User
+    {
+        $user = User::factory()->create();
+
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => $role,
+            'role_value' => 1,
+        ]);
+
+        return $user;
+    }
+
+    private function buildUpdatePayload(string $caption, string $link_url): array
+    {
+        return [
+            'redirect_path' => $this->edit_button_url,
+            'slideshows_id' => $this->slideshow->id,
+            'display_flags' => [$this->item->id => ShowType::show],
+            'link_urls' => [$this->item->id => $link_url],
+            'captions' => [$this->item->id => $caption],
+            'link_targets' => [$this->item->id => '_self'],
+        ];
+    }
+
+    /**
+     * 権限設定しないとモデレータは編集画面にも公開画面の編集ボタンにもアクセスできないこと。
+     */
+    public function testModeratorCannotAccessEditScreen(): void
+    {
+        $user = $this->createUserWithRole('role_article');
+
+        $index_response = $this->actingAs($user)->get($this->index_path);
+        $index_response->assertStatus(200);
+        $index_response->assertDontSee($this->edit_button_url);
+
+        $edit_response = $this->actingAs($user)->get($this->edit_path);
+        $edit_response->assertStatus(200);
+        $edit_response->assertSee('権限がありません');
+    }
+
+    /**
+     * モデレータは権限設定すると編集画面にも公開画面の編集ボタンにもアクセスできること。
+     */
+    public function testModeratorCanAccessEditScreen(): void
+    {
+        $this->enableModeratorEdit();
+        $user = $this->createUserWithRole('role_article');
+
+        $index_response = $this->actingAs($user)->get($this->index_path);
+        $index_response->assertStatus(200);
+        $index_response->assertSee($this->edit_button_url);
+
+        $edit_response = $this->actingAs($user)->get($this->edit_path);
+        $edit_response->assertStatus(200);
+        $edit_response->assertSee('項目の追加行');
+    }
+
+    /**
+     * 権限設定しないと編集者は編集画面にも公開画面の編集ボタンにもアクセスできないこと。
+     */
+    public function testEditorCannotAccessEditScreen(): void
+    {
+        $user = $this->createUserWithRole('role_reporter');
+
+        $index_response = $this->actingAs($user)->get($this->index_path);
+        $index_response->assertStatus(200);
+        $index_response->assertDontSee($this->edit_button_url);
+
+        $edit_response = $this->actingAs($user)->get($this->edit_path);
+        $edit_response->assertStatus(200);
+        $edit_response->assertSee('権限がありません');
+    }
+
+    /**
+     * 編集者は権限設定すると編集画面にも公開画面の編集ボタンにもアクセスできること。
+     */
+    public function testEditorCanAccessEditScreen(): void
+    {
+        $this->enableEditorEdit();
+        $user = $this->createUserWithRole('role_reporter');
+
+        $index_response = $this->actingAs($user)->get($this->index_path);
+        $index_response->assertStatus(200);
+        $index_response->assertSee($this->edit_button_url);
+
+        $edit_response = $this->actingAs($user)->get($this->edit_path);
+        $edit_response->assertStatus(200);
+        $edit_response->assertSee('項目の追加行');
+    }
+
+    /**
+     * プラグイン管理者は編集画面にアクセスできず、公開画面にも編集ボタンが表示されないこと。
+     */
+    public function testPluginManagerCannotAccessEditScreen(): void
+    {
+        $user = $this->createUserWithRole('role_arrangement');
+
+        $index_response = $this->actingAs($user)->get($this->index_path);
+        $index_response->assertStatus(200);
+        $index_response->assertDontSee($this->edit_button_url);
+
+        $edit_response = $this->actingAs($user)->get($this->edit_path);
+        $edit_response->assertStatus(200);
+        $edit_response->assertSee('権限がありません');
+    }
+
+    /**
+     * モデレータは項目更新ができること。
+     */
+    public function testModeratorCanUpdateItems(): void
+    {
+        $this->enableModeratorEdit();
+        $user = $this->createUserWithRole('role_article');
+
+        $payload = $this->buildUpdatePayload('モデレータ更新', 'https://example.com/moderator');
+
+        $response = $this->actingAs($user)->post($this->update_items_path, $payload);
+
+        $response->assertStatus(302);
+        $this->assertEquals('モデレータ更新', $this->item->fresh()->caption);
+        $this->assertEquals('https://example.com/moderator', $this->item->fresh()->link_url);
+    }
+
+    /**
+     * 権限がないモデレータは項目更新できないこと。
+     */
+    public function testModeratorCannotUpdateItemsWithoutPermission(): void
+    {
+        $user = $this->createUserWithRole('role_article');
+
+        $payload = $this->buildUpdatePayload('モデレータ更新NG', 'https://example.com/moderator-ng');
+
+        $response = $this->actingAs($user)->post($this->update_items_path, $payload);
+
+        $response->assertStatus(200);
+        $response->assertSee('権限がありません');
+        $this->assertNull($this->item->fresh()->caption);
+        $this->assertNull($this->item->fresh()->link_url);
+    }
+
+    /**
+     * 編集者は項目更新ができること。
+     */
+    public function testEditorCanUpdateItems(): void
+    {
+        $this->enableEditorEdit();
+        $user = $this->createUserWithRole('role_reporter');
+
+        $payload = $this->buildUpdatePayload('編集者更新', 'https://example.com/editor');
+
+        $response = $this->actingAs($user)->post($this->update_items_path, $payload);
+
+        $response->assertStatus(302);
+        $this->assertEquals('編集者更新', $this->item->fresh()->caption);
+        $this->assertEquals('https://example.com/editor', $this->item->fresh()->link_url);
+    }
+
+    /**
+     * 権限がない編集者は項目更新できないこと。
+     */
+    public function testEditorCannotUpdateItemsWithoutPermission(): void
+    {
+        $user = $this->createUserWithRole('role_reporter');
+
+        $payload = $this->buildUpdatePayload('編集者更新NG', 'https://example.com/editor-ng');
+
+        $response = $this->actingAs($user)->post($this->update_items_path, $payload);
+
+        $response->assertStatus(200);
+        $response->assertSee('権限がありません');
+        $this->assertNull($this->item->fresh()->caption);
+        $this->assertNull($this->item->fresh()->link_url);
+    }
+
+    /**
+     * プラグイン管理者は項目更新ができないこと。
+     */
+    public function testPluginManagerCannotUpdateItems(): void
+    {
+        $user = $this->createUserWithRole('role_arrangement');
+
+        $payload = $this->buildUpdatePayload('管理者更新NG', 'https://example.com/deny');
+
+        $response = $this->actingAs($user)->post($this->update_items_path, $payload);
+
+        $response->assertStatus(200);
+        $response->assertSee('権限がありません');
+        $this->assertNull($this->item->fresh()->caption);
+        $this->assertNull($this->item->fresh()->link_url);
+    }
+}


### PR DESCRIPTION
# 概要
- スライドショーの画像編集を設定メニュー外から開けるようにし、モデレータ／編集者が自分で画像を差し替えられるようにしました。
- 権限設定画面にて、モデレータ/編集者の編集可否を設定できます。
- 公開画面の編集ボタンは投稿権限を持つユーザーだけに表示され、権限のない利用者には表示されません。
- 権限が不足している場合は『権限がありません』と伝わるようメッセージを整理しました。

※ プラグイン管理者は編集不可になりました。他のプラグインと整合性をもたせるためです。

## 特記事項
- declareRole を `posts.*` 権限に差し替え、モデレータ／編集者がバケツ権限で操作できるようにしています。
- 編集画面の Blade を `core.cms_frame_base` に変更し、公開画面から直接呼び出す構造にしています。
- SlideshowsEditPermissionFeatureTest を追加し、ロールごとの画面表示・更新可否を Feature テストで検証しています。

# レビュー完了希望日
- 特に指定なし

# 関連Pull requests/Issues

- #2276
- #2270

# DB変更の有無
無し

# チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
