### PR TITLE
[サイト管理] 新規プラグイン作成時の投稿権限初期値を追加しました

### DIFF
--- a/app/Models/Common/Buckets.php
+++ b/app/Models/Common/Buckets.php
@@ -3,6 +3,7 @@
 namespace App\Models\Common;
 
 use App\Models\Common\BucketsRoles;
+use App\Models\Core\Configs;
 use App\Traits\ConnectRoleTrait;
 use Database\Factories\Common\BucketsFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -13,6 +14,30 @@ class Buckets extends Model
 {
     use ConnectRoleTrait;
     use HasFactory;
+
+    /**
+     * 新規バケツの投稿権限初期値に対応するConfig名
+     */
+    private const DEFAULT_NEW_BUCKET_POST_ROLE_CONFIGS = [
+        'role_article' => 'new_bucket_role_article_post_flag',
+        'role_reporter' => 'new_bucket_role_reporter_post_flag',
+    ];
+
+    /**
+     * 新規バケツの投稿権限初期値を適用する対象プラグイン
+     */
+    private const DEFAULT_POST_ROLE_TARGET_PLUGINS = [
+        'bbses',
+        'blogs',
+        'cabinets',
+        'calendars',
+        'contents',
+        'databases',
+        'faqs',
+        'photoalbums',
+        'reservations',
+        'slideshows',
+    ];
 
     /**
      * create()やupdate()で入力を受け付ける ホワイトリスト
@@ -26,6 +51,13 @@ class Buckets extends Model
 
     // Buckets のrole
     private $buckets_roles = null;
+
+    protected static function booted()
+    {
+        static::deleting(function ($bucket) {
+            BucketsRoles::where('buckets_id', $bucket->id)->delete();
+        });
+    }
 
     /**
      * 投稿権限データをrole の配列で返却
@@ -219,6 +251,104 @@ class Buckets extends Model
             }
         }
         return true;
+    }
+
+    /**
+     * 新規バケツ作成時の投稿権限初期値を適用する。
+     */
+    public function initializeDefaultPostRoles(): void
+    {
+        $default_post_role_flags = self::getDefaultNewBucketPostRoleFlags();
+
+        foreach ($default_post_role_flags as $role => $post_flag) {
+            if ((int) $post_flag !== 1) {
+                continue;
+            }
+
+            BucketsRoles::firstOrCreate(
+                [
+                    'buckets_id' => $this->id,
+                    'role' => $role,
+                ],
+                [
+                    'post_flag' => 1,
+                    'approval_flag' => 0,
+                ]
+            );
+        }
+    }
+
+    /**
+     * 投稿権限設定を持つプラグインの新規バケツなら、投稿権限初期値を適用する。
+     */
+    public function initializeDefaultPostRolesIfTargetPlugin(): void
+    {
+        if (!self::isDefaultPostRoleTargetPlugin($this->plugin_name)) {
+            return;
+        }
+
+        $this->initializeDefaultPostRoles();
+    }
+
+    /**
+     * 新規バケツを作成し、対象プラグインだけ投稿権限初期値を適用する。
+     */
+    public static function createWithDefaultPostRoles(array $attributes): self
+    {
+        $bucket = self::create($attributes);
+        $bucket->initializeDefaultPostRolesIfTargetPlugin();
+
+        return $bucket;
+    }
+
+    /**
+     * バケツを作成または更新し、新規作成時だけ投稿権限初期値を適用する。
+     */
+    public static function updateOrCreateWithDefaultPostRoles(array $attributes, array $values = []): self
+    {
+        $bucket = self::updateOrCreate($attributes, $values);
+
+        if ($bucket->wasRecentlyCreated) {
+            $bucket->initializeDefaultPostRolesIfTargetPlugin();
+        }
+
+        return $bucket;
+    }
+
+    /**
+     * 新規バケツの投稿権限初期値を適用する対象プラグインか判定する。
+     */
+    public static function isDefaultPostRoleTargetPlugin(?string $plugin_name): bool
+    {
+        return in_array($plugin_name, self::DEFAULT_POST_ROLE_TARGET_PLUGINS, true);
+    }
+
+    /**
+     * 新規バケツ作成時の投稿権限初期値を取得する。
+     */
+    public static function getDefaultNewBucketPostRoleFlags(): array
+    {
+        $config_names = array_values(self::DEFAULT_NEW_BUCKET_POST_ROLE_CONFIGS);
+        $configs = Configs::getSharedConfigs();
+
+        if ($configs->isEmpty()) {
+            $configs = Configs::whereIn('name', $config_names)->get();
+        }
+
+        return self::resolveDefaultNewBucketPostRoleFlags($configs);
+    }
+
+    /**
+     * Config群から新規バケツ作成時の投稿権限初期値を解決する。
+     */
+    private static function resolveDefaultNewBucketPostRoleFlags($configs): array
+    {
+        $configs = collect($configs);
+
+        return [
+            'role_article' => (int) Configs::getConfigsValue($configs, self::DEFAULT_NEW_BUCKET_POST_ROLE_CONFIGS['role_article'], 0),
+            'role_reporter' => (int) Configs::getConfigsValue($configs, self::DEFAULT_NEW_BUCKET_POST_ROLE_CONFIGS['role_reporter'], 0),
+        ];
     }
 
     protected static function newFactory()

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -331,6 +331,20 @@ class SiteManage extends ManagePluginBase
              'value'    => $request->additional_theme]
         );
 
+        // 新規バケツ作成時のモデレータ投稿権限
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'new_bucket_role_article_post_flag'],
+            ['category' => 'general',
+             'value'    => (isset($request->new_bucket_role_article_post_flag) ? $request->new_bucket_role_article_post_flag : 0)]
+        );
+
+        // 新規バケツ作成時の編集者投稿権限
+        $configs = Configs::updateOrCreate(
+            ['name'     => 'new_bucket_role_reporter_post_flag'],
+            ['category' => 'general',
+             'value'    => (isset($request->new_bucket_role_reporter_post_flag) ? $request->new_bucket_role_reporter_post_flag : 0)]
+        );
+
         // 画面の基本の背景色
         $configs = Configs::updateOrCreate(
             ['name'     => 'base_background_color'],

--- a/app/Plugins/User/Bbses/BbsesPlugin.php
+++ b/app/Plugins/User/Bbses/BbsesPlugin.php
@@ -761,7 +761,7 @@ class BbsesPlugin extends UserPluginBase
         }
 
         // バケツの取得。なければ登録。
-        $bucket = Buckets::updateOrCreate(
+        $bucket = Buckets::updateOrCreateWithDefaultPostRoles(
             ['id' => $bucket_id],
             ['bucket_name' => $request->name, 'plugin_name' => 'bbses'],
         );

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1333,7 +1333,7 @@ WHERE status = 0
         // 画面から渡ってくるblogs_id が空ならバケツとブログを新規登録
         if (empty($request->blogs_id)) {
             // バケツの登録
-            $bucket = Buckets::create([
+            $bucket = Buckets::createWithDefaultPostRoles([
                 'bucket_name' => $request->blog_name,
                 'plugin_name' => 'blogs'
             ]);

--- a/app/Plugins/User/Cabinets/CabinetsPlugin.php
+++ b/app/Plugins/User/Cabinets/CabinetsPlugin.php
@@ -1129,7 +1129,7 @@ class CabinetsPlugin extends UserPluginBase
     private function saveCabinet($request, $frame_id, $bucket_id)
     {
         // バケツの取得。なければ登録。
-        $bucket = Buckets::updateOrCreate(
+        $bucket = Buckets::updateOrCreateWithDefaultPostRoles(
             ['id' => $bucket_id],
             ['bucket_name' => $request->name, 'plugin_name' => 'cabinets'],
         );

--- a/app/Plugins/User/Calendars/CalendarsPlugin.php
+++ b/app/Plugins/User/Calendars/CalendarsPlugin.php
@@ -598,7 +598,7 @@ class CalendarsPlugin extends UserPluginBase
         }
 
         // バケツの取得。なければ登録。
-        $bucket = Buckets::updateOrCreate(
+        $bucket = Buckets::updateOrCreateWithDefaultPostRoles(
             ['id' => $bucket_id],
             ['bucket_name' => $request->name, 'plugin_name' => 'calendars'],
         );

--- a/app/Plugins/User/Contents/ContentsPlugin.php
+++ b/app/Plugins/User/Contents/ContentsPlugin.php
@@ -550,7 +550,7 @@ class ContentsPlugin extends UserPluginBase
 
         // バケツがまだ登録されていなかったら登録する。
         if (empty($this->buckets)) {
-            $bucket = Buckets::create([
+            $bucket = Buckets::createWithDefaultPostRoles([
                 'bucket_name' => $request->bucket_name ?? '無題',
                 'plugin_name' => 'contents'
             ]);

--- a/app/Plugins/User/Databases/DatabasesPlugin.php
+++ b/app/Plugins/User/Databases/DatabasesPlugin.php
@@ -2136,10 +2136,10 @@ class DatabasesPlugin extends UserPluginBase
         // 画面から渡ってくるdatabases_id が空ならバケツとブログを新規登録
         if (empty($databases_id)) {
             // バケツの登録
-            $bucket = new Buckets();
-            $bucket->bucket_name = $request->databases_name;
-            $bucket->plugin_name = 'databases';
-            $bucket->save();
+            $bucket = Buckets::createWithDefaultPostRoles([
+                'bucket_name' => $request->databases_name,
+                'plugin_name' => 'databases',
+            ]);
 
             if (empty($request->copy_databases_id)) {
                 // 登録
@@ -2359,7 +2359,7 @@ class DatabasesPlugin extends UserPluginBase
             BucketsRoles::where('buckets_id', $databases->bucket_id)->delete();
 
             // backetsの削除
-            Buckets::where('id', $databases->bucket_id)->delete();
+            Buckets::destroy($databases->bucket_id);
 
             // change: このバケツを表示している全ページのフレームのバケツIDを消す
             // // バケツIDの取得のためにFrame を取得(Frame を更新する前に取得しておく)

--- a/app/Plugins/User/Faqs/FaqsPlugin.php
+++ b/app/Plugins/User/Faqs/FaqsPlugin.php
@@ -961,10 +961,11 @@ class FaqsPlugin extends UserPluginBase
         // 画面から渡ってくるfaqs_id が空ならバケツとFAQを新規登録
         if (empty($request->faqs_id)) {
             // バケツの登録
-            $bucket_id = DB::table('buckets')->insertGetId([
+            $bucket = Buckets::createWithDefaultPostRoles([
                 'bucket_name' => $request->faq_name,
                 'plugin_name' => 'faqs'
             ]);
+            $bucket_id = $bucket->id;
 
             // FAQデータ新規オブジェクト
             $faqs = new Faqs();
@@ -1043,7 +1044,7 @@ class FaqsPlugin extends UserPluginBase
             Frame::where('id', $frame_id)->update(['bucket_id' => null]);
 
             // backetsの削除
-            Buckets::where('id', $frame->bucket_id)->delete();
+            Buckets::destroy($frame->bucket_id);
         }
         // 削除処理はredirect 付のルートで呼ばれて、処理後はページの再表示が行われるため、ここでは何もしない。
     }

--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -1833,7 +1833,7 @@ class PhotoalbumsPlugin extends UserPluginBase
     private function savePhotoalbum($request, $frame_id, $bucket_id)
     {
         // バケツの取得。なければ登録。
-        $bucket = Buckets::updateOrCreate(
+        $bucket = Buckets::updateOrCreateWithDefaultPostRoles(
             ['id' => $bucket_id],
             ['bucket_name' => $request->name, 'plugin_name' => 'photoalbums'],
         );

--- a/app/Plugins/User/Reservations/ReservationsPlugin.php
+++ b/app/Plugins/User/Reservations/ReservationsPlugin.php
@@ -1611,7 +1611,7 @@ class ReservationsPlugin extends UserPluginBase
         if (empty($request->reservations_id)) {
             // 画面から渡ってくるid が空ならバケツと施設を新規登録
             // バケツの登録
-            $bucket = Buckets::create([
+            $bucket = Buckets::createWithDefaultPostRoles([
                 'bucket_name' => $request->reservation_name,
                 'plugin_name' => 'reservations'
             ]);
@@ -1701,7 +1701,7 @@ class ReservationsPlugin extends UserPluginBase
             Frame::where('bucket_id', $reservation->bucket_id)->update(['bucket_id' => null]);
 
             // backetsの削除
-            Buckets::where('id', $reservation->bucket_id)->delete();
+            Buckets::destroy($reservation->bucket_id);
 
             // 施設予約を削除する。
             $reservation->delete();

--- a/app/Plugins/User/Slideshows/SlideshowsPlugin.php
+++ b/app/Plugins/User/Slideshows/SlideshowsPlugin.php
@@ -242,10 +242,10 @@ class SlideshowsPlugin extends UserPluginBase
             /**
              * 新規登録用の処理
              */
-            $bucket = new Buckets();
-            $bucket->bucket_name = '無題';
-            $bucket->plugin_name = 'slideshows';
-            $bucket->save();
+            $bucket = Buckets::createWithDefaultPostRoles([
+                'bucket_name' => '無題',
+                'plugin_name' => 'slideshows',
+            ]);
 
             // スライドショーデータ新規オブジェクト
             $slideshows = new Slideshows();
@@ -325,7 +325,7 @@ class SlideshowsPlugin extends UserPluginBase
             $slideshows = Slideshows::find($slideshows_id);
 
             // backetsの削除
-            Buckets::where('id', $slideshows->bucket_id)->delete();
+            Buckets::destroy($slideshows->bucket_id);
 
             // バケツIDの取得のためにFrame を取得(Frame を更新する前に取得しておく)
             $frame = Frame::where('id', $frame_id)->first();

--- a/app/Plugins/User/UserPluginBase.php
+++ b/app/Plugins/User/UserPluginBase.php
@@ -615,6 +615,7 @@ class UserPluginBase extends PluginBase
     {
         // Buckets の取得
         $buckets = $this->getBuckets($frame_id);
+        $default_post_role_flags = [];
 
         if ($this->frame->plugin_name == 'contents' || $buckets) {
             // 固定記事プラグイン(=コンテンツプラグイン)はバケツありなし、どちらでも表示する。
@@ -624,10 +625,15 @@ class UserPluginBase extends PluginBase
             return $this->commonView('empty_bucket_setting');
         }
 
+        if ($this->frame->plugin_name == 'contents' && empty($buckets)) {
+            $default_post_role_flags = Buckets::getDefaultNewBucketPostRoleFlags();
+        }
+
         return $this->commonView('frame_edit_roles', [
-            'buckets'      => $buckets,
-            'plugin_name'  => $this->frame->plugin_name,
-            'use_approval' => $use_approval,
+            'buckets'                 => $buckets,
+            'plugin_name'             => $this->frame->plugin_name,
+            'use_approval'            => $use_approval,
+            'default_post_role_flags' => $default_post_role_flags,
         ]);
     }
 

--- a/resources/views/plugins/common/frame_edit_roles.blade.php
+++ b/resources/views/plugins/common/frame_edit_roles.blade.php
@@ -18,6 +18,12 @@
 {{-- 登録後メッセージ表示 --}}
 @include('plugins.common.flash_message_for_frame')
 
+@php
+    $default_post_role_flags = $default_post_role_flags ?? [];
+    $role_article_post_checked = $buckets ? $buckets->canPost("role_article") : !empty($default_post_role_flags['role_article']);
+    $role_reporter_post_checked = $buckets ? $buckets->canPost("role_reporter") : !empty($default_post_role_flags['role_reporter']);
+@endphp
+
 <form action="{{ url("/redirect/plugin/$frame->plugin_name/saveBucketsRoles/$page->id/$frame_id#frame-$frame_id") }}" name="{{$frame->plugin_name}}_buckets_form" method="POST">
     {{ csrf_field() }}
     <input type="hidden" name="redirect_path" value="{{ url("/plugin/$frame->plugin_name/editBucketsRoles/$page->id/$frame_id#frame-$frame_id") }}">
@@ -38,7 +44,7 @@
                     <th>モデレータ</th>
                     <td>
                         <div class="custom-control custom-checkbox custom-control-inline">
-                            @if($buckets && $buckets->canPost("role_article"))
+                            @if($role_article_post_checked)
                                 <input name="role_article[post]" value="1" type="checkbox" class="custom-control-input" id="role_article_post" checked="checked">
                             @else
                                 <input name="role_article[post]" value="1" type="checkbox" class="custom-control-input" id="role_article_post">
@@ -64,7 +70,7 @@
                     <th>編集者</th>
                     <td>
                         <div class="custom-control custom-checkbox custom-control-inline">
-                            @if($buckets && $buckets->canPost("role_reporter"))
+                            @if($role_reporter_post_checked)
                                 <input name="role_reporter[post]" value="1" type="checkbox" class="custom-control-input" id="role_reporter_post" checked="checked">
                             @else
                                 <input name="role_reporter[post]" value="1" type="checkbox" class="custom-control-input" id="role_reporter_post">

--- a/resources/views/plugins/manage/site/pdf/base_main.blade.php
+++ b/resources/views/plugins/manage/site/pdf/base_main.blade.php
@@ -47,6 +47,14 @@
         <td>{{$base_layout_title}}</td>
     </tr>
     <tr nobr="true">
+        <td>プラグイン新規作成時のモデレータ投稿権限</td>
+        @if (Configs::getConfigsValue($configs, 'new_bucket_role_article_post_flag', 0) == '1') <td>許可する</td> @else <td>許可しない</td> @endif
+    </tr>
+    <tr nobr="true">
+        <td>プラグイン新規作成時の編集者投稿権限</td>
+        @if (Configs::getConfigsValue($configs, 'new_bucket_role_reporter_post_flag', 0) == '1') <td>許可する</td> @else <td>許可しない</td> @endif
+    </tr>
+    <tr nobr="true">
         <td>背景色</td>
         <td>{{Configs::getConfigsValue($configs, 'base_background_color', null)}}</td>
     </tr>

--- a/resources/views/plugins/manage/site/site.blade.php
+++ b/resources/views/plugins/manage/site/site.blade.php
@@ -551,6 +551,34 @@
                 </select>
             </div>
 
+            {{-- プラグイン新規作成時の投稿権限 --}}
+            <div class="form-group">
+                <label class="col-form-label">プラグイン新規作成時の投稿権限</label>
+                <p class="mb-2 text-muted">
+                    掲示板やブログなどを新しく作成したとき、投稿を許可する権限の初期値です。
+                    既存のプラグイン設定は変更されません。
+                </p>
+                <div class="border rounded bg-light p-3">
+                    <div class="custom-control custom-checkbox">
+                        @if(Configs::getConfigsValueAndOld($configs, "new_bucket_role_article_post_flag", 0) == 1)
+                            <input type="checkbox" name="new_bucket_role_article_post_flag" value="1" id="new_bucket_role_article_post_flag" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="checkbox" name="new_bucket_role_article_post_flag" value="1" id="new_bucket_role_article_post_flag" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="new_bucket_role_article_post_flag">モデレータにも投稿を許可する</label>
+                    </div>
+                    <div class="custom-control custom-checkbox mt-2">
+                        @if(Configs::getConfigsValueAndOld($configs, "new_bucket_role_reporter_post_flag", 0) == 1)
+                            <input type="checkbox" name="new_bucket_role_reporter_post_flag" value="1" id="new_bucket_role_reporter_post_flag" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="checkbox" name="new_bucket_role_reporter_post_flag" value="1" id="new_bucket_role_reporter_post_flag" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="new_bucket_role_reporter_post_flag">編集者にも投稿を許可する</label>
+                    </div>
+                </div>
+                <small class="form-text text-muted">作成後は、各プラグインの権限設定で個別に変更できます。</small>
+            </div>
+
             {{-- Submitボタン --}}
             <div class="form-group text-center">
                 <button type="submit" class="btn btn-primary form-horizontal"><i class="fas fa-check"></i> 更新</button>

--- a/tests/Feature/Plugins/Manage/SiteManage/SiteManageNewBucketDefaultRolesTest.php
+++ b/tests/Feature/Plugins/Manage/SiteManage/SiteManageNewBucketDefaultRolesTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature\Plugins\Manage\SiteManage;
+
+use App\Enums\BaseHeaderFontColorClass;
+use App\Enums\BaseLoginRedirectPage;
+use App\Enums\SmartphoneMenuTemplateType;
+use App\Models\Core\Configs;
+use App\Models\Core\UsersRoles;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * サイト管理のプラグイン新規作成時向け初期権限設定を検証する。
+ *
+ * 画面表示と保存結果の整合が崩れないことを、
+ * 管理画面のHTTP経路経由で守る。
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class SiteManageNewBucketDefaultRolesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * 未設定状態では両方のチェックボックスが未チェックで表示されること。
+     */
+    public function testIndexShowsBothCheckboxesUncheckedWhenConfigsAreMissing(): void
+    {
+        $admin = $this->createSiteAdminUser();
+
+        $response = $this->actingAs($admin)->get('/manage/site');
+
+        $response->assertOk();
+        $response->assertSee('プラグイン新規作成時の投稿権限');
+        $response->assertDontSee('id="new_bucket_role_article_post_flag" class="custom-control-input" checked="checked"', false);
+        $response->assertDontSee('id="new_bucket_role_reporter_post_flag" class="custom-control-input" checked="checked"', false);
+    }
+
+    /**
+     * 保存済みの設定があれば、画面のチェック状態へ反映されること。
+     */
+    public function testIndexShowsSavedFlagValues(): void
+    {
+        $admin = $this->createSiteAdminUser();
+        $this->setDefaultPostRoleConfigs(1, 0);
+
+        $response = $this->actingAs($admin)->get('/manage/site');
+
+        $response->assertOk();
+        $response->assertSee('id="new_bucket_role_article_post_flag" class="custom-control-input" checked="checked"', false);
+        $response->assertDontSee('id="new_bucket_role_reporter_post_flag" class="custom-control-input" checked="checked"', false);
+    }
+
+    /**
+     * 両方ONで保存した設定がConfigに反映され、再表示時にも維持されること。
+     */
+    public function testUpdateCanSaveBothFlagsAsEnabled(): void
+    {
+        $admin = $this->createSiteAdminUser();
+
+        $response = $this->actingAs($admin)->post('/manage/site/update', $this->buildBasePayload([
+            'new_bucket_role_article_post_flag' => 1,
+            'new_bucket_role_reporter_post_flag' => 1,
+        ]));
+
+        $response->assertRedirect('/manage/site');
+        $this->assertDatabaseHas('configs', [
+            'name' => 'new_bucket_role_article_post_flag',
+            'category' => 'general',
+            'value' => '1',
+        ]);
+        $this->assertDatabaseHas('configs', [
+            'name' => 'new_bucket_role_reporter_post_flag',
+            'category' => 'general',
+            'value' => '1',
+        ]);
+    }
+
+    /**
+     * 片方だけONでも保存でき、画面再表示も保存内容に追従すること。
+     */
+    public function testUpdateCanSaveOnlyOneFlagAsEnabled(): void
+    {
+        $admin = $this->createSiteAdminUser();
+
+        $response = $this->actingAs($admin)->post('/manage/site/update', $this->buildBasePayload([
+            'new_bucket_role_article_post_flag' => 1,
+        ]));
+
+        $response->assertRedirect('/manage/site');
+        $this->assertDatabaseHas('configs', [
+            'name' => 'new_bucket_role_article_post_flag',
+            'category' => 'general',
+            'value' => '1',
+        ]);
+        $this->assertDatabaseHas('configs', [
+            'name' => 'new_bucket_role_reporter_post_flag',
+            'category' => 'general',
+            'value' => '0',
+        ]);
+    }
+
+    /**
+     * 一度ONにした設定を外して保存すると、Configが0に戻ること。
+     */
+    public function testUpdateCanTurnFlagsOffAgain(): void
+    {
+        $admin = $this->createSiteAdminUser();
+        $this->setDefaultPostRoleConfigs(1, 1);
+
+        $response = $this->actingAs($admin)->post('/manage/site/update', $this->buildBasePayload());
+
+        $response->assertRedirect('/manage/site');
+        $this->assertDatabaseHas('configs', [
+            'name' => 'new_bucket_role_article_post_flag',
+            'category' => 'general',
+            'value' => '0',
+        ]);
+        $this->assertDatabaseHas('configs', [
+            'name' => 'new_bucket_role_reporter_post_flag',
+            'category' => 'general',
+            'value' => '0',
+        ]);
+    }
+
+    /**
+     * サイト管理者権限を持つユーザーを作成する。
+     */
+    private function createSiteAdminUser(): User
+    {
+        $user = User::factory()->create();
+
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'manage',
+            'role_name' => 'admin_site',
+            'role_value' => 1,
+        ]);
+
+        return $user;
+    }
+
+    /**
+     * プラグイン新規作成時用の投稿権限Configを保存する。
+     */
+    private function setDefaultPostRoleConfigs(int $articleFlag, int $reporterFlag): void
+    {
+        Configs::updateOrCreate(
+            ['name' => 'new_bucket_role_article_post_flag'],
+            ['category' => 'general', 'value' => $articleFlag]
+        );
+        Configs::updateOrCreate(
+            ['name' => 'new_bucket_role_reporter_post_flag'],
+            ['category' => 'general', 'value' => $reporterFlag]
+        );
+    }
+
+    /**
+     * サイト基本設定更新に必要な最低限の入力値を組み立てる。
+     */
+    private function buildBasePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'base_site_name' => 'テストサイト',
+            'base_theme' => '',
+            'base_layout' => '0|0|0|0',
+            'additional_theme' => '',
+            'base_background_color' => '',
+            'base_header_color' => '',
+            'base_header_font_color_class' => BaseHeaderFontColorClass::navbar_dark,
+            'base_header_optional_class' => '',
+            'body_optional_class' => '',
+            'center_area_optional_class' => '',
+            'footer_area_optional_class' => '',
+            'base_header_hidden' => 0,
+            'base_header_login_link' => 0,
+            'base_login_password_reset' => 0,
+            'base_login_redirect_previous_page' => BaseLoginRedirectPage::top_page,
+            'base_login_redirect_select_page' => '',
+            'use_mypage' => 0,
+            'mypage_top_notice' => '',
+            'mypage_bottom_notice' => '',
+            'smartphone_menu_template' => SmartphoneMenuTemplateType::none,
+        ], $overrides);
+    }
+}

--- a/tests/Feature/Plugins/User/Bbses/BbsesDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Bbses/BbsesDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Bbses;
+
+use App\Models\Common\Buckets;
+use App\Models\Common\BucketsRoles;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Bbses の新規バケツ初期権限を検証する。
+ *
+ * 新規作成時だけ初期権限が入り、既存バケツ更新では
+ * 権限を増やしたり上書きしたりしないことを守る。
+ */
+class BbsesDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * 新規作成時は、サイト管理の初期値どおりにBucketsRolesが作られること。
+     */
+    public function testSaveBucketsCreatesDefaultRolesOnlyOnNewBucket(): void
+    {
+        $this->assertSaveBucketsCreatesDefaultRoles('bbses', [
+            'name' => '掲示板テスト',
+            'use_like' => 0,
+            'like_button_name' => '',
+        ], 1, 0);
+    }
+
+    /**
+     * 既存バケツ更新では新規初期化を走らせず、既存権限も上書きしないこと。
+     */
+    public function testSaveBucketsDoesNotInitializeRolesOnExistingBucketUpdate(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('bbses');
+        $bucket = Buckets::factory()->create([
+            'bucket_name' => '既存掲示板',
+            'plugin_name' => 'bbses',
+        ]);
+        $frame->update(['bucket_id' => $bucket->id]);
+        BucketsRoles::create([
+            'buckets_id' => $bucket->id,
+            'role' => 'role_article',
+            'post_flag' => 0,
+            'approval_flag' => 1,
+        ]);
+        $this->setDefaultPostRoleConfigs(1, 1);
+
+        $response = $this->actingAs($admin)->post("/redirect/plugin/bbses/saveBuckets/{$page->id}/{$frame->id}/{$bucket->id}", [
+            'redirect_path' => url("/plugin/bbses/editBuckets/{$page->id}/{$frame->id}#frame-{$frame->id}"),
+            'name' => '既存掲示板を更新',
+            'use_like' => 0,
+            'like_button_name' => '',
+        ]);
+
+        $response->assertStatus(302);
+
+        $this->assertDatabaseCount('buckets_roles', 1);
+        $this->assertDatabaseHas('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_article',
+            'post_flag' => 0,
+            'approval_flag' => 1,
+        ]);
+        $this->assertDatabaseMissing('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_reporter',
+        ]);
+    }
+}

--- a/tests/Feature/Plugins/User/Blogs/BlogsDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Blogs/BlogsDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Blogs;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Blogs の新規バケツ初期権限を検証する。
+ *
+ * ブログ設定の新規保存経路で、サイト管理の投稿権限初期値が
+ * 新しいバケツへ適用されることを守る。
+ */
+class BlogsDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * ブログ新規作成では、サイト管理の初期値どおりの投稿権限が作られること。
+     */
+    public function testSaveBucketsCreatesDefaultRolesOnBlogCreation(): void
+    {
+        $this->assertSaveBucketsCreatesDefaultRoles('blogs', [
+            'blogs_id' => '',
+            'blog_name' => 'ブログテスト',
+            'rss' => 0,
+            'rss_count' => 10,
+            'use_like' => 0,
+            'like_button_name' => '',
+            'use_view_count_spectator' => 0,
+            'narrowing_down_type' => 0,
+            'narrowing_down_type_for_created_id' => 0,
+            'narrowing_down_type_for_posted_month' => 0,
+        ]);
+    }
+}

--- a/tests/Feature/Plugins/User/Cabinets/CabinetsDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Cabinets/CabinetsDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Cabinets;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Cabinets の新規バケツ初期権限を検証する。
+ *
+ * キャビネット設定の新規保存経路で、サイト管理の投稿権限初期値が
+ * 新しいバケツへ適用されることを守る。
+ */
+class CabinetsDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * キャビネット新規作成では、サイト管理の初期値どおりの投稿権限が作られること。
+     */
+    public function testSaveBucketsCreatesDefaultRolesOnCabinetCreation(): void
+    {
+        $this->assertSaveBucketsCreatesDefaultRoles('cabinets', [
+            'name' => 'キャビネットテスト',
+            'upload_max_size' => '2048',
+        ]);
+    }
+}

--- a/tests/Feature/Plugins/User/Calendars/CalendarsDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Calendars/CalendarsDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Calendars;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Calendars の新規バケツ初期権限を検証する。
+ *
+ * カレンダー設定の新規保存経路で、サイト管理の投稿権限初期値が
+ * 新しいバケツへ適用されることを守る。
+ */
+class CalendarsDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * カレンダー新規作成では、サイト管理の初期値どおりの投稿権限が作られること。
+     */
+    public function testSaveBucketsCreatesDefaultRolesOnCalendarCreation(): void
+    {
+        $this->assertSaveBucketsCreatesDefaultRoles('calendars', [
+            'name' => 'カレンダーテスト',
+        ]);
+    }
+}

--- a/tests/Feature/Plugins/User/Contents/ContentsDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Contents/ContentsDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Contents;
+
+use App\Models\Common\Buckets;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * contents の新規バケツ初期権限を検証する。
+ *
+ * バケツ未作成時の画面表示と、初回投稿で実際に保存される権限が
+ * 一致することをHTTP経路で守る。
+ */
+class ContentsDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * バケツ未作成の権限画面では、サイト管理の初期値をチェック状態に反映すること。
+     */
+    public function testEditBucketsRolesShowsSiteDefaultsBeforeBucketExists(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('contents');
+        $this->setDefaultPostRoleConfigs(1, 0);
+
+        $response = $this->actingAs($admin)->get("/plugin/contents/editBucketsRoles/{$page->id}/{$frame->id}");
+
+        $response->assertOk();
+        $response->assertSee('id="role_article_post" checked="checked"', false);
+        $response->assertDontSee('id="role_reporter_post" checked="checked"', false);
+    }
+
+    /**
+     * サイト管理の初期値が両方OFFなら、未作成バケツの画面でも未チェック表示になること。
+     */
+    public function testEditBucketsRolesShowsUncheckedWhenSiteDefaultsAreOff(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('contents');
+        $this->setDefaultPostRoleConfigs(0, 0);
+
+        $response = $this->actingAs($admin)->get("/plugin/contents/editBucketsRoles/{$page->id}/{$frame->id}");
+
+        $response->assertOk();
+        $response->assertDontSee('id="role_article_post" checked="checked"', false);
+        $response->assertDontSee('id="role_reporter_post" checked="checked"', false);
+    }
+
+    /**
+     * 初回投稿で作られるバケツには、サイト管理の初期値どおりの投稿権限だけが作られること。
+     */
+    public function testFirstStoreCreatesBucketsRolesFromSiteDefaults(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('contents');
+        $this->setDefaultPostRoleConfigs(1, 0);
+
+        $response = $this->actingAs($admin)->post("/redirect/plugin/contents/store/{$page->id}/{$frame->id}", [
+            'redirect_path' => url("/plugin/contents/edit/{$page->id}/{$frame->id}#frame-{$frame->id}"),
+            'contents' => '初回投稿本文',
+            'bucket_name' => '固定記事テスト',
+        ]);
+
+        $response->assertStatus(302);
+
+        $bucket = Buckets::query()->findOrFail($frame->fresh()->bucket_id);
+        $this->assertFrameUsesBucket($frame, $bucket);
+        $this->assertDefaultPostRolesForBucket($bucket, 1, 0);
+    }
+}

--- a/tests/Feature/Plugins/User/Databases/DatabasesDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Databases/DatabasesDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Databases;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Databases の新規バケツ初期権限を検証する。
+ *
+ * データベース設定の新規保存経路で、サイト管理の投稿権限初期値が
+ * 新しいバケツへ適用されることを守る。
+ */
+class DatabasesDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * データベース新規作成では、サイト管理の初期値どおりの投稿権限が作られること。
+     */
+    public function testSaveBucketsCreatesDefaultRolesOnDatabaseCreation(): void
+    {
+        $this->assertSaveBucketsCreatesDefaultRoles('databases', [
+            'databases_name' => 'データベーステスト',
+            'copy_databases_id' => '',
+            'posted_role_display_control_flag' => 0,
+            'search_results_empty_message' => '',
+            'use_like' => 0,
+            'like_button_name' => '',
+            'mail_send_flag' => 0,
+            'mail_send_address' => '',
+            'user_mail_send_flag' => 0,
+            'from_mail_name' => '',
+            'mail_subject' => '',
+            'mail_databaseat' => '',
+            'data_save_flag' => 0,
+            'after_message' => '',
+            'numbering_use_flag' => 0,
+            'numbering_prefix' => '',
+            'save_searched_word' => 0,
+            'full_text_search' => 0,
+        ]);
+    }
+}

--- a/tests/Feature/Plugins/User/DefaultBucketRolesFeatureTestTrait.php
+++ b/tests/Feature/Plugins/User/DefaultBucketRolesFeatureTestTrait.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature\Plugins\User;
+
+use App\Models\Common\Buckets;
+use App\Models\Common\Frame;
+use App\Models\Common\Page;
+use App\Models\Core\Configs;
+use App\Models\Core\UsersRoles;
+use App\User;
+
+/**
+ * 新規バケツ投稿権限Featureテストの共通補助を提供する。
+ *
+ * プラグインごとの公開保存経路は各テストクラスに残し、
+ * 管理者作成・フレーム作成・権限検証だけを共有する。
+ */
+trait DefaultBucketRolesFeatureTestTrait
+{
+    /**
+     * 指定プラグインの新規保存経路で、投稿権限初期値が作られることを検証する。
+     */
+    protected function assertSaveBucketsCreatesDefaultRoles(
+        string $plugin_name,
+        array $payload,
+        int $article_flag = 1,
+        int $reporter_flag = 1
+    ): void {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame($plugin_name);
+        $this->setDefaultPostRoleConfigs($article_flag, $reporter_flag);
+
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/{$plugin_name}/saveBuckets/{$page->id}/{$frame->id}",
+            array_merge(
+                [
+                    'redirect_path' => url("/plugin/{$plugin_name}/createBuckets/{$page->id}/{$frame->id}#frame-{$frame->id}"),
+                ],
+                $payload
+            )
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+
+        $bucket = Buckets::query()
+            ->where('plugin_name', $plugin_name)
+            ->latest('id')
+            ->firstOrFail();
+
+        $this->assertFrameUsesBucket($frame, $bucket);
+        $this->assertDefaultPostRolesForBucket($bucket, $article_flag, $reporter_flag);
+    }
+
+    /**
+     * フレームが作成されたバケツを表示対象にしていることを検証する。
+     */
+    protected function assertFrameUsesBucket(Frame $frame, Buckets $bucket): void
+    {
+        $this->assertDatabaseHas('frames', [
+            'id' => $frame->id,
+            'bucket_id' => $bucket->id,
+        ]);
+    }
+
+    /**
+     * 指定バケツに、サイト管理の初期値どおりの投稿権限が作られたことを検証する。
+     */
+    protected function assertDefaultPostRolesForBucket(Buckets $bucket, int $article_flag, int $reporter_flag): void
+    {
+        $this->assertDefaultPostRoleForBucket($bucket, 'role_article', $article_flag);
+        $this->assertDefaultPostRoleForBucket($bucket, 'role_reporter', $reporter_flag);
+    }
+
+    /**
+     * 指定ロールの投稿権限が、初期値ONなら存在し、OFFなら存在しないことを検証する。
+     */
+    private function assertDefaultPostRoleForBucket(Buckets $bucket, string $role, int $post_flag): void
+    {
+        if ($post_flag === 1) {
+            $this->assertDatabaseHas('buckets_roles', [
+                'buckets_id' => $bucket->id,
+                'role' => $role,
+                'post_flag' => 1,
+                'approval_flag' => 0,
+            ]);
+            return;
+        }
+
+        $this->assertDatabaseMissing('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => $role,
+        ]);
+    }
+
+    /**
+     * コンテンツ管理者権限を持つユーザーを作成する。
+     */
+    protected function createContentAdminUser(): User
+    {
+        $user = User::factory()->create();
+
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin',
+            'role_value' => 1,
+        ]);
+
+        return $user;
+    }
+
+    /**
+     * バケツ未作成のプラグインフレームを作成する。
+     *
+     * @return array{0: \App\Models\Common\Page, 1: \App\Models\Common\Frame}
+     */
+    protected function createPluginFrame(string $plugin_name): array
+    {
+        $page = Page::factory()->create();
+        $frame = Frame::create([
+            'page_id' => $page->id,
+            'area_id' => 2,
+            'plugin_name' => $plugin_name,
+            'bucket_id' => null,
+            'template' => 'default',
+            'display_sequence' => 1,
+        ]);
+
+        return [$page, $frame];
+    }
+
+    /**
+     * 新規バケツ用の投稿権限Configを保存する。
+     */
+    protected function setDefaultPostRoleConfigs(int $article_flag, int $reporter_flag): void
+    {
+        Configs::updateOrCreate(
+            ['name' => 'new_bucket_role_article_post_flag'],
+            ['category' => 'general', 'value' => $article_flag]
+        );
+        Configs::updateOrCreate(
+            ['name' => 'new_bucket_role_reporter_post_flag'],
+            ['category' => 'general', 'value' => $reporter_flag]
+        );
+    }
+}

--- a/tests/Feature/Plugins/User/Faqs/FaqsDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Faqs/FaqsDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Faqs;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Faqs の新規バケツ初期権限を検証する。
+ *
+ * Buckets::create() へ寄せた新規作成経路で、
+ * 初期権限が正しく適用されることを守る。
+ */
+class FaqsDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * FAQ新規作成では、サイト管理の初期値どおりの投稿権限が作られること。
+     */
+    public function testSaveBucketsCreatesDefaultRolesOnFaqCreation(): void
+    {
+        $this->assertSaveBucketsCreatesDefaultRoles('faqs', [
+            'faqs_id' => '',
+            'faq_name' => 'FAQテスト',
+            'view_count' => 10,
+            'rss' => 0,
+            'rss_count' => 0,
+            'sequence_conditions' => 0,
+            'display_posted_at_flag' => 0,
+        ], 1, 0);
+    }
+}

--- a/tests/Feature/Plugins/User/Photoalbums/PhotoalbumsDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Photoalbums/PhotoalbumsDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Photoalbums;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Photoalbums の新規バケツ初期権限を検証する。
+ *
+ * フォトアルバム設定の新規保存経路で、サイト管理の投稿権限初期値が
+ * 新しいバケツへ適用されることを守る。
+ */
+class PhotoalbumsDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * フォトアルバム新規作成では、サイト管理の初期値どおりの投稿権限が作られること。
+     */
+    public function testSaveBucketsCreatesDefaultRolesOnPhotoalbumCreation(): void
+    {
+        $this->assertSaveBucketsCreatesDefaultRoles('photoalbums', [
+            'name' => 'フォトアルバムテスト',
+            'image_upload_max_size' => '2048',
+            'image_upload_max_px' => 'asis',
+            'video_upload_max_size' => '2048',
+        ]);
+    }
+}

--- a/tests/Feature/Plugins/User/Reservations/ReservationsDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Reservations/ReservationsDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Reservations;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Reservations の新規バケツ初期権限を検証する。
+ *
+ * 施設予約設定の新規保存経路で、サイト管理の投稿権限初期値が
+ * 新しいバケツへ適用されることを守る。
+ */
+class ReservationsDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * 施設予約新規作成では、サイト管理の初期値どおりの投稿権限が作られること。
+     */
+    public function testSaveBucketsCreatesDefaultRolesOnReservationCreation(): void
+    {
+        $this->assertSaveBucketsCreatesDefaultRoles('reservations', [
+            'reservations_id' => '',
+            'reservation_name' => '施設予約テスト',
+        ]);
+    }
+}

--- a/tests/Feature/Plugins/User/Slideshows/SlideshowsDefaultBucketRolesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Slideshows/SlideshowsDefaultBucketRolesFeatureTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Slideshows;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Slideshows の新規バケツ初期権限を検証する。
+ *
+ * スライドショー設定の新規保存経路で、サイト管理の投稿権限初期値が
+ * 新しいバケツへ適用されることを守る。
+ */
+class SlideshowsDefaultBucketRolesFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * スライドショー新規作成では、サイト管理の初期値どおりの投稿権限が作られること。
+     */
+    public function testSaveBucketsCreatesDefaultRolesOnSlideshowCreation(): void
+    {
+        $this->assertSaveBucketsCreatesDefaultRoles('slideshows', [
+            'slideshows_name' => 'スライドショーテスト',
+            'control_display_flag' => 0,
+            'indicators_display_flag' => 0,
+            'fade_use_flag' => 0,
+            'image_interval' => 5000,
+            'height' => '',
+        ]);
+    }
+}

--- a/tests/Unit/Models/Common/BucketsDefaultPostRolesTest.php
+++ b/tests/Unit/Models/Common/BucketsDefaultPostRolesTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Tests\Unit\Models\Common;
+
+use App\Models\Common\Buckets;
+use App\Models\Common\BucketsRoles;
+use App\Models\Core\Configs;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+/**
+ * Buckets の新規バケツ向け投稿権限初期化を検証する。
+ *
+ * Config 解決、重複防止、既存権限の保護、削除時の後始末を
+ * 公開メソッド経由で守るテストに絞る。
+ */
+class BucketsDefaultPostRolesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 各テストで共有Configの差し込みを外し、DBフォールバックを検証しやすくする。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clearSharedConfigsFromRequest();
+    }
+
+    /**
+     * Config未登録の環境では既存挙動を保ち、初期権限を追加しないこと。
+     */
+    public function testInitializeDefaultPostRolesDoesNotCreateRolesWhenConfigIsMissing(): void
+    {
+        $bucket = $this->createBucket();
+
+        $bucket->initializeDefaultPostRoles();
+
+        $this->assertDatabaseCount('buckets_roles', 0);
+    }
+
+    /**
+     * モデレータだけONなら、そのロールだけに投稿権限を初期投入すること。
+     */
+    public function testInitializeDefaultPostRolesCreatesOnlyArticleRoleWhenEnabled(): void
+    {
+        $bucket = $this->createBucket();
+        $this->setDefaultPostRoleConfigs(1, 0);
+
+        $bucket->initializeDefaultPostRoles();
+
+        $this->assertDatabaseHas('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_article',
+            'post_flag' => 1,
+            'approval_flag' => 0,
+        ]);
+        $this->assertDatabaseMissing('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_reporter',
+        ]);
+    }
+
+    /**
+     * 編集者だけONなら、そのロールだけに投稿権限を初期投入すること。
+     */
+    public function testInitializeDefaultPostRolesCreatesOnlyReporterRoleWhenEnabled(): void
+    {
+        $bucket = $this->createBucket();
+        $this->setDefaultPostRoleConfigs(0, 1);
+
+        $bucket->initializeDefaultPostRoles();
+
+        $this->assertDatabaseHas('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_reporter',
+            'post_flag' => 1,
+            'approval_flag' => 0,
+        ]);
+        $this->assertDatabaseMissing('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_article',
+        ]);
+    }
+
+    /**
+     * 両方ONなら、対象2ロールの初期権限をまとめて作成すること。
+     */
+    public function testInitializeDefaultPostRolesCreatesBothRolesWhenEnabled(): void
+    {
+        $bucket = $this->createBucket();
+        $this->setDefaultPostRoleConfigs(1, 1);
+
+        $bucket->initializeDefaultPostRoles();
+
+        $this->assertDatabaseCount('buckets_roles', 2);
+        $this->assertDatabaseHas('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_article',
+            'post_flag' => 1,
+            'approval_flag' => 0,
+        ]);
+        $this->assertDatabaseHas('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_reporter',
+            'post_flag' => 1,
+            'approval_flag' => 0,
+        ]);
+    }
+
+    /**
+     * 同じ初期化を繰り返しても、権限レコードが重複しないこと。
+     */
+    public function testInitializeDefaultPostRolesIsIdempotent(): void
+    {
+        $bucket = $this->createBucket();
+        $this->setDefaultPostRoleConfigs(1, 1);
+
+        $bucket->initializeDefaultPostRoles();
+        $bucket->initializeDefaultPostRoles();
+
+        $this->assertDatabaseCount('buckets_roles', 2);
+    }
+
+    /**
+     * 既存のBucketsRolesがある場合は、その設定を勝手に上書きしないこと。
+     */
+    public function testInitializeDefaultPostRolesDoesNotOverwriteExistingRole(): void
+    {
+        $bucket = $this->createBucket();
+        $this->setDefaultPostRoleConfigs(1, 0);
+
+        BucketsRoles::create([
+            'buckets_id' => $bucket->id,
+            'role' => 'role_article',
+            'post_flag' => 0,
+            'approval_flag' => 1,
+        ]);
+
+        $bucket->initializeDefaultPostRoles();
+
+        $this->assertDatabaseCount('buckets_roles', 1);
+        $this->assertDatabaseHas('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_article',
+            'post_flag' => 0,
+            'approval_flag' => 1,
+        ]);
+    }
+
+    /**
+     * 共通作成APIでは、投稿権限設定を持つプラグインだけ初期権限を作成すること。
+     */
+    public function testCreateWithDefaultPostRolesAppliesOnlyTargetPlugin(): void
+    {
+        $this->setDefaultPostRoleConfigs(1, 1);
+
+        $target_bucket = Buckets::createWithDefaultPostRoles([
+            'bucket_name' => '対象掲示板',
+            'plugin_name' => 'bbses',
+        ]);
+        $non_target_bucket = Buckets::createWithDefaultPostRoles([
+            'bucket_name' => '対象外リンクリスト',
+            'plugin_name' => 'linklists',
+        ]);
+
+        $this->assertDatabaseHas('buckets_roles', [
+            'buckets_id' => $target_bucket->id,
+            'role' => 'role_article',
+            'post_flag' => 1,
+        ]);
+        $this->assertDatabaseHas('buckets_roles', [
+            'buckets_id' => $target_bucket->id,
+            'role' => 'role_reporter',
+            'post_flag' => 1,
+        ]);
+        $this->assertDatabaseMissing('buckets_roles', [
+            'buckets_id' => $non_target_bucket->id,
+        ]);
+    }
+
+    /**
+     * 共通更新APIでは、新規作成時だけ初期権限を作成し、既存バケツ更新では作成しないこと。
+     */
+    public function testUpdateOrCreateWithDefaultPostRolesAppliesOnlyWhenCreated(): void
+    {
+        $this->setDefaultPostRoleConfigs(1, 0);
+
+        $bucket = Buckets::updateOrCreateWithDefaultPostRoles(
+            ['id' => null],
+            ['bucket_name' => '新規ブログ', 'plugin_name' => 'blogs']
+        );
+        BucketsRoles::query()->delete();
+
+        Buckets::updateOrCreateWithDefaultPostRoles(
+            ['id' => $bucket->id],
+            ['bucket_name' => '更新ブログ', 'plugin_name' => 'blogs']
+        );
+
+        $this->assertDatabaseCount('buckets_roles', 0);
+    }
+
+    /**
+     * 対象プラグインの判定は、権限設定タブを持つ代表プラグインだけを対象にすること。
+     */
+    public function testIsDefaultPostRoleTargetPlugin(): void
+    {
+        $this->assertTrue(Buckets::isDefaultPostRoleTargetPlugin('bbses'));
+        $this->assertTrue(Buckets::isDefaultPostRoleTargetPlugin('databases'));
+        $this->assertFalse(Buckets::isDefaultPostRoleTargetPlugin('learningtasks'));
+        $this->assertFalse(Buckets::isDefaultPostRoleTargetPlugin('linklists'));
+        $this->assertFalse(Buckets::isDefaultPostRoleTargetPlugin('whatsnews'));
+        $this->assertFalse(Buckets::isDefaultPostRoleTargetPlugin(null));
+    }
+
+    /**
+     * Buckets削除時は関連するBucketsRolesも同時に片づけること。
+     */
+    public function testDestroyRemovesRelatedBucketsRoles(): void
+    {
+        $bucket = $this->createBucket();
+        BucketsRoles::create([
+            'buckets_id' => $bucket->id,
+            'role' => 'role_article',
+            'post_flag' => 1,
+            'approval_flag' => 0,
+        ]);
+        BucketsRoles::create([
+            'buckets_id' => $bucket->id,
+            'role' => 'role_reporter',
+            'post_flag' => 1,
+            'approval_flag' => 0,
+        ]);
+
+        Buckets::destroy($bucket->id);
+
+        $this->assertDatabaseMissing('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_article',
+        ]);
+        $this->assertDatabaseMissing('buckets_roles', [
+            'buckets_id' => $bucket->id,
+            'role' => 'role_reporter',
+        ]);
+    }
+
+    /**
+     * テスト対象のバケツを1件作成する。
+     */
+    private function createBucket(): Buckets
+    {
+        return Buckets::factory()->create([
+            'plugin_name' => 'contents',
+        ]);
+    }
+
+    /**
+     * 新規バケツ用の投稿権限Configを保存する。
+     */
+    private function setDefaultPostRoleConfigs(int $article_flag, int $reporter_flag): void
+    {
+        Configs::updateOrCreate(
+            ['name' => 'new_bucket_role_article_post_flag'],
+            ['category' => 'general', 'value' => $article_flag]
+        );
+        Configs::updateOrCreate(
+            ['name' => 'new_bucket_role_reporter_post_flag'],
+            ['category' => 'general', 'value' => $reporter_flag]
+        );
+
+        $this->clearSharedConfigsFromRequest();
+    }
+
+    /**
+     * Request属性の共有Configを外し、DBフォールバックの条件をそろえる。
+     */
+    private function clearSharedConfigsFromRequest(): void
+    {
+        app(Request::class)->attributes->remove('configs');
+    }
+}


### PR DESCRIPTION
## 概要

サイト基本設定に「プラグイン新規作成時の投稿権限」を追加しました。

サイト管理者が、掲示板・ブログ・データベースなどのプラグインを新しく作成したときに、モデレータ・編集者へ投稿権限を初期付与するかを設定できます。

## 背景と目的

現状では、バケツを新規作成した際の「権限設定」において、モデレータと編集者の両方が投稿できない状態になります。
そのため、環境によっては、バケツを配置するたびに、各プラグインの権限設定で「投稿できる」に手動でチェックを入れる必要があります。

この手動設定を忘れると、ユーザーから「投稿できない」と問い合わせが発生します。
特に学校などの環境では、コンテンツ管理者以外が投稿する運用が一般的であり、現在の初期設定が実運用と合わないケースがあります。

また、NC2やNC3では、モデレータや一般ユーザーが投稿できる状態を基本とし、「投稿してほしくないプラグイン」の場合に個別に設定を変更する運用でした。
Connect-CMSでも、サイト単位で新規バケツ作成時の投稿権限初期値を設定できるようにすることで、運用に合わせた初期状態を選べるようにします。

## 修正内容

**サイト基本設定:**
サイト基本設定画面に「プラグイン新規作成時の投稿権限」を追加しました。
モデレータ、編集者それぞれについて、投稿を許可するかをチェックボックスで設定できます。
設定値は `new_bucket_role_article_post_flag` と `new_bucket_role_reporter_post_flag` として保存します。
サイト設計書PDF出力にも同設定を追加しました。

**共通処理:**
`Buckets` に新規バケツ作成時の投稿権限初期化処理を追加しました。
Config の値に従い、`role_article` / `role_reporter` の `buckets_roles` を作成します。
既存の権限設定がある場合は上書きしません。
同じ初期化処理が複数回呼ばれても、権限レコードが重複しないようにしています。
バケツ削除時に、関連する `buckets_roles` を削除するようにしました。

**対象プラグイン:**
投稿権限設定を持つプラグインの新規作成処理で、共通の初期化処理を通るようにしました。
対象は以下です。

- 掲示板
- ブログ
- キャビネット
- カレンダー
- 固定記事
- データベース
- FAQ
- フォトアルバム
- 施設予約
- スライドショー

**対象外:**
課題管理は投稿権限設定を持たないため、今回の初期投稿権限の適用対象外です。
リンクリストや新着情報など、投稿権限設定を持たないプラグインも対象外です。

**権限設定画面:**
固定記事のようにバケツ未作成の状態で権限設定画面を表示するケースでは、サイト基本設定の初期値をチェック状態に反映するようにしました。

**テスト:**
`Buckets` の共通処理に対するUnitテストを追加しました。
対象プラグインごとにFeatureテストを追加し、新規作成時に初期投稿権限が作成されることを確認しています。
サイト基本設定画面の保存・表示に関するFeatureテストを追加しました。

## 影響範囲

新しく作成する対象プラグインの投稿権限初期値に影響します。
既存のプラグイン設定や既存の `buckets_roles` は変更しません。
各プラグイン作成後は、従来どおり個別の権限設定画面で変更できます。

## 完了条件

- [x] サイト管理で、新規バケツ作成時の投稿権限初期値を設定できること
- [x] 初期設定でモデレータを投稿可能にできること
- [x] 初期設定で編集者を投稿可能にできること
- [x] 対象プラグインの新規作成時に、設定した初期値が反映されること
- [x] 既存プラグインの権限設定を変更しないこと

## 特記事項
<!-- 影響範囲・除外事項・注意点・既知の制約などがあれば記載してください。 -->

# レビュー完了希望日
<!--
「〇月〇日までに確認希望」「不具合対応のため今週中に確認希望」「軽微な改修のため急ぎません」など、
優先度・期限の目安が分かる形で記載してください。
-->

# 関連Pull requests/Issues
<!--
関連する Pull Request / Issue があれば記載してください。
Issue をクローズする場合は `Fixes #123` の形式で記載してください。
-->

# 参考
<!--
レビュー時の参考情報（仕様書、関連Wiki、スクリーンショット、再現手順、問い合わせ内容など）があれば記載してください。
-->

# DB変更の有無
<!--
この Pull Request にマイグレーション追加・変更、または DB に影響する変更があるかを記載してください。
「有り」の場合は、影響範囲や実施時の注意点（既存データへの影響、実行順序など）も概要欄に補足してください。
-->

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
