### PR TITLE
[キャビネット] 名前変更はボタン押下でのみ確定するようにしました

### DIFF
--- a/resources/views/plugins/user/cabinets/default/index.blade.php
+++ b/resources/views/plugins/user/cabinets/default/index.blade.php
@@ -311,7 +311,7 @@
 
                 <div class="form-group">
                     <label for="newItemName{{$frame_id}}">新しい名前</label>
-                    <input type="text" class="form-control" id="newItemName{{$frame_id}}" v-model="newItemName" maxlength="100" @keyup.enter="!isRenameInProgress && confirmRename()" :disabled="isRenameInProgress">
+                    <input type="text" class="form-control" id="newItemName{{$frame_id}}" v-model="newItemName" maxlength="100" :disabled="isRenameInProgress">
                 </div>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
# 概要
キャビネットの名前変更モーダルでEnterキーだけでは確定されないようにし、[変更]ボタンを押したときだけリネームを実行するようにしました。

## 背景や目的
MacOSにて、IMEの変換確定でEnterを押すだけでリネームを実行してしまい、意図せず確定してしまうケースがあったためです。

## 変更内容
- 名前変更入力欄のEnterキー押下イベント（@keyup.enter）を削除し、ボタン押下のみでconfirmRenameが走るようにしました。

# レビュー完了希望日
- 急ぎではありませんが、誤操作防止のため早めに見ていただけると助かります。

# 関連Pull requests/Issues
- なし

# 参考
- なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
