### PR TITLE
[ページ管理] ページごとに検索避け設定を行えるようにしました

### DIFF
--- a/app/Enums/PageMetaRobots.php
+++ b/app/Enums/PageMetaRobots.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * ページのmeta robots設定
+ */
+final class PageMetaRobots extends EnumsBase
+{
+    const noindex = 'noindex';
+    const nofollow = 'nofollow';
+    const noarchive = 'noarchive';
+    const nosnippet = 'nosnippet';
+    const noimageindex = 'noimageindex';
+    const notranslate = 'notranslate';
+
+    const enum = [
+        self::noindex => '検索結果に表示させない（noindex）',
+        self::nofollow => 'ページ内のリンク先を検索エンジンに辿らせない（nofollow）',
+        self::noarchive => '検索結果にキャッシュ（保存版）を出さない（noarchive）',
+        self::nosnippet => '検索結果にページの説明を表示させない（nosnippet）',
+        self::noimageindex => 'ページ内の画像を画像検索に載せない（noimageindex）',
+    ];
+
+    /**
+     * 指定された値を説明文の配列に変換
+     */
+    public static function descriptions(array $values): array
+    {
+        $members = static::getMembers();
+
+        $descriptions = [];
+        foreach ($values as $value) {
+            if (array_key_exists($value, $members)) {
+                $descriptions[] = $members[$value];
+            }
+        }
+
+        return $descriptions;
+    }
+}

--- a/app/Models/Common/Page.php
+++ b/app/Models/Common/Page.php
@@ -40,6 +40,7 @@ class Page extends Model
         'class',
         'othersite_url',
         'othersite_url_target',
+        'meta_robots',
         'transfer_lower_page_flag',
         'password',
     ];
@@ -537,6 +538,26 @@ class Page extends Model
         if ($this->getSimpleLayout() == '1111') {
             return "ヘッダー、左、右、フッター";
         }
+    }
+
+    /**
+     * メタrobotsの有効値を取得（自ページから親を遡って検索）
+     */
+    public function getMetaRobots(?Collection $page_tree = null): ?string
+    {
+        if (empty($this->id)) {
+            return null;
+        }
+
+        $page_tree = $this->getPageTreeByGoingBackParent($page_tree);
+
+        foreach ($page_tree as $page) {
+            if (!empty($page->meta_robots)) {
+                return $page->meta_robots;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Rules/CustomValiMetaRobots.php
+++ b/app/Rules/CustomValiMetaRobots.php
@@ -13,14 +13,7 @@ class CustomValiMetaRobots implements Rule
     /**
      * @var array<string>
      */
-    private $invalid_values = [];
-
-    /**
-     * Create a new rule instance.
-     */
-    public function __construct()
-    {
-    }
+    private $invalidValues = [];
 
     /**
      * Determine if the validation rule passes.
@@ -49,9 +42,9 @@ class CustomValiMetaRobots implements Rule
 
         $allowed = PageMetaRobots::getMemberKeys();
 
-        $this->invalid_values = array_diff($values, $allowed);
+        $this->invalidValues = array_diff($values, $allowed);
 
-        return empty($this->invalid_values);
+        return empty($this->invalidValues);
     }
 
     /**
@@ -59,10 +52,11 @@ class CustomValiMetaRobots implements Rule
      */
     public function message()
     {
-        if (!empty($this->invalid_values)) {
-            return ':attributeに不正な値（' . implode(', ', $this->invalid_values) . '）が含まれています。';
+        if (!empty($this->invalidValues)) {
+            return ':attributeに不正な値（' . implode(', ', $this->invalidValues) . '）が含まれています。';
         }
 
         return ':attributeに不正な値が含まれています。';
     }
 }
+

--- a/app/Rules/CustomValiMetaRobots.php
+++ b/app/Rules/CustomValiMetaRobots.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use App\Enums\PageMetaRobots;
+
+/**
+ * meta robots値のバリデーション
+ */
+class CustomValiMetaRobots implements Rule
+{
+    /**
+     * @var array<string>
+     */
+    private $invalid_values = [];
+
+    /**
+     * Create a new rule instance.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     */
+    public function passes($attribute, $value)
+    {
+        if (is_null($value) || $value === '') {
+            return true;
+        }
+
+        $values = [];
+
+        if (is_array($value)) {
+            $values = $value;
+        } else {
+            $values = [$value];
+        }
+
+        $values = array_filter($values, function ($item) {
+            return $item !== null && $item !== '';
+        });
+
+        if (empty($values)) {
+            return true;
+        }
+
+        $allowed = PageMetaRobots::getMemberKeys();
+
+        $this->invalid_values = array_diff($values, $allowed);
+
+        return empty($this->invalid_values);
+    }
+
+    /**
+     * Get the validation error message.
+     */
+    public function message()
+    {
+        if (!empty($this->invalid_values)) {
+            return ':attributeに不正な値（' . implode(', ', $this->invalid_values) . '）が含まれています。';
+        }
+
+        return ':attributeに不正な値が含まれています。';
+    }
+}

--- a/database/migrations/2025_09_25_101737_add_meta_robots_to_pages_table.php
+++ b/database/migrations/2025_09_25_101737_add_meta_robots_to_pages_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMetaRobotsToPagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->string('meta_robots')->nullable()->after('transfer_lower_page_flag')->comment('検索避け設定（robots meta）');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->dropColumn('meta_robots');
+        });
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -41,6 +41,17 @@ if (! isset($cc_configs)) {
 @if (Configs::getConfigsValue($cc_configs, 'description'))
     <meta name="description" content="{{ StringUtils::getNobrValue(Configs::getConfigsValue($cc_configs, 'description')) }}">
 @endif
+{{-- 検索避け設定 --}}
+@php
+    $meta_robots = null;
+    if (isset($page)) {
+        $page_tree = app('request')->attributes->get('page_tree');
+        $meta_robots = $page->getMetaRobots($page_tree);
+    }
+@endphp
+@if ($meta_robots)
+    <meta name="robots" content="{{$meta_robots}}">
+@endif
 
     {{-- OGP Settings --}}
 @if (Configs::getConfigsValue($cc_configs, 'og_site_name'))

--- a/resources/views/plugins/manage/page/page.blade.php
+++ b/resources/views/plugins/manage/page/page.blade.php
@@ -6,6 +6,7 @@
  * @category ページ管理
 --}}
 @php
