### PR TITLE
[新着情報] 初回表示時の読込方法の選択肢名を改善しました

### DIFF
--- a/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews_frame.blade.php
@@ -126,7 +126,7 @@
     <div class="form-group row">
         <label class="{{$frame->getSettingLabelClass(true)}}">初回表示時の読込方法</label>
         <div class="{{$frame->getSettingInputClass()}}">
-            @foreach ([UseType::not_use => '開いたときに表示する', UseType::use => '開いたあとに表示する'] as $key => $value)
+            @foreach ([UseType::not_use => 'ページを開くときに表示する', UseType::use => 'ページを開いたあとに表示する'] as $key => $value)
                 <div class="custom-control custom-radio custom-control-inline">
                     <input
                         type="radio"
@@ -142,8 +142,8 @@
                 </div>
             @endforeach
             <small class="text-muted d-block">新着情報の読み込み方法を選ぶ設定です。</small>
-            <small class="text-muted d-block">通常は、「開いたときに表示する」の設定でご利用いただけます。</small>
-            <small class="text-muted d-block">新着情報プラグインを多数配置して表示が遅いと感じる場合は、「開いたあとに表示する」を選びます。ページの読み込みが早くなることがあります。</small>
+            <small class="text-muted d-block">通常は、「ページを開くときに表示する」の設定でご利用いただけます。</small>
+            <small class="text-muted d-block">新着情報プラグインを多数配置して表示が遅いと感じる場合は、「ページを開いたあとに表示する」を選びます。ページの読み込みが早くなることがあります。</small>
         </div>
     </div>
 


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

選択肢名をより分かりやすくするため、以下のように変更しました。
- 変更前: 「開いたときに表示する」「開いたあとに表示する」
- 変更後: 「ページを開くときに表示する」「ページを開いたあとに表示する」
<img width="600" alt="image" src="https://github.com/user-attachments/assets/1d5dca85-0c25-4747-9296-8f19af237791" />

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

#2416 

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
