### PR TITLE
[フォトアルバム] 一覧で画像とフォルダのもっと見る機能を追加しました

### DIFF
--- a/app/Enums/PhotoalbumFrameConfig.php
+++ b/app/Enums/PhotoalbumFrameConfig.php
@@ -25,6 +25,8 @@ final class PhotoalbumFrameConfig extends EnumsBase
     const embed_code = 'embed_code';
     const play_view = 'play_view';
     const description_list_length = 'description_list_length';
+    const load_more_use_flag = 'load_more_use_flag';
+    const load_more_count = 'load_more_count';
 
     // key/valueの連想配列
     const enum = [
@@ -38,5 +40,7 @@ final class PhotoalbumFrameConfig extends EnumsBase
         self::embed_code => '動画埋め込みコード',
         self::play_view => '動画の再生形式',
         self::description_list_length => '一覧の説明表示文字数',
+        self::load_more_use_flag => 'もっと見る機能',
+        self::load_more_count => 'もっと見る表示件数',
     ];
 }

--- a/config/photoalbums.php
+++ b/config/photoalbums.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+
+    // 「もっと見る」初期表示件数（フォルダ）
+    'load_more_folder_limit' => 10,
+
+    // 「もっと見る」初期表示件数（画像）
+    'load_more_image_limit' => 10,
+
+    // 「もっと見る」表示件数の最大値
+    'load_more_max_limit' => 100,
+
+];

--- a/resources/views/plugins/user/photoalbums/card/index_folder_items.blade.php
+++ b/resources/views/plugins/user/photoalbums/card/index_folder_items.blade.php
@@ -1,0 +1,56 @@
+{{--
+ * フォトアルバム画面テンプレート（フォルダの一覧項目）
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォトアルバム・プラグイン
+--}}
+@php
+if ($frame->isExpandNarrow()) {
+    // 右・左エリア = スマホ表示と同等にする
+    $col_class = 'col-12';
+} else {
+    // メインエリア・フッターエリア
+    $col_class = 'col-md-4';
+}
+@endphp
+@foreach($photoalbum_folder_items as $photoalbum_content)
+    <div class="{{$col_class}}">
+        <div class="card ml-3 mb-3 mt-3 p-0 mx-auto">
+            <a href="{{url('/')}}/plugin/photoalbums/changeDirectory/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}/#frame-{{$frame->id}}" class="text-center">
+                {{-- カバー画像が指定されていれば使用し、指定されていなければ、グレーのカバーを使用 --}}
+                @if ($covers->where('parent_id', $photoalbum_content->id)->first())
+                    <img src="{{url('/')}}/file/{{$covers->where('parent_id', $photoalbum_content->id)->first()->getCoverFileId()}}?size=small"
+                         id="cover_{{$frame_id}}_{{$photoalbum_content->id}}"
+                         style="max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"
+                         class="img-fluid"
+                         loading="lazy"
+                         decoding="async"
+                    >
+                @else
+                    <svg class="bd-placeholder-img card-img-top" width="100%" height="150" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap">
+                        <title>{{$photoalbum_content->name}}</title>
+                        <rect fill="#868e96" width="100%" height="100%"></rect>
+                        <text fill="#dee2e6"x="50%" y="50%" text-anchor="middle" dominant-baseline="central">{{$photoalbum_content->name}}</text>
+                    </svg>
+                @endif
+            </a>
+            <div class="card-body">
+                @if ($download_check)
+                <div class="custom-control custom-checkbox">
+                    <input type="checkbox" class="custom-control-input" id="customCheck_{{$photoalbum_content->id}}" name="photoalbum_content_id[]" value="{{$photoalbum_content->id}}" data-name="{{$photoalbum_content->displayName}}">
+                    <label class="custom-control-label" for="customCheck_{{$photoalbum_content->id}}"></label>
+                </div>
+                @endif
+                <h5 class="card-title">{{$photoalbum_content->name}}</h5>
+                <p class="card-text">{!!nl2br(e($photoalbum_content->description))!!}</p>
+                @can('posts.update', [[$photoalbum_content, $frame->plugin_name, $buckets]])
+                <a href="{{url('/')}}/plugin/photoalbums/edit/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}" class="btn btn-sm btn-success">
+                    <i class="far fa-edit"></i> 編集
+                </a>
+                @endcan
+            </div>
+        </div>
+    </div>
+@endforeach

--- a/resources/views/plugins/user/photoalbums/default/index_folder.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_folder.blade.php
@@ -7,61 +7,39 @@
  * @category フォトアルバム・プラグイン
 --}}
 {{-- データ一覧にアルバムが含まれる場合 --}}
-@if ($photoalbum_contents->where('is_folder', 1)->isNotEmpty())
 @php
-if ($frame->isExpandNarrow()) {
-    // 右・左エリア = スマホ表示と同等にする
-    $left_class = 'col-12';
-    $right_class = 'col-12';
-} else {
-    // メインエリア・フッターエリア
-    $left_class = 'col-sm-4';
-    $right_class = 'col-sm-8';
-}
+    $photoalbum_folder_items = $photoalbum_folder_items ?? $photoalbum_contents->where('is_folder', 1)->values();
+    $photoalbum_folder_total = $photoalbum_folder_total ?? $photoalbum_folder_items->count();
+    $photoalbum_folder_offset = $photoalbum_folder_offset ?? $photoalbum_folder_items->count();
+    $photoalbum_folder_limit = $photoalbum_folder_limit ?? $photoalbum_folder_total;
+    $photoalbum_load_more_use = $photoalbum_load_more_use ?? \App\Enums\UseType::not_use;
+    $folder_list_id = 'photoalbum-folder-list-' . $frame_id;
+    $folder_row_id = 'photoalbum-folder-row-' . $frame_id;
 @endphp
-<div class="row">
-    @foreach($photoalbum_contents->where('is_folder', 1) as $photoalbum_content)
-    <div class="{{$left_class}} mt-3">
-        <div class="card sm-4">
-            <a href="{{url('/')}}/plugin/photoalbums/changeDirectory/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}/#frame-{{$frame->id}}" class="text-center">
-                {{-- カバー画像が指定されていれば使用し、指定されていなければ、グレーのカバーを使用 --}}
-                @if ($covers->where('parent_id', $photoalbum_content->id)->first())
-                    <img src="{{url('/')}}/file/{{$covers->where('parent_id', $photoalbum_content->id)->first()->getCoverFileId()}}?size=small"
-                         id="cover_{{$loop->iteration}}"
-                         style="max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"
-                         class="img-fluid"
-                         loading="lazy"
-                         decoding="async"
-                    >
-                @else
-                    <svg class="bd-placeholder-img card-img-top" width="100%" height="150" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap">
-                        <title>{{$photoalbum_content->name}}</title>
-                        <rect fill="#868e96" width="100%" height="100%"></rect>
-                        <text fill="#dee2e6"x="50%" y="50%" text-anchor="middle" dominant-baseline="central">{{$photoalbum_content->name}}</text>
-                    </svg>
-                @endif
-            </a>
-        </div>
+@if ($photoalbum_folder_total > 0)
+<div id="{{$folder_list_id}}"
+     data-more-url="{{url('/')}}/json/photoalbums/moreContents/{{$page->id}}/{{$frame_id}}/{{$parent_id ?? 0}}"
+     data-offset="{{$photoalbum_folder_offset}}"
+     data-limit="{{$photoalbum_folder_limit}}"
+     data-total="{{$photoalbum_folder_total}}">
+    <div class="row" id="{{$folder_row_id}}">
+        @include('plugins.user.photoalbums.default.index_folder_items', ['photoalbum_folder_items' => $photoalbum_folder_items])
     </div>
-    <div class="{{$right_class}} mt-3">
-        <div class="d-flex">
-            @if ($download_check)
-            <div class="custom-control custom-checkbox">
-                <input type="checkbox" class="custom-control-input" id="customCheck_{{$photoalbum_content->id}}" name="photoalbum_content_id[]" value="{{$photoalbum_content->id}}" data-name="{{$photoalbum_content->displayName}}">
-                <label class="custom-control-label" for="customCheck_{{$photoalbum_content->id}}"></label>
-            </div>
-            @endif
-            <h5 class="card-title">{{$photoalbum_content->name}}</h5>
-        </div>
-        <p class="card-text">{!!nl2br(e($photoalbum_content->description))!!}</p>
-        <div class="d-flex justify-content-between align-items-center">
-            @can('posts.update', [[$photoalbum_content, $frame->plugin_name, $buckets]])
-            <a href="{{url('/')}}/plugin/photoalbums/edit/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}" class="btn btn-sm btn-success">
-                <i class="far fa-edit"></i> 編集
-            </a>
-            @endcan
-        </div>
-    </div>
-    @endforeach
 </div>
+@if ($photoalbum_load_more_use == \App\Enums\UseType::use && $photoalbum_folder_total > $photoalbum_folder_offset)
+    <div class="text-center mt-3 photoalbum-load-more-wrap">
+        <button type="button"
+                class="btn btn-outline-secondary photoalbum-load-more"
+                data-target="folder"
+                data-container="#{{$folder_list_id}}"
+                data-row="#{{$folder_row_id}}"
+                data-status="#photoalbum-folder-status-{{$frame_id}}"
+                data-label="フォルダをもっと見る">
+            フォルダをもっと見る
+        </button>
+        <div id="photoalbum-folder-status-{{$frame_id}}" class="small text-muted mt-1">
+            表示中 {{$photoalbum_folder_offset}} / {{$photoalbum_folder_total}}
+        </div>
+    </div>
+@endif
 @endif

--- a/resources/views/plugins/user/photoalbums/default/index_folder_items.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_folder_items.blade.php
@@ -1,0 +1,62 @@
+{{--
+ * フォトアルバム画面テンプレート（フォルダの一覧項目）
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォトアルバム・プラグイン
+--}}
+@php
+if ($frame->isExpandNarrow()) {
+    // 右・左エリア = スマホ表示と同等にする
+    $left_class = 'col-12';
+    $right_class = 'col-12';
+} else {
+    // メインエリア・フッターエリア
+    $left_class = 'col-sm-4';
+    $right_class = 'col-sm-8';
+}
+@endphp
+@foreach($photoalbum_folder_items as $photoalbum_content)
+    <div class="{{$left_class}} mt-3">
+        <div class="card sm-4">
+            <a href="{{url('/')}}/plugin/photoalbums/changeDirectory/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}/#frame-{{$frame->id}}" class="text-center">
+                {{-- カバー画像が指定されていれば使用し、指定されていなければ、グレーのカバーを使用 --}}
+                @if ($covers->where('parent_id', $photoalbum_content->id)->first())
+                    <img src="{{url('/')}}/file/{{$covers->where('parent_id', $photoalbum_content->id)->first()->getCoverFileId()}}?size=small"
+                         id="cover_{{$frame_id}}_{{$photoalbum_content->id}}"
+                         style="max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"
+                         class="img-fluid"
+                         loading="lazy"
+                         decoding="async"
+                    >
+                @else
+                    <svg class="bd-placeholder-img card-img-top" width="100%" height="150" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap">
+                        <title>{{$photoalbum_content->name}}</title>
+                        <rect fill="#868e96" width="100%" height="100%"></rect>
+                        <text fill="#dee2e6"x="50%" y="50%" text-anchor="middle" dominant-baseline="central">{{$photoalbum_content->name}}</text>
+                    </svg>
+                @endif
+            </a>
+        </div>
+    </div>
+    <div class="{{$right_class}} mt-3">
+        <div class="d-flex">
+            @if ($download_check)
+            <div class="custom-control custom-checkbox">
+                <input type="checkbox" class="custom-control-input" id="customCheck_{{$photoalbum_content->id}}" name="photoalbum_content_id[]" value="{{$photoalbum_content->id}}" data-name="{{$photoalbum_content->displayName}}">
+                <label class="custom-control-label" for="customCheck_{{$photoalbum_content->id}}"></label>
+            </div>
+            @endif
+            <h5 class="card-title">{{$photoalbum_content->name}}</h5>
+        </div>
+        <p class="card-text">{!!nl2br(e($photoalbum_content->description))!!}</p>
+        <div class="d-flex justify-content-between align-items-center">
+            @can('posts.update', [[$photoalbum_content, $frame->plugin_name, $buckets]])
+            <a href="{{url('/')}}/plugin/photoalbums/edit/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}" class="btn btn-sm btn-success">
+                <i class="far fa-edit"></i> 編集
+            </a>
+            @endcan
+        </div>
+    </div>
+@endforeach

--- a/resources/views/plugins/user/photoalbums/default/index_head.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_head.blade.php
@@ -61,7 +61,7 @@
 
         {{-- 一覧のチェックボックスによる削除、ダウンロードの制御(編集権限あり or フレームでダウンロードOK) --}}
         @if ($download_check)
-        $('#app_{{$frame_id}} input[type="checkbox"][name="photoalbum_content_id[]"]').on('change', function(){
+        $('#app_{{$frame_id}}').on('change', 'input[type="checkbox"][name="photoalbum_content_id[]"]', function(){
 
             $('#selected-contents{{$frame_id}}').html('');
 
@@ -88,11 +88,18 @@
         });
         @endif
 
-        // 埋め込みコードの表示
-        $('#app_{{$frame_id}} .embed_code_check').on('click', function(){
-            $("#" + $(this).data('name')).slideToggle();
-            $("#" + $(this).data('name')).focus();
-            $("#" + $(this).data('name')).select();
+        // 埋め込みコードの表示（もっと見るで追加された要素にも対応するため委譲）
+        $('#app_{{$frame_id}}').on('click', '.embed_code_check', function (event) {
+            event.preventDefault();
+
+            var targetId = $(this).data('name');
+            if (!targetId) {
+                return;
+            }
+
+            $("#" + targetId).slideToggle();
+            $("#" + targetId).focus();
+            $("#" + targetId).select();
         });
     });
 

--- a/resources/views/plugins/user/photoalbums/default/index_image.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_image.blade.php
@@ -7,118 +7,42 @@
  * @category フォトアルバム・プラグイン
 --}}
 {{-- データ一覧に画像が含まれる場合 --}}
-@if ($photoalbum_contents->where('is_folder', 0)->isNotEmpty())
 @php
-if ($frame->isExpandNarrow()) {
-    // 右・左エリア = スマホ表示と同等にする
-    $col_class = 'col-12';
-} else {
-    // メインエリア・フッターエリア
-    $col_class = 'col-md-4';
-}
-
-$play_view_default = \App\Enums\PhotoalbumPlayviewType::play_in_list;
-$play_view = FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::play_view, $play_view_default);
-$description_list_length = FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::description_list_length);
-$image_modal_id = 'photoalbum-image-modal-' . $frame_id;
+    $photoalbum_image_items = $photoalbum_image_items ?? (($photoalbum_contents ?? collect())->where('is_folder', 0)->values());
+    $photoalbum_image_total = $photoalbum_image_total ?? $photoalbum_image_items->count();
+    $photoalbum_image_offset = $photoalbum_image_offset ?? $photoalbum_image_items->count();
+    $photoalbum_image_limit = $photoalbum_image_limit ?? $photoalbum_image_total;
+    $photoalbum_load_more_use = $photoalbum_load_more_use ?? \App\Enums\UseType::not_use;
+    $image_modal_id = 'photoalbum-image-modal-' . $frame_id;
+    $image_list_id = 'photoalbum-image-list-' . $frame_id;
+    $image_row_id = 'photoalbum-image-row-' . $frame_id;
 @endphp
-<div class="row">
-    @foreach($photoalbum_contents->where('is_folder', 0) as $photoalbum_content)
-    @php
-        $description_attr = str_replace(["\r\n", "\r", "\n"], '\\n', (string) $photoalbum_content->description);
-    @endphp
-    <div class="{{$col_class}}">
-        <div class="card mt-3 shadow-sm">
-        @if ($photoalbum_content->upload->is_image)
-            {{-- 画像 --}}
-            <img src="{{url('/')}}/file/{{$photoalbum_content->upload_id}}?size=small"
-                 id="photo_{{$frame_id}}_{{$loop->iteration}}"
-                 style="max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"
-                 class="img-fluid photoalbum-thumbnail"
-                 data-toggle="modal"
-                 data-target="#{{$image_modal_id}}"
-                 data-thumb="{{url('/')}}/file/{{$photoalbum_content->upload_id}}?size=small"
-                 data-full="{{url('/')}}/file/{{$photoalbum_content->upload_id}}"
-                 data-title="{{e($photoalbum_content->name)}}"
-                 data-description="{{e($description_attr)}}"
-                 loading="lazy"
-                 decoding="async"
-            >
-        @elseif ($photoalbum_content->isVideo($photoalbum_content->mimetype) && $play_view == PhotoalbumPlayviewType::play_in_detail)
-            {{-- 動画：一覧はサムネイル画像のみで詳細画面で再生する --}}
-            <a href="{{url('/')}}/plugin/photoalbums/detail/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}">
-                <img src="{{url('/')}}/file/{{$photoalbum_content->poster_upload_id}}"
-                     style="width: 100%; max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"
-                     id="popup_photo_{{$frame_id}}_{{$loop->iteration}}"
-                     class="img-fluid"
-                     loading="lazy"
-                     decoding="async"/>
-            </a>
-        @elseif ($photoalbum_content->isVideo($photoalbum_content->mimetype))
-            {{-- 動画：一覧で再生する --}}
-            <video controls controlsList="nodownload"
-                 src="{{url('/')}}/file/{{$photoalbum_content->upload_id}}"
-                 id="video_{{$loop->iteration}}"
-                 style="width: 100%; max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"
-                 class="img-fluid"
-                 @if ($photoalbum_content->poster_upload_id) poster="{{url('/')}}/file/{{$photoalbum_content->poster_upload_id}}" @endif
-                 oncontextmenu="return false;"
-            ></video>
-        @endif
-            <div class="card-body">
-                <div class="d-flex">
-                    @if ($download_check)
-                        <div class="custom-control custom-checkbox d-inline">
-                            <input type="checkbox" class="custom-control-input" id="customCheck_{{$photoalbum_content->id}}" name="photoalbum_content_id[]" value="{{$photoalbum_content->id}}" data-name="{{$photoalbum_content->name}}">
-                            <label class="custom-control-label" for="customCheck_{{$photoalbum_content->id}}"></label>
-                        </div>
-                    @endif
-                    @if ($photoalbum_content->name)
-                        @if ($photoalbum_content->isVideo($photoalbum_content->mimetype) && $play_view == PhotoalbumPlayviewType::play_in_detail)
-                            <a href="{{url('/')}}/plugin/photoalbums/detail/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}">
-                                <h5 class="card-title d-flex text-break">{{$photoalbum_content->name}}</h5>
-                            </a>
-                        @else
-                            <h5 class="card-title d-flex text-break">{{$photoalbum_content->name}}</h5>
-                        @endif
-                    @endif
-                </div>
-                @if ($photoalbum_content->description)
-                    <div class="card-text">
-                    {{-- 一覧での説明文字数によって切り取って出力する --}}
-                    @if ($photoalbum_content->isVideo($photoalbum_content->mimetype) &&
-                         $play_view == PhotoalbumPlayviewType::play_in_detail &&
-                         $description_list_length !== '' && $description_list_length < mb_strlen(strip_tags($photoalbum_content->description)))
-                        {{ mb_substr(strip_tags($photoalbum_content->description), 0, $description_list_length) }}...
-                    @else
-                        {!!nl2br(e($photoalbum_content->description))!!}
-                    @endif
-                    </div>
-                @endif
-                {{-- 動画を一覧で再生する設定の場合は埋め込みコードを表示する--}}
-                @if (($photoalbum_content->isVideo($photoalbum_content->mimetype)) &&
-                      FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::embed_code) &&
-                      $play_view == PhotoalbumPlayviewType::play_in_list)
-                    <div class="card-text">
-                        <a class="embed_code_check" data-name="embed_code{{$photoalbum_content->id}}" style="color: #007bff; cursor: pointer;" id="a_embed_code_check{{$photoalbum_content->id}}"><small>埋め込みコード</small> <i class="fas fa-caret-right"></i></a>
-                        <input type="text" name="embed_code[{{$frame_id}}]" value='<iframe width="400" height="300" src="{{url('/')}}/download/plugin/photoalbums/embed/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}" frameborder="0" scrolling="no" allowfullscreen></iframe>' class="form-control" id="embed_code{{$photoalbum_content->id}}" style="display: none;">
-                    </div>
-                @endif
-                @if (FrameConfig::getConfigValue($frame_configs, PhotoalbumFrameConfig::posted_at, ShowType::not_show))
-                    <div class="card-text"><small>登録日：{{$photoalbum_content->getUpdateOrCreatedAt('Y年n月j日')}}</small></div>
-                @endif
-                <div class="d-flex justify-content-between align-items-center">
-                    @can('posts.update', [[$photoalbum_content, $frame->plugin_name, $buckets]])
-                    <a href="{{url('/')}}/plugin/photoalbums/edit/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}" class="btn btn-sm btn-success">
-                        <i class="far fa-edit"></i> 編集
-                    </a>
-                    @endcan
-                </div>
-            </div>
+@if ($photoalbum_image_total > 0)
+<div id="{{$image_list_id}}"
+     data-more-url="{{url('/')}}/json/photoalbums/moreContents/{{$page->id}}/{{$frame_id}}/{{$parent_id ?? 0}}"
+     data-offset="{{$photoalbum_image_offset}}"
+     data-limit="{{$photoalbum_image_limit}}"
+     data-total="{{$photoalbum_image_total}}">
+    <div class="row" id="{{$image_row_id}}">
+        @include('plugins.user.photoalbums.default.index_image_items', ['photoalbum_image_items' => $photoalbum_image_items, 'image_modal_id' => $image_modal_id])
+    </div>
+</div>
+@if ($photoalbum_load_more_use == \App\Enums\UseType::use && $photoalbum_image_total > $photoalbum_image_offset)
+    <div class="text-center mt-3 photoalbum-load-more-wrap">
+        <button type="button"
+                class="btn btn-outline-secondary photoalbum-load-more"
+                data-target="image"
+                data-container="#{{$image_list_id}}"
+                data-row="#{{$image_row_id}}"
+                data-status="#photoalbum-image-status-{{$frame_id}}"
+                data-label="画像をもっと見る">
+            画像をもっと見る
+        </button>
+        <div id="photoalbum-image-status-{{$frame_id}}" class="small text-muted mt-1">
+            表示中 {{$photoalbum_image_offset}} / {{$photoalbum_image_total}}
         </div>
     </div>
-    @endforeach
-</div>
+@endif
 
 <div class="modal fade" id="{{$image_modal_id}}" tabindex="-1" role="dialog" aria-labelledby="{{$image_modal_id}}-label" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-middle">{{-- モーダルウィンドウの縦表示位置を調整・画像を大きく見せる --}}

--- a/resources/views/plugins/user/photoalbums/default/index_image_items.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/index_image_items.blade.php
@@ -1,0 +1,119 @@
+{{--
+ * フォトアルバム画面テンプレート（画像・動画の一覧項目）
+ *
+ * @author 永原　篤 <nagahara@opensource-workshop.jp>
+ * @author 牟田口 満 <mutaguchi@opensource-workshop.jp>
+ * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
+ * @category フォトアルバム・プラグイン
+--}}
+@php
+if ($frame->isExpandNarrow()) {
+    // 右・左エリア = スマホ表示と同等にする
+    $col_class = 'col-12';
+} else {
+    // メインエリア・フッターエリア
+    $col_class = 'col-md-4';
+}
+
+$play_view_default = \App\Enums\PhotoalbumPlayviewType::play_in_list;
+$play_view = FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::play_view, $play_view_default);
+$description_list_length = FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::description_list_length);
+$image_modal_id = $image_modal_id ?? ('photoalbum-image-modal-' . $frame_id);
+@endphp
+@foreach($photoalbum_image_items as $photoalbum_content)
+@php
+    $description_attr = str_replace(["\r\n", "\r", "\n"], '\\n', (string) $photoalbum_content->description);
+@endphp
+<div class="{{$col_class}}">
+    <div class="card mt-3 shadow-sm">
+    @if ($photoalbum_content->upload->is_image)
+        {{-- 画像 --}}
+        <img src="{{url('/')}}/file/{{$photoalbum_content->upload_id}}?size=small"
+             id="photo_{{$frame_id}}_{{$photoalbum_content->id}}"
+             style="max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"
+             class="img-fluid photoalbum-thumbnail"
+             data-toggle="modal"
+             data-target="#{{$image_modal_id}}"
+             data-thumb="{{url('/')}}/file/{{$photoalbum_content->upload_id}}?size=small"
+             data-full="{{url('/')}}/file/{{$photoalbum_content->upload_id}}"
+             data-title="{{e($photoalbum_content->name)}}"
+             data-description="{{e($description_attr)}}"
+             loading="lazy"
+             decoding="async"
+        >
+    @elseif ($photoalbum_content->isVideo($photoalbum_content->mimetype) && $play_view == PhotoalbumPlayviewType::play_in_detail)
+        {{-- 動画：一覧はサムネイル画像のみで詳細画面で再生する --}}
+        <a href="{{url('/')}}/plugin/photoalbums/detail/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}">
+            <img src="{{url('/')}}/file/{{$photoalbum_content->poster_upload_id}}"
+                 style="width: 100%; max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"
+                 id="popup_photo_{{$frame_id}}_{{$photoalbum_content->id}}"
+                 class="img-fluid"
+                 loading="lazy"
+                 decoding="async"/>
+        </a>
+    @elseif ($photoalbum_content->isVideo($photoalbum_content->mimetype))
+        {{-- 動画：一覧で再生する --}}
+        <video controls controlsList="nodownload"
+             src="{{url('/')}}/file/{{$photoalbum_content->upload_id}}"
+             id="video_{{$frame_id}}_{{$photoalbum_content->id}}"
+             style="width: 100%; max-height: 200px; object-fit: scale-down; cursor:pointer; border-radius: 3px;"
+             class="img-fluid"
+             @if ($photoalbum_content->poster_upload_id) poster="{{url('/')}}/file/{{$photoalbum_content->poster_upload_id}}" @endif
+             oncontextmenu="return false;"
+        ></video>
+    @endif
+        <div class="card-body">
+            <div class="d-flex">
+                @if ($download_check)
+                    <div class="custom-control custom-checkbox d-inline">
+                        <input type="checkbox" class="custom-control-input" id="customCheck_{{$photoalbum_content->id}}" name="photoalbum_content_id[]" value="{{$photoalbum_content->id}}" data-name="{{$photoalbum_content->name}}">
+                        <label class="custom-control-label" for="customCheck_{{$photoalbum_content->id}}"></label>
+                    </div>
+                @endif
+                @if ($photoalbum_content->name)
+                    @if ($photoalbum_content->isVideo($photoalbum_content->mimetype) && $play_view == PhotoalbumPlayviewType::play_in_detail)
+                        <a href="{{url('/')}}/plugin/photoalbums/detail/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}">
+                            <h5 class="card-title d-flex text-break">{{$photoalbum_content->name}}</h5>
+                        </a>
+                    @else
+                        <h5 class="card-title d-flex text-break">{{$photoalbum_content->name}}</h5>
+                    @endif
+                @endif
+            </div>
+            @if ($photoalbum_content->description)
+                <div class="card-text">
+                {{-- 一覧での説明文字数によって切り取って出力する --}}
+                @if ($photoalbum_content->isVideo($photoalbum_content->mimetype) &&
+                     $play_view == PhotoalbumPlayviewType::play_in_detail &&
+                     $description_list_length !== '' && $description_list_length < mb_strlen(strip_tags($photoalbum_content->description)))
+                    {{ mb_substr(strip_tags($photoalbum_content->description), 0, $description_list_length) }}...
+                @else
+                    {!!nl2br(e($photoalbum_content->description))!!}
+                @endif
+                </div>
+            @endif
+            {{-- 動画を一覧で再生する設定の場合は埋め込みコードを表示する--}}
+            @if (($photoalbum_content->isVideo($photoalbum_content->mimetype)) &&
+                  FrameConfig::getConfigValueAndOld($frame_configs, PhotoalbumFrameConfig::embed_code) &&
+                  $play_view == PhotoalbumPlayviewType::play_in_list)
+                <div class="card-text">
+                    <a class="embed_code_check" data-name="embed_code{{$photoalbum_content->id}}" style="color: #007bff; cursor: pointer;" id="a_embed_code_check{{$photoalbum_content->id}}"><small>埋め込みコード</small> <i class="fas fa-caret-right"></i></a>
+                    <input type="text" name="embed_code[{{$frame_id}}]" value='<iframe width="400" height="300" src="{{url('/')}}/download/plugin/photoalbums/embed/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}" frameborder="0" scrolling="no" allowfullscreen></iframe>' class="form-control" id="embed_code{{$photoalbum_content->id}}" style="display: none;">
+                </div>
+            @endif
+            @if (FrameConfig::getConfigValue($frame_configs, PhotoalbumFrameConfig::posted_at, ShowType::not_show))
+                <div class="card-text"><small>登録日：{{$photoalbum_content->getUpdateOrCreatedAt('Y年n月j日')}}</small></div>
+            @endif
+            <div class="d-flex justify-content-between align-items-center">
+                @can('posts.update', [[$photoalbum_content, $frame->plugin_name, $buckets]])
+                <div class="btn-group">
+                    <a href="{{url('/')}}/plugin/photoalbums/edit/{{$page->id}}/{{$frame_id}}/{{$photoalbum_content->id}}#frame-{{$frame->id}}" class="btn btn-sm btn-success">
+                        <i class="far fa-edit"></i> 編集
+                    </a>
+                </div>
+                @endcan
+            </div>
+        </div>
+    </div>
+</div>
+@endforeach


### PR DESCRIPTION
# 概要
- フォトアルバムの一覧画面に「もっと見る」機能を追加しました。
- フォルダ一覧と画像一覧を段階的に読み込めるようにしました。
- 表示設定で「もっと見る機能」と「もっと見る表示件数」を設定できるようにしました。

## 背景や目的
- 一覧件数が多い場合に初期表示の情報量が多くなり、閲覧性と読み込み体感が下がっていました。
- 既存の表示機能（画像モーダル、ダウンロード選択、編集導線）を維持しながら、段階表示できるようにすることが目的です。

## 変更内容
- フォトアルバム一覧に「もっと見る」ボタンを追加しました。
  - フォルダ一覧の追加表示
  - 画像一覧の追加表示
- 表示件数の進捗表示（表示中 x / total）を追加しました。
- フレーム表示設定に以下を追加しました。
  - もっと見る機能（使用する / 使用しない）
  - もっと見る表示件数
- 既定値を「使用しない」に設定しました。
- もっと見る関連の設定値を `config/photoalbums.php` に追加しました。

### 画面イメージ

<img width="400" alt="image" src="https://github.com/user-attachments/assets/a3011183-d7ee-4ff6-9585-3c2905ae8054" />

## 特記事項
- 既存データの移行は不要です。

# レビュー完了希望日
軽微な改修なので急ぎません。

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
