### PR TITLE
[データベース] 各テンプレートで一時保存や公開前ラベルを初期表示画面（一覧画面）に表示

### DIFF
--- a/resources/views/plugins/user/databases/card_02/card_common.blade.php
+++ b/resources/views/plugins/user/databases/card_02/card_common.blade.php
@@ -84,37 +84,10 @@
                                 ])
                             </div>
                             <div class="text-right mb-1">
-                                @if ($input->status == 2)
-                                    @can('role_update_or_approval',[[$input, $frame->plugin_name, $buckets]])
-                                        <span class="badge badge-warning align-bottom">承認待ち</span>
-                                    @endcan
-                                    @can('posts.approval',[[$input, $frame->plugin_name, $buckets]])
-                                        <form action="{{url('/')}}/plugin/databases/approval/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}" method="post" name="form_approval" class="d-inline">
-                                            {{ csrf_field() }}
-                                            <button type="submit" class="btn btn-primary btn-sm" onclick="javascript:return confirm('承認します。\nよろしいですか？');">
-                                                <i class="fas fa-check"></i> <span class="d-none d-sm-inline">承認</span>
-                                            </button>
-                                        </form>
-                                    @endcan
-                                @endif
-                                @can('role_update_or_approval',[[$input, $frame->plugin_name, $buckets]])
-                                    @if (!empty($input->expires_at) && $input->expires_at <= Carbon::now())
-                                        <span class="badge badge-secondary align-bottom">公開終了</span>
-                                    @endif
-
-                                    @if ($input->posted_at > Carbon::now())
-                                        <span class="badge badge-info align-bottom">公開前</span>
-                                    @endif
-                                @endcan
-                                @can('posts.update',[[$input, $frame->plugin_name, $buckets]])
-                                    @if ($input->status == 1)
-                                        <span class="badge badge-warning align-bottom">一時保存</span>
-                                    @endif
-
-                                    <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}'">
-                                        <i class="far fa-edit"></i> 編集
-                                    </button>
-                                @endcan
+                                {{-- ステータス表示＋ボタン --}}
+                                @include('plugins.user.databases.default.databases_include_status_and_button', [
+                                    'add_badge_class' => 'align-bottom',
+                                ])
                             </div>
                         </div>
                     </div>

--- a/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
@@ -69,37 +69,11 @@
 @can('role_update_or_approval', [[$inputs, $frame->plugin_name, $buckets]])
 <div class="row mt-2">
     <div class="col-12 text-right mb-1">
-        @if ($inputs->status == 2)
-            @can('role_update_or_approval',[[$inputs, $frame->plugin_name, $buckets]])
-                <span class="badge badge-warning align-bottom">承認待ち</span>
-            @endcan
-            @can('posts.approval',[[$inputs, $frame->plugin_name, $buckets]])
-                <form action="{{url('/')}}/plugin/databases/approval/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}" method="post" name="form_approval" class="d-inline">
-                    {{ csrf_field() }}
-                    <button type="submit" class="btn btn-primary btn-sm" onclick="javascript:return confirm('承認します。\nよろしいですか？');">
-                        <i class="fas fa-check"></i> <span class="d-none d-sm-inline">承認</span>
-                    </button>
-                </form>
-            @endcan
-        @endif
-        @can('role_update_or_approval',[[$inputs, $frame->plugin_name, $buckets]])
-            @if (!empty($inputs->expires_at) && $inputs->expires_at <= Carbon::now())
-                <span class="badge badge-secondary align-bottom">公開終了</span>
-            @endif
-
-            @if ($inputs->posted_at > Carbon::now())
-                <span class="badge badge-info align-bottom">公開前</span>
-            @endif
-        @endcan
-        @can('posts.update',[[$inputs, $frame->plugin_name, $buckets]])
-            @if ($inputs->status == 1)
-                <span class="badge badge-warning align-bottom">一時保存</span>
-            @endif
-
-            <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}'">
-                <i class="far fa-edit"></i> 編集
-            </button>
-        @endcan
+        {{-- ステータス表示＋ボタン --}}
+        @include('plugins.user.databases.default.databases_include_status_and_button', [
+            'add_badge_class' => 'align-bottom',
+            'input' => $inputs,
+        ])        
     </div>
 </div>
 @endcan

--- a/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/card_02/databases_detail.blade.php
@@ -73,7 +73,7 @@
         @include('plugins.user.databases.default.databases_include_status_and_button', [
             'add_badge_class' => 'align-bottom',
             'input' => $inputs,
-        ])        
+        ])
     </div>
 </div>
 @endcan

--- a/resources/views/plugins/user/databases/default/databases.blade.php
+++ b/resources/views/plugins/user/databases/default/databases.blade.php
@@ -72,37 +72,10 @@
             <div class="row mt-2">
                 <div class="col">
                     <div class="text-right">
-                        @if ($input->status == 2)
-                            @can('role_update_or_approval',[[$input, $frame->plugin_name, $buckets]])
-                                <span class="badge badge-warning align-bottom">承認待ち</span>
-                            @endcan
-                            @can('posts.approval',[[$input, $frame->plugin_name, $buckets]])
-                                <form action="{{url('/')}}/plugin/databases/approval/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}" method="post" name="form_approval" class="d-inline">
-                                    {{ csrf_field() }}
-                                    <button type="submit" class="btn btn-primary btn-sm" onclick="javascript:return confirm('承認します。\nよろしいですか？');">
-                                        <i class="fas fa-check"></i> <span class="d-none d-sm-inline">承認</span>
-                                    </button>
-                                </form>
-                            @endcan
-                        @endif
-                        @can('role_update_or_approval',[[$input, $frame->plugin_name, $buckets]])
-                            @if (!empty($input->expires_at) && $input->expires_at <= Carbon::now())
-                                <span class="badge badge-secondary align-bottom">公開終了</span>
-                            @endif
-
-                            @if ($input->posted_at > Carbon::now())
-                                <span class="badge badge-info align-bottom">公開前</span>
-                            @endif
-                        @endcan
-                        @can('posts.update',[[$input, $frame->plugin_name, $buckets]])
-                            @if ($input->status == 1)
-                                <span class="badge badge-warning align-bottom">一時保存</span>
-                            @endif
-
-                            <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}'">
-                                <i class="far fa-edit"></i> 編集
-                            </button>
-                        @endcan
+                        {{-- ステータス表示＋ボタン --}}
+                        @include('plugins.user.databases.default.databases_include_status_and_button', [
+                            'add_badge_class' => 'align-bottom',
+                        ])
 
                         {{-- いいねボタン --}}
                         @include('plugins.common.like', [

--- a/resources/views/plugins/user/databases/default/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_detail.blade.php
@@ -63,37 +63,11 @@
 @can('role_update_or_approval', [[$inputs, $frame->plugin_name, $buckets]])
 <div class="row mt-2">
     <div class="col-12 text-right mb-1">
-        @if ($inputs->status == 2)
-            @can('role_update_or_approval',[[$inputs, $frame->plugin_name, $buckets]])
-                <span class="badge badge-warning align-bottom">承認待ち</span>
-            @endcan
-            @can('posts.approval',[[$inputs, $frame->plugin_name, $buckets]])
-                <form action="{{url('/')}}/plugin/databases/approval/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}" method="post" name="form_approval" class="d-inline">
-                    {{ csrf_field() }}
-                    <button type="submit" class="btn btn-primary btn-sm" onclick="javascript:return confirm('承認します。\nよろしいですか？');">
-                        <i class="fas fa-check"></i> <span class="d-none d-sm-inline">承認</span>
-                    </button>
-                </form>
-            @endcan
-        @endif
-        @can('role_update_or_approval',[[$inputs, $frame->plugin_name, $buckets]])
-            @if (!empty($inputs->expires_at) && $inputs->expires_at <= Carbon::now())
-                <span class="badge badge-secondary align-bottom">公開終了</span>
-            @endif
-
-            @if ($inputs->posted_at > Carbon::now())
-                <span class="badge badge-info align-bottom">公開前</span>
-            @endif
-        @endcan
-        @can('posts.update',[[$inputs, $frame->plugin_name, $buckets]])
-            @if ($inputs->status == 1)
-                <span class="badge badge-warning align-bottom">一時保存</span>
-            @endif
-
-            <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}'">
-                <i class="far fa-edit"></i> 編集
-            </button>
-        @endcan
+        {{-- ステータス表示＋ボタン --}}
+        @include('plugins.user.databases.default.databases_include_status_and_button', [
+            'add_badge_class' => 'align-bottom',
+            'input' => $inputs,
+        ])
     </div>
 </div>
 @endcan

--- a/resources/views/plugins/user/databases/default/databases_include_status_and_button.blade.php
+++ b/resources/views/plugins/user/databases/default/databases_include_status_and_button.blade.php
@@ -1,0 +1,58 @@
+{{--
+ * ステータス表示＋ボタン
+ *
+ * @author 牟田口 満 <akagane99@gmail.com>
+ * @category データベース・プラグイン
+ *
+ * @param $use_button        承認ボタン・編集ボタンを使う
+ * @param $add_badge_class   ラベルのクラス追加    
+ * @param $input             データベースの1件のデータ
+ *
+ * // 暗黙で利用
+ * @param $frame
+ * @param $frame_id
+ * @param $buckets
+ * @param $page
+--}}
+@php
+    // 承認ボタン・編集ボタンを使うかどうかのフラグ
+    $use_button = $use_button ?? 1;
+    // ラベルのクラス追加
+    $add_badge_class = $add_badge_class ?? '';
+@endphp
+    
+@if ($input->status == 2)
+    @can('role_update_or_approval',[[$input, $frame->plugin_name, $buckets]])
+        <span class="badge badge-warning {{$add_badge_class}}">承認待ち</span>
+    @endcan
+    @if ($use_button)
+        @can('posts.approval',[[$input, $frame->plugin_name, $buckets]])
+            <form action="{{url('/')}}/plugin/databases/approval/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}" method="post" name="form_approval" class="d-inline">
+                {{ csrf_field() }}
+                <button type="submit" class="btn btn-primary btn-sm" onclick="javascript:return confirm('承認します。\nよろしいですか？');">
+                    <i class="fas fa-check"></i> <span class="d-none d-sm-inline">承認</span>
+                </button>
+            </form>
+        @endcan
+    @endif
+@endif
+@can('role_update_or_approval',[[$input, $frame->plugin_name, $buckets]])
+    @if (!empty($input->expires_at) && $input->expires_at <= Carbon::now())
+        <span class="badge badge-secondary {{$add_badge_class}}">公開終了</span>
+    @endif
+
+    @if ($input->posted_at > Carbon::now())
+        <span class="badge badge-info {{$add_badge_class}}">公開前</span>
+    @endif
+@endcan
+@can('posts.update',[[$input, $frame->plugin_name, $buckets]])
+    @if ($input->status == 1)
+        <span class="badge badge-warning {{$add_badge_class}}">一時保存</span>
+    @endif
+
+    @if ($use_button)
+        <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}'">
+            <i class="far fa-edit"></i> 編集
+        </button>
+    @endif
+@endcan

--- a/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
@@ -59,12 +59,11 @@
                                 <td class="{{$column->classname}}">
                                     <a href="{{url('/')}}/plugin/databases/detail/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}">
                                         @include('plugins.user.databases.default.databases_include_value')
-
-                                        {{-- ステータス表示のみ --}}
-                                        @include('plugins.user.databases.default.databases_include_status_and_button', [
-                                            'use_button' => 0,
-                                        ])
                                     </a>
+                                    {{-- ステータス表示のみ --}}
+                                    @include('plugins.user.databases.default.databases_include_status_and_button', [
+                                        'use_button' => 0,
+                                    ])
                                 </td>
                                 @php
                                 $is_first = false;

--- a/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases.blade.php
@@ -59,6 +59,11 @@
                                 <td class="{{$column->classname}}">
                                     <a href="{{url('/')}}/plugin/databases/detail/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}">
                                         @include('plugins.user.databases.default.databases_include_value')
+
+                                        {{-- ステータス表示のみ --}}
+                                        @include('plugins.user.databases.default.databases_include_status_and_button', [
+                                            'use_button' => 0,
+                                        ])
                                     </a>
                                 </td>
                                 @php

--- a/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
@@ -66,37 +66,11 @@
 @can('role_update_or_approval', [[$inputs, $frame->plugin_name, $buckets]])
 <div class="row mt-2">
     <div class="col-12 text-right mb-1">
-        @if ($inputs->status == 2)
-            @can('role_update_or_approval',[[$inputs, $frame->plugin_name, $buckets]])
-                <span class="badge badge-warning align-bottom">承認待ち</span>
-            @endcan
-            @can('posts.approval',[[$inputs, $frame->plugin_name, $buckets]])
-                <form action="{{url('/')}}/plugin/databases/approval/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}" method="post" name="form_approval" class="d-inline">
-                    {{ csrf_field() }}
-                    <button type="submit" class="btn btn-primary btn-sm" onclick="javascript:return confirm('承認します。\nよろしいですか？');">
-                        <i class="fas fa-check"></i> <span class="d-none d-sm-inline">承認</span>
-                    </button>
-                </form>
-            @endcan
-        @endif
-        @can('role_update_or_approval',[[$inputs, $frame->plugin_name, $buckets]])
-            @if (!empty($inputs->expires_at) && $inputs->expires_at <= Carbon::now())
-                <span class="badge badge-secondary align-bottom">公開終了</span>
-            @endif
-
-            @if ($inputs->posted_at > Carbon::now())
-                <span class="badge badge-info align-bottom">公開前</span>
-            @endif
-        @endcan
-        @can('posts.update',[[$inputs, $frame->plugin_name, $buckets]])
-            @if ($inputs->status == 1)
-                <span class="badge badge-warning align-bottom">一時保存</span>
-            @endif
-
-            <button type="button" class="btn btn-success btn-sm ml-2" onclick="location.href='{{url('/')}}/plugin/databases/input/{{$page->id}}/{{$frame_id}}/{{$inputs->id}}#frame-{{$frame_id}}'">
-                <i class="far fa-edit"></i> 編集
-            </button>
-        @endcan
+        {{-- ステータス表示＋ボタン --}}
+        @include('plugins.user.databases.default.databases_include_status_and_button', [
+            'add_badge_class' => 'align-bottom',
+            'input' => $inputs,
+        ])        
     </div>
 </div>
 @endcan

--- a/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
+++ b/resources/views/plugins/user/databases/design-table-dl/databases_detail.blade.php
@@ -70,7 +70,7 @@
         @include('plugins.user.databases.default.databases_include_status_and_button', [
             'add_badge_class' => 'align-bottom',
             'input' => $inputs,
-        ])        
+        ])
     </div>
 </div>
 @endcan

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -62,6 +62,11 @@
                                 <td class="{{$column->classname}}">
                                     <a href="{{url('/')}}/plugin/databases/detail/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}">
                                         @include('plugins.user.databases.default.databases_include_value')
+
+                                        {{-- ステータス表示のみ --}}
+                                        @include('plugins.user.databases.default.databases_include_status_and_button', [
+                                            'use_button' => 0,
+                                        ])
                                     </a>
                                 </td>
                                 @php

--- a/resources/views/plugins/user/databases/table/databases.blade.php
+++ b/resources/views/plugins/user/databases/table/databases.blade.php
@@ -62,12 +62,11 @@
                                 <td class="{{$column->classname}}">
                                     <a href="{{url('/')}}/plugin/databases/detail/{{$page->id}}/{{$frame_id}}/{{$input->id}}#frame-{{$frame_id}}">
                                         @include('plugins.user.databases.default.databases_include_value')
-
-                                        {{-- ステータス表示のみ --}}
-                                        @include('plugins.user.databases.default.databases_include_status_and_button', [
-                                            'use_button' => 0,
-                                        ])
                                     </a>
+                                    {{-- ステータス表示のみ --}}
+                                    @include('plugins.user.databases.default.databases_include_status_and_button', [
+                                        'use_button' => 0,
+                                    ])
                                 </td>
                                 @php
                                 $is_first = false;


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* tableテンプレートが非対応だったため、対応しました。
* ステータスラベル表示を共通部品にしたため、各テンプレートに適用しました。

# 修正後画面

## tableテンプレート 初期表示画面（一覧画面）

<img width="829" height="423" alt="image" src="https://github.com/user-attachments/assets/3415bed7-2dbf-4764-a332-e1341db2da01" />

## design-table-dlテンプレート
### 初期表示画面（一覧画面）
<img width="836" height="433" alt="image" src="https://github.com/user-attachments/assets/5025d544-2c70-4e7d-af88-c5d3b14fba8f" />

### 詳細画面
<img width="840" height="333" alt="image" src="https://github.com/user-attachments/assets/b1874d5c-a1f7-4442-aef2-66499c7bb3f2" />


## defaultテンプレート
### 初期表示画面（一覧画面）
<img width="836" height="904" alt="image" src="https://github.com/user-attachments/assets/d6db6b7d-9ec0-4335-9e4c-5e13dfac6007" />

### 詳細画面
<img width="834" height="347" alt="image" src="https://github.com/user-attachments/assets/a4b413ae-c456-4b6e-aec6-bb2bce06a5c8" />

## card_02テンプレート
### 初期表示画面（一覧画面）
<img width="835" height="572" alt="image" src="https://github.com/user-attachments/assets/4883682f-2ea0-4087-91d9-fc898f38ee6d" />

### 詳細画面
<img width="836" height="326" alt="image" src="https://github.com/user-attachments/assets/2f0f9cc1-19fa-4f34-8f75-9026f79da65e" />


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

急ぎません

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms-ideas/issues/186

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
