### PR TITLE
[イベント] 既存データの編集時に403エラーが発生する不具合を修正しました

### DIFF
--- a/app/Plugins/User/Conventions/ConventionsPlugin.php
+++ b/app/Plugins/User/Conventions/ConventionsPlugin.php
@@ -90,7 +90,7 @@ class ConventionsPlugin extends UserPluginBase
             $join->on('conventions.id', '=', 'convention_posts.convention_id')
                 ->where('conventions.bucket_id', '=', $this->frame->bucket_id);
         })
-        ->firstOrNew(['conventions.id' => $id]);
+        ->firstOrNew(['convention_posts.id' => $id]);
         return $this->post;
     }
 


### PR DESCRIPTION
# 概要

イベントプラグインにおいて、既存データの編集ボタンをクリックした際に「403 Forbidden.（権限がありません）」というエラーが発生する不具合を修正しました。

## 発生していた問題
- イベント（Conventions）の既存データを編集しようとすると、一部のデータで403エラーが発生
- 新規作成は正常に動作
- 一部のデータ（IDが偶然一致するもの）のみ編集可能だった

## 原因
`ConventionsPlugin.php` の `getPost()` メソッドにおいて、投稿データを取得する際の検索条件が誤っていました。

**修正前:**
```php
->firstOrNew(['conventions.id' => $id]);
```
イベント設定ID（conventions.id）で検索していたため、投稿ID（$id）と一致しないデータが取得できませんでした。

**修正後:**
```php
->firstOrNew(['convention_posts.id' => $id]);
```
正しく投稿ID（convention_posts.id）で検索するように修正しました。

## 変更内容
- `app/Plugins/User/Conventions/ConventionsPlugin.php` の93行目を修正
- `firstOrNew()` の検索条件を `conventions.id` から `convention_posts.id` に変更

# レビュー完了希望日

不具合対応なので、できるだけ早めにお願いします。

# 関連Pull requests/Issues

なし

# 参考

なし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule