### PR TITLE
[サイト管理・各プラグイン] カテゴリ管理の登録／削除時にフラッシュメッセージを表示するようにしました

### DIFF
--- a/app/Models/Common/Categories.php
+++ b/app/Models/Common/Categories.php
@@ -381,6 +381,23 @@ class Categories extends Model
     }
 
     /**
+     * カテゴリ１件削除（削除したカテゴリ名を返却）
+     *
+     * プラグイン側カテゴリ管理で削除後のフラッシュメッセージにカテゴリ名を含めるために使用する。
+     * 対象プラグインに属するカテゴリのみを削除対象とし、見つからない場合は空文字を返す。
+     */
+    public static function deletePluginCategoryWithName(string $plugin_name, int $id): string
+    {
+        // 削除前に対象プラグインのカテゴリ名を取得（target で絞り込み、別プラグインの ID を誤って表示しないようにする）
+        $category = Categories::where('id', $id)->where('target', $plugin_name)->first();
+        $category_name = $category ? $category->category : '';
+
+        self::deleteCategories($plugin_name, $id);
+
+        return $category_name;
+    }
+
+    /**
      * バケツ削除時のカテゴリ削除
      */
     public static function destroyBucketsCategories(string $plugin_name, int $target_id)

--- a/app/Models/Common/Categories.php
+++ b/app/Models/Common/Categories.php
@@ -384,17 +384,19 @@ class Categories extends Model
      * カテゴリ１件削除（削除したカテゴリ名を返却）
      *
      * プラグイン側カテゴリ管理で削除後のフラッシュメッセージにカテゴリ名を含めるために使用する。
-     * 対象プラグインに属するカテゴリのみを削除対象とし、見つからない場合は空文字を返す。
+     * 対象プラグインに属するカテゴリのみを削除対象とし、見つからない場合は削除せず null を返す。
      */
-    public static function deletePluginCategoryWithName(string $plugin_name, int $id): string
+    public static function deletePluginCategoryWithName(string $plugin_name, int $id): ?string
     {
         // 削除前に対象プラグインのカテゴリ名を取得（target で絞り込み、別プラグインの ID を誤って表示しないようにする）
         $category = Categories::where('id', $id)->where('target', $plugin_name)->first();
-        $category_name = $category ? $category->category : '';
+        if (!$category) {
+            return null;
+        }
 
         self::deleteCategories($plugin_name, $id);
 
-        return $category_name;
+        return $category->category;
     }
 
     /**

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -549,7 +549,7 @@ class SiteManage extends ManagePluginBase
         }
 
         // return $this->categories($request, $id, null, true);
-        return redirect()->back();
+        return redirect()->back()->with('flash_message', '変更しました。');
     }
 
     /**
@@ -557,6 +557,10 @@ class SiteManage extends ManagePluginBase
      */
     public function deleteCategories($request, $id)
     {
+        // 削除メッセージ用にカテゴリ名を事前取得
+        $category = Categories::find($id);
+        $category_name = $category ? $category->category : '';
+
         // deleted_id, deleted_nameを自動セットするため、複数件削除する時はdestroy()を利用する。
         //
         // カテゴリ削除
@@ -564,7 +568,7 @@ class SiteManage extends ManagePluginBase
         Categories::destroy($id);
 
         // return $this->categories($request, $id, null, true);
-        return redirect()->back();
+        return redirect()->back()->with('flash_message', '【 '. $category_name .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -557,9 +557,12 @@ class SiteManage extends ManagePluginBase
      */
     public function deleteCategories($request, $id)
     {
-        // 削除メッセージ用にカテゴリ名を事前取得
+        // 削除メッセージ用にカテゴリ名を事前取得（対象が存在しない場合は削除せず通知）
         $category = Categories::find($id);
-        $category_name = $category ? $category->category : '';
+        if (!$category) {
+            return redirect()->back()->with('flash_message', 'カテゴリが見つかりませんでした。');
+        }
+        $category_name = $category->category;
 
         // deleted_id, deleted_nameを自動セットするため、複数件削除する時はdestroy()を利用する。
         //

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -568,7 +568,7 @@ class SiteManage extends ManagePluginBase
         Categories::destroy($id);
 
         // return $this->categories($request, $id, null, true);
-        return redirect()->back()->with('flash_message', '【 '. $category_name .' 】を削除しました。');
+        return redirect()->back()->with('flash_message', '【 '. e($category_name) .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -548,7 +548,6 @@ class SiteManage extends ManagePluginBase
             }
         }
 
-        // return $this->categories($request, $id, null, true);
         return redirect()->back()->with('flash_message', '変更しました。');
     }
 
@@ -570,7 +569,6 @@ class SiteManage extends ManagePluginBase
         // Categories::where('id', $id)->delete();
         Categories::destroy($id);
 
-        // return $this->categories($request, $id, null, true);
         return redirect()->back()->with('flash_message', '【 '. e($category_name) .' 】を削除しました。');
     }
 

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1509,11 +1509,7 @@ WHERE status = 0
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
-        // 削除メッセージ用にカテゴリ名を事前取得
-        $category = Categories::find($id);
-        $category_name = $category ? $category->category : '';
-
-        Categories::deleteCategories($this->frame->plugin_name, $id);
+        $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1500,8 +1500,8 @@ WHERE status = 0
 
         Categories::savePluginCategories($request, $this->frame->plugin_name, $blog_frame->blogs_id);
 
-        // return $this->listCategories($request, $page_id, $frame_id, $id, null, true);
-        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '変更しました。');
     }
 
     /**
@@ -1509,10 +1509,14 @@ WHERE status = 0
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
+        // 削除メッセージ用にカテゴリ名を事前取得
+        $category = Categories::find($id);
+        $category_name = $category ? $category->category : '';
+
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
-        // return $this->listCategories($request, $page_id, $frame_id, $id, null, true);
-        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1512,6 +1512,10 @@ WHERE status = 0
         $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        if ($category_name === null) {
+            session()->flash('flash_message_for_frame' . $frame_id, 'カテゴリが見つかりませんでした。');
+            return;
+        }
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1516,7 +1516,7 @@ WHERE status = 0
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
-        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -4560,7 +4560,7 @@ AND databases_inputs.posted_at <= NOW()
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
-        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -4544,7 +4544,8 @@ AND databases_inputs.posted_at <= NOW()
 
         Categories::savePluginCategories($request, $this->frame->plugin_name, $database_frame->databases_id);
 
-        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '変更しました。');
     }
 
     /**
@@ -4552,9 +4553,14 @@ AND databases_inputs.posted_at <= NOW()
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
+        // 削除メッセージ用にカテゴリ名を事前取得
+        $category = Categories::find($id);
+        $category_name = $category ? $category->category : '';
+
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
-        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -4553,11 +4553,7 @@ AND databases_inputs.posted_at <= NOW()
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
-        // 削除メッセージ用にカテゴリ名を事前取得
-        $category = Categories::find($id);
-        $category_name = $category ? $category->category : '';
-
-        Categories::deleteCategories($this->frame->plugin_name, $id);
+        $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -4556,6 +4556,10 @@ AND databases_inputs.posted_at <= NOW()
         $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        if ($category_name === null) {
+            session()->flash('flash_message_for_frame' . $frame_id, 'カテゴリが見つかりませんでした。');
+            return;
+        }
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 

--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -1110,8 +1110,8 @@ class FaqsPlugin extends UserPluginBase
 
         Categories::savePluginCategories($request, $this->frame->plugin_name, $faq_frame->faqs_id);
 
-        // return $this->listCategories($request, $page_id, $frame_id, $id, null, true);
-        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '変更しました。');
     }
 
     /**
@@ -1119,10 +1119,14 @@ class FaqsPlugin extends UserPluginBase
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
+        // 削除メッセージ用にカテゴリ名を事前取得
+        $category = Categories::find($id);
+        $category_name = $category ? $category->category : '';
+
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
-        // return $this->listCategories($request, $page_id, $frame_id, $id, null, true);
-        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -1126,7 +1126,7 @@ class FaqsPlugin extends UserPluginBase
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
-        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -1122,6 +1122,10 @@ class FaqsPlugin extends UserPluginBase
         $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        if ($category_name === null) {
+            session()->flash('flash_message_for_frame' . $frame_id, 'カテゴリが見つかりませんでした。');
+            return;
+        }
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 

--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -1119,11 +1119,7 @@ class FaqsPlugin extends UserPluginBase
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
-        // 削除メッセージ用にカテゴリ名を事前取得
-        $category = Categories::find($id);
-        $category_name = $category ? $category->category : '';
-
-        Categories::deleteCategories($this->frame->plugin_name, $id);
+        $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -2380,8 +2380,8 @@ class LearningtasksPlugin extends UserPluginBase
 
         Categories::savePluginCategories($request, $this->frame->plugin_name, $learningtask->id);
 
-        // return $this->listCategories($request, $page_id, $frame_id, $id, null, true);
-        // saveCategoriesはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+        // saveCategoriesはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '変更しました。');
     }
 
     /**
@@ -2389,10 +2389,14 @@ class LearningtasksPlugin extends UserPluginBase
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
+        // 削除メッセージ用にカテゴリ名を事前取得
+        $category = Categories::find($id);
+        $category_name = $category ? $category->category : '';
+
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
-        // return $this->listCategories($request, $page_id, $frame_id, $id, null, true);
-        // deleteCategoriesはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+        // deleteCategoriesはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -2392,6 +2392,10 @@ class LearningtasksPlugin extends UserPluginBase
         $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // deleteCategoriesはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        if ($category_name === null) {
+            session()->flash('flash_message_for_frame' . $frame_id, 'カテゴリが見つかりませんでした。');
+            return;
+        }
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -2396,7 +2396,7 @@ class LearningtasksPlugin extends UserPluginBase
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
         // deleteCategoriesはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
-        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 
     /**

--- a/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
+++ b/app/Plugins/User/Learningtasks/LearningtasksPlugin.php
@@ -2389,11 +2389,7 @@ class LearningtasksPlugin extends UserPluginBase
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
-        // 削除メッセージ用にカテゴリ名を事前取得
-        $category = Categories::find($id);
-        $category_name = $category ? $category->category : '';
-
-        Categories::deleteCategories($this->frame->plugin_name, $id);
+        $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // deleteCategoriesはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');

--- a/app/Plugins/User/Linklists/LinklistsPlugin.php
+++ b/app/Plugins/User/Linklists/LinklistsPlugin.php
@@ -619,6 +619,10 @@ class LinklistsPlugin extends UserPluginBase
         $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        if ($category_name === null) {
+            session()->flash('flash_message_for_frame' . $frame_id, 'カテゴリが見つかりませんでした。');
+            return;
+        }
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 }

--- a/app/Plugins/User/Linklists/LinklistsPlugin.php
+++ b/app/Plugins/User/Linklists/LinklistsPlugin.php
@@ -616,11 +616,7 @@ class LinklistsPlugin extends UserPluginBase
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
-        // 削除メッセージ用にカテゴリ名を事前取得
-        $category = Categories::find($id);
-        $category_name = $category ? $category->category : '';
-
-        Categories::deleteCategories($this->frame->plugin_name, $id);
+        $category_name = Categories::deletePluginCategoryWithName($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
         session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');

--- a/app/Plugins/User/Linklists/LinklistsPlugin.php
+++ b/app/Plugins/User/Linklists/LinklistsPlugin.php
@@ -623,6 +623,6 @@ class LinklistsPlugin extends UserPluginBase
         Categories::deleteCategories($this->frame->plugin_name, $id);
 
         // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
-        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. e($category_name) .' 】を削除しました。');
     }
 }

--- a/app/Plugins/User/Linklists/LinklistsPlugin.php
+++ b/app/Plugins/User/Linklists/LinklistsPlugin.php
@@ -607,7 +607,8 @@ class LinklistsPlugin extends UserPluginBase
 
         Categories::savePluginCategories($request, $this->frame->plugin_name, $linklist->id);
 
-        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
+        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '変更しました。');
     }
 
     /**
@@ -615,6 +616,13 @@ class LinklistsPlugin extends UserPluginBase
      */
     public function deleteCategories($request, $page_id, $frame_id, $id = null)
     {
+        // 削除メッセージ用にカテゴリ名を事前取得
+        $category = Categories::find($id);
+        $category_name = $category ? $category->category : '';
+
         Categories::deleteCategories($this->frame->plugin_name, $id);
+
+        // このメソッドはredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここではフラッシュメッセージのみセットする。
+        session()->flash('flash_message_for_frame' . $frame_id, '【 '. $category_name .' 】を削除しました。');
     }
 }

--- a/resources/views/plugins/common/user_list_category.blade.php
+++ b/resources/views/plugins/common/user_list_category.blade.php
@@ -14,6 +14,9 @@
 {{-- エラーメッセージ --}}
 @include('plugins.common.errors_all')
 
+{{-- 登録後メッセージ表示 --}}
+@include('plugins.common.flash_message_for_frame')
+
 {{-- 削除ボタンのアクション --}}
 <script type="text/javascript">
     function form_delete(id) {

--- a/resources/views/plugins/manage/site/categories.blade.php
+++ b/resources/views/plugins/manage/site/categories.blade.php
@@ -22,6 +22,9 @@
         {{-- エラーメッセージ --}}
         @include('plugins.common.errors_all')
 
+        {{-- 登録後メッセージ表示 --}}
+        @include('plugins.common.flash_message')
+
         {{-- 削除ボタンのアクション --}}
         <script type="text/javascript">
             function form_delete(id) {


### PR DESCRIPTION
# 概要
管理者メニュー＞サイト管理＞カテゴリ管理で「変更」ボタン押下後にフラッシュメッセージが表示されず、保存が完了したかわかりづらい状態でした。同じ問題が各プラグイン（ブログ、データベース、FAQ、課題管理、リンクリスト）のカテゴリ管理画面にも存在していたため、一貫した UX になるようフラッシュメッセージを表示するよう修正しました。

## 変更内容
### サイト管理のカテゴリ管理
- `SiteManage::saveCategories()` / `deleteCategories()` で `redirect()->back()->with('flash_message', ...)` を返すように変更。削除時は事前にカテゴリ名を取得してメッセージに含める。
- `resources/views/plugins/manage/site/categories.blade.php` に `@include('plugins.common.flash_message')` を追加。

### 各プラグイン（ブログ、データベース、FAQ、課題管理、リンクリスト）のカテゴリ管理
- 共通ビュー `resources/views/plugins/common/user_list_category.blade.php` に `@include('plugins.common.flash_message_for_frame')` を追加（1 箇所で 5 プラグインに反映）。
- 各プラグインの `saveCategories()` / `deleteCategories()` の末尾で `session()->flash('flash_message_for_frame' . \$frame_id, ...)` をセット。これらのメソッドは redirect 付のルートで呼ばれて戻り値を持たない設計のため、`OpacsPlugin` と同じ方式を踏襲。
- 削除時はカテゴリ名を事前取得してメッセージに含める（`ReservationManage` と同じ UX）。

# レビュー完了希望日
軽微な改修なので急ぎません

# 関連Pull requests/Issues
特になし

# 参考
- 手本とした既存実装:
  - サイト管理側: `app/Plugins/Manage/ReservationManage/ReservationManage.php` (saveCategories / deleteCategories)
  - ユーザープラグイン側: `app/Plugins/User/Opacs/OpacsPlugin.php` (`session()->flash('flash_message_for_frame' . \$frame_id, ...)` パターン)

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule

# 動作確認
## サイト管理
1. 管理 → サイト管理 → カテゴリ管理 を開く
2. 既存カテゴリを編集して「変更」 → 「変更しました。」が表示されること
3. 追加行にデータを入れて「変更」 → 「変更しました。」が表示されること
4. ゴミ箱アイコン → confirm → 「【 カテゴリ名 】を削除しました。」が表示されること
5. 必須項目を空にして「変更」 → errors のみ表示され、成功メッセージは出ないこと

## 各プラグイン（ブログ、データベース、FAQ、課題管理、リンクリスト）
各プラグインで以下を確認:
1. フレームメニュー → カテゴリ → 個別カテゴリ編集 → 「変更」 → 「変更しました。」がフレーム内に表示されること
2. 個別カテゴリ削除 → 「【 カテゴリ名 】を削除しました。」が表示されること
3. 同一ページに同種プラグインのフレームを 2 つ配置した場合、操作したフレームのみに表示されること（フレーム単位のキーによる動作確認）
4. バリデーションエラー時は errors のみ表示され、成功メッセージは出ないこと