### PR TITLE
[テーマ管理] 必須項目の説明を追加しました

### DIFF
--- a/resources/views/plugins/manage/theme/theme.blade.php
+++ b/resources/views/plugins/manage/theme/theme.blade.php
@@ -100,7 +100,7 @@
 
             {{-- ディレクトリ名 --}}
             <div class="form-group row">
-                <label for="dir_name" class="col-md-3 col-form-label text-md-right">ディレクトリ名</label>
+                <label for="dir_name" class="col-md-3 col-form-label text-md-right">ディレクトリ名 <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-9">
                     @if ($errors)
                     <input type="text" name="dir_name" id="dir_name" value="{{old('dir_name', '')}}" class="form-control">
@@ -108,11 +108,15 @@
                     <input type="text" name="dir_name" id="dir_name" value="" class="form-control">
                     @endif
                     @if ($errors && $errors->has('dir_name')) <div class="text-danger">{{$errors->first('dir_name')}}</div> @endif
+                    <small class="text-muted">
+                        <div>※ テーマファイルを保存するフォルダ名です。</div>
+                        <div>※ 英数字と記号の「-」「_」のみ使用できます。</div>
+                    </small>
                 </div>
             </div>
             {{-- テーマ名 --}}
             <div class="form-group row">
-                <label for="theme_name" class="col-md-3 col-form-label text-md-right">テーマ名</label>
+                <label for="theme_name" class="col-md-3 col-form-label text-md-right">テーマ名 <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-9">
                     @if ($errors)
                     <input type="text" name="theme_name" id="theme_name" value="{{old('theme_name', '')}}" class="form-control">
@@ -121,6 +125,7 @@
                     @endif
                     @if ($errors && $errors->has('theme_name')) <div class="text-danger">{{$errors->first('theme_name')}}</div> @endif
                     <small class="text-muted">
+                        <div>※ サイト管理で表示・選択されるテーマ名です。</div>
                         <div>※ 独自テーマを作成できます。独自テーマではCSS、javascript、画像を独自に定義することができます。</div>
                         <div>※ 作成した独自テーマは<a href="{{ url('/manage/site') }}" target="_blank">サイト管理</a>から設定することができます。</div>
                         <div>※ テーマファイルはサーバ上の [ドキュメントルート]/public/themes/Users/[ディレクトリ名] に作成されます。</div>

--- a/resources/views/plugins/manage/theme/theme_generate.blade.php
+++ b/resources/views/plugins/manage/theme/theme_generate.blade.php
@@ -76,7 +76,7 @@
 
             {{-- ディレクトリ名 --}}
             <div class="form-group row">
-                <label for="dir_name" class="col-md-2 col-form-label text-md-right">ディレクトリ名</label>
+                <label for="dir_name" class="col-md-2 col-form-label text-md-right">ディレクトリ名 <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-10">
                     @if ($errors || $theme_css)
                     <input type="text" name="dir_name" id="dir_name" value="{{old('dir_name', '')}}" class="form-control">
@@ -84,11 +84,15 @@
                     <input type="text" name="dir_name" id="dir_name" value="" class="form-control">
                     @endif
                     @if ($errors && $errors->has('dir_name')) <div class="text-danger">{{$errors->first('dir_name')}}</div> @endif
+                    <small class="text-muted">
+                        <div>※ テーマファイルを保存するフォルダ名です。</div>
+                        <div>※ 英数字と記号の「-」「_」のみ使用できます。</div>
+                    </small>
                 </div>
             </div>
             {{-- テーマ名 --}}
             <div class="form-group row">
-                <label for="theme_name" class="col-md-2 col-form-label text-md-right">テーマ名</label>
+                <label for="theme_name" class="col-md-2 col-form-label text-md-right">テーマ名 <span class="badge badge-danger">必須</span></label>
                 <div class="col-md-10">
                     @if ($errors || $theme_css)
                     <input type="text" name="theme_name" id="theme_name" value="{{old('theme_name', '')}}" class="form-control">
@@ -96,6 +100,9 @@
                     <input type="text" name="theme_name" id="theme_name" value="" class="form-control">
                     @endif
                     @if ($errors && $errors->has('theme_name')) <div class="text-danger">{{$errors->first('theme_name')}}</div> @endif
+                    <small class="text-muted">
+                        <div>※ サイト管理で表示・選択されるテーマ名です。</div>
+                    </small>
                 </div>
             </div>
             {{-- テーマセット --}}


### PR DESCRIPTION
# 概要

テーマ管理の新規作成/カスタムテーマ生成で必須表示と説明文を追加しました。

## 背景や目的

ディレクトリ名・テーマ名が必須であることや入力規則が分かりづらく、混乱を防ぐためです。

## 変更内容

- 「ディレクトリ名」「テーマ名」に必須バッジを追加しました。
- 各項目の意味とディレクトリ名の入力規則を説明として追加しました。

# レビュー完了希望日

軽微な改修なので急ぎません。

# 関連Pull requests/Issues

なし

# 参考

なし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