+use App\Enums\PageMetaRobots;
 use App\Models\Common\Page;
 @endphp
 
@@ -196,6 +197,7 @@ use App\Models\Common\Page;
                 <th nowrap><i class="fas fa-window-restore" title="新ウィンドウ"></i></th>
                 <th nowrap><i class="fas fa-network-wired" title="IPアドレス制限"></i></th>
                 <th nowrap><i class="fas fa-external-link-alt" title="外部リンク"></i></th>
+                <th nowrap><i class="fas fa-robot" title="検索避け設定"></i></th>
                 <th nowrap><i class="fas fa-swatchbook" title="クラス名"></i></th>
             </thead>
             <tbody>
@@ -419,6 +421,29 @@ use App\Models\Common\Page;
                     </td>
                     <td class="table-text p-1 text-center">
                         <div>@if($page_item->othersite_url)<i class="fas fa-external-link-alt" title="{{$page_item->othersite_url}}"></i>@endif</div>
+                    </td>
+                    <td class="table-text p-1 text-center">
+                        @if ($page_item->meta_robots)
+                            @php
+                            $meta_robots_descriptions = implode('、', PageMetaRobots::descriptions(explode(',', $page_item->meta_robots)));
+                            $meta_robots_tooltip = $meta_robots_descriptions ?: $page_item->meta_robots;
+                            @endphp
+                            <div><i class="fas fa-robot" title="{{$meta_robots_tooltip}}"></i></div>
+                        @else
+                            @php
+                            $meta_robots_parent = null;
+                            foreach ($page_tree as $page_tmp) {
+                                if ($page_tmp->meta_robots) {
+                                    $meta_robots_parent = $page_tmp->meta_robots;
+                                    break;
+                                }
+                            }
+                            $meta_robots_parent_description = $meta_robots_parent ? implode('、', PageMetaRobots::descriptions(explode(',', $meta_robots_parent))) : '';
+                            @endphp
+                            @if ($meta_robots_parent)
+                                <div><i class="fas fa-robot text-warning" title="{{$meta_robots_parent_description}}(親ページを継承)"></i></div>
+                            @endif
+                        @endif
                     </td>
                     <td class="table-text p-1 text-center">
                         <div>@if($page_item->class)<i class="fas fa-swatchbook" title="{{$page_item->class}}"></i>@endif</div>

--- a/resources/views/plugins/manage/page/page_form.blade.php
+++ b/resources/views/plugins/manage/page/page_form.blade.php
@@ -24,7 +24,7 @@ use App\Models\Common\Page;
     {{ csrf_field() }}
 
     @php
-    // 自分のページから親を遡って取得（＋トップページ）
+    // 検索避け設定で継承表示に使うため、自分自身から親ページを順に取得
     $page_tree = $page->getPageTreeByGoingBackParent(null);
     @endphp
 


### PR DESCRIPTION
 # 概要
  - ページごとに meta robots を設定できるよう、robots 指示の候補を Enum 化し管理画面で選択式の UI を追加しました。
  - 設定値の継承ロジックを利用しつつ、説明文やツールチップを平易な表現に整理して利用者向けの説明を補完しました。
  - 公開ページで有効な robots 指示を解決して meta タグに出力する処理を追加し、管理設定と表示結果を連動させています。

  # レビュー完了希望日
  急ぎません

  # 関連Pull requests/Issues
  なし

  # 参考
  なし

  # DB変更の有無
  有り

  # チェックリスト

  - [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-
  cms/wiki/Pull-requests-Rule