### PR TITLE
[フォトアルバム] 一覧で埋め込みコードが表示されない問題を修正しました

### DIFF
--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -1733,7 +1733,7 @@ class PhotoalbumsPlugin extends UserPluginBase
         foreach ($frame_config_names as $key => $value) {
 
             // 空の場合はレコード削除
-            if (empty($request->$value)) {
+            if ($request->$value === null || $request->$value === '') {
                 FrameConfig::where('frame_id', $frame_id)->where('name', $value)->forceDelete();
                 continue;
             }

--- a/config/app.php
+++ b/config/app.php
@@ -338,6 +338,7 @@ $app_array = [
         'SmartphoneMenuTemplateType' => \App\Enums\SmartphoneMenuTemplateType::class,
         'MenuFrameConfig' => \App\Enums\MenuFrameConfig::class,
         'MailAuthMethod' => \App\Enums\MailAuthMethod::class,
+        'PhotoalbumPlayviewType' => \App\Enums\PhotoalbumPlayviewType::class,
 
         // utils
         'DateUtils' => \App\Utilities\Date\DateUtils::class,

--- a/resources/views/plugins/user/photoalbums/default/index_image.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_image.blade.php
@@ -16,6 +16,10 @@ if ($frame->isExpandNarrow()) {
     // メインエリア・フッターエリア
     $col_class = 'col-md-4';
 }
+
+$play_view_default = \App\Enums\PhotoalbumPlayviewType::play_in_list;
+$play_view = FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::play_view, $play_view_default);
+$description_list_length = FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::description_list_length);
 @endphp
 <div class="row">
     @foreach($photoalbum_contents->where('is_folder', 0) as $photoalbum_content)
@@ -52,7 +56,7 @@ if ($frame->isExpandNarrow()) {
                $("#popup_photo_{{$frame_id}}_{{$loop->iteration}}").attr('src', "{{url('/')}}/file/{{$photoalbum_content->upload_id}}");
             });
             </script>
-        @elseif ($photoalbum_content->isVideo($photoalbum_content->mimetype) && FrameConfig::getConfigValue($frame_configs, PhotoalbumFrameConfig::play_view))
+        @elseif ($photoalbum_content->isVideo($photoalbum_content->mimetype) && $play_view == PhotoalbumPlayviewType::play_in_detail)
             {{-- 動画：一覧はサムネイル画像のみで詳細画面で再生する --}}
             <a href="{{url('/')}}/plugin/photoalbums/detail/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}">
                 <img src="{{url('/')}}/file/{{$photoalbum_content->poster_upload_id}}"
@@ -80,7 +84,7 @@ if ($frame->isExpandNarrow()) {
                         </div>
                     @endif
                     @if ($photoalbum_content->name)
-                        @if ($photoalbum_content->isVideo($photoalbum_content->mimetype) && FrameConfig::getConfigValue($frame_configs, PhotoalbumFrameConfig::play_view))
+                        @if ($photoalbum_content->isVideo($photoalbum_content->mimetype) && $play_view == PhotoalbumPlayviewType::play_in_detail)
                             <a href="{{url('/')}}/plugin/photoalbums/detail/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}">
                                 <h5 class="card-title d-flex text-break">{{$photoalbum_content->name}}</h5>
                             </a>
@@ -92,9 +96,8 @@ if ($frame->isExpandNarrow()) {
                 @if ($photoalbum_content->description)
                     <div class="card-text">
                     {{-- 一覧での説明文字数によって切り取って出力する --}}
-                    @php $description_list_length = FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::description_list_length); @endphp
                     @if ($photoalbum_content->isVideo($photoalbum_content->mimetype) &&
-                         FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::play_view) &&
+                         $play_view == PhotoalbumPlayviewType::play_in_detail &&
                          $description_list_length !== '' && $description_list_length < mb_strlen(strip_tags($photoalbum_content->description)))
                         {{ mb_substr(strip_tags($photoalbum_content->description), 0, $description_list_length) }}...
                     @else
@@ -105,7 +108,7 @@ if ($frame->isExpandNarrow()) {
                 {{-- 動画を一覧で再生する設定の場合は埋め込みコードを表示する--}}
                 @if (($photoalbum_content->isVideo($photoalbum_content->mimetype)) &&
                       FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::embed_code) &&
-                      FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::play_view) == 0)
+                      $play_view == PhotoalbumPlayviewType::play_in_list)
                     <div class="card-text">
                         <a class="embed_code_check" data-name="embed_code{{$photoalbum_content->id}}" style="color: #007bff; cursor: pointer;" id="a_embed_code_check{{$photoalbum_content->id}}"><small>埋め込みコード</small> <i class="fas fa-caret-right"></i></a>
                         <input type="text" name="embed_code[{{$frame_id}}]" value='<iframe width="400" height="300" src="{{url('/')}}/download/plugin/photoalbums/embed/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}" frameborder="0" scrolling="no" allowfullscreen></iframe>' class="form-control" id="embed_code{{$photoalbum_content->id}}" style="display: none;">


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->
フォトアルバムの動画一覧で「埋め込みコード」が表示されない不具合を修正しました。

## 原因
再生形式が「一覧で再生」の設定でも、設定値0が空扱いで削除され、一覧での表示判定ができなくなっていたためです。

## 変更内容
- フレーム設定の空判定をnull/空文字に限定し、0を削除対象から除外しました。
- 一覧表示の再生形式判定をEnum値で明示しました。
- 一覧用の設定値取得を先にまとめ、判定処理を整理しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
