### PR TITLE
[フレーム] 公開設定のラジオボタン選択状態が正しく表示されない不具合を修正しました

### DIFF
--- a/resources/views/core/cms_frame_edit.blade.php
+++ b/resources/views/core/cms_frame_edit.blade.php
@@ -196,7 +196,7 @@
                                 id="{{ "content_open_type_{$key}" }}"
                                 name="content_open_type"
                                 class="custom-control-input"
-                                {{ old('content_open_type', $frame->content_open_type) ? 'checked' : '' }}
+                                {{ old('content_open_type', $frame->content_open_type) == $key ? 'checked' : '' }}
                                 v-model="v_content_open_type"
                             >
                             <label class="custom-control-label" for="{{ "content_open_type_{$key}" }}">


### PR DESCRIPTION
## 概要
フレーム編集画面の「公開設定」で「限定公開」を選択して保存した後、画面を再表示すると「公開」が選択されてしまう不具合を修正しました。

## 変更内容
- ラジオボタンの`checked`属性判定ロジックを修正
- 修正前: `{{ old('content_open_type', $frame->content_open_type) ? 'checked' : '' }}`
- 修正後: `{{ old('content_open_type', $frame->content_open_type) == $key ? 'checked' : '' }}`

## テスト方法
1. フレーム編集画面で「限定公開」を選択して保存
2. 画面を再表示して「限定公開」が選択されていることを確認
3. 他の公開設定でも同様に動作することを確認

## レビュー完了希望日
なし

## 関連PR/Issues
https://github.com/opensource-workshop/connect-cms/issues/2274

## 参考情報
なし

## DB変更の有無
なし

## チェックリスト
- [x] 動作確認済み
- [x] コーディング規約に準拠