### PR TITLE
[テーマ管理] 編集画面で編集中のテーマ名を確認できるようにしました

### DIFF
--- a/app/Plugins/Manage/ThemeManage/ThemeManage.php
+++ b/app/Plugins/Manage/ThemeManage/ThemeManage.php
@@ -346,6 +346,7 @@ class ThemeManage extends ManagePluginBase
 
         // ディレクトリ名
         $dir_name = basename($request->dir_name);
+        $theme_name = $this->getUserThemeName($dir_name);
 
         // CSS ファイル取得
         $css = File::get(public_path() . '/themes/Users/' . $dir_name . '/themes.css');
@@ -354,6 +355,7 @@ class ThemeManage extends ManagePluginBase
             "function"    => __FUNCTION__,
             "plugin_name" => "theme",
             "dir_name"    => $dir_name,
+            "theme_name"  => $theme_name,
             "css"         => $css,
         ]);
     }
@@ -370,6 +372,7 @@ class ThemeManage extends ManagePluginBase
 
         // ディレクトリ名
         $dir_name = basename($request->dir_name);
+        $theme_name = $this->getUserThemeName($dir_name);
 
         // CSS
         $css = $request->css;
@@ -381,6 +384,7 @@ class ThemeManage extends ManagePluginBase
             "function"    => __FUNCTION__,
             "plugin_name" => "theme",
             "dir_name"    => $dir_name,
+            "theme_name"  => $theme_name,
             "css"         => $css,
         ]);
     }
@@ -401,6 +405,7 @@ class ThemeManage extends ManagePluginBase
 
         // ディレクトリ名
         $dir_name = basename($request->dir_name);
+        $theme_name = $this->getUserThemeName($dir_name);
 
         // ディレクトリの存在チェック
         if (!File::isDirectory(public_path() . '/themes/Users/' . basename($request->dir_name) . '/wysiwyg')) {
@@ -422,7 +427,8 @@ class ThemeManage extends ManagePluginBase
             "function"    => __FUNCTION__,
             "plugin_name" => "theme",
             "dir_name"    => $dir_name,
-            "template"         => $template,
+            "theme_name"  => $theme_name,
+            "template"    => $template,
         ]);
     }
 
@@ -438,6 +444,7 @@ class ThemeManage extends ManagePluginBase
 
         // ディレクトリ名
         $dir_name = basename($request->dir_name);
+        $theme_name = $this->getUserThemeName($dir_name);
 
         // テンプレート
         $template = $request->template;
@@ -449,7 +456,8 @@ class ThemeManage extends ManagePluginBase
             "function"    => __FUNCTION__,
             "plugin_name" => "theme",
             "dir_name"    => $dir_name,
-            "template"         => $template,
+            "theme_name"  => $theme_name,
+            "template"    => $template,
         ]);
     }
 
@@ -469,6 +477,7 @@ class ThemeManage extends ManagePluginBase
 
         // ディレクトリ名
         $dir_name = basename($request->dir_name);
+        $theme_name = $this->getUserThemeName($dir_name);
 
         // ファイル名
         $js_path = public_path() . '/themes/Users/' . $dir_name . '/themes.js';
@@ -485,6 +494,7 @@ class ThemeManage extends ManagePluginBase
             "function"    => __FUNCTION__,
             "plugin_name" => "theme",
             "dir_name"    => $dir_name,
+            "theme_name"  => $theme_name,
             "js"          => $js,
         ]);
     }
@@ -501,6 +511,7 @@ class ThemeManage extends ManagePluginBase
 
         // ディレクトリ名
         $dir_name = basename($request->dir_name);
+        $theme_name = $this->getUserThemeName($dir_name);
 
         // JavaScript
         $js = $request->js;
@@ -512,8 +523,27 @@ class ThemeManage extends ManagePluginBase
             "function"    => __FUNCTION__,
             "plugin_name" => "theme",
             "dir_name"    => $dir_name,
+            "theme_name"  => $theme_name,
             "js"          => $js,
         ]);
+    }
+
+    /**
+     * ユーザ・テーマ名の取得
+     */
+    private function getUserThemeName($dir_name)
+    {
+        $theme_ini_path = public_path() . '/themes/Users/' . $dir_name . '/themes.ini';
+        if (!File::exists($theme_ini_path)) {
+            return '';
+        }
+
+        $theme_inis = parse_ini_file($theme_ini_path);
+        if (empty($theme_inis) || !array_key_exists('theme_name', $theme_inis)) {
+            return '';
+        }
+
+        return $theme_inis['theme_name'];
     }
 
     /**
@@ -534,11 +564,7 @@ class ThemeManage extends ManagePluginBase
         $dir_name = basename($request->dir_name);
 
         // テーマ設定ファイル取得
-        $theme_inis = parse_ini_file(public_path() . '/themes/Users/' . $dir_name . '/themes.ini');
-        $theme_name = '';
-        if (!empty($theme_inis) && array_key_exists('theme_name', $theme_inis)) {
-            $theme_name = $theme_inis['theme_name'];
-        }
+        $theme_name = $this->getUserThemeName($dir_name);
 
         return view('plugins.manage.theme.theme_name_edit', [
             "function"    => __FUNCTION__,

--- a/resources/views/plugins/manage/theme/theme_css_edit.blade.php
+++ b/resources/views/plugins/manage/theme/theme_css_edit.blade.php
@@ -22,6 +22,11 @@
         <form action="{{url('/')}}/manage/theme/saveCss" method="post">
             {{csrf_field()}}
             <input name="dir_name" type="hidden" value="{{$dir_name}}" />
+
+            <div class="alert alert-info">
+                編集中のテーマ: <strong>{{$theme_name}}</strong>（ディレクトリ名: <code>{{$dir_name}}</code>）
+            </div>
+
             <textarea name="css" id="css" class="form-control" rows=20
                 placeholder="（例）&#13;
 .navbar-dark .navbar-brand {&#13;

--- a/resources/views/plugins/manage/theme/theme_js_edit.blade.php
+++ b/resources/views/plugins/manage/theme/theme_js_edit.blade.php
@@ -22,6 +22,11 @@
         <form action="{{url('/')}}/manage/theme/saveJs" method="post">
             {{csrf_field()}}
             <input name="dir_name" type="hidden" value="{{$dir_name}}" />
+
+            <div class="alert alert-info">
+                編集中のテーマ: <strong>{{$theme_name}}</strong>（ディレクトリ名: <code>{{$dir_name}}</code>）
+            </div>
+
             <textarea name="js" id="js" class="form-control" rows=20>{{$js}}</textarea>
             @include('plugins.common.codemirror', ['element_id' => 'js', 'mode' => 'javascript()', 'height' => '500px'])
 

--- a/resources/views/plugins/manage/theme/theme_template_edit.blade.php
+++ b/resources/views/plugins/manage/theme/theme_template_edit.blade.php
@@ -22,6 +22,11 @@
         <form action="{{url('/')}}/manage/theme/saveTemplate" method="POST">
             {{csrf_field()}}
             <input name="dir_name" type="hidden" value="{{$dir_name}}" />
+
+            <div class="alert alert-info">
+                編集中のテーマ: <strong>{{$theme_name}}</strong>（ディレクトリ名: <code>{{$dir_name}}</code>）
+            </div>
+
             <textarea name="template" id="template" class="form-control" rows=20
                 placeholder="（例）&#13;
 templates : [&#13;


### PR DESCRIPTION
# 概要
テーマ管理のテーマ編集画面で、現在編集中のテーマ名を確認できるようにしました。

## 変更内容
- `ThemeManage` にユーザ・テーマ名を取得する共通処理を追加しました。
- CSS編集、JavaScript編集、テンプレート編集の各画面でテーマ名を view に渡すようにしました。
- 各編集画面のフォーム上部に、編集中のテーマ名とディレクトリ名を表示する案内を追加しました。

## 背景と目的
現状は CSS編集、JavaScript編集、テンプレート編集の画面で、どのテーマを編集中なのかを画面上で確認できませんでした。
そのため、複数のテーマを運用している場合に編集対象を誤認しやすく、作業しづらい状態でした。
編集中のテーマ名を表示することで、編集対象を分かりやすくし、操作ミスを防ぎやすくすることを目的としています。

## 特記事項
- 画面表示の改善のみで、DB への影響はありません。
- テーマ名は既存の `themes.ini` から取得しています。

# レビュー完了希望日
軽微な改修のため急ぎません。

# 関連Pull requests/Issues
なし

# 参考
確認手順:
1. 管理画面の「テーマ管理」を開きます。
2. 任意のユーザ・テーマで「CSS編集」「JavaScript編集」「テンプレート編集」を開きます。
3. 各画面のフォーム上部に、編集中のテーマ名とディレクトリ名が表示されることを確認します。

# DB変更の有無
無し

# チェックリスト

- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule