### PR TITLE
[固定記事] モデレーター・編集者が一時保存を閲覧・編集できない問題を修正しました

### DIFF
--- a/app/Plugins/User/Contents/ContentsPlugin.php
+++ b/app/Plugins/User/Contents/ContentsPlugin.php
@@ -213,7 +213,7 @@ class ContentsPlugin extends UserPluginBase
             // bugfix: 承認あり なら、自分の承認ありデータも見れる必要あり。
             // $query->Where('status', '=', 0)
             $query->where(function ($tmp_query) use ($table_name) {
-                $tmp_query->WhereIn($table_name . '.status', [StatusType::active, StatusType::approval_pending])
+                $tmp_query->WhereIn($table_name . '.status', [StatusType::active, StatusType::temporary, StatusType::approval_pending])
                     ->orWhere($table_name . '.created_id', '=', Auth::user()->id);
             });
 


### PR DESCRIPTION
# 概要
- 不具合修正：モデレーター・編集者が他人作成データの一時保存を閲覧・編集できない問題を解消しました（固定記事の取得権限で一時保存ステータスも取得対象に追加）。

## 背景や目的
- 固定記事で他ユーザーが最初に作成したデータの場合、モデレーター/編集者が自分で作成した一時保存さえ閲覧・再編集できず、共同編集に支障が出ていました。

## 変更内容
- canPostUser（モデレーター/編集者相当）で取得するステータスに `temporary` を追加し、一時保存も一覧・表示できるように調整（不具合修正）。

## 特記事項

### 不具合の再現手順
1. 固定記事でユーザーAが新規データを作成（公開 or 一時保存）。
2. 同じバケツをモデレーター/編集者権限のユーザーBが開き、一時保存として編集・保存する。
3. ユーザーBで固定記事を表示すると、自分が一時保存した内容が出てこない。

### 権限ごとの閲覧範囲

#### 変更前
| 権限 | 公開 | 一時保存 | 承認待ち | 補足 |
| --- | --- | --- | --- | --- |
| コンテンツ管理者 | ○ | ○ | ○ | 全件取得 |
| 承認者 | ○ | × | ○ | 承認待ちまで |
| モデレーター/編集者 | ○ | 自分初回登録分のみ | ○ | 他人が最初に作ったデータの一時保存は見えない |
| その他 | ○ | × | × | 公開のみ |

#### 変更後
| 権限 | 公開 | 一時保存 | 承認待ち | 補足 |
| --- | --- | --- | --- | --- |
| コンテンツ管理者 | ○ | ○ | ○ | 変更なし |
| 承認者 | ○ | × | ○ | 変更なし |
| モデレーター/編集者 | ○ | ○ | ○ | 他人が最初に作ったデータの一時保存も閲覧・再編集可 |
| その他 | ○ | × | × | 変更なし |

# レビュー完了希望日
- 特に指定なし

# 関連Pull requests/Issues
- なし

# 参考
- なし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
