### PR TITLE
[固定記事] ページ権限昇格ユーザが自分の一時保存/承認待ち記事を閲覧できるよう修正しました

### DIFF
--- a/app/Models/Common/Buckets.php
+++ b/app/Models/Common/Buckets.php
@@ -95,18 +95,30 @@ class Buckets extends Model
     /**
      * ユーザーの投稿権限の有無確認
      */
-    public function canPostUser($user)
+    public function canPostUser($user, $frame = null)
     {
         // ユーザーの持つBASE権限を全て確認し、ひとつでも投稿権限があれば、投稿可能となる。
         if (empty($user)) {
             return false;
         }
 
-        if (!array_key_exists('base', (array)$user->user_roles)) {
+        $request = app(Request::class);
+
+        // app\Http\Middleware\ConnectPage.php でセットした値
+        $page = $request->attributes->get('page');
+        $page_tree = $request->attributes->get('page_tree');
+
+        // フレームがあれば、フレームを配置したページから親を遡ってページロールを取得
+        $page_roles = $this->choicePageRolesByGoingBackParentPageOrFramePage($page, $page_tree, $frame);
+
+        // ユーザロール取得。所属グループのページ権限あったら、そっちからとる
+        $user_roles = $this->choiceUserRolesOrPageRoles($user, $page_roles);
+
+        if (!array_key_exists('base', (array)$user_roles)) {
             return false;
         }
 
-        $user_roles_base = $user->user_roles['base'];
+        $user_roles_base = $user_roles['base'];
         if (empty($user_roles_base)) {
             return false;
         }

--- a/app/Models/Common/Buckets.php
+++ b/app/Models/Common/Buckets.php
@@ -97,7 +97,7 @@ class Buckets extends Model
      */
     public function canPostUser($user, $frame = null)
     {
-        // ユーザーの持つBASE権限を全て確認し、ひとつでも投稿権限があれば、投稿可能となる。
+        // ユーザーの BASE 権限（ページ権限で昇格した場合も含む）を全て確認し、ひとつでも投稿権限があれば、投稿可能となる。
         if (empty($user)) {
             return false;
         }

--- a/app/Plugins/User/Contents/ContentsPlugin.php
+++ b/app/Plugins/User/Contents/ContentsPlugin.php
@@ -206,7 +206,7 @@ class ContentsPlugin extends UserPluginBase
             //
             $query->WhereIn($table_name . '.status', [StatusType::active, StatusType::approval_pending]);
 
-        } elseif ($this->buckets && $this->buckets->canPostUser(Auth::user())) {
+        } elseif ($this->buckets && $this->buckets->canPostUser(Auth::user(), $this->frame)) {
             //
             // モデレータ or 編集者権限の場合、Active ＋ 自分の全ステータス記事の取得
             //
@@ -218,24 +218,8 @@ class ContentsPlugin extends UserPluginBase
             });
 
         } else {
-            // その他（ゲスト、およびページ権限でのみモデレータ/編集者に昇格したユーザ）
-            // bugfix: Buckets::canPostUser() は BASE 権限のみ走査するため、ページ権限で
-            //         role_reporter/role_article 等に昇格したユーザは上の elseif に入らず
-            //         ここへ落ちる。自分が一時保存・承認待ちした記事すら見えなくなるため、
-            //         「他人の未公開は見せない」設計は維持しつつ、自分の作成分のみ閲覧許可。
-            $query->where(function ($tmp_query) use ($table_name) {
-                $tmp_query->where($table_name . '.status', StatusType::active);
-                if (Auth::check()) {
-                    $tmp_query->orWhere(function ($own_query) use ($table_name) {
-                        $own_query->where($table_name . '.created_id', '=', Auth::user()->id)
-                            ->whereIn($table_name . '.status', [
-                                StatusType::active,
-                                StatusType::temporary,
-                                StatusType::approval_pending,
-                            ]);
-                    });
-                }
-            });
+            // その他（ゲスト）
+            $query->where($table_name . '.status', StatusType::active);
         }
 
         return $query;

--- a/app/Plugins/User/Contents/ContentsPlugin.php
+++ b/app/Plugins/User/Contents/ContentsPlugin.php
@@ -218,8 +218,24 @@ class ContentsPlugin extends UserPluginBase
             });
 
         } else {
-            // その他（ゲスト）
-            $query->where($table_name . '.status', StatusType::active);
+            // その他（ゲスト、およびページ権限でのみモデレータ/編集者に昇格したユーザ）
+            // bugfix: Buckets::canPostUser() は BASE 権限のみ走査するため、ページ権限で
+            //         role_reporter/role_article 等に昇格したユーザは上の elseif に入らず
+            //         ここへ落ちる。自分が一時保存・承認待ちした記事すら見えなくなるため、
+            //         「他人の未公開は見せない」設計は維持しつつ、自分の作成分のみ閲覧許可。
+            $query->where(function ($tmp_query) use ($table_name) {
+                $tmp_query->where($table_name . '.status', StatusType::active);
+                if (Auth::check()) {
+                    $tmp_query->orWhere(function ($own_query) use ($table_name) {
+                        $own_query->where($table_name . '.created_id', '=', Auth::user()->id)
+                            ->whereIn($table_name . '.status', [
+                                StatusType::active,
+                                StatusType::temporary,
+                                StatusType::approval_pending,
+                            ]);
+                    });
+                }
+            });
         }
 
         return $query;

