### PR TITLE
[管理画面] Connect-CMS更新情報取得失敗時の案内表示を改善しました

### DIFF
--- a/resources/views/plugins/manage/index/index.blade.php
+++ b/resources/views/plugins/manage/index/index.blade.php
@@ -86,10 +86,17 @@
     <div class="card-header bg-primary cc-primary-font-color">Connect-CMS 更新情報等</div>
     <div class="list-group">
         <div class="list-group-item list-group-item-action">
-            <div class="d-flex w-100 justify-content-between">
-                @foreach($errors as $error)
-                {{$error}}
-                @endforeach
+            <div class="w-100">
+                Connect-CMS 更新情報は<a href="https://connect-cms.jp/news" target="_blank" rel="noopener">公式サイトの最新情報</a>をご覧ください。
+                @if (config('app.debug') && !empty($errors))
+                    <div class="mt-2 text-muted">
+                        <small>
+                            @foreach($errors as $error)
+                                {{$error}}<br>
+                            @endforeach
+                        </small>
+                    </div>
+                @endif
             </div>
         </div>
     </div>


### PR DESCRIPTION
# 概要

Connect-CMS 更新情報が取得できない場合の案内文を公式サイトへのリンクに変更し、debug時のみエラー詳細を表示します。

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ef09d015-134f-4ffb-b1c3-525752fd6cb0" />


## 背景や目的

外部サイトへ接続できない環境ではエラー文が表示されるため、利用者に公式サイトの最新情報への導線を案内できるようにします。

## 変更内容

- 管理者メニューの「Connect-CMS 更新情報等」欄で、取得失敗時に公式サイトリンクを表示します
- debugモード `APP_DEBUG=true` 時のみエラー詳細を補足表示します 
- エラー時のレイアウトを調整します

## 特記事項

- 影響範囲: 管理者メニューの表示のみです
- 取得処理の変更はありません

# レビュー完了希望日

急ぎません

# 関連Pull requests/Issues

ありません


# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule