### PR TITLE
[新着情報] FAQを新着情報の対象にしました

### DIFF
--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -44,6 +44,11 @@ class FaqsPlugin extends UserPluginBase
      */
     public $post = null;
 
+    /**
+     * 新着機能を使うか
+     */
+    public $use_whatsnew = true;
+
     /* コアから呼び出す関数 */
 
     /**
@@ -357,6 +362,7 @@ class FaqsPlugin extends UserPluginBase
                           'frames.id                   as frame_id',
                           'faqs_posts.id              as post_id',
                           'faqs_posts.post_title      as post_title',
+                          'faqs_posts.post_text       as post_detail',
                           'faqs_posts.important       as important',
                           'faqs_posts.posted_at       as posted_at',
                           'faqs_posts.created_name    as posted_name',


### PR DESCRIPTION
# 概要

FAQの投稿が新着情報に表示されるようにします。

## 背景や目的

FAQが新着情報に出ず、FAQを新着情報として扱うには別途ブログ投稿が必要でした。
上記の手間を削減し、サイト運営の効率化を図ります。

## 変更内容

- FAQプラグインを新着情報の対象として扱うようにしました。
- 新着の詳細表示でFAQ本文を使えるようにしました。

## 特記事項

- 新着情報 - 表示設定で「対象プラグイン」にFAQを追加してください。
- 新着情報 - 表示設定のプラグイン並び順はプラグイン管理の表示順に基づいています。
  - サイト運営時にはよく使うプラグインの表示順の先頭になるようにすると、運用しやすいです。
<img width="700" alt="image" src="https://github.com/user-attachments/assets/99434dac-1e7f-47af-81b1-e3f12290b909" />


# レビュー完了希望日

軽微な改修なので急ぎません。

# 関連Pull requests/Issues

なし

# 参考

なし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