--- a/tests/Unit/Models/Common/BucketsTest.php
+++ b/tests/Unit/Models/Common/BucketsTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Unit\Models\Common;
+
+use App\Models\Common\Buckets;
+use App\Models\Common\BucketsRoles;
+use App\Models\Common\Frame;
+use App\Models\Common\Group;
+use App\Models\Common\GroupUser;
+use App\Models\Common\Page;
+use App\Models\Common\PageRole;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+/**
+ * Buckets モデルのユニットテスト
+ *
+ * canPostUser() / needApprovalUser() はページ権限による昇格をマージしてから
+ * 判定する必要があるため、以下を個別に検証する。
+ *  (i)   BASE 権限モデレータ
+ *  (ii)  ページ権限昇格モデレータ
+ *  (iii) 未ログイン
+ *  (iv)  $frame = null のフォールバック
+ */
+class BucketsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 初期設定
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * サービスコンテナにページ文脈付きの Request を注入する。
+     * Buckets::canPostUser() / needApprovalUser() が参照する attributes をここで仕込む。
+     */
+    private function bindRequestWithPage(?Page $page): Request
+    {
+        $request = new Request();
+        if ($page) {
+            $request->attributes->set('page', $page);
+            $request->attributes->set('page_tree', collect([$page]));
+        }
+        $this->app->instance(Request::class, $request);
+        return $request;
+    }
+
+    /**
+     * 指定ロールに投稿権限 ON ／承認要否を任意指定したバケツを作る。
+     */
+    private function createBucketWithRole(string $role, int $post_flag = 1, int $approval_flag = 0): Buckets
+    {
+        $bucket = Buckets::factory()->create();
+        BucketsRoles::create([
+            'buckets_id' => $bucket->id,
+            'role' => $role,
+            'post_flag' => $post_flag,
+            'approval_flag' => $approval_flag,
+        ]);
+        return $bucket;
+    }
+
+    /**
+     * グループに所属するユーザを作り、指定ページ／ロールのページ権限を付与する。
+     */
+    private function grantPageRoleViaGroup(User $user, Page $page, string $role_name): void
+    {
+        $group = Group::factory()->create();
+        GroupUser::create(['group_id' => $group->id, 'user_id' => $user->id]);
+        PageRole::create([
+            'page_id' => $page->id,
+            'group_id' => $group->id,
+            'target' => 'base',
+            'role_name' => $role_name,
+            'role_value' => 1,
+        ]);
+    }
+
+    /**
+     * (i) BASE 権限モデレータ：BASE ロールに直接投稿権限があるユーザは投稿可能
+     */
+    public function testCanPostUserReturnsTrueWhenBaseRoleGrantsPost(): void
+    {
+        $bucket = $this->createBucketWithRole('role_article');
+        $this->bindRequestWithPage(null);
+
+        $user = User::factory()->create();
+        $user->user_roles = ['base' => ['role_article' => 1]];
+
+        $this->assertTrue($bucket->canPostUser($user));
+    }
+
+    /**
+     * (ii) ページ権限昇格モデレータ：BASE はゲストでも、ページ権限昇格で投稿可能になる
+     *
+     * 本 PR の主要な回帰防止ポイント。
+     */
+    public function testCanPostUserReturnsTrueWhenPageRoleElevatesGuestToPostableRole(): void
+    {
+        $bucket = $this->createBucketWithRole('role_article');
+
+        $page = Page::factory()->create();
+        Page::fixTree();
+        $page->refresh();
+
+        $user = User::factory()->create();
+        $user->user_roles = ['base' => ['role_guest' => 1]];
+
+        $this->grantPageRoleViaGroup($user, $page, 'role_article');
+
+        $frame = new Frame(['page_id' => $page->id]);
+        $this->bindRequestWithPage($page);
+
+        $this->assertTrue($bucket->canPostUser($user, $frame));
+    }
+
+    /**
+     * (iii) 未ログイン：$user が null の場合は常に false
+     */
+    public function testCanPostUserReturnsFalseForUnauthenticatedUser(): void
+    {
+        $bucket = $this->createBucketWithRole('role_article');
+        $this->bindRequestWithPage(null);
+
+        $this->assertFalse($bucket->canPostUser(null));
+    }
+
+    /**
+     * (iv) $frame = null のフォールバック：フレーム未指定でも $request の page 文脈から昇格を解決できる
+     */
+    public function testCanPostUserResolvesPageRoleWithoutFrame(): void
+    {
+        $bucket = $this->createBucketWithRole('role_article');
+
+        $page = Page::factory()->create();
+        Page::fixTree();
+        $page->refresh();
+
+        $user = User::factory()->create();
+        $user->user_roles = ['base' => ['role_guest' => 1]];
+
+        $this->grantPageRoleViaGroup($user, $page, 'role_article');
+
+        $this->bindRequestWithPage($page);
+
+        // 第2引数 $frame を渡さず、デフォルト null でも同等に解決できる事
+        $this->assertTrue($bucket->canPostUser($user));
+    }
+
+    /**
+     * ネガティブケース：BASE ゲストのみ・ページ権限昇格なしのユーザは投稿不可
+     */
+    public function testCanPostUserReturnsFalseForGuestWithoutPageElevation(): void
+    {
+        $bucket = $this->createBucketWithRole('role_article');
+        $this->bindRequestWithPage(null);
+
+        $user = User::factory()->create();
+        $user->user_roles = ['base' => ['role_guest' => 1]];
+
+        $this->assertFalse($bucket->canPostUser($user));
+    }
+
+    /**
+     * コンパニオンテスト：needApprovalUser() もページ権限昇格を認識して承認要否を正しく返す事
+     *
+     * canPostUser() と同じ前段処理（ConnectRoleTrait 経由）を使うため、
+     * 将来 canPostUser() の修正が波及した際に回帰検知できるよう双子テストとして残す。
+     */
+    public function testNeedApprovalUserRecognizesPageRoleElevation(): void
+    {
+        // バケツは role_article に対して「承認不要（approval_flag = 0）」
+        $bucket = $this->createBucketWithRole('role_article', 1, 0);
+
+        $page = Page::factory()->create();
+        Page::fixTree();
+        $page->refresh();
+
+        $user = User::factory()->create();
+        $user->user_roles = ['base' => ['role_guest' => 1]];
+
+        $this->grantPageRoleViaGroup($user, $page, 'role_article');
+
+        $frame = new Frame(['page_id' => $page->id]);
+        $this->bindRequestWithPage($page);
+
+        // ページ権限昇格が認識されなければ「BASE ゲストのみ」→ needApprovalUser は true のままになる。
+        // 正しく昇格が効けば role_article の approval_flag=0 により承認不要 (false) となる。
+        $this->assertFalse($bucket->needApprovalUser($user, $frame));
+    }
+}


