### PR TITLE
[スライドショー] 項目追加の分かりにくさを改善しました（末尾追加に統一・導線/ハイライト）

### DIFF
--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -492,6 +492,8 @@ class SlideshowsPlugin extends UserPluginBase
         $slideshows_item->display_sequence = $max_display_sequence;
         $slideshows_item->save();
 
+        session()->flash('slideshow_highlight_item_ids', [$slideshows_item->id]);
+
         // フラッシュメッセージ設定
         $request->merge([
             'flash_message' => 'スライドショー項目を登録しました。'
@@ -604,6 +606,7 @@ class SlideshowsPlugin extends UserPluginBase
     private function savePdfImages(\Illuminate\Http\Request $request, array $base64_images)
     {
         $index = 1;
+        $added_item_ids = [];
         foreach ($base64_images as $base64_image) {
 
             // 画像をUploadsへ登録する
@@ -638,8 +641,13 @@ class SlideshowsPlugin extends UserPluginBase
             $slideshows_item->display_flag = ShowType::show;
             $slideshows_item->display_sequence = $max_display_sequence;
             $slideshows_item->save();
+            $added_item_ids[] = $slideshows_item->id;
 
             $index++;
+        }
+
+        if (!empty($added_item_ids)) {
+            session()->flash('slideshow_highlight_item_ids', $added_item_ids);
         }
     }
 

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit.blade.php
@@ -47,11 +47,32 @@
                                 スライドショーに表示させる画像やリンクを設定します。
                                 <a href="https://manual.connect-cms.jp/user/slideshows/index.html" target="_brank"><i class="fas fa-question-circle" data-toggle="tooltip" title="オンラインマニュアルはこちら"></i></a>
                             </li>
-                            <li>PDFを選択して追加することで、PDFの内容を画像に変換して登録できます。</li>
+                            {{-- PDFサムネイル機能が使えるときだけPDF登録の導線を表示する --}}
+                            @if (!empty(config('connect.PDF_THUMBNAIL_API_URL')))
+                                <li>PDFを選択して追加することで、PDFの内容を画像に変換して登録できます。</li>
+                            @endif
                         </ul>
                     @endif
                 </div>
 
+                <div class="d-flex flex-wrap align-items-center mb-2">
+                    <button
+                        type="button"
+                        class="btn btn-outline-success btn-sm mr-2 mb-2"
+                        onclick="scroll_to_slideshow_add_row();"
+                    >
+                        <i class="fas fa-plus"></i> 項目の追加行へ
+                    </button>
+                    @if (!empty(config('connect.PDF_THUMBNAIL_API_URL')))
+                        <button
+                            type="button"
+                            class="btn btn-outline-success btn-sm mr-2 mb-2"
+                            onclick="scroll_to_slideshow_add_pdf_row();"
+                        >
+                            <i class="fas fa-plus"></i> PDF追加行へ
+                        </button>
+                    @endif
+                </div>
                 {{-- 項目一覧 --}}
                 <div class="table-responsive">
                     <table class="table table-hover table-sm">
@@ -67,11 +88,6 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{-- 新規登録用の行 --}}
-                            <tr>
-                                <th colspan="7">【項目の追加行】</th>
-                            </tr>
-                            @include('plugins.user.slideshows.default.slideshows_edit_row_add')
                             <tr>
                                 <th colspan="7">【既存の設定行】</th>
                             </tr>
@@ -80,6 +96,13 @@
                                 @include('plugins.user.slideshows.default.slideshows_edit_row')
                             @endforeach
                         </tbody>
+                        <tfoot>
+                            {{-- 新規登録用の行 --}}
+                            <tr class="table-active">
+                                <th colspan="7">【項目の追加行】</th>
+                            </tr>
+                            @include('plugins.user.slideshows.default.slideshows_edit_row_add')
+                        </tfoot>
                     </table>
                 </div>
                 {{-- ボタンエリア --}}
@@ -158,11 +181,64 @@
         }
 
         /**
+         * 追加行へスクロール
+         */
+        function scroll_to_slideshow_add_row() {
+            const add_row = document.getElementById('slideshow-add-row');
+            if (!add_row) {
+                return;
+            }
+            add_row.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            add_row.classList.add('table-warning');
+            setTimeout(() => add_row.classList.remove('table-warning'), 2000);
+            const focus_target = document.getElementById('slideshow-add-link-url');
+            if (focus_target) {
+                setTimeout(() => focus_target.focus(), 300);
+            }
+        }
+
+        /**
+         * PDF追加行へスクロール
+         */
+        function scroll_to_slideshow_add_pdf_row() {
+            const add_row = document.getElementById('slideshow-add-pdf-row');
+            if (!add_row) {
+                return;
+            }
+            add_row.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            add_row.classList.add('table-warning');
+            setTimeout(() => add_row.classList.remove('table-warning'), 2000);
+        }
+
+        /**
          * ツールチップ
          */
         $(function () {
             // 有効化
             $('[data-toggle="tooltip"]').tooltip()
+
+            const highlight_item_ids = @json(session('slideshow_highlight_item_ids'));
+            const highlight_item_id = @json(session('slideshow_highlight_item_id'));
+            let highlight_ids = [];
+            if (Array.isArray(highlight_item_ids)) {
+                highlight_ids = highlight_item_ids;
+            } else if (highlight_item_id) {
+                highlight_ids = [highlight_item_id];
+            }
+            if (highlight_ids.length > 0) {
+                const first_row = document.getElementById('slideshow-item-' + highlight_ids[0]);
+                if (first_row) {
+                    first_row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+                highlight_ids.forEach((item_id) => {
+                    const highlight_row = document.getElementById('slideshow-item-' + item_id);
+                    if (!highlight_row) {
+                        return;
+                    }
+                    highlight_row.classList.add('table-warning');
+                    setTimeout(() => highlight_row.classList.remove('table-warning'), 2000);
+                });
+            }
         })
 
         /**

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
@@ -5,7 +5,7 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category スライドショー・プラグイン
 --}}
-<tr>
+<tr id="slideshow-item-{{ $item->id }}">
     {{-- 表示順 --}}
     <td class="d-none d-lg-display d-lg-table-cell text-nowrap" style="text-align:center; vertical-align:middle;">
         {{-- 上移動 --}}

--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row_add.blade.php
@@ -5,7 +5,7 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category スライドショー・プラグイン
 --}}
-<tr>
+<tr id="slideshow-add-row">
     <td class="d-none d-lg-display d-lg-table-cell"></td>
     <td class="d-none d-lg-display d-lg-table-cell"></td>
     {{-- 画像ファイル --}}
@@ -60,6 +60,7 @@
         <input
             type="text"
             name="link_url"
+            id="slideshow-add-link-url"
             class="form-control @if ($errors && $errors->has('link_url')) border-danger @endif"
             value="{{ old('link_url') }}"
             placeholder="例：https://connect-cms.jp/"
@@ -103,7 +104,7 @@
 {{-- PDF選択 --}}
 
 @if (!empty(config('connect.PDF_THUMBNAIL_API_URL')))
-<tr>
+<tr id="slideshow-add-pdf-row">
     <td class="d-none d-lg-display d-lg-table-cell"></td>
     <td class="d-none d-lg-display d-lg-table-cell"></td>
     <td class="d-table-cell align-middle">


### PR DESCRIPTION
# 概要

スライドショーの項目追加UIを末尾追加に統一し、先頭導線と追加後ハイライトを追加しました。

## 背景や目的

フォーム/データベースの項目設定と挙動を揃え、追加位置の分かりにくさを解消するためです。

## 変更内容

- 追加行を`tfoot`へ移動し、先頭に追加行への導線と注記を追加しました。
- 追加後に新規行へスクロールし、行を一時的に強調表示します。
- PDF追加は追加された全行を強調表示します。

## 特記事項

UIのみの変更です。

# レビュー完了希望日

軽微な改修なので急ぎません。

# 関連Pull requests/Issues

なし

# 参考

なし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule