### PR TITLE
[サイト内検索] 隠しページ（ページ管理＞メニュー非表示のページ）は検索に含めない設定を追加

### DIFF
--- a/app/Enums/SearchsFrameSelect.php
+++ b/app/Enums/SearchsFrameSelect.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * フレームの選択
+ *
+ * @author 牟田口 満 <akagane99@gmail.com>
+ * @category サイト内検索
+ * @package Enums
+ */
+class SearchsFrameSelect extends EnumsBase
+{
+    // 定数メンバ
+    /** 全て表示する */
+    const ALL_FRAMES = 0;
+    /** 選択したものだけ表示する */
+    const SELECTED_ONLY = 1;
+
+    /** key/valueの連想配列 */
+    const enum = [
+        self::ALL_FRAMES => '全て表示する',
+        self::SELECTED_ONLY => '選択したものだけ表示する',
+    ];
+}

--- a/app/Enums/SearchsFrameSelect.php
+++ b/app/Enums/SearchsFrameSelect.php
@@ -11,17 +11,17 @@ use App\Enums\EnumsBase;
  * @category サイト内検索
  * @package Enums
  */
-class SearchsFrameSelect extends EnumsBase
+final class SearchsFrameSelect extends EnumsBase
 {
     // 定数メンバ
     /** 全て表示する */
-    const ALL_FRAMES = 0;
+    const all_frames = 0;
     /** 選択したものだけ表示する */
-    const SELECTED_ONLY = 1;
+    const selected_only = 1;
 
     /** key/valueの連想配列 */
     const enum = [
-        self::ALL_FRAMES => '全て表示する',
-        self::SELECTED_ONLY => '選択したものだけ表示する',
+        self::all_frames => '全て表示する',
+        self::selected_only => '選択したものだけ表示する',
     ];
 }

--- a/app/Enums/SearchsPageSelect.php
+++ b/app/Enums/SearchsPageSelect.php
@@ -11,17 +11,17 @@ use App\Enums\EnumsBase;
  * @category サイト内検索
  * @package Enums
  */
-class SearchsPageSelect extends EnumsBase
+final class SearchsPageSelect extends EnumsBase
 {
     // 定数メンバ
     /** 全て表示する */
-    const ALL_PAGES = 0;
+    const all_pages = 0;
     /** ページ管理のメニュー表示条件に従う */
-    const MENU_VISIBLE_ONLY = 1;
+    const menu_visible_only = 1;
 
     /** key/valueの連想配列 */
     const enum = [
-        self::ALL_PAGES => '全て表示する',
-        self::MENU_VISIBLE_ONLY => 'ページ管理のメニュー表示条件に従う',
+        self::all_pages => '全て表示する',
+        self::menu_visible_only => 'ページ管理のメニュー表示条件に従う',
     ];
 }

--- a/app/Enums/SearchsPageSelect.php
+++ b/app/Enums/SearchsPageSelect.php
@@ -5,7 +5,7 @@ namespace App\Enums;
 use App\Enums\EnumsBase;
 
 /**
- * 通知の埋め込みタグ
+ * ページの選択
  *
  * @author 牟田口 満 <akagane99@gmail.com>
  * @category サイト内検索

--- a/app/Enums/SearchsPageSelect.php
+++ b/app/Enums/SearchsPageSelect.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+
+/**
+ * 通知の埋め込みタグ
+ * 
+ * @author 牟田口 満 <akagane99@gmail.com>
+ * @category サイト内検索
+ * @package Enums
+ */
+class SearchsPageSelect extends EnumsBase
+{
+    // 定数メンバ
+    /** 全て表示する */
+    const ALL_PAGES = 0;
+    /** ページ管理のメニュー表示条件に従う */
+    const MENU_VISIBLE_ONLY = 1;
+
+    // key/valueの連想配列
+    const enum = [
+        self::ALL_PAGES => '全て表示する',
+        self::MENU_VISIBLE_ONLY => 'ページ管理のメニュー表示条件に従う',
+    ];
+}

--- a/app/Enums/SearchsPageSelect.php
+++ b/app/Enums/SearchsPageSelect.php
@@ -6,7 +6,7 @@ use App\Enums\EnumsBase;
 
 /**
  * 通知の埋め込みタグ
- * 
+ *
  * @author 牟田口 満 <akagane99@gmail.com>
  * @category サイト内検索
  * @package Enums
@@ -19,7 +19,7 @@ class SearchsPageSelect extends EnumsBase
     /** ページ管理のメニュー表示条件に従う */
     const MENU_VISIBLE_ONLY = 1;
 
