### PR TITLE
[スライドショー] スマホ表示で並び替え・表示制御ボタンを表示するようにしました

### DIFF
--- a/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
+++ b/resources/views/plugins/user/slideshows/default/slideshows_edit_row.blade.php
@@ -7,7 +7,8 @@
 --}}
 <tr id="slideshow-item-{{ $item->id }}">
     {{-- 表示順 --}}
-    <td class="d-none d-lg-display d-lg-table-cell text-nowrap" style="text-align:center; vertical-align:middle;">
+    <td class="d-block d-lg-table-cell text-nowrap" style="text-align:center; vertical-align:middle;">
+        <div class="d-lg-none font-weight-bold mb-1">表示順</div>
         {{-- 上移動 --}}
         <button type="button" class="btn btn-default btn-xs p-1" @if ($loop->first) disabled @endif onclick="javascript:submit_display_sequence({{ $item->id }}, {{ $item->display_sequence }}, 'up')">
             <i class="fas fa-arrow-up"></i>
@@ -19,7 +20,8 @@
         </button>
     </td>
     {{-- 表示フラグ--}}
-    <td class="d-none d-lg-display d-lg-table-cell" style="text-align:center; vertical-align:middle;">
+    <td class="d-block d-lg-table-cell" style="text-align:center; vertical-align:middle;">
+        <div class="d-lg-none font-weight-bold mb-1">表示/非表示</div>
         <div class="custom-control custom-checkbox">
             <input
                 type="checkbox"


### PR DESCRIPTION
# 概要
- スライドショーの項目編集で、スマホ表示時にも「↑」「↓」と表示/非表示が見えるようにしました。

## 背景や目的
- スマホ/タブレット表示で並び替えと表示制御ができず、運用に支障が出ていたためです。

## 変更内容
- 既存行の表示順・表示/非表示の列を小画面でも表示するようにしました。
- 小画面用の見出しラベルを追加しました。

# レビュー完了希望日
軽微な改修なので急ぎません。

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
