### PR TITLE
[新着情報] テンプレート初期値と表示名を見直しました

### DIFF
--- a/app/Http/Controllers/Core/FrameCore.php
+++ b/app/Http/Controllers/Core/FrameCore.php
@@ -72,7 +72,7 @@ class FrameCore
         $frame->frame_design = "default";
         $frame->plugin_name = $request->add_plugin;
         $frame->frame_col = 0;
-        $frame->template = "default";
+        $frame->template = config('cc_plugin_defaults.default_template_map.' . $request->add_plugin, 'default');
         $frame->bucket_id = null;
         $frame->display_sequence = 0;
         $frame->save();

--- a/config/cc_plugin_defaults.php
+++ b/config/cc_plugin_defaults.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    // Plugin-specific default templates keyed by plugin_name.
+    'default_template_map' => [
+        'whatsnews' => 'onerow',
+    ],
+];

--- a/resources/views/plugins/user/whatsnews/card_03/template.ini
+++ b/resources/views/plugins/user/whatsnews/card_03/template.ini
@@ -1,0 +1,2 @@
+template_name = カード表示（3列）
+display_sequence = 3

--- a/resources/views/plugins/user/whatsnews/card_04/template.ini
+++ b/resources/views/plugins/user/whatsnews/card_04/template.ini
@@ -1,0 +1,2 @@
+template_name = カード表示（4列）
+display_sequence = 4

--- a/resources/views/plugins/user/whatsnews/card_04_top_thumbnail/template.ini
+++ b/resources/views/plugins/user/whatsnews/card_04_top_thumbnail/template.ini
@@ -1,0 +1,2 @@
+template_name = カード表示（4列・上部サムネイル）
+display_sequence = 5

--- a/resources/views/plugins/user/whatsnews/default/template.ini
+++ b/resources/views/plugins/user/whatsnews/default/template.ini
@@ -1,0 +1,2 @@
+template_name = 縦並び表示
+display_sequence = 2

--- a/resources/views/plugins/user/whatsnews/onerow/template.ini
+++ b/resources/views/plugins/user/whatsnews/onerow/template.ini
@@ -1,0 +1,2 @@
+template_name = 一行表示
+display_sequence = 1


### PR DESCRIPTION
# 概要

新着情報プラグインで、初期テンプレートとテンプレート表示名・並び順の見直しを行いました。

## 背景や目的

初期配置時に、よく使うテンプレートが「onerow」であり、「default」から変更する作業が手間になっていました。
そのため、初期値と表示名を整理しました。

## 変更内容

- 新着情報の初期テンプレートを設定ファイルで管理するようにしました。初期値: onerow（一行表示）
- 新着情報テンプレートの `template.ini` を整備し、日本語名と表示順を設定しました。

  | 物理名 | 和名 |
  |---|---|
  | onerow | 一行表示 |
  | default | 縦並び表示 |
  | card_03 | カード表示（3列） |
  | card_04 | カード表示（4列） |
  | card_04_top_thumbnail | カード表示（4列・上部サムネイル） |

## 特記事項

- 既存フレームのテンプレート値は変更していません（新規追加時の初期値のみ）。
- 初期テンプレートは `config/cc_plugin_defaults.php` で確認できます。

# レビュー完了希望日

軽微な改修なので急ぎません。

# 関連Pull requests/Issues

なし

# 参考

なし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
