### PR TITLE
[新着情報] 初回表示時の読込方法の説明を分かりやすくしました

### DIFF
--- a/app/Enums/WhatsnewFrameConfig.php
+++ b/app/Enums/WhatsnewFrameConfig.php
@@ -24,6 +24,6 @@ final class WhatsnewFrameConfig extends EnumsBase
         self::border => '記事間の罫線',
         self::post_detail => '記事本文',
         self::post_detail_length => '記事本文の文字数',
-        self::async => '非同期表示',
+        self::async => '初回表示時の読込方法',
     ];
 }

--- a/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
@@ -120,13 +120,13 @@
         </div>
     </div>
 
-    {{-- 非同期表示 --}}
-    <h5><span class="badge badge-secondary">非同期表示</span></h5>
+    {{-- 初回表示時の読込方法 --}}
+    <h5><span class="badge badge-secondary">初回表示時の読込方法</span></h5>
 
     <div class="form-group row">
-        <label class="{{$frame->getSettingLabelClass(true)}}">非同期表示</label>
-        <div class="{{$frame->getSettingInputClass(true)}}">
-            @foreach (UseType::enum as $key => $value)
+        <label class="{{$frame->getSettingLabelClass(true)}}">初回表示時の読込方法</label>
+        <div class="{{$frame->getSettingInputClass()}}">
+            @foreach ([UseType::not_use => '開いたときに表示する', UseType::use => '開いたあとに表示する'] as $key => $value)
                 <div class="custom-control custom-radio custom-control-inline">
                     <input
                         type="radio"
@@ -141,6 +141,9 @@
                     </label>
                 </div>
             @endforeach
+            <small class="text-muted d-block">新着情報の読み込み方法を選ぶ設定です。</small>
+            <small class="text-muted d-block">通常は、「開いたときに表示する」の設定でご利用いただけます。</small>
+            <small class="text-muted d-block">新着情報プラグインを多数配置して表示が遅いと感じる場合は、「開いたあとに表示する」を選びます。ページの読み込みが早くなることがあります。</small>
         </div>
     </div>
 

--- a/tests/Browser/User/WhatsnewsPluginTest.php
+++ b/tests/Browser/User/WhatsnewsPluginTest.php
@@ -174,7 +174,7 @@ class WhatsnewsPluginTest extends DuskTestCase
         // マニュアル用データ出力
         $this->putManualData('[
             {"path": "user/whatsnews/editView/images/editView",
-             "comment": "<ul class=\"mb-0\"><li>本文・サムネイル・罫線の表示・非表示を設定できます。</li></ul>"
+             "comment": "<ul class=\"mb-0\"><li>本文・サムネイル・罫線に加え、新着情報を開いたときに表示するか、開いたあとに表示するかを選ぶ「初回表示時の読込方法」を設定できます。</li></ul>"
             }
         ]', null, 4, 'basic');
     }


### PR DESCRIPTION
# 概要

新着情報プラグインの表示設定にある「非同期表示」の名称と説明を見直し、初回表示時の挙動が分かかるような表現に変更しました。

## 変更内容
- 設定名を「非同期表示」から「初回表示時の読込方法」へ変更しました。
- 選択肢名を「開いたときに表示する」「開いたあとに表示する」へ変更しました。
- 補足文を見直し、通常は「開いたときに表示する」で利用できることと、「開いたあとに表示する」を選ぶ場面が伝わるようにしました。
- マニュアル用コメントも新しい設定名に合わせて更新しました。

<img width="600" alt="image" src="https://github.com/user-attachments/assets/02cd54b5-6d49-47de-ae73-26361715c7c3" />


## 背景と目的
表示設定にある「非同期表示」は、技術的な意味が伝わりにくく、利用者が設定を判断しづらい状態でした。
そのため、初回表示時の読み込み方法を選ぶ設定であることが分かる名称に変更し、一般利用者にも判断しやすい説明へ改善することを目的として対応しました。

## 特記事項
- 動作や保存値は変更しておらず、表示上の文言のみを見直しています。

# レビュー完了希望日
軽微な改修のため、急ぎません。

# 関連Pull requests/Issues
なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule