### PR TITLE
[ブログ] 削除導線と警告文を改善しました

### DIFF
--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -252,6 +252,15 @@
                         </div>
                     </div>
                 @endcan
+                @can('posts.delete',[[$post, $frame->plugin_name, $buckets]])
+                    <form action="{{url('/')}}/redirect/plugin/blogs/delete/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}" method="POST" class="d-inline">
+                        {{csrf_field()}}
+                        <input type="hidden" name="redirect_path" value="{{URL::to($page->permanent_link)}}">
+                        <button type="submit" class="btn btn-danger btn-sm ml-1" onclick="javascript:return confirm('【重要】この記事のみを削除します。\n削除を実行すると、データの復旧は一切できません。\nこの記事が失われます。よろしいですか？')">
+                            <i class="fas fa-trash-alt"></i> <span class="d-none d-sm-inline">削除</span>
+                        </button>
+                    </form>
+                @endcan
                 </div>
             </footer>
         </article>

--- a/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_edit_blog.blade.php
@@ -224,13 +224,13 @@
 <div id="collapse{{$blog_frame->id}}" class="collapse">
     <div class="card border-danger">
         <div class="card-body">
-            <span class="text-danger">ブログを削除します。<br>このブログに記載した記事も削除され、元に戻すことはできないため、よく確認して実行してください。</span>
+            <span class="text-danger">【重要】削除を実行すると、データの復旧は一切できません。<br>すべての記事が失われます。よろしいですか？</span>
 
             <div class="text-center">
                 {{-- 削除ボタン --}}
                 <form action="{{url('/')}}/redirect/plugin/blogs/destroyBuckets/{{$page->id}}/{{$frame_id}}/{{$blog->id}}#frame-{{$frame->id}}" method="POST">
                     {{csrf_field()}}
-                    <button type="submit" class="btn btn-danger" onclick="javascript:return confirm('データを削除します。\nよろしいですか？')"><i class="fas fa-check"></i> 本当に削除する</button>
+                    <button type="submit" class="btn btn-danger" onclick="javascript:return confirm('【重要】このブログ全体を削除します。\n削除を実行すると、データの復旧は一切できません。\nすべての記事が失われます。よろしいですか？')"><i class="fas fa-check"></i> 本当に削除する</button>
                 </form>
             </div>
 

--- a/resources/views/plugins/user/blogs/default/blogs_input.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_input.blade.php
@@ -177,7 +177,7 @@ use App\Models\User\Blogs\BlogsPosts;
                 <form action="{{url('/')}}/redirect/plugin/blogs/delete/{{$page->id}}/{{$frame_id}}/{{$blogs_posts->id}}#frame-{{$frame->id}}" method="POST">
                     {{csrf_field()}}
                     <input type="hidden" name="redirect_path" value="{{URL::to($page->permanent_link)}}">
-                    <button type="submit" class="btn btn-danger" onclick="javascript:return confirm('データを削除します。\nよろしいですか？')"><i class="fas fa-check"></i> 本当に削除する</button>
+                    <button type="submit" class="btn btn-danger" onclick="javascript:return confirm('【重要】この記事のみを削除します。\n削除を実行すると、データの復旧は一切できません。\nこの記事が失われます。よろしいですか？')"><i class="fas fa-check"></i> 本当に削除する</button>
                 </form>
             </div>
 

--- a/resources/views/plugins/user/blogs/default/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_show.blade.php
@@ -172,6 +172,15 @@
                 </div>
             </div>
         @endcan
+        @can('posts.delete',[[$post, $frame->plugin_name, $buckets]])
+            <form action="{{url('/')}}/redirect/plugin/blogs/delete/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}" method="POST" class="d-inline">
+                {{csrf_field()}}
+                <input type="hidden" name="redirect_path" value="{{URL::to($page->permanent_link)}}">
+                <button type="submit" class="btn btn-danger btn-sm ml-1" onclick="javascript:return confirm('【重要】この記事のみを削除します。\n削除を実行すると、データの復旧は一切できません。\nこの記事が失われます。よろしいですか？')">
+                    <i class="fas fa-trash-alt"></i> <span class="d-none d-sm-inline">削除</span>
+                </button>
+            </form>
+        @endcan
         </div>
     </footer>
 </article>


### PR DESCRIPTION
# 概要
ブログ記事の削除導線を一覧/詳細に追加し、削除確認文言を統一しました。

## 背景や目的
記事の削除ボタンが見つけづらく、記事削除のつもりで先にブログバケツの削除ボタンを見つけてしまい、全記事削除が発生したためです。

## 変更内容
- 記事一覧/詳細に削除ボタンを追加しました。
- 記事/ブログ削除のconfirm文言を統一して明確化しました。
- ブログ削除の警告文を強調しました。
- メッセージ変更の詳細:
  - ブログ削除(confirm): 「【重要】このブログ全体を削除します…すべての記事が失われます。」に変更しました。
  - 記事削除(confirm): 「【重要】この記事のみを削除します…この記事が失われます。」に変更しました。
  - ブログ削除(警告文): 「【重要】削除を実行すると…すべての記事が失われます。」に変更しました。

## 特記事項
- 期待する効果:
  - 削除対象（ブログ全体/記事単体）の誤認を減らします。
  - 取り消し不可の認識を強め、誤操作の抑止を図ります。
- 画像データの削除はしていないため、文言には含めていません。

# レビュー完了希望日
軽微な改修なので急ぎません。

# 関連Pull requests/Issues
ありません。

# 参考
ありません。

# DB変更の有無
無し

# チェックリスト
- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule