### PR TITLE
[データベース] 動画型: 再生回数の表示と並び替えに対応しました

### DIFF
--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -321,6 +321,7 @@ class DatabasesPlugin extends UserPluginBase
                 'databases_columns.body_flag',
                 'uploads.client_original_name',
                 'uploads.download_count',
+                'uploads.play_count',
             )
             ->leftJoin('databases_columns', 'databases_columns.id', '=', 'databases_input_cols.databases_columns_id')
             ->leftJoin('uploads', 'uploads.id', '=', 'databases_input_cols.value')
@@ -495,7 +496,7 @@ class DatabasesPlugin extends UserPluginBase
                                                 })
                                                ->where('databases_id', $database->id);
                 // ダウンロード件数でのソート
-                if ($sort_column_option === 'downloadcount') {
+                if ($sort_column_option === 'downloadcount' || $sort_column_option === 'playcount') {
                     $inputs_query = $inputs_query->leftjoin('uploads', 'databases_input_cols.value', 'uploads.id');
                 }
             }
@@ -798,12 +799,16 @@ class DatabasesPlugin extends UserPluginBase
             } elseif ($sort_column_id && ctype_digit($sort_column_id) && $sort_column_order == DatabaseSortFlag::order_asc) {
                 if ($sort_column_option === 'downloadcount') {
                     $inputs_query->orderBy('uploads.download_count', 'asc');
+                } elseif ($sort_column_option === 'playcount') {
+                    $inputs_query->orderBy('uploads.play_count', 'asc');
                 } else {
                     $inputs_query->orderBy('databases_input_cols.value', 'asc');
                 }
             } elseif ($sort_column_id && ctype_digit($sort_column_id) && $sort_column_order == DatabaseSortFlag::order_desc) {
                 if ($sort_column_option === 'downloadcount') {
                     $inputs_query->orderBy('uploads.download_count', 'desc');
+                } elseif ($sort_column_option === 'playcount') {
+                    $inputs_query->orderBy('uploads.play_count', 'desc');
                 } else {
                     $inputs_query->orderBy('databases_input_cols.value', 'desc');
                 }
@@ -848,7 +853,7 @@ class DatabasesPlugin extends UserPluginBase
             // Log::debug(var_export(DB::getQueryLog(), true));
 
             // 登録データ詳細の取得
-            $input_cols = DatabasesInputCols::select('databases_input_cols.*', 'uploads.client_original_name', 'uploads.download_count')
+            $input_cols = DatabasesInputCols::select('databases_input_cols.*', 'uploads.client_original_name', 'uploads.download_count', 'uploads.play_count')
                                             ->leftJoin('uploads', 'uploads.id', '=', 'databases_input_cols.value')
                                             ->whereIn('databases_inputs_id', $inputs->pluck('id'))
                                             ->orderBy('databases_inputs_id', 'asc')->orderBy('databases_columns_id', 'asc')
@@ -2888,6 +2893,10 @@ class DatabasesPlugin extends UserPluginBase
         $column->show_download_button = (empty($request->show_download_button)) ? 0 : $request->show_download_button;
         // ダウンロード件数で並び替え
         $column->sort_download_count = (empty($request->sort_download_count)) ? 0 : $request->sort_download_count;
+        // 再生回数を表示する
+        $column->show_play_count = (empty($request->show_play_count)) ? 0 : $request->show_play_count;
+        // 再生回数で並び替え
+        $column->sort_play_count = (empty($request->sort_play_count)) ? 0 : $request->sort_play_count;
         // 行グループ
         $column->row_group = $request->row_group;
         // 列グループ

--- a/database/migrations/2025_12_22_000001_add_play_count_to_databases_columns_table.php
+++ b/database/migrations/2025_12_22_000001_add_play_count_to_databases_columns_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPlayCountToDatabasesColumnsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->integer('show_play_count')->default(0)->comment('再生回数を表示する')->after('show_download_count');
+            $table->integer('sort_play_count')->default(0)->comment('再生回数で並び替え')->after('sort_download_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases_columns', function (Blueprint $table) {
+            $table->dropColumn('show_play_count');
+            $table->dropColumn('sort_play_count');
+        });
+    }
+}

--- a/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_row_detail.blade.php
@@ -708,6 +708,23 @@
                 </div>
                 @endif
 
+                {{-- 再生回数でのソートを行う --}}
+                @if ($column->column_type == DatabaseColumnType::video)
+                <div class="form-group row">
+                    <label class="{{$frame->getSettingLabelClass(true)}}">再生回数で並べ替え</label>
+                    <div class="{{$frame->getSettingInputClass(true)}}">
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="0" id="sort_play_count_0" name="sort_play_count" class="custom-control-input" @if(old('sort_play_count', $column->sort_play_count) == 0) checked="checked" @endif>
+                            <label class="custom-control-label" for="sort_play_count_0">使用しない</label>
+                        </div>
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="1" id="sort_play_count_1" name="sort_play_count" class="custom-control-input" @if(old('sort_play_count', $column->sort_play_count) == 1) checked="checked" @endif>
+                            <label class="custom-control-label" for="sort_play_count_1">使用する</label>
+                        </div>
+                    </div>
+                </div>
+                @endif
+
                 {{-- 検索対象指定 --}}
                 <div class="form-group row">
                     <label class="{{$frame->getSettingLabelClass(true)}}">検索対象指定</label>
