### PR TITLE
[テーマ管理] 「テーマ編集」の表記を「名称変更・削除」に変更しました

### DIFF
--- a/app/Plugins/Manage/ThemeManage/ThemeManage.php
+++ b/app/Plugins/Manage/ThemeManage/ThemeManage.php
@@ -547,10 +547,10 @@ class ThemeManage extends ManagePluginBase
     }
 
     /**
-     * テーマ名編集画面
+     * 名称変更・削除画面
      *
-     * @method_title 名前の編集
-     * @method_desc ユーザ・テーマ毎の名前を編集できます。
+     * @method_title 名称変更・削除
+     * @method_desc ユーザ・テーマ毎の名称変更や削除ができます。
      * @method_detail
      */
     public function editName($request, $id, $errors = array())

--- a/resources/views/plugins/manage/theme/theme.blade.php
+++ b/resources/views/plugins/manage/theme/theme.blade.php
@@ -62,7 +62,7 @@
         form_js.dir_name.value = dir_name;
         form_js.submit();
     }
-    // テーマ名編集画面へ
+    // 名称変更・削除画面へ
     function view_name_edit(dir_name)
     {
         form_name.dir_name.value = dir_name;
@@ -85,7 +85,7 @@
                <a href="javascript:view_js_edit('{{$dir['dir']}}');" id="js_edit_{{$loop->iteration}}">［JavaScript編集］</a>
                <a href="javascript:view_list_images('{{$dir['dir']}}');" id="image_edit_{{$loop->iteration}}">［画像管理］</a>
                <a href="javascript:view_template_edit('{{$dir['dir']}}');" id="template_edit_{{$loop->iteration}}">［テンプレート編集］</a>
-               <a href="javascript:view_name_edit('{{$dir['dir']}}');" id="name_edit_{{$loop->iteration}}">［テーマ編集］</a>
+               <a href="javascript:view_name_edit('{{$dir['dir']}}');" id="name_edit_{{$loop->iteration}}">［名称変更・削除］</a>
         </li>
     @endforeach
 </ul>

--- a/resources/views/plugins/manage/theme/theme_manage_tab.blade.php
+++ b/resources/views/plugins/manage/theme/theme_manage_tab.blade.php
@@ -49,7 +49,7 @@
                 @endif
                 @if ($function == "editName")
                     <li role="presentation" class="nav-item">
-                        <span class="nav-link"><span class="active">テーマ名編集</span></span>
+                        <span class="nav-link"><span class="active">名称変更・削除</span></span>
                     </li>
                 @endif
             </ul>

--- a/resources/views/plugins/manage/theme/theme_name_edit.blade.php
+++ b/resources/views/plugins/manage/theme/theme_name_edit.blade.php
@@ -1,5 +1,5 @@
 {{--
- * テーマ名編集テンプレート
+ * 名称変更・削除テンプレート
  *
  * @author 永原　篤 <nagahara@opensource-workshop.jp>
  * @copyright OpenSource-WorkShop Co.,Ltd. All Rights Reserved

--- a/tests/Browser/Manage/ThemeManageTest.php
+++ b/tests/Browser/Manage/ThemeManageTest.php
@@ -135,7 +135,7 @@ class ThemeManageTest extends DuskTestCase
     }
 
     /**
-     * ユーザ・テーマの名前管理
+     * ユーザ・テーマの名称変更・削除
      */
     private function editName()
     {
@@ -151,8 +151,8 @@ class ThemeManageTest extends DuskTestCase
         // マニュアル用データ出力
         $this->putManualData('[
             {"path": "manage/theme/editName/images/editName",
-             "name": "ユーザ・テーマの名前の編集",
-             "comment": "<ul class=\"mb-0\"><li>ユーザ・テーマの名前を変更できます。</li></ul>"
+             "name": "ユーザ・テーマの名称変更・削除",
+             "comment": "<ul class=\"mb-0\"><li>ユーザ・テーマの名称変更や削除ができます。</li></ul>"
             }
         ]', null, 3);
     }


### PR DESCRIPTION
# 概要
テーマ管理で表示している「テーマ編集」の表記を、「名称変更・削除」に修正しました。

## 背景と目的
従来の「テーマ編集」という表記では、画面で実行できる内容が直感的に伝わりにくい状態でした。
そのため、実際の機能内容に合わせて「名称変更・削除」と分かる表記に見直しました。

## 変更内容

- テーマ管理画面の「［テーマ編集］」表記を「［名称変更・削除］」に変更
- 遷移先画面のタブ表示を「名称変更・削除」に変更
- マニュアル向けの機能名・説明文も「名称変更・削除」に合わせて更新

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

有り / 無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
