### PR TITLE
[コア] 画像未登録時のデフォルト画像を "NO IMAGE" に変更しました

### DIFF
--- a/app/Http/Controllers/Core/UploadController.php
+++ b/app/Http/Controllers/Core/UploadController.php
@@ -67,7 +67,7 @@ class UploadController extends ConnectController
                 $no_image_path = public_path("/uploads/no_image/{$no_image}");
             } else {
                 // 標準no_image
-                $no_image_path = storage_path(config('connect.no_image_path'));
+                $no_image_path = public_path(config('connect.no_image_path'));
             }
             return response()->download($no_image_path, null, $headers)->setEtag(md5_file($no_image_path));
         }

--- a/config/connect.php
+++ b/config/connect.php
@@ -3,7 +3,7 @@
 return [
 
     // 画像がなかった場合の「no image」
-    'no_image_path' => 'app/public/no_image.png',
+    'no_image_path' => 'images/core/no_image/no_image3.png',
 
     // 画像に権限がなかった場合の「forbidden」
     'forbidden_image_path' => 'app/public/forbidden.png',


### PR DESCRIPTION
# 概要
画像が未登録の場合に表示される標準の No Image 画像を、従来の表示より目立ちにくい `"NO IMAGE"` 画像に変更しました。

## 変更内容
- 標準の No Image 画像の参照先を `public/images/core/no_image/no_image3.png` に変更しました。
- 画像未登録時に返す標準画像の取得元を `storage` 配下から `public` 配下に変更しました。
- 管理画面で個別に設定したカスタム No Image 画像は、これまでどおり優先されます。

## 背景と目的
画像が登録されていない場合に表示される既定アイコンが「画像エラー」のように見え、利用者に強い違和感を与えていました。
そのため、画像未登録時でも自然に見える控えめな画像へ差し替えることを目的として対応しました。

## 特記事項
- 変更対象は標準の No Image 画像のみです。
- 管理画面で設定済みのカスタム No Image 画像がある環境では、その画像が引き続き使用されます。
- DB 変更はありません。

# レビュー完了希望日
軽微な表示調整のため、ご都合のよいタイミングで確認をお願いします。

# 関連Pull requests/Issues
なし

# 参考
- 変更ファイル
  - `config/connect.php`
  - `app/Http/Controllers/Core/UploadController.php`

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule