### PR TITLE
  [システム] Option Plugins用設定ファイルをgitignoreに追加しました

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,2 +1,5 @@
 cc_api_config.php
 cc_shibboleth_config.php
+
+# Option Plugins 用設定ファイル
+option/


### PR DESCRIPTION
  ## 概要
  Option Plugins用の設定ファイルディレクトリ (`config/option/`) をGit管理対象外にする設定を追加しました。

  ### 変更内容
  - `config/.gitignore` にて `option/` ディレクトリを除外対象に追加
  - Option Plugins用設定ファイルのコメントを追記

  ### 背景・目的
  Option Pluginsの設定ファイルには環境固有の情報が含まれる可能性があるため、Git管理対象外とすることでセキュリティと環境分離を向上させる。

  ## レビュー完了希望日
  特になし

  ## 関連PR/Issues
  なし

  ## 参考情報
  なし

  ## DB変更
  - [ ] DB変更あり
  - [x] DB変更なし