### PR TITLE
[WYSIWYG] 画像・メディアの挿入/編集ダイアログのラベル「ソース」を「URL / ファイル」変更しました

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -268,6 +268,10 @@
     window.cc_templates = {{!!$templates_file!!}};
 </script>
 <script type="text/javascript">
+    {{-- 翻訳カスタム --}}
+    tinymce.util.I18n.add('ja', {
+        'Source': 'URL / ファイル'
+    });
     tinymce.init({
         // see) https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#sandbox-iframes-exclusions
         sandbox_iframes: true,


### PR DESCRIPTION
# 概要

画像・メディアの挿入/編集ダイアログのラベル「ソース」を「URL / ファイル」変更しました。
<img width="300" alt="image" src="https://github.com/user-attachments/assets/de5ff5cc-c5c5-47b6-afb4-7de71c12fbfb" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/fe3f3fe1-8318-42d4-9306-5e589885a4c9" />


## 背景 / 目的

メディアや画像を追加する画面でファイル選択する項目のラベルが「ソース」と表示されており、「ソース」が一般利用者になじみがない単語でした。
利用者にとって分かりやすい表現にすることで迷わずファイルアップロードできるようにします。

# レビュー完了希望日
- 可能なタイミングでご確認ください

# 関連Pull requests/Issues
- なし

# 参考
- なし

# DB変更の有無
無し

# チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
