### PR TITLE
[新着情報] 三点リーダがエンティティ表示される問題を修正しました

### DIFF
--- a/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
+++ b/app/Plugins/User/Whatsnews/WhatsnewsPlugin.php
@@ -250,7 +250,8 @@ class WhatsnewsPlugin extends UserPluginBase
         }
 
         // 記事詳細から、最初の画像を抜き出して設定する。
-        $whatsnews = $this->addWhatsnewsValues($whatsnews);
+        $post_detail_length = FrameConfig::getConfigValueAndOld($this->frame_configs, WhatsnewFrameConfig::post_detail_length);
+        $whatsnews = $this->addWhatsnewsValues($whatsnews, $post_detail_length);
 
         // 一旦オブジェクト変数へ。（Singleton のため。フレーム表示確認でコアが使用する）
         $this->whatsnews_results = array($whatsnews, $link_pattern, $link_base);
@@ -314,19 +315,28 @@ class WhatsnewsPlugin extends UserPluginBase
         }
 
         // タイトルのタグを取り除き, データベース、ウィジウィグ型のタイトル指定に対応
-        $whatsnew->post_title_strip_tags = strip_tags($whatsnew->post_title);
+        $whatsnew->post_title_strip_tags = $this->stripTagsAndDecodeEntities($whatsnew->post_title);
 
         // タグを取り除き、指定に応じて文字数制限した本文
+        $post_detail_strip_tags = $this->stripTagsAndDecodeEntities($whatsnew->post_detail);
         if ($post_detail_length) {
-            $whatsnew->post_detail_strip_tags = mb_substr(strip_tags($whatsnew->post_detail), 0, $post_detail_length);
-            if (mb_strlen(strip_tags($whatsnew->post_detail)) > $post_detail_length) {
+            $whatsnew->post_detail_strip_tags = mb_substr($post_detail_strip_tags, 0, $post_detail_length);
+            if (mb_strlen($post_detail_strip_tags) > $post_detail_length) {
                 $whatsnew->post_detail_strip_tags = $whatsnew->post_detail_strip_tags . '...';
             }
         } else {
-            $whatsnew->post_detail_strip_tags = strip_tags($whatsnew->post_detail);
+            $whatsnew->post_detail_strip_tags = $post_detail_strip_tags;
         }
 
         return $whatsnew;
+    }
+
+    /**
+     * 新着表示用にタグを除去し、本文中のHTMLエンティティを文字として扱える形に戻す。
+     */
+    private function stripTagsAndDecodeEntities(?string $value): string
+    {
+        return html_entity_decode(strip_tags($value ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8');
     }
 
     private function buildQueryGetWhatsnews($whatsnews_frame, $union_sqls)

--- a/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/card_04/whatsnews.blade.php
@@ -112,12 +112,7 @@
                         {{-- 本文 --}}
                         @if (FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail))
                         <dd class="whatsnew_post_detail">
-                            @if (FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length) == 0 ||
-                                mb_strlen(strip_tags($whatsnew->post_detail)) <= FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length))
-                                {{ strip_tags($whatsnew->post_detail) }}
-                            @else
-                                {{ mb_substr(strip_tags($whatsnew->post_detail), 0, FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length)) }}...
-                            @endif
+                            {{ $whatsnew->post_detail_strip_tags }}
                         </dd>
                         @endif
                     </dl>

--- a/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
@@ -63,12 +63,7 @@
         {{-- 本文 --}}
         @if (FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail))
         <div>
-            @if (FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length) == 0 ||
-                 mb_strlen(strip_tags($whatsnew->post_detail)) <= FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length))
-                {{ strip_tags($whatsnew->post_detail) }}
-            @else
-                {{ mb_substr(strip_tags($whatsnew->post_detail), 0, FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length)) }}...
-            @endif
+            {{ $whatsnew->post_detail_strip_tags }}
         </div>
         @endif
 

--- a/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
@@ -90,12 +90,7 @@
             {{-- 本文 --}}
             @if (FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail))
             <div>
-                @if (FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length) == 0 ||
-                     mb_strlen(strip_tags($whatsnew->post_detail)) <= FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length))
-                    {{ strip_tags($whatsnew->post_detail) }}
-                @else
-                    {{ mb_substr(strip_tags($whatsnew->post_detail), 0, FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail_length)) }}...
-                @endif
+                {{ $whatsnew->post_detail_strip_tags }}
             </div>
             @endif
         </div>


### PR DESCRIPTION
# 概要
## 変更の概要
新着情報プラグインで、本文やタイトルに含まれるHTMLエンティティを表示用の文字に戻すようにしました。

## 変更内容
- 新着情報の表示用整形で、タグ除去後にHTMLエンティティをデコードするようにしました。
- 初期表示と「もっと見る」などの非同期表示で、同じ整形済み本文を使うようにしました。
- 本文の文字数制限でシステムが追加する省略記号は、従来どおり `...` のままにしています。

## 背景と目的
新着情報プラグインで、記事本文などに含まれる三点リーダが `&hellip;` という文字列のまま表示される場合がありました。
利用者には記号として `…` と表示される必要があるため、表示用の文字列を作る時点でHTMLエンティティを通常の文字に戻します。

## 特記事項
- DB変更はありません。
- 対象は新着情報プラグインの表示用文字列の整形処理です。
- HTMLタグは従来どおり除去したうえで表示します。

# レビュー完了希望日
軽微な不具合対応のため、急ぎません。

# 関連Pull requests/Issues
なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule