### PR TITLE
[FAQ] カテゴリ別表示でのアコーディオン制御を修正しました

### DIFF
--- a/resources/views/plugins/user/faqs/category/faqs.blade.php
+++ b/resources/views/plugins/user/faqs/category/faqs.blade.php
@@ -42,6 +42,7 @@
 
 {{-- FAQ表示 --}}
 @if (isset($faqs_posts))
+<div class="accordion" id="accordionFaq{{$frame_id}}">
     {{-- 検索フォーム --}}
     @include('plugins.user.faqs.search_form')
     
@@ -77,7 +78,7 @@
         @if ($loop->first || $sorted_posts[$loop->index - 1]->categories_id !== $post->categories_id)
             {{-- カテゴリ名 --}}
             <h2 class="faq-category-title mt-1" id="{{$post->category}}"><span class="badge" style="color:{{$post->category_color}};background-color:{{$post->category_background_color}};">{{$post->category}}</span></h1>
-            <div class="accordion faq-category" id="accordionFaq{{$frame_id}}">
+            <div class="accordion faq-category" id="accordionFaq{{$frame_id}}_category_{{$post->categories_id}}">
         @endif
         {{-- FAQの要素呼び出し --}}
         @include('plugins.user.faqs.default.faq', ['post' => $post, 'hide_category' => true])
@@ -89,6 +90,6 @@
 
     {{-- ページング処理 --}}
     @include('plugins.common.user_paginate', ['posts' => $faqs_posts, 'frame' => $frame, 'aria_label_name' => $faq_frame->faq_name, 'class' => 'mt-3'])
-
+</div>
 @endif
 @endsection


### PR DESCRIPTION
## 概要
FAQプラグインのカテゴリ別表示テンプレートで発生していたアコーディオン制御の不具合を修正しました。
※クライアントより問い合わせあり
```
今回のアップデート前から発生していた挙動なのですが、
FAQプラグインでテンプレートを「カテゴリ別表示」にした場合
下記☆マークをつけた動きは想定されているものでしょうか？

◯FAQプラグインの設定
・カテゴリ：A、Bの2つを用意
・Aに3つ、Bに2つのQAを用意(A-1、A-2、A-3、B-1、B-2とします。)

◯挙動
テンプレート：defaultにした場合
A-1 → A-2 → B-1 → A-3 → B-2 の順に記事をクリック
→ 前に開いていたQAは閉じ、クリックしたQAが開く

テンプレート：カテゴリ別表示にした場合
1)A-1をクリック → A-1が開く
2)A-2をクリック → A-1が閉じA-2が開く
3)B-1をクリック → A-2が閉じB-1が開く
4)A-3をクリック → B-1が開いたままA-3が開く ☆
5)B-2をクリック → B-1が開いたままB-2が開く ☆、A-3は閉じる
6)A-1をクリック → A-1が開く、B-1、B-2は開いたまま ☆
```

### 変更の背景・目的
カテゴリ別表示において、以下の意図しない動作が発生していました：
- 異なるカテゴリのFAQ項目を複数同時に開くことができる状態
- カテゴリを跨いだ際の排他制御が正しく動作しない

### 参考（問題事象の再現画像：両カテゴリ共に展開されてしまっている）
<img width="808" height="862" alt="image" src="https://github.com/user-attachments/assets/19df5517-14df-42f6-856f-73b363d85df5" />

### 変更内容
`resources/views/plugins/user/faqs/category/faqs.blade.php` を修正し、全FAQ項目が統一されたaccordion親要素を参照するよう改善しました。

**修正箇所**:
- 45行目: `<div class="accordion" id="accordionFaq{{$frame_id}}">`を追加
- 93行目: 対応する`</div>`を追加

**動作改善**:
- ✅ 同一カテゴリ内では1つのFAQのみ開く
- ✅ 異なるカテゴリ間でも排他制御が正しく動作
- ✅ defaultテンプレートへの影響なし

## レビュー完了希望日
特になし

## 関連PR/Issues
なし

## 参考情報
Bootstrap アコーディオンの標準動作に準拠した修正

## DB変更の有無
- [ ] あり
- [x] なし

## チェックリスト
- [x] 修正内容を確認済み
- [x] 既存機能への影響がないことを確認済み
- [x] defaultテンプレートに変更がないことを確認済み