### PR TITLE
[コア] [WYSIWYGエディタ] sandbox_iframes_exclusionsにcalendar.google.comを追加

### DIFF
--- a/resources/views/plugins/common/wysiwyg.blade.php
+++ b/resources/views/plugins/common/wysiwyg.blade.php
@@ -306,6 +306,7 @@
             'dailymotion.com',
             'embed.music.apple.com',
             'google.com',
+            'calendar.google.com',
             'open.spotify.com',
             'giphy.com',
             'dai.ly',


### PR DESCRIPTION
# 概要
Googleカレンダーのiframeを固定記事プラグインに埋め込もうとしたところ、sandbox_iframes_exclusions にcalendar.google.com が含まれていないため表示できませんでした。
google.com はホワイトリストに含まれていますが、サブドメインの calendar.google.com は別途指定が必要なため追加しました。

# レビュー完了希望日

急ぎませんが、実用上必要なため使えるようになると嬉しいです。

# 関連Pull requests/Issues

#2219

# 参考

https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#sandbox-iframes-exclusions

# DB変更の有無

 無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
