### PR TITLE
[メニュー] 初期作成時にアイコンが表示されない問題を修正しました

### DIFF
--- a/app/Plugins/User/Menus/MenusPlugin.php
+++ b/app/Plugins/User/Menus/MenusPlugin.php
@@ -87,7 +87,7 @@ class MenusPlugin extends UserPluginBase
     public function index($request, $page_id, $frame_id)
     {
         // メニュー
-        $menu = Menu::where('frame_id', $frame_id)->first();
+        $menu = Menu::where('frame_id', $frame_id)->first() ?? $this->getDefaultMenu($frame_id);
         //Log::debug(json_encode( $menu, JSON_UNESCAPED_UNICODE));
 
         // ページに対する権限
@@ -231,6 +231,21 @@ class MenusPlugin extends UserPluginBase
     private function isModeratorEditAllowed(): bool
     {
         return (bool) FrameConfig::getConfigValue($this->frame_configs, MenuFrameConfig::menu_allow_moderator_edit, 0);
+    }
+
+    /**
+     * メニュー設定が未保存のフレームでも、表示時は初期設定で扱う。
+     */
+    private function getDefaultMenu($frame_id): Menu
+    {
+        return new Menu([
+            'frame_id' => $frame_id,
+            'select_flag' => 0,
+            'page_ids' => '',
+            'folder_close_font' => 0,
+            'folder_open_font' => 0,
+            'indent_font' => 0,
+        ]);
     }
 
     /**

--- a/tests/Feature/Plugins/User/Menus/MenusModeratorEditFeatureTest.php
+++ b/tests/Feature/Plugins/User/Menus/MenusModeratorEditFeatureTest.php
@@ -11,6 +11,10 @@ use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
+/**
+ * メニュープラグインの編集権限と、表示設定が保存されていない初期状態の公開表示を検証する。
+ * 画面経由の保存結果と、公開メニューに出る利用者視点の表示をFeatureテストで守る。
+ */
 class MenusModeratorEditFeatureTest extends TestCase
 {
     use RefreshDatabase;
@@ -269,5 +273,50 @@ class MenusModeratorEditFeatureTest extends TestCase
         $permitted_response->assertStatus(200);
         $permitted_response->assertSee('menu-edit-button');
         $permitted_response->assertDontSee('設定メニュー');
+    }
+
+    /**
+     * ディレクトリ展開式は、メニュー設定を保存していない新規フレームでも配下ページの存在と展開状態を示す。
+     */
+    public function testOpenCurrentTreeShowsChildrenWithDefaultSettingsWhenMenuIsNotSaved(): void
+    {
+        $parent = $this->createPublicPage('親ページ', '/parent-page', $this->page);
+        $this->createPublicPage('子ページ', '/parent-page/child-page', $parent);
+        Frame::whereKey($this->frame->id)->update(['template' => 'opencurrenttree']);
+        $this->frame = $this->frame->fresh();
+
+        $root_response = $this->get($this->index_url);
+        $root_response->assertStatus(200);
+        $root_response->assertSee('親ページ');
+        $root_response->assertSee('fas fa-plus', false);
+        $root_response->assertDontSee('子ページ');
+
+        Frame::whereKey($this->frame->id)->update(['page_id' => $parent->id]);
+        $this->frame = $this->frame->fresh();
+
+        $parent_response = $this->get("/plugin/menus/index/{$parent->id}/{$this->frame->id}");
+        $parent_response->assertStatus(200);
+        $parent_response->assertSee('親ページ');
+        $parent_response->assertSee('子ページ');
+        $parent_response->assertSee('fas fa-minus', false);
+
+        $this->assertNull(Menu::where('frame_id', $this->frame->id)->first());
+    }
+
+    /**
+     * メニュー表示対象のページ階層を作る。
+     */
+    private function createPublicPage(string $name, string $permanent_link, Page $parent): Page
+    {
+        $page = Page::factory()->create([
+            'page_name' => $name,
+            'permanent_link' => $permanent_link,
+            'base_display_flag' => 1,
+            'membership_flag' => 0,
+        ]);
+
+        $page->appendToNode($parent)->save();
+
+        return $page->fresh();
     }
 }


### PR DESCRIPTION
# 概要
## 変更の概要
メニューを新規作成した直後でも、配下ページの存在を示すアイコンと配下ページが正しく表示されるようにしました。

## 変更内容
- メニュー設定がまだ保存されていないフレームでも、表示時は初期設定のメニューとして扱うようにしました。
- 未保存状態のディレクトリ展開式テンプレートで、親ページに配下ページを示す `+` が表示されることをFeatureテストで確認しました。
- 親ページ表示時に配下ページが展開されることをFeatureテストで確認しました。

## 背景と目的
ディレクトリ展開式のメニューは、配下ページがある場合に `+` などのアイコンで階層を示します。
しかし新規作成直後はメニュー設定の保存データがまだ無いため、表示側でアイコン出力に必要な設定を参照できず、配下ページがあることが分かりにくい状態でした。

この変更により、新規作成直後でもページ管理の表示条件に従って、階層メニューとして自然に利用できるようにします。

## 特記事項
- 既存の保存済みメニュー設定の挙動は変更していません。
- DB変更はありません。

# レビュー完了希望日
不具合対応のため、可能であれば今週中に確認希望です。

# 関連Pull requests/Issues
なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule