### PR TITLE
[テーマ管理] 画像管理で jpeg と webp のアップロードに対応しました

### DIFF
--- a/app/Plugins/Manage/ThemeManage/ThemeManage.php
+++ b/app/Plugins/Manage/ThemeManage/ThemeManage.php
@@ -693,9 +693,10 @@ class ThemeManage extends ManagePluginBase
             $extension            = $request->file('image')->getClientOriginalExtension();
 
             // 拡張子チェック
-            if (mb_strtolower($extension) != 'jpg' && mb_strtolower($extension) != 'png' && mb_strtolower($extension) != 'gif') {
+            $allowed_extensions = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+            if (!in_array(mb_strtolower($extension), $allowed_extensions, true)) {
                 $validator = Validator::make($request->all(), []);
-                $validator->errors()->add('not_extension', 'jpg, png, gif 以外はアップロードできません。');
+                $validator->errors()->add('not_extension', implode(', ', $allowed_extensions) . ' 以外はアップロードできません。');
                 return $this->listImages($request, $id)->withErrors($validator);
             }
 


### PR DESCRIPTION
# 概要

管理者メニュー＞テーマ管理＞画像管理の画像アップロードで、現状は `jpg` / `png` / `gif` のみ許可されており、`webp` などの最近主流の画像形式がアップロードできませんでした。近年の画像形式の利用状況に合わせて `jpeg` と `webp` を追加で許可するように変更しました。

併せて、`!=` の連鎖による拡張子チェックを `in_array()` に書き換えて可読性を改善し、エラーメッセージは `$allowed_extensions` 配列から動的生成するようにしてハードコーディングを減らしました。

変更ファイル: `app/Plugins/Manage/ThemeManage/ThemeManage.php`

# レビュー完了希望日

軽微な改修なので急ぎません。

# 関連Pull requests/Issues

無し

# 参考

無し

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule