### PR TITLE
[メニュー] パンくず選択表示でメニュー非表示ページが表示されない問題を修正しました

### DIFF
--- a/resources/views/plugins/user/menus/breadcrumbs/menus.blade.php
+++ b/resources/views/plugins/user/menus/breadcrumbs/menus.blade.php
@@ -15,7 +15,13 @@
         <ol class="breadcrumb">
         @foreach($ancestors_breadcrumbs as $ancestor)
             {{-- パンくずはdisplay_flag を継承した値を持っていないので、ページの表示フラグを参照 --}}
-            @if ($ancestor->base_display_flag == 1)
+            @php
+                $is_display_ancestor = ($ancestor->base_display_flag == 1);
+                if (!$is_display_ancestor && $menu && $menu->select_flag == 1 && $menu->onPage($ancestor->id)) {
+                    $is_display_ancestor = true;
+                }
+            @endphp
+            @if ($is_display_ancestor)
                 @if ($loop->last)
                     <li class="breadcrumb-item {{$ancestor->getClass()}} active" aria-current="page">{{$ancestor->page_name}}</li>
                 @else


### PR DESCRIPTION
# 概要
- パンくずテンプレートで「選択したもののみ」指定時、ページ管理で非表示のページでも選択されていれば表示されるよう表示判定を調整しました。

# レビュー完了希望日
- 特に指定なし

# 関連Pull requests/Issues
- なし

# 参考
- なし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
