### PR TITLE
[カウンター]昨日のカウンター数の取得条件を追加しました

### DIFF
--- a/app/Models/User/Counters/CounterCount.php
+++ b/app/Models/User/Counters/CounterCount.php
@@ -44,6 +44,8 @@ class CounterCount extends Model
                     $join->on('yesterday_counts.counter_id', '=', 'counter_counts.counter_id')
                             ->where('yesterday_counts.counted_at', (new Carbon($counted_at))->subDay()->format('Y-m-d'));
                 })
+                // yesterday_counts の updated_at で降順（新しい順）に並び替え
+                ->orderBy('yesterday_counts.updated_at', 'desc')
                 ->first();
 
         return $counter_count;


### PR DESCRIPTION
昨日のカウンター数の取得条件を追加しました

# 概要
昨日のカウンター数の取得条件を追加しました
同日重複のカウンターカウントレコードができたときに不正なレコードを取得してしまうためソート条件を追加した。
根本的な重複の解決にはなっていない。

# レビュー完了希望日
軽微な改修なので急ぎません

# 関連Pull requests/Issues
#2300

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
