### PR TITLE
[マイページ] プロフィールのメールアドレスが必須とならない問題を修正しました

### DIFF
--- a/app/Plugins/Mypage/ProfileMypage/ProfileMypage.php
+++ b/app/Plugins/Mypage/ProfileMypage/ProfileMypage.php
@@ -104,7 +104,12 @@ class ProfileMypage extends MypagePluginBase
                 $validator_array['column']['userid'] = UsersTool::getDefaultColumnAdditionalRules($base_rules, $users_column);
             } elseif ($users_column->column_type == UserColumnType::user_email) {
                 // $validator_array['column']['email'] = ['nullable', 'email', 'max:255', Rule::unique('users')->ignore($id)];
-                $base_rules = ['nullable', 'email', 'max:255', new CustomValiUserEmailUnique($request->columns_set_id, $id)];
+                $base_rules = ['email', 'max:255', new CustomValiUserEmailUnique($request->columns_set_id, $id)];
+                if ($users_column->required) {
+                    array_unshift($base_rules, 'required');
+                } else {
+                    array_unshift($base_rules, 'nullable');
+                }
                 $validator_array['column']['email'] = UsersTool::getDefaultColumnAdditionalRules($base_rules, $users_column);
             } elseif ($users_column->column_type == UserColumnType::user_password) {
                 // 入力があったら、ここで現在のパスワードチェック

--- a/resources/views/plugins/mypage/profile/edit_form.blade.php
+++ b/resources/views/plugins/mypage/profile/edit_form.blade.php
@@ -45,10 +45,12 @@ use App\Models\Core\UsersColumns;
         @elseif ($column->column_type == UserColumnType::user_email)
             {{-- メールアドレス --}}
             <div class="form-group row">
-                <label for="email" class="col-md-4 col-form-label text-md-right">{{$column->column_name}}</label>
+                <label for="email" class="col-md-4 col-form-label text-md-right">
+                    {{$column->column_name}} @if ($column->required)<span class="badge badge-danger">必須</span>@endif
+                </label>
 
                 <div class="col-md-8">
-                    <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email', $user->email) }}" placeholder="{{ $column->place_holder ?? __('messages.input_email') }}">
+                    <input id="email" type="text" class="form-control @if ($errors->has('email')) border-danger @endif" name="email" value="{{ old('email', $user->email) }}" placeholder="{{ $column->place_holder ?? __('messages.input_email') }}" @if ($column->required) required @endif>
                     @include('plugins.common.errors_inline', ['name' => 'email'])
                     <div class="small {{ $column->caption_color }}">{!! nl2br((string)$column->caption) !!}</div>
                 </div>
@@ -117,4 +119,3 @@ use App\Models\Core\UsersColumns;
         </div>
     </div>
 </form>
-


### PR DESCRIPTION
# 概要
- マイページのプロフィール変更で、メールアドレス必須設定が反映されるようにしました。

## 背景や目的
- ユーザー項目でメールアドレスが必須であるにもかかわらず、マイページのプロフィール変更では必須扱いになっていませんでした。
- 管理側の必須設定と挙動を一致させるために修正しました。

## 変更内容
- メールアドレスが必須の場合、バリデーションで必須判定されるようにしました。
- マイページの入力欄に必須バッジと `required` 属性を付与しました。

# レビュー完了希望日
軽微な改修なので急ぎません。

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
