### PR TITLE
[Configsデータ] 新規インストール時にエラーが発生する問題を修正しました

### DIFF
--- a/database/migrations/2025_10_29_000000_remove_mail_auth_method_from_migration.php
+++ b/database/migrations/2025_10_29_000000_remove_mail_auth_method_from_migration.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * マイグレーションでConfigsレコードを作成するのを廃止
+ *
+ * 背景:
+ * - 2025_10_09_160056_add_mail_oauth2_to_configs.php でmail_auth_methodをinsertしていた
+ * - 新規インストール時、migrate実行後にConfigsテーブルにレコードが1件存在する状態になる
+ * - DefaultConfigsTableSeeder の条件 if (Configs::count() == 0) が false になる
+ * - 基本設定レコード（base_site_name等）が投入されず、エラーが発生する
+ *
+ * 対応:
+ * - mail_auth_methodレコードを削除
+ * - 以降はデフォルト値（MailAuthMethod::smtp）で動作
+ * - 管理画面で認証方式変更時に自動作成される（updateOrCreate使用）
+ *
+ * 関連Issue:
+ * - https://github.com/opensource-workshop/connect-cms/issues/2293
+ */
+class RemoveMailAuthMethodFromMigration extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // マイグレーションで作成したmail_auth_methodレコードを削除
+        DB::table('configs')
+            ->where('category', 'mail')
+            ->where('name', 'mail_auth_method')
+            ->delete();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // rollback時は元に戻す
+        DB::table('configs')->insert([
+            'category' => 'mail',
+            'name' => 'mail_auth_method',
+            'value' => 'smtp',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## 概要

新規インストール時、マイグレーション実行後にシーダーが正常に動作せず、500エラーが発生する問題を修正しました。

### 問題の原因

- `2025_10_09_160056_add_mail_oauth2_to_configs.php` でconfigsテーブルに直接レコードを挿入していた
- マイグレーション実行後、configsテーブルに1件レコードが存在する状態になる
- `DefaultConfigsTableSeeder` の条件 `if (Configs::count() == 0)` が false となり、基本設定が投入されない
- 基本設定レコード（base_site_name等）が存在しないため、画面表示時に「Attempt to read property 'value' on null」エラーが発生

### 対応内容

- 新しいマイグレーション `2025_10_29_000000_remove_mail_auth_method_from_migration.php` を追加
- マイグレーションで作成した `mail_auth_method` レコードを削除
- 以降は `MailAuthMethod::smtp` をデフォルト値として動作（コードは既に対応済み）
- 管理画面でメール認証方式を変更すると `updateOrCreate` で自動作成される

### 影響範囲

- **既存環境**: `mail_auth_method` レコードが削除されますが、コードがデフォルト値で動作するため機能に影響なし
- **新規インストール**: configsテーブルが空の状態でシーダーが実行され、正常にインストール完了

## レビュー完了希望日

できるだけ早く

## 関連PR/Issues

- Fixes #2293

## 参考情報

- `MailServiceProvider.php`、`SystemManage.php` では既に `getConfigsValue()` の第3引数でデフォルト値を指定済み
- メール設定画面で認証方式を変更すると `updateOrCreate` でレコードが作成される

## DB変更

なし（マイグレーションによるデータ削除のみ）

## チェックリスト

- [x] コーディング規約に従っている
- [x] 既存機能への影響を確認した
- [x] テストを実施した
- [x] ドキュメントの更新が不要であることを確認した