### PR TITLE
[フォーム] 不正な正規表現設定時にシステムエラーが発生する問題を修正しました

### DIFF
--- a/app/Plugins/User/Forms/FormsPlugin.php
+++ b/app/Plugins/User/Forms/FormsPlugin.php
@@ -613,7 +613,7 @@ class FormsPlugin extends UserPluginBase
             $validator_rule[] = 'min:' . $forms_column->rule_min;
         }
         // 正規表現チェック
-        if ($forms_column->rule_regex) {
+        if ($forms_column->rule_regex !== null && $forms_column->rule_regex !== '') {
             if ($this->isValidRegex($forms_column->rule_regex)) {
                 $validator_rule[] = 'nullable';
                 $validator_rule[] = 'regex:' . $forms_column->rule_regex;
@@ -2298,7 +2298,7 @@ class FormsPlugin extends UserPluginBase
             $validator_attributes['rule_word_count'] = '入力文字数';
         }
         // 正規表現の指定時、書式が正しいかチェック
-        if ($request->rule_regex) {
+        if ($request->rule_regex !== null && $request->rule_regex !== '') {
             $validator_values['rule_regex'] = [
                 function ($attribute, $value, $fail) {
                     if (! $this->isValidRegex($value)) {


### PR DESCRIPTION
# 概要
- フォーム項目詳細の正規表現入力で不正なパターンが登録されても500エラーにならないように、更新時に書式チェックを追加
- 不正な正規表現が残っている場合でもバリデーション生成時にスキップし、警告ログを残して処理継続

# レビュー完了希望日
- 特に指定なし

# 関連Pull requests/Issues
- なし

# 参考
- なし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