@@ -769,6 +786,23 @@
                         <div class="custom-control custom-radio custom-control-inline">
                             <input type="radio" value="1" id="show_download_count_1" name="show_download_count" class="custom-control-input" @if(old('show_download_count', $column->show_download_count) == 1) checked="checked" @endif>
                             <label class="custom-control-label" for="show_download_count_1" id="label_show_download_count_1">表示する</label>
+                        </div>
+                    </div>
+                </div>
+                @endif
+
+                {{-- 再生回数を表示する --}}
+                @if ($column->column_type == DatabaseColumnType::video)
+                <div class="form-group row">
+                    <label class="{{$frame->getSettingLabelClass(true)}}">再生回数を表示する</label>
+                    <div class="{{$frame->getSettingInputClass(true)}}">
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="0" id="show_play_count_0" name="show_play_count" class="custom-control-input" @if(old('show_play_count', $column->show_play_count) == 0) checked="checked" @endif>
+                            <label class="custom-control-label" for="show_play_count_0" id="label_show_play_count_0">表示しない</label>
+                        </div>
+                        <div class="custom-control custom-radio custom-control-inline">
+                            <input type="radio" value="1" id="show_play_count_1" name="show_play_count" class="custom-control-input" @if(old('show_play_count', $column->show_play_count) == 1) checked="checked" @endif>
+                            <label class="custom-control-label" for="show_play_count_1" id="label_show_play_count_1">表示する</label>
                         </div>
                     </div>
                 </div>

--- a/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_edit_view.blade.php
@@ -324,8 +324,15 @@
                 @foreach($columns->whereIn('sort_flag', [1, 2, 3]) as $sort_column)
 
                     @php
-                        $sort_option = $sort_column->sort_download_count ? '_downloadcount' : null;
-                        $sort_option_name = $sort_column->sort_download_count ? 'ダウンロード数' : null;
+                        $sort_option = null;
+                        $sort_option_name = null;
+                        if ($sort_column->column_type == DatabaseColumnType::file && $sort_column->sort_download_count) {
+                            $sort_option = '_downloadcount';
+                            $sort_option_name = 'ダウンロード数';
+                        } elseif ($sort_column->column_type == DatabaseColumnType::video && $sort_column->sort_play_count) {
+                            $sort_option = '_playcount';
+                            $sort_option_name = '再生回数';
+                        }
                     @endphp
 
                     @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 2)

--- a/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_ctrl_head.blade.php
@@ -192,8 +192,15 @@
                         @foreach($sort_columns as $sort_column)
 
                             @php
-                                $sort_option = $sort_column->sort_download_count ? '_downloadcount' : null;
-                                $sort_option_name = $sort_column->sort_download_count ? 'ダウンロード数' : null;
+                                $sort_option = null;
+                                $sort_option_name = null;
+                                if ($sort_column->column_type == DatabaseColumnType::file && $sort_column->sort_download_count) {
+                                    $sort_option = '_downloadcount';
+                                    $sort_option_name = 'ダウンロード数';
+                                } elseif ($sort_column->column_type == DatabaseColumnType::video && $sort_column->sort_play_count) {
+                                    $sort_option = '_playcount';
+                                    $sort_option_name = '再生回数';
+                                }
                             @endphp
 
                             @if($sort_column->sort_flag == 1 || $sort_column->sort_flag == 2)

--- a/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_detail_value.blade.php
@@ -46,7 +46,11 @@
             $value = '';
         }
         else {
-            $value = '<video src="' . url('/') . '/file/' . $obj->value . '" class="img-fluid" controls />';
+            $value = '<video src="' . url('/') . '/file/' . $obj->value . '" class="img-fluid" controls></video>';
+            if ($column->show_play_count) {
+                $value .= '<span class="ml-4 databases-media-play-count-label">再生回数：</span>';
+                $value .= '<span class="databases-media-play-count">'. $obj->play_count . '</span>';
+            }
         }
     }
     // リンク型

--- a/resources/views/plugins/user/databases/default/databases_include_value.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_value.blade.php
@@ -49,7 +49,11 @@
             $value = '';
         }
         else {
-            $value = '<video src="' . url('/') . '/file/' . $obj->value . '" class="img-fluid" controls />';
+            $value = '<video src="' . url('/') . '/file/' . $obj->value . '" class="img-fluid" controls></video>';
+            if ($column->show_play_count) {
+                $value .= '<span class="ml-4 databases-media-play-count-label">再生回数：</span>';
+                $value .= '<span class="databases-media-play-count">'. $obj->play_count . '</span>';
+            }
         }
     }
     // リンク型


### PR DESCRIPTION
# 概要
データベースの動画型に再生回数表示の設定を追加しました。また、再生回数での並び替えも可能です。

## 背景や目的

データベースプラグインで動画を管理する際、再生回数は「どのコンテンツが実際に視聴されているか」を把握するために有用です。視聴数に応じてコンテンツの改善や整理、優先表示の判断ができるため、運用の意思決定に役立てることを目的としています。また、利用者側も再生回数から人気や有用性の目安を得られるため、視聴するコンテンツ選びの助けになります。

## 変更内容

- 動画型の項目詳細画面に"再生回数で並べ替え"可否、"再生回数で並び替え"可否の設定を追加しました
- 動画型の項目に動画と併せて、再生回数を表示します。
- 動画型の再生回数によって並び替えをします。

# レビュー完了希望日
可能なタイミングでご確認ください。

# 関連Pull requests/Issues

#2322

# 参考
ありません。

# DB変更の有無
有り
項目追加: `databases_columns.show_play_count` `databases_columns.sort_play_count`

# チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