-    // key/valueの連想配列
+    /** key/valueの連想配列 */
     const enum = [
         self::ALL_PAGES => '全て表示する',
         self::MENU_VISIBLE_ONLY => 'ページ管理のメニュー表示条件に従う',

--- a/app/Models/User/Searchs/Searchs.php
+++ b/app/Models/User/Searchs/Searchs.php
@@ -21,7 +21,7 @@ class Searchs extends Model
         'frame_select',
         'target_frame_ids',
         'recieve_keyword',
-        'narrow_down_label',
+        'page_select',
     ];
 
     /**

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -171,7 +171,7 @@ class SearchsPlugin extends UserPluginBase
         foreach ($union_sqls as $union_sql) {
             // フレームの選択が行われる場合
             // 選択したものだけ表示する
-            if ($searchs_frame->frame_select == SearchsFrameSelect::SELECTED_ONLY) {
+            if ($searchs_frame->frame_select == SearchsFrameSelect::selected_only) {
                 $union_sql->whereIn('frames.id', explode(',', $searchs_frame->target_frame_ids));
             }
 
@@ -480,12 +480,12 @@ class SearchsPlugin extends UserPluginBase
     private function fetchSearchablePageIds($request, $searchs_frame)
     {
         // ページの選択「ページ管理のメニュー表示条件に従う」
-        if ($searchs_frame->page_select == SearchsPageSelect::MENU_VISIBLE_ONLY) {
+        if ($searchs_frame->page_select == SearchsPageSelect::menu_visible_only) {
             // 表示ページのみをDBレベルで絞り込む
             $pages = Page::where('base_display_flag', 1)->get();
 
             // フレームの選択「選択したものだけ表示する」
-            if ($searchs_frame->frame_select == SearchsFrameSelect::SELECTED_ONLY) {
+            if ($searchs_frame->frame_select == SearchsFrameSelect::selected_only) {
                 // 選択したフレームに紐づくページ を追加取得してマージ
                 $pages_frame = Page::whereIn('id', function ($query) use ($searchs_frame) {
                     $query->select('page_id')

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -478,15 +478,10 @@ class SearchsPlugin extends UserPluginBase
      */
     private function fetchSearchablePageIds($request, $searchs_frame)
     {
-        $pages = Page::get();
-
         // ページの選択「ページ管理のメニュー表示条件に従う」
         if ($searchs_frame->page_select == SearchsPageSelect::MENU_VISIBLE_ONLY) {
-
-            // 表示ページのみに絞る
-            $pages = $pages->filter(function ($page) {
-                return $page->base_display_flag == 1;
-            });
+            // 表示ページのみをDBレベルで絞り込む
+            $pages = Page::where('base_display_flag', 1)->get();
 
             // フレームの選択「選択したものだけ表示する」
             if ($searchs_frame->frame_select == 1) {
@@ -499,6 +494,9 @@ class SearchsPlugin extends UserPluginBase
 
                 $pages = $pages->merge($pages_frame)->unique('id');
             }
+        } else {
+            // 全ページを検索対象とする
+            $pages = Page::get();
         }
 
         // 見れないページ除外

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -163,7 +163,7 @@ class SearchsPlugin extends UserPluginBase
 
         // 各プラグインのSQL をUNION
         // 公開されているページ、フレームを検索対象とする
-        $searchable_page_ids = $this->fetchSearchablePageIds($request);
+        $searchable_page_ids = $this->fetchSearchablePageIds($request, $searchs_frame);
         $searchable_frame_ids = Frame::visible()->get()->pluck('id');
 
         foreach ($union_sqls as $union_sql) {
@@ -427,6 +427,7 @@ class SearchsPlugin extends UserPluginBase
         $searchs->frame_select      = intval($request->frame_select);
         $searchs->target_frame_ids  = empty($request->target_frame_ids) ? "": implode(',', $request->target_frame_ids);
         $searchs->recieve_keyword   = intval($request->recieve_keyword);
+        $searchs->page_select       = intval($request->page_select);
 
         // データ保存
         $searchs->save();
@@ -474,9 +475,28 @@ class SearchsPlugin extends UserPluginBase
     /**
      * 検索対象のページIDを取得する
      */
-    private function fetchSearchablePageIds($request)
+    private function fetchSearchablePageIds($request, $searchs_frame)
     {
         $pages = Page::get();
+
+        // ページの選択「ページ管理のメニュー表示条件に従う」
+        if ($searchs_frame->page_select == 1) {
+
+            // 表示ページのみに絞る
+            $pages = $pages->filter(function ($page) {
+                return $page->base_display_flag == 1;
+            });
+
+            // フレームの選択「選択したものだけ表示する」
+            if ($searchs_frame->frame_select == 1) {
+                // 選択したフレームに紐づくページ を追加取得してマージ
+                $frame_page_ids =  Frame::whereIn('frames.id', explode(',', $searchs_frame->target_frame_ids))->get()->pluck('page_id')->toArray();
+                $pages_frame = Page::whereIn('pages.id', $frame_page_ids)->get();
+
+                $pages = $pages->merge($pages_frame)->unique('id');
+            }
+        }
+
         // 見れないページ除外
         $visible_page_ids = [];
         foreach ($pages as $page) {

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -491,8 +491,11 @@ class SearchsPlugin extends UserPluginBase
             // フレームの選択「選択したものだけ表示する」
             if ($searchs_frame->frame_select == 1) {
                 // 選択したフレームに紐づくページ を追加取得してマージ
-                $frame_page_ids = Frame::whereIn('frames.id', explode(',', $searchs_frame->target_frame_ids))->get()->pluck('page_id')->toArray();
-                $pages_frame = Page::whereIn('pages.id', $frame_page_ids)->get();
+                $pages_frame = Page::whereIn('id', function ($query) use ($searchs_frame) {
+                    $query->select('page_id')
+                        ->from('frames')
+                        ->whereIn('id', explode(',', $searchs_frame->target_frame_ids));
+                })->get();  
 
                 $pages = $pages->merge($pages_frame)->unique('id');
             }

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -14,6 +14,7 @@ use App\Models\User\Searchs\Searchs;
 use App\Plugins\User\UserPluginBase;
 use App\Traits\ConnectCommonTrait;
 
+use App\Enums\SearchsPageSelect;
 use App\Enums\SearchsTargetPlugin;
 
 /**
@@ -480,7 +481,7 @@ class SearchsPlugin extends UserPluginBase
         $pages = Page::get();
 
         // ページの選択「ページ管理のメニュー表示条件に従う」
-        if ($searchs_frame->page_select == 1) {
+        if ($searchs_frame->page_select == SearchsPageSelect::MENU_VISIBLE_ONLY) {
 
             // 表示ページのみに絞る
             $pages = $pages->filter(function ($page) {

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -490,7 +490,7 @@ class SearchsPlugin extends UserPluginBase
             // フレームの選択「選択したものだけ表示する」
             if ($searchs_frame->frame_select == 1) {
                 // 選択したフレームに紐づくページ を追加取得してマージ
-                $frame_page_ids =  Frame::whereIn('frames.id', explode(',', $searchs_frame->target_frame_ids))->get()->pluck('page_id')->toArray();
+                $frame_page_ids = Frame::whereIn('frames.id', explode(',', $searchs_frame->target_frame_ids))->get()->pluck('page_id')->toArray();
                 $pages_frame = Page::whereIn('pages.id', $frame_page_ids)->get();
 
                 $pages = $pages->merge($pages_frame)->unique('id');

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -14,6 +14,7 @@ use App\Models\User\Searchs\Searchs;
 use App\Plugins\User\UserPluginBase;
 use App\Traits\ConnectCommonTrait;
 
+use App\Enums\SearchsFrameSelect;
 use App\Enums\SearchsPageSelect;
 use App\Enums\SearchsTargetPlugin;
 
@@ -170,7 +171,7 @@ class SearchsPlugin extends UserPluginBase
         foreach ($union_sqls as $union_sql) {
             // フレームの選択が行われる場合
             // 選択したものだけ表示する
-            if ($searchs_frame->frame_select == 1) {
+            if ($searchs_frame->frame_select == SearchsFrameSelect::SELECTED_ONLY) {
                 $union_sql->whereIn('frames.id', explode(',', $searchs_frame->target_frame_ids));
             }
 
@@ -484,7 +485,7 @@ class SearchsPlugin extends UserPluginBase
             $pages = Page::where('base_display_flag', 1)->get();
 
             // フレームの選択「選択したものだけ表示する」
-            if ($searchs_frame->frame_select == 1) {
+            if ($searchs_frame->frame_select == SearchsFrameSelect::SELECTED_ONLY) {
                 // 選択したフレームに紐づくページ を追加取得してマージ
                 $pages_frame = Page::whereIn('id', function ($query) use ($searchs_frame) {
                     $query->select('page_id')

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -491,7 +491,7 @@ class SearchsPlugin extends UserPluginBase
                     $query->select('page_id')
                         ->from('frames')
                         ->whereIn('id', explode(',', $searchs_frame->target_frame_ids));
-                })->get();  
+                })->get();
 
                 $pages = $pages->merge($pages_frame)->unique('id');
             }

--- a/database/migrations/2019_12_22_085641_create_searchs_table.php
+++ b/database/migrations/2019_12_22_085641_create_searchs_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\SearchsFrameSelect;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
@@ -21,7 +22,7 @@ class CreateSearchsTable extends Migration
             $table->integer('view_posted_name')->default('0');
             $table->integer('view_posted_at')->default('0');
             $table->text('target_plugins');
-            $table->integer('frame_select')->default('0');
+            $table->integer('frame_select')->default(SearchsFrameSelect::ALL_FRAMES);
             $table->text('target_frame_ids')->nullable();
             $table->timestamps();
         });

--- a/database/migrations/2019_12_22_085641_create_searchs_table.php
+++ b/database/migrations/2019_12_22_085641_create_searchs_table.php
@@ -22,7 +22,7 @@ class CreateSearchsTable extends Migration
             $table->integer('view_posted_name')->default('0');
             $table->integer('view_posted_at')->default('0');
             $table->text('target_plugins');
-            $table->integer('frame_select')->default(SearchsFrameSelect::ALL_FRAMES);
+            $table->integer('frame_select')->default(SearchsFrameSelect::all_frames);
             $table->text('target_frame_ids')->nullable();
             $table->timestamps();
         });

--- a/database/migrations/2026_03_16_164135_add_select_page_from_searchs.php
+++ b/database/migrations/2026_03_16_164135_add_select_page_from_searchs.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\SearchsPageSelect;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,7 +15,7 @@ class AddSelectPageFromSearchs extends Migration
     public function up()
     {
         Schema::table('searchs', function (Blueprint $table) {
-            $table->integer('page_select')->default(0)->comment('ページの選択フラグ')->after('recieve_keyword');
+            $table->integer('page_select')->default(SearchsPageSelect::ALL_PAGES)->comment('ページの選択フラグ')->after('recieve_keyword');
         });
     }
 

--- a/database/migrations/2026_03_16_164135_add_select_page_from_searchs.php
+++ b/database/migrations/2026_03_16_164135_add_select_page_from_searchs.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSelectPageFromSearchs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('searchs', function (Blueprint $table) {
+            $table->integer('page_select')->default(0)->comment('ページの選択フラグ')->after('recieve_keyword');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('searchs', function (Blueprint $table) {
+            $table->dropColumn('page_select');
+        });
+    }
+}

--- a/database/migrations/2026_03_16_164135_add_select_page_from_searchs.php
+++ b/database/migrations/2026_03_16_164135_add_select_page_from_searchs.php
@@ -15,7 +15,7 @@ class AddSelectPageFromSearchs extends Migration
     public function up()
     {
         Schema::table('searchs', function (Blueprint $table) {
-            $table->integer('page_select')->default(SearchsPageSelect::ALL_PAGES)->comment('ページの選択フラグ')->after('recieve_keyword');
+            $table->integer('page_select')->default(SearchsPageSelect::all_pages)->comment('ページの選択フラグ')->after('recieve_keyword');
         });
     }
 

--- a/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
@@ -147,6 +147,28 @@
                 </div>
             </div>
 
+            <div class="form-group row">
+                <label class="{{$frame->getSettingLabelClass()}}">ページの選択</label><br />
+                <div class="{{$frame->getSettingInputClass(true)}}">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if(old('page_select', $searchs->page_select) == 0)
+                            <input type="radio" value="0" id="page_select_0" name="page_select" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="0" id="page_select_0" name="page_select" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="page_select_0">全て表示する</label>
+                    </div>
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if(old('page_select', $searchs->page_select) == 1)
+                            <input type="radio" value="1" id="page_select_1" name="page_select" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="page_select_1" name="page_select" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="page_select_1">ページ管理のメニュー表示条件に従う</label>
+                    </div>
+                </div>
+            </div>
+
             <div class="form-group row mb-0">
                 <label class="{{$frame->getSettingLabelClass()}}">フレームの選択</label>
                 <div class="{{$frame->getSettingInputClass(true)}}">
@@ -172,7 +194,10 @@
             <div class="form-group row">
                 <div class="{{$frame->getSettingLabelClass()}}"></div>
                 <div class="{{$frame->getSettingInputClass()}}">
-                    <small class="text-muted">※ 「選択したものだけ表示する」を選択した場合、「固定記事」は検索対象外になります。</small><br>
+                    <small class="text-muted">
+                        ※ 「選択したものだけ表示する」を選択した場合、「固定記事」は検索対象外になります。<br>
+                        　　また、メニュー非表示ページでも、選択したフレームは検索対象になります。<br>
+                    </small>
                 </div>
             </div>
 

--- a/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
@@ -5,6 +5,9 @@
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved
  * @category 検索プラグイン
 --}}
+@php
+use App\Enums\SearchsPageSelect;
+@endphp
 @extends('core.cms_frame_base_setting')
 
 @section("core.cms_frame_edit_tab_$frame->id")
@@ -150,22 +153,16 @@
             <div class="form-group row">
                 <label class="{{$frame->getSettingLabelClass()}}">ページの選択</label><br />
                 <div class="{{$frame->getSettingInputClass(true)}}">
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if(old('page_select', $searchs->page_select) == 0)
-                            <input type="radio" value="0" id="page_select_0" name="page_select" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="0" id="page_select_0" name="page_select" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="page_select_0">全て表示する</label>
-                    </div>
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if(old('page_select', $searchs->page_select) == 1)
-                            <input type="radio" value="1" id="page_select_1" name="page_select" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="1" id="page_select_1" name="page_select" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="page_select_1">ページ管理のメニュー表示条件に従う</label>
-                    </div>
+                    @foreach (SearchsPageSelect::enum as $key => $item)
+                        <div class="custom-control custom-radio custom-control-inline">
+                            @if(old('page_select', $searchs->page_select) == $key)
+                                <input type="radio" value="{{$key}}" id="page_select_{{$key}}" name="page_select" class="custom-control-input" checked="checked">
+                            @else
+                                <input type="radio" value="{{$key}}" id="page_select_{{$key}}" name="page_select" class="custom-control-input">
+                            @endif
+                            <label class="custom-control-label" for="page_select_{{$key}}">{{ SearchsPageSelect::getDescription($key) }}</label>
+                        </div>
+                    @endforeach
                 </div>
             </div>
 

--- a/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
@@ -6,6 +6,7 @@
  * @category 検索プラグイン
 --}}
 @php
+use App\Enums\SearchsFrameSelect;
 use App\Enums\SearchsPageSelect;
 @endphp
 @extends('core.cms_frame_base_setting')
@@ -169,22 +170,16 @@ use App\Enums\SearchsPageSelect;
             <div class="form-group row mb-0">
                 <label class="{{$frame->getSettingLabelClass()}}">フレームの選択</label>
                 <div class="{{$frame->getSettingInputClass(true)}}">
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if(old('frame_select', $searchs->frame_select) == 0)
-                            <input type="radio" value="0" id="frame_select_0" name="frame_select" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="0" id="frame_select_0" name="frame_select" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="frame_select_0">全て表示する</label>
-                    </div>
-                    <div class="custom-control custom-radio custom-control-inline">
-                        @if(old('frame_select', $searchs->frame_select) == 1)
-                            <input type="radio" value="1" id="frame_select_1" name="frame_select" class="custom-control-input" checked="checked">
-                        @else
-                            <input type="radio" value="1" id="frame_select_1" name="frame_select" class="custom-control-input">
-                        @endif
-                        <label class="custom-control-label" for="frame_select_1">選択したものだけ表示する</label>
-                    </div>
+                    @foreach (SearchsFrameSelect::enum as $key => $item)
+                        <div class="custom-control custom-radio custom-control-inline">
+                            @if(old('frame_select', $searchs->frame_select) == $key)
+                                <input type="radio" value="{{$key}}" id="frame_select_{{$key}}" name="frame_select" class="custom-control-input" checked="checked">
+                            @else
+                                <input type="radio" value="{{$key}}" id="frame_select_{{$key}}" name="frame_select" class="custom-control-input">
+                            @endif
+                            <label class="custom-control-label" for="frame_select_{{$key}}">{{ SearchsFrameSelect::getDescription($key) }}</label>
+                        </div>
+                    @endforeach
                 </div>
             </div>
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms-ideas/issues/183
  * こちらの実装です。
* Searchsモデルの `narrow_down_label` は既に削除済みカラムだったため、`$fillable` から消しました。

# 修正後画面
## サイト内検索＞設定変更（新規作成）

<img width="744" height="833" alt="image" src="https://github.com/user-attachments/assets/c876a317-11fa-46d5-b937-93afbc327f86" />


# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->
急ぎません

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

なし

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

あり

# チェックリスト

- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
