### PR TITLE
[docker] docker-composeでWARNを出ないようにする対応

### DIFF
--- a/docker/app/setup.sh
+++ b/docker/app/setup.sh
@@ -12,7 +12,7 @@ chown 1000:1000 .env
 sed -i 's/DB_HOST=127.0.0.1/DB_HOST=db/g' .env
 sed -i 's/DB_DATABASE=laravel/DB_DATABASE=$DB_DATABASE/g' .env
 sed -i 's/DB_USERNAME=root/DB_USERNAME=$DB_USERNAME/g' .env
-sed -i 's/DB_PASSWORD=/DB_PASSWORD=$DB_PASSWORD/g' .env
+sed -i 's/^DB_PASSWORD=/DB_PASSWORD=$DB_PASSWORD/g' .env
 
 ## mailhog設定
 sed -i 's/MAIL_HOST=smtp.mailtrap.io/MAIL_HOST=mailhog/g' .env


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

docker/app/setup.sh で `.env` の `DB_PASSWORD` の置換処理がありますが、 `.env` の `NC2_DB_PASSWORD`、`NC3_DB_PASSWORD` まで置換されていたため、修正しました。

## WARN内容

```shell
********:~/connect-cms$ docker-compose exec app php -v
WARN[0000] The "DB_PASSWORDnc2_homestead" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DB_PASSWORDnc3_homestead" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DB_PASSWORDnc2_homestead" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DB_PASSWORDnc3_homestead" variable is not set. Defaulting to a blank string. 
PHP 7.4.33 (cli) (built: Nov 15 2022 06:03:30) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
```

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

軽微な改修なので急ぎません

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

ラベルは権限がないのか、付けれませんでした。