### PR TITLE
[データベース] 表示件数の切り替えをすべてのテンプレートで利用できるようにしました

### DIFF
--- a/resources/views/plugins/user/databases/card_02/card_common.blade.php
+++ b/resources/views/plugins/user/databases/card_02/card_common.blade.php
@@ -13,6 +13,11 @@
     @if ($default_hide_list)
     @else
 
+        {{-- データベースの表示件数変更セレクトボックス --}}
+        @include('plugins.user.databases.default.databases_include_view_count')
+        {{-- 現在表示している件数テキスト --}}
+        @include('plugins.user.databases.default.databases_include_page_total_views')
+
 <div class="row">
 
     @php

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -17,6 +17,10 @@
 
     @if ($default_hide_list)
     @else
+        {{-- データベースの表示件数変更セレクトボックス --}}
+        @include('plugins.user.databases.default.databases_include_view_count')
+        {{-- 現在表示している件数テキスト --}}
+        @include('plugins.user.databases.default.databases_include_page_total_views')
         @php
             $database_show_like_list = FrameConfig::getConfigValueAndOld($frame_configs, DatabaseFrameConfig::database_show_like_list, ShowType::show);
             $like_button_caption = $database_frame->like_button_name ?: Like::like_button_default;


### PR DESCRIPTION
# 概要

データベースの一覧で、表示件数セレクトと現在表示件数テキストがdefault以外のテンプレートでも表示されるようにしました。

## 背景や目的

defaultテンプレートのみ表示されていたため、他テンプレートでも同様に操作できるよう統一しました。

## 変更内容

- tableテンプレートに表示件数セレクト/件数表示のincludeを追加しました。
- cardテンプレート共通部（card_02/card_03）に同じincludeを追加しました。

# レビュー完了希望日

軽微な改修なので急ぎません。

# 関連Pull requests/Issues

なし

# 参考

なし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
