### PR TITLE
[メニュー] テンプレート選択にマニュアル導線を追加しました

### DIFF
--- a/resources/views/core/cms_frame_edit.blade.php
+++ b/resources/views/core/cms_frame_edit.blade.php
@@ -117,6 +117,15 @@
                     @endforeach
                 </select>
                 @if ($frame->plugin_name == 'menus')
+                    <div class="alert alert-info small mt-2 mb-0" role="alert">
+                        テンプレートの特徴や表示イメージは
+                        <a href="https://connect-cms.jp/manual/user/menus/templates" target="_blank" rel="noopener">
+                            マニュアル
+                        </a>
+                        を参照してください。
+                    </div>
+                @endif
+                @if ($frame->plugin_name == 'menus')
                     <small class="text-muted">※ 「タブ」「ドロップダウン」「マウスオーバードロップダウン」系テンプレートは、スマートフォンでは表示されません。</small>
                 @endif
             </div>


### PR DESCRIPTION
# 概要
- メニュープラグインのフレーム設定でテンプレートを切り替える際、どのテンプレートがどのように表示されるのかをすぐ確認できず、選択に迷うケースがありました。
- テンプレート選択プルダウンの直下に `alert-info` の案内を追加し、公式マニュアルのテンプレート一覧へ直接遷移できるようにしました。

<img width="719" height="184" alt="image" src="https://github.com/user-attachments/assets/63194bac-25c8-468a-9635-3779cdaa4cec" />

# レビュー完了希望日
- 急ぎません

# 関連Pull requests/Issues
- なし

# 参考
- https://connect-cms.jp/manual/user/menus/templates

# DB変更の有無
無し

# チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