### PR DESCRIPTION
# 概要

デフォルト権限が「ゲスト」のユーザが、ページ権限設定によりモデレータ／編集者に昇格している場合、固定記事（Contents プラグイン）で自分が「一時保存」または「承認待ち」した記事が、投稿者本人から見えなくなる不具合を修正しました。

## 原因

`app/Models/Common/Buckets.php` の `canPostUser()` がユーザの BASE 権限（`$user->user_roles['base']`）のみを走査していたため、ページ権限でモデレータ／編集者に昇格したユーザを検知できず、`ContentsPlugin::appendAuthWhere()` 内の投稿者向け分岐（Active ＋ 自分の全ステータスを返す分岐）に入れずゲスト扱い（Active のみ）になっていました。

なお、同モデルの `needApprovalUser()` は 2021-08-04 の修正でページ権限昇格に対応済みで、ブログプラグインは `UserPluginBase::appendAuthWhereBase()` 経由で `isCan()` を使っているため、いずれも同事象は起きません。今回の修正は `needApprovalUser()` と同じパターンを `canPostUser()` に適用するものです。

## 変更内容

- `app/Models/Common/Buckets.php`
    - `canPostUser($user, $frame = null)` にフレーム引数を追加
    - `choicePageRolesByGoingBackParentPageOrFramePage()` ＋ `choiceUserRolesOrPageRoles()` でページ権限昇格をマージしてから BASE 権限を走査するように変更（`needApprovalUser()` と同じ方式）
    - メソッド冒頭コメントをページ権限昇格対応に合わせて更新
- `app/Plugins/User/Contents/ContentsPlugin.php`
    - `appendAuthWhere()` から `canPostUser()` を呼び出す際、`$this->frame` を渡すように変更
- `tests/Unit/Models/Common/BucketsTest.php`（新設）
    - `canPostUser()` / `needApprovalUser()` のページ権限昇格対応を検証するユニットテストを追加

# レビュー完了希望日

不具合対応のため、お手隙で早めにご確認いただけると助かります。

# 関連Pull requests/Issues

特になし

# 参考

- `app/Models/Common/Buckets.php` の `needApprovalUser()`（ページ権限昇格対応の先行実装）
- `app/Plugins/User/UserPluginBase.php::appendAuthWhereBase()`（ブログ等が使用している共通処理）

# 動作確認手順

### 再現環境のセットアップ

1. BASE 権限「ゲスト (role_guest のみ)」のユーザ `u_guest_promoted` を作成
2. テスト用ページ P を用意し、ページ権限設定でグループ経由等で `u_guest_promoted` に「モデレータ (role_article)」または「編集者 (role_reporter)」を付与
3. ページ P に固定記事プラグインを配置し、バケツの投稿権限設定で該当ロールを ON

### 動作確認チェックリスト

- [x] ゲスト昇格ユーザが自分の一時保存記事を閲覧できる
- [x] ゲスト昇格ユーザが自分の承認待ち記事を閲覧できる
- [x] 未ログイン訪問者は Active のみ閲覧できる（従来動作）
- [x] `role_article_admin` ユーザは引き続き全ステータスの記事を閲覧できる（従来動作）
- [x] `role_approval` 権限保有者は Active + 承認待ちを閲覧できる（従来動作）
- [x] 追加したユニットテスト `tests/Unit/Models/Common/BucketsTest.php` がグリーン

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule