### PR TITLE
[アップロードファイル管理] 詳細な絞り込みと並べ替えを追加しました

### DIFF
--- a/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
+++ b/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Log;
 
 use App\Models\Common\Uploads;
 use App\Models\Core\Configs;
+use App\Models\Core\Plugins;
 use App\Utilities\Storage\StorageUsageCalculator;
 
 use App\Plugins\Manage\ManagePluginBase;
@@ -35,6 +36,51 @@ class UploadfileManage extends ManagePluginBase
      * 表示件数の許可された値
      */
     private $allowed_per_page = [10, 50, 100];
+
+    /**
+     * 検索条件として扱う項目
+     */
+    private $search_condition_keys = [
+        'client_original_name',
+        'id',
+        'size_from',
+        'size_to',
+        'size_unit',
+        'page_name',
+        'created_at_from',
+        'created_at_to',
+        'plugin_names',
+        'sort',
+    ];
+
+    /**
+     * 並べ替えの許可された値
+     */
+    private $allowed_sorts = [
+        'id_asc',
+        'id_desc',
+        'client_original_name_asc',
+        'client_original_name_desc',
+        'size_asc',
+        'size_desc',
+        'created_at_asc',
+        'created_at_desc',
+        'plugin_name_asc',
+        'plugin_name_desc',
+        'page_name_asc',
+        'page_name_desc',
+        'download_count_desc',
+        'play_count_desc',
+    ];
+
+    /**
+     * ファイルサイズ検索で許可する単位
+     */
+    private $allowed_size_units = [
+        'byte',
+        'KB',
+        'MB',
+    ];
 
     /**
      *  権限定義
@@ -83,34 +129,11 @@ class UploadfileManage extends ManagePluginBase
                                 ->leftJoin('plugins', 'plugins.plugin_name', '=', 'uploads.plugin_name')
                                 ->leftJoin('pages', 'pages.id', '=', 'uploads.page_id');
 
-        if ($request->session()->has('search_condition.client_original_name')) {
-            $uploads_query->where('client_original_name', 'like', '%' . $request->session()->get('search_condition.client_original_name') . '%');
-        }
+        $search_condition = $request->session()->get('search_condition', []);
+        $this->applySearchConditions($uploads_query, $search_condition);
 
         // 表示順
-        $sort = 'id_desc';
-        if ($request->session()->has('search_condition.sort')) {
-            $sort = session('search_condition.sort');
-        }
-        if ($sort == 'id_asc') {
-            $uploads_query->orderBy('id', 'asc');
-        } elseif ($sort == 'id_desc') {
-            $uploads_query->orderBy('id', 'desc');
-        } elseif ($sort == 'client_original_name_asc') {
-            $uploads_query->orderBy('client_original_name', 'asc');
-        } elseif ($sort == 'client_original_name_desc') {
-            $uploads_query->orderBy('client_original_name', 'desc');
-        } elseif ($sort == 'size_asc') {
-            $uploads_query->orderBy('size', 'asc');
-        } elseif ($sort == 'size_desc') {
-            $uploads_query->orderBy('size', 'desc');
-        } elseif ($sort == 'created_at_asc') {
-            $uploads_query->orderBy('created_at', 'asc');
-        } elseif ($sort == 'created_at_desc') {
-            $uploads_query->orderBy('created_at', 'desc');
-        } elseif ($sort == 'download_count_desc') {
-            $uploads_query->orderBy('download_count', 'desc');
-        }
+        $this->applySort($uploads_query, $this->getSort($search_condition));
 
         // 表示件数の取得 ※デフォルトは10件
         $per_page = $this->allowed_per_page[0];
@@ -128,6 +151,11 @@ class UploadfileManage extends ManagePluginBase
         // データ使用量の計算
         $storage_usage = StorageUsageCalculator::getDataUsage();
 
+        // プラグイン絞り込み用の一覧
+        $uploadfile_plugins = Plugins::orderBy('display_sequence')
+                                     ->orderBy('plugin_name')
+                                     ->get();
+
         // 入力値をsessionへ保存（検索用）
         $request->flash();
 
@@ -138,6 +166,9 @@ class UploadfileManage extends ManagePluginBase
             "uploads"     => $uploads,
             "allowed_per_page" => $this->allowed_per_page,
             "storage_usage" => $storage_usage,
+            "search_condition_keys" => $this->search_condition_keys,
+            "is_search_condition_set" => $this->isSearchConditionSet($search_condition),
+            "uploadfile_plugins" => $uploadfile_plugins,
         ]);
     }
 
@@ -147,10 +178,7 @@ class UploadfileManage extends ManagePluginBase
     public function search($request)
     {
         // 検索ボタンが押されたときはここが実行される。検索条件を設定してindex を呼ぶ。
-        $search_condition = [
-            "client_original_name" => $request->input('search_condition.client_original_name'),
-            "sort"                 => $request->input('search_condition.sort'),
-        ];
+        $search_condition = $this->getSearchConditionFromRequest($request);
 
         session(["search_condition" => $search_condition]);
 
@@ -160,6 +188,163 @@ class UploadfileManage extends ManagePluginBase
         }
 
         return redirect("/manage/uploadfile");
+    }
+
+    /**
+     * リクエストから検索条件を取得する
+     */
+    private function getSearchConditionFromRequest($request)
+    {
+        $search_condition = [];
+        foreach ($this->search_condition_keys as $key) {
+            $value = $request->input('search_condition.' . $key);
+            $search_condition[$key] = is_string($value) ? trim($value) : $value;
+        }
+
+        if (!in_array($search_condition['sort'], $this->allowed_sorts)) {
+            $search_condition['sort'] = 'id_desc';
+        }
+        if (!in_array($search_condition['size_unit'], $this->allowed_size_units)) {
+            $search_condition['size_unit'] = 'MB';
+        }
+
+        return $search_condition;
+    }
+
+    /**
+     * 検索条件をクエリに適用する
+     */
+    private function applySearchConditions($uploads_query, array $search_condition)
+    {
+        if (!empty($search_condition['client_original_name'])) {
+            $uploads_query->where('uploads.client_original_name', 'like', '%' . $search_condition['client_original_name'] . '%');
+        }
+
+        if (!empty($search_condition['id']) && is_numeric($search_condition['id'])) {
+            $uploads_query->where('uploads.id', intval($search_condition['id']));
+        }
+
+        if (isset($search_condition['size_from']) && is_numeric($search_condition['size_from'])) {
+            $uploads_query->where('uploads.size', '>=', $this->convertSizeToBytes($search_condition['size_from'], $search_condition['size_unit'] ?? 'MB'));
+        }
+
+        if (isset($search_condition['size_to']) && is_numeric($search_condition['size_to'])) {
+            $uploads_query->where('uploads.size', '<=', $this->convertSizeToBytes($search_condition['size_to'], $search_condition['size_unit'] ?? 'MB'));
+        }
+
+        if (!empty($search_condition['page_name'])) {
+            $uploads_query->where('pages.page_name', 'like', '%' . $search_condition['page_name'] . '%');
+        }
+
+        if (!empty($search_condition['created_at_from'])) {
+            $uploads_query->whereDate('uploads.created_at', '>=', $search_condition['created_at_from']);
+        }
+
+        if (!empty($search_condition['created_at_to'])) {
+            $uploads_query->whereDate('uploads.created_at', '<=', $search_condition['created_at_to']);
+        }
+
+        $plugin_names = $this->getSelectedPluginNames($search_condition);
+        if (!empty($plugin_names)) {
+            $uploads_query->whereIn('uploads.plugin_name', $plugin_names);
+        }
+    }
+
+    /**
+     * 入力されたファイルサイズをbyteに変換する
+     */
+    private function convertSizeToBytes($size, $unit)
+    {
+        if ($unit == 'MB') {
+            return intval($size * 1024 * 1024);
+        } elseif ($unit == 'KB') {
+            return intval($size * 1024);
+        }
+
+        return intval($size);
+    }
+
+    /**
+     * 選択されたプラグイン名を配列で取得する
+     */
+    private function getSelectedPluginNames(array $search_condition)
+    {
+        if (empty($search_condition['plugin_names'])) {
+            return [];
+        }
+
+        $plugin_names = is_array($search_condition['plugin_names'])
+            ? $search_condition['plugin_names']
+            : [$search_condition['plugin_names']];
+
+        return array_values(array_filter($plugin_names, function ($plugin_name) {
+            return $plugin_name !== '';
+        }));
+    }
+
+    /**
+     * 並べ替え条件を取得する
+     */
+    private function getSort(array $search_condition)
+    {
+        if (!empty($search_condition['sort']) && in_array($search_condition['sort'], $this->allowed_sorts)) {
+            return $search_condition['sort'];
+        }
+
+        return 'id_desc';
+    }
+
+    /**
+     * 並べ替え条件をクエリに適用する
+     */
+    private function applySort($uploads_query, $sort)
+    {
+        if ($sort == 'id_asc') {
+            $uploads_query->orderBy('uploads.id', 'asc');
+        } elseif ($sort == 'id_desc') {
+            $uploads_query->orderBy('uploads.id', 'desc');
+        } elseif ($sort == 'client_original_name_asc') {
+            $uploads_query->orderBy('uploads.client_original_name', 'asc')->orderBy('uploads.id', 'asc');
+        } elseif ($sort == 'client_original_name_desc') {
+            $uploads_query->orderBy('uploads.client_original_name', 'desc')->orderBy('uploads.id', 'desc');
+        } elseif ($sort == 'size_asc') {
+            $uploads_query->orderBy('uploads.size', 'asc')->orderBy('uploads.id', 'asc');
+        } elseif ($sort == 'size_desc') {
+            $uploads_query->orderBy('uploads.size', 'desc')->orderBy('uploads.id', 'desc');
+        } elseif ($sort == 'created_at_asc') {
+            $uploads_query->orderBy('uploads.created_at', 'asc')->orderBy('uploads.id', 'asc');
+        } elseif ($sort == 'created_at_desc') {
+            $uploads_query->orderBy('uploads.created_at', 'desc')->orderBy('uploads.id', 'desc');
+        } elseif ($sort == 'plugin_name_asc') {
+            $uploads_query->orderBy('plugins.display_sequence', 'asc')->orderBy('uploads.plugin_name', 'asc')->orderBy('uploads.id', 'asc');
+        } elseif ($sort == 'plugin_name_desc') {
+            $uploads_query->orderBy('plugins.display_sequence', 'desc')->orderBy('uploads.plugin_name', 'desc')->orderBy('uploads.id', 'desc');
+        } elseif ($sort == 'page_name_asc') {
+            $uploads_query->orderBy('pages.page_name', 'asc')->orderBy('uploads.id', 'asc');
+        } elseif ($sort == 'page_name_desc') {
+            $uploads_query->orderBy('pages.page_name', 'desc')->orderBy('uploads.id', 'desc');
+        } elseif ($sort == 'download_count_desc') {
+            $uploads_query->orderBy('uploads.download_count', 'desc')->orderBy('uploads.id', 'desc');
+        } elseif ($sort == 'play_count_desc') {
+            $uploads_query->orderBy('uploads.play_count', 'desc')->orderBy('uploads.id', 'desc');
+        }
+    }
+
+    /**
+     * 検索条件が指定されているか判定する
+     */
+    private function isSearchConditionSet(array $search_condition)
+    {
+        foreach ($this->search_condition_keys as $key) {
+            if ($key == 'sort') {
+                continue;
+            }
+            if (isset($search_condition[$key]) && $search_condition[$key] !== '') {
+                return true;
+            }
+        }
+
+        return !empty($search_condition['sort']) && $search_condition['sort'] != 'id_desc';
     }
 
     /**

--- a/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
+++ b/app/Plugins/Manage/UploadfileManage/UploadfileManage.php
@@ -336,10 +336,22 @@ class UploadfileManage extends ManagePluginBase
     private function isSearchConditionSet(array $search_condition)
     {
         foreach ($this->search_condition_keys as $key) {
-            if ($key == 'sort') {
+            if ($key == 'sort' || $key == 'size_unit') {
                 continue;
             }
-            if (isset($search_condition[$key]) && $search_condition[$key] !== '') {
+            if (!isset($search_condition[$key])) {
+                continue;
+            }
+            if (is_array($search_condition[$key])) {
+                $search_condition_values = array_filter($search_condition[$key], function ($value) {
+                    return $value !== null && $value !== '';
+                });
+                if (!empty($search_condition_values)) {
+                    return true;
+                }
+                continue;
+            }
+            if ($search_condition[$key] !== '') {
                 return true;
             }
         }

--- a/resources/views/plugins/manage/uploadfile/index.blade.php
+++ b/resources/views/plugins/manage/uploadfile/index.blade.php
@@ -97,10 +97,10 @@
             <div class="card">
                 <button class="btn btn-link p-0 text-left collapsed" type="button" data-toggle="collapse" data-target="#search_collapse" aria-expanded="false" aria-controls="search_collapse">
                     <div class="card-header" id="search_condition">
-                        絞り込み条件 <i class="fas fa-angle-down"></i>@if (Session::has('search_condition.client_original_name') || Session::has('search_condition.sort'))<span class="badge badge-pill badge-primary ml-2">条件設定中</span>@endif
+                        絞り込み条件 <i class="fas fa-angle-down"></i>@if ($is_search_condition_set)<span class="badge badge-pill badge-primary ml-2">条件設定中</span>@endif
                    </div>
                 </button>
-                @if (Session::has('search_condition.client_original_name') || Session::has('search_condition.sort'))
+                @if ($is_search_condition_set)
                 <div id="search_collapse" class="collapse show" aria-labelledby="search_condition" data-parent="#search_accordion">
                 @else
                 <div id="search_collapse" class="collapse" aria-labelledby="search_condition" data-parent="#search_accordion">
@@ -118,6 +118,86 @@
                                 </div>
                             </div>
 
+                            {{-- ID --}}
+                            <div class="form-group row">
+                                <label for="search_condition_id" class="col-md-3 col-form-label text-md-right">ID</label>
+                                <div class="col-md-9">
+                                    <input type="number" name="search_condition[id]" id="search_condition_id" value="{{Session::get('search_condition.id')}}" class="form-control" min="1">
+                                </div>
+                            </div>
+
+                            {{-- ファイルサイズ --}}
+                            <div class="form-group row">
+                                <label for="search_condition_size_from" class="col-md-3 col-form-label text-md-right">ファイルサイズ</label>
+                                <div class="col-md-9">
+                                    <div class="form-row align-items-center">
+                                        <div class="col-md-4">
+                                            <input type="number" name="search_condition[size_from]" id="search_condition_size_from" value="{{Session::get('search_condition.size_from')}}" class="form-control" min="0" step="1" placeholder="以上">
+                                        </div>
+                                        <div class="col-md-1 text-center">〜</div>
+                                        <div class="col-md-4">
+                                            <input type="number" name="search_condition[size_to]" id="search_condition_size_to" value="{{Session::get('search_condition.size_to')}}" class="form-control" min="0" step="1" placeholder="以下">
+                                        </div>
+                                        <div class="col-md-2">
+                                            <select name="search_condition[size_unit]" id="search_condition_size_unit" class="form-control">
+                                                @foreach(['byte', 'KB', 'MB'] as $size_unit)
+                                                    <option value="{{$size_unit}}"@if(Session::get('search_condition.size_unit', 'MB') == $size_unit) selected @endif>{{$size_unit}}</option>
+                                                @endforeach
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {{-- ページ名 --}}
+                            <div class="form-group row">
+                                <label for="search_condition_page_name" class="col-md-3 col-form-label text-md-right">ページ名</label>
+                                <div class="col-md-9">
+                                    <input type="text" name="search_condition[page_name]" id="search_condition_page_name" value="{{Session::get('search_condition.page_name')}}" class="form-control">
+                                </div>
+                            </div>
+
+                            {{-- アップロード日付 --}}
+                            <div class="form-group row">
+                                <label for="search_condition_created_at_from" class="col-md-3 col-form-label text-md-right">アップロード日付</label>
+                                <div class="col-md-9">
+                                    <div class="form-row align-items-center">
+                                        <div class="col-md-5">
+                                            <input type="date" name="search_condition[created_at_from]" id="search_condition_created_at_from" value="{{Session::get('search_condition.created_at_from')}}" class="form-control">
+                                        </div>
+                                        <div class="col-md-1 text-center">〜</div>
+                                        <div class="col-md-5">
+                                            <input type="date" name="search_condition[created_at_to]" id="search_condition_created_at_to" value="{{Session::get('search_condition.created_at_to')}}" class="form-control">
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {{-- プラグイン --}}
+                            <div class="form-group row">
+                                <label class="col-md-3 col-form-label text-md-right">プラグイン</label>
+                                <div class="col-md-9">
+                                    @php
+                                        $selected_plugin_names = Session::get('search_condition.plugin_names', []);
+                                        if (!is_array($selected_plugin_names)) {
+                                            $selected_plugin_names = [$selected_plugin_names];
+                                        }
+                                    @endphp
+                                    <div class="form-row">
+                                        @foreach($uploadfile_plugins as $uploadfile_plugin)
+                                            <div class="col-md-4 col-sm-6">
+                                                <div class="custom-control custom-checkbox">
+                                                    <input type="checkbox" name="search_condition[plugin_names][]" value="{{$uploadfile_plugin->plugin_name}}" id="search_condition_plugin_names_{{$loop->iteration}}" class="custom-control-input"@if(in_array($uploadfile_plugin->plugin_name, $selected_plugin_names)) checked="checked" @endif>
+                                                    <label class="custom-control-label" for="search_condition_plugin_names_{{$loop->iteration}}">
+                                                        {{$uploadfile_plugin->plugin_name_full}}
+                                                    </label>
+                                                </div>
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                </div>
+                            </div>
+
                             {{-- 並べ替え --}}
                             <div class="form-group row">
                                 <label for="sort" class="col-md-3 col-form-label text-md-right">並べ替え</label>
@@ -131,7 +211,12 @@
                                         <option value="size_desc"@if(Session::get('search_condition.sort') == "size_desc") selected @endif>サイズ 降順</option>
                                         <option value="created_at_asc"@if(Session::get('search_condition.sort') == "created_at_asc") selected @endif>アップロード日時 昇順</option>
                                         <option value="created_at_desc"@if(Session::get('search_condition.sort') == "created_at_desc") selected @endif>アップロード日時 降順</option>
+                                        <option value="plugin_name_asc"@if(Session::get('search_condition.sort') == "plugin_name_asc") selected @endif>プラグイン 昇順</option>
+                                        <option value="plugin_name_desc"@if(Session::get('search_condition.sort') == "plugin_name_desc") selected @endif>プラグイン 降順</option>
+                                        <option value="page_name_asc"@if(Session::get('search_condition.sort') == "page_name_asc") selected @endif>ページ名 昇順</option>
+                                        <option value="page_name_desc"@if(Session::get('search_condition.sort') == "page_name_desc") selected @endif>ページ名 降順</option>
                                         <option value="download_count_desc"@if(Session::get('search_condition.sort') == "download_count_desc") selected @endif>ダウンロード数 降順</option>
+                                        <option value="play_count_desc"@if(Session::get('search_condition.sort') == "play_count_desc") selected @endif>再生回数 降順</option>
                                     </select>
                                 </div>
                             </div>
@@ -170,8 +255,18 @@
             {{-- (右側)表示件数選択 --}}
             <form method="post" action="{{url('/')}}/manage/uploadfile/search" class="form-inline">
                 {{ csrf_field() }}
-                <input type="hidden" name="search_condition[client_original_name]" value="{{Session::get('search_condition.client_original_name')}}">
-                <input type="hidden" name="search_condition[sort]" value="{{Session::get('search_condition.sort')}}">
+                @foreach($search_condition_keys as $search_condition_key)
+                    @php
+                        $search_condition_value = Session::get('search_condition.' . $search_condition_key);
+                    @endphp
+                    @if(is_array($search_condition_value))
+                        @foreach($search_condition_value as $value)
+                            <input type="hidden" name="search_condition[{{$search_condition_key}}][]" value="{{$value}}">
+                        @endforeach
+                    @else
+                        <input type="hidden" name="search_condition[{{$search_condition_key}}]" value="{{$search_condition_value}}">
+                    @endif
+                @endforeach
                 <label for="per_page_quick" class="mr-2 mb-0">表示件数:</label>
                 <select name="uploadfile_per_page" id="per_page_quick" class="form-control form-control-sm" onchange="this.form.submit()">
                     @foreach($allowed_per_page as $per_page_option)

--- a/tests/Feature/Plugins/Manage/UploadfileManage/UploadfileManageSearchTest.php
+++ b/tests/Feature/Plugins/Manage/UploadfileManage/UploadfileManageSearchTest.php
@@ -116,6 +116,24 @@ class UploadfileManageSearchTest extends TestCase
     }
 
     /**
+     * 検索条件を指定せずに検索や表示件数変更をしても、既定の単位や並べ替えだけで条件設定中扱いにならないこと。
+     */
+    public function testIndexDoesNotTreatDefaultSizeUnitAsSearchCondition(): void
+    {
+        $plugin = new UploadfileManage();
+        $plugin->search($this->makeRequest('POST', '/manage/uploadfile/search', [
+            'search_condition' => [
+                'sort' => 'id_desc',
+            ],
+            'uploadfile_per_page' => 50,
+        ]));
+
+        $view = $plugin->index($this->makeRequest('GET', '/manage/uploadfile'));
+
+        $this->assertFalse($view->getData()['is_search_condition_set']);
+    }
+
+    /**
      * プラグインはチェックボックスで複数選択でき、選択したプラグインのファイルだけをまとめて表示できること。
      */
     public function testIndexCanFilterByMultiplePlugins(): void
@@ -200,21 +218,21 @@ class UploadfileManageSearchTest extends TestCase
         $page_beta = Page::factory()->create(['page_name' => 'Beta page', 'permanent_link' => '/beta']);
         $page_gamma = Page::factory()->create(['page_name' => 'Gamma page', 'permanent_link' => '/gamma']);
         $page_alpha = Page::factory()->create(['page_name' => 'Alpha page', 'permanent_link' => '/alpha']);
-        $this->savePlugin('zeta', 'Zeta plugin', 30);
-        $this->savePlugin('alpha', 'Alpha plugin', 10);
+        $this->savePlugin('alpha', 'Alpha plugin', 30);
+        $this->savePlugin('zeta', 'Zeta plugin', 10);
         $this->savePlugin('middle', 'Middle plugin', 20);
 
         Uploads::factory()->create([
             'client_original_name' => 'sort-one.txt',
             'size' => 200,
-            'plugin_name' => 'zeta',
+            'plugin_name' => 'alpha',
             'page_id' => $page_beta->id,
             'created_at' => '2024-02-01 00:00:00',
         ]);
         Uploads::factory()->create([
             'client_original_name' => 'sort-two.txt',
             'size' => 100,
-            'plugin_name' => 'alpha',
+            'plugin_name' => 'zeta',
             'page_id' => $page_gamma->id,
             'created_at' => '2024-01-01 00:00:00',
         ]);
@@ -251,10 +269,12 @@ class UploadfileManageSearchTest extends TestCase
      */
     private function savePlugin(string $plugin_name, string $plugin_name_full, int $display_sequence = 0): void
     {
-        Plugins::updateOrCreate(
+        $plugin = Plugins::updateOrCreate(
             ['plugin_name' => $plugin_name],
-            ['plugin_name_full' => $plugin_name_full, 'display_sequence' => $display_sequence, 'display_flag' => 1]
+            ['plugin_name_full' => $plugin_name_full, 'display_flag' => 1]
         );
+        $plugin->display_sequence = $display_sequence;
+        $plugin->save();
     }
 
     /**

--- a/tests/Feature/Plugins/Manage/UploadfileManage/UploadfileManageSearchTest.php
+++ b/tests/Feature/Plugins/Manage/UploadfileManage/UploadfileManageSearchTest.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Tests\Feature\Plugins\Manage\UploadfileManage;
+
+use App\Models\Common\Page;
+use App\Models\Common\Uploads;
+use App\Models\Core\Plugins;
+use App\Plugins\Manage\UploadfileManage\UploadfileManage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+/**
+ * アップロードファイル管理一覧の検索・並べ替えを検証するFeatureテスト。
+ *
+ * 管理プラグインの公開メソッドを通して、ユーザーが指定した条件が一覧結果へ反映されることを守る。
+ */
+class UploadfileManageSearchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * ファイルサイズ、ページ名、アップロード日付、プラグインの条件を組み合わせても、該当ファイルだけに絞り込めること。
+     */
+    public function testIndexCanFilterBySizePageCreatedAtAndPlugin(): void
+    {
+        $target_page = Page::factory()->create(['page_name' => '教材ページ', 'permanent_link' => '/materials']);
+        $other_page = Page::factory()->create(['page_name' => '連絡ページ', 'permanent_link' => '/notices']);
+        $this->savePlugin('forms', 'フォーム');
+        $this->savePlugin('blogs', 'ブログ');
+
+        Uploads::factory()->create([
+            'client_original_name' => 'target-form.pdf',
+            'size' => 2048,
+            'plugin_name' => 'forms',
+            'page_id' => $target_page->id,
+            'created_at' => '2024-06-10 10:00:00',
+        ]);
+        Uploads::factory()->create([
+            'client_original_name' => 'too-small.pdf',
+            'size' => 512,
+            'plugin_name' => 'forms',
+            'page_id' => $target_page->id,
+            'created_at' => '2024-06-10 10:00:00',
+        ]);
+        Uploads::factory()->create([
+            'client_original_name' => 'wrong-page.pdf',
+            'size' => 2048,
+            'plugin_name' => 'forms',
+            'page_id' => $other_page->id,
+            'created_at' => '2024-06-10 10:00:00',
+        ]);
+        Uploads::factory()->create([
+            'client_original_name' => 'wrong-plugin.pdf',
+            'size' => 2048,
+            'plugin_name' => 'blogs',
+            'page_id' => $target_page->id,
+            'created_at' => '2024-06-10 10:00:00',
+        ]);
+        Uploads::factory()->create([
+            'client_original_name' => 'wrong-date.pdf',
+            'size' => 2048,
+            'plugin_name' => 'forms',
+            'page_id' => $target_page->id,
+            'created_at' => '2024-07-10 10:00:00',
+        ]);
+
+        $plugin = new UploadfileManage();
+        $response = $plugin->search($this->makeRequest('POST', '/manage/uploadfile/search', [
+            'search_condition' => [
+                'size_from' => '1',
+                'size_to' => '3',
+                'size_unit' => 'KB',
+                'page_name' => '教材',
+                'created_at_from' => '2024-06-01',
+                'created_at_to' => '2024-06-30',
+                'plugin_names' => ['forms'],
+                'sort' => 'id_desc',
+            ],
+        ]));
+
+        $this->assertSame(url('/manage/uploadfile'), $response->getTargetUrl());
+
+        $this->assertSame(['target-form.pdf'], $this->getUploadFileNames($plugin->index($this->makeRequest('GET', '/manage/uploadfile'))));
+    }
+
+    /**
+     * IDを指定した場合は、同名や近い属性のファイルではなく指定IDのファイルだけを表示できること。
+     */
+    public function testIndexCanFilterById(): void
+    {
+        $target = Uploads::factory()->create(['client_original_name' => 'id-target.pdf']);
+        Uploads::factory()->create(['client_original_name' => 'id-other.pdf']);
+
+        $plugin = new UploadfileManage();
+        $response = $plugin->search($this->makeRequest('POST', '/manage/uploadfile/search', [
+            'search_condition' => [
+                'id' => $target->id,
+                'sort' => 'id_desc',
+            ],
+        ]));
+
+        $this->assertSame(url('/manage/uploadfile'), $response->getTargetUrl());
+
+        $this->assertSame(['id-target.pdf'], $this->getUploadFileNames($plugin->index($this->makeRequest('GET', '/manage/uploadfile'))));
+    }
+
+    /**
+     * プラグインはチェックボックスで複数選択でき、選択したプラグインのファイルだけをまとめて表示できること。
+     */
+    public function testIndexCanFilterByMultiplePlugins(): void
+    {
+        $this->savePlugin('forms', 'フォーム');
+        $this->savePlugin('blogs', 'ブログ');
+        $this->savePlugin('cabinets', 'キャビネット');
+        Uploads::factory()->create(['client_original_name' => 'forms-file.pdf', 'plugin_name' => 'forms']);
+        Uploads::factory()->create(['client_original_name' => 'blogs-file.pdf', 'plugin_name' => 'blogs']);
+        Uploads::factory()->create(['client_original_name' => 'cabinets-file.pdf', 'plugin_name' => 'cabinets']);
+
+        $plugin = new UploadfileManage();
+        $plugin->search($this->makeRequest('POST', '/manage/uploadfile/search', [
+            'search_condition' => [
+                'plugin_names' => ['forms', 'blogs'],
+                'sort' => 'client_original_name_asc',
+            ],
+        ]));
+
+        $this->assertSame(
+            ['blogs-file.pdf', 'forms-file.pdf'],
+            $this->getUploadFileNames($plugin->index($this->makeRequest('GET', '/manage/uploadfile')))
+        );
+    }
+
+    /**
+     * ファイルサイズの下限・上限ちょうどのファイルは検索結果に含まれ、範囲外の直前・直後は除外されること。
+     */
+    public function testIndexIncludesFileSizeBoundaryValues(): void
+    {
+        Uploads::factory()->create(['client_original_name' => 'size-before.txt', 'size' => 1023]);
+        Uploads::factory()->create(['client_original_name' => 'size-lower.txt', 'size' => 1024]);
+        Uploads::factory()->create(['client_original_name' => 'size-upper.txt', 'size' => 2048]);
+        Uploads::factory()->create(['client_original_name' => 'size-after.txt', 'size' => 2049]);
+
+        $plugin = new UploadfileManage();
+        $plugin->search($this->makeRequest('POST', '/manage/uploadfile/search', [
+            'search_condition' => [
+                'size_from' => '1',
+                'size_to' => '2',
+                'size_unit' => 'KB',
+                'sort' => 'size_asc',
+            ],
+        ]));
+
+        $this->assertSame(
+            ['size-lower.txt', 'size-upper.txt'],
+            $this->getUploadFileNames($plugin->index($this->makeRequest('GET', '/manage/uploadfile')))
+        );
+    }
+
+    /**
+     * アップロード日付の開始日・終了日に作成されたファイルは時刻に関わらず含まれ、範囲外の日付は除外されること。
+     */
+    public function testIndexIncludesUploadDateBoundaryValues(): void
+    {
+        Uploads::factory()->create(['client_original_name' => 'date-before.txt', 'created_at' => '2024-05-31 23:59:59']);
+        Uploads::factory()->create(['client_original_name' => 'date-lower.txt', 'created_at' => '2024-06-01 00:00:00']);
+        Uploads::factory()->create(['client_original_name' => 'date-upper.txt', 'created_at' => '2024-06-30 23:59:59']);
+        Uploads::factory()->create(['client_original_name' => 'date-after.txt', 'created_at' => '2024-07-01 00:00:00']);
+
+        $plugin = new UploadfileManage();
+        $plugin->search($this->makeRequest('POST', '/manage/uploadfile/search', [
+            'search_condition' => [
+                'created_at_from' => '2024-06-01',
+                'created_at_to' => '2024-06-30',
+                'sort' => 'created_at_asc',
+            ],
+        ]));
+
+        $this->assertSame(
+            ['date-lower.txt', 'date-upper.txt'],
+            $this->getUploadFileNames($plugin->index($this->makeRequest('GET', '/manage/uploadfile')))
+        );
+    }
+
+    /**
+     * ID、ファイルサイズ、アップロード日付、プラグイン、ページ名の並べ替えが一覧の表示順に反映されること。
+     */
+    public function testIndexCanSortByRequestedColumns(): void
+    {
+        $page_beta = Page::factory()->create(['page_name' => 'Beta page', 'permanent_link' => '/beta']);
+        $page_gamma = Page::factory()->create(['page_name' => 'Gamma page', 'permanent_link' => '/gamma']);
+        $page_alpha = Page::factory()->create(['page_name' => 'Alpha page', 'permanent_link' => '/alpha']);
+        $this->savePlugin('zeta', 'Zeta plugin', 30);
+        $this->savePlugin('alpha', 'Alpha plugin', 10);
+        $this->savePlugin('middle', 'Middle plugin', 20);
+
+        Uploads::factory()->create([
+            'client_original_name' => 'sort-one.txt',
+            'size' => 200,
+            'plugin_name' => 'zeta',
+            'page_id' => $page_beta->id,
+            'created_at' => '2024-02-01 00:00:00',
+        ]);
+        Uploads::factory()->create([
+            'client_original_name' => 'sort-two.txt',
+            'size' => 100,
+            'plugin_name' => 'alpha',
+            'page_id' => $page_gamma->id,
+            'created_at' => '2024-01-01 00:00:00',
+        ]);
+        Uploads::factory()->create([
+            'client_original_name' => 'sort-three.txt',
+            'size' => 300,
+            'plugin_name' => 'middle',
+            'page_id' => $page_alpha->id,
+            'created_at' => '2024-03-01 00:00:00',
+        ]);
+
+        $plugin = new UploadfileManage();
+        $this->assertUploadOrder($plugin, 'id_asc', ['sort-one.txt', 'sort-two.txt', 'sort-three.txt']);
+        $this->assertUploadOrder($plugin, 'id_desc', ['sort-three.txt', 'sort-two.txt', 'sort-one.txt']);
+        $this->assertUploadOrder($plugin, 'size_asc', ['sort-two.txt', 'sort-one.txt', 'sort-three.txt']);
+        $this->assertUploadOrder($plugin, 'created_at_asc', ['sort-two.txt', 'sort-one.txt', 'sort-three.txt']);
+        $this->assertUploadOrder($plugin, 'plugin_name_asc', ['sort-two.txt', 'sort-three.txt', 'sort-one.txt']);
+        $this->assertUploadOrder($plugin, 'page_name_asc', ['sort-three.txt', 'sort-one.txt', 'sort-two.txt']);
+    }
+
+    /**
+     * テスト対象メソッドに渡すセッション付きリクエストを作成する。
+     */
+    private function makeRequest(string $method, string $uri, array $parameters = []): Request
+    {
+        $request = Request::create($uri, $method, $parameters);
+        $request->setLaravelSession($this->app['session.store']);
+
+        return $request;
+    }
+
+    /**
+     * 検索・並べ替えで参照するプラグイン表示名を用意する。
+     */
+    private function savePlugin(string $plugin_name, string $plugin_name_full, int $display_sequence = 0): void
+    {
+        Plugins::updateOrCreate(
+            ['plugin_name' => $plugin_name],
+            ['plugin_name_full' => $plugin_name_full, 'display_sequence' => $display_sequence, 'display_flag' => 1]
+        );
+    }
+
+    /**
+     * 指定した並べ替え条件でファイル名が期待順に表示されることを確認する。
+     */
+    private function assertUploadOrder(UploadfileManage $plugin, string $sort, array $expected_file_names): void
+    {
+        session(['search_condition' => ['sort' => $sort]]);
+
+        $this->assertSame($expected_file_names, $this->getUploadFileNames($plugin->index($this->makeRequest('GET', '/manage/uploadfile'))));
+    }
+
+    /**
+     * 一覧Viewから表示対象のファイル名だけを取り出す。
+     */
+    private function getUploadFileNames($view): array
+    {
+        return $view->getData()['uploads']->getCollection()->pluck('client_original_name')->all();
+    }
+}


### PR DESCRIPTION
# 概要
アップロードファイル一覧で、ID・ファイルサイズ・ページ名・アップロード日付・プラグインによる絞り込みと、関連項目の並べ替えをできるようにしました。

## 変更内容
- ファイルサイズ、ページ名、アップロード日付、プラグイン、IDの絞り込み条件を追加しました。
- ファイルサイズは `byte` / `KB` / `MB` を選べるようにし、画面入力値を内部でbyteへ変換して検索します。
- プラグイン検索は `plugins` テーブルの一覧を使い、チェックボックスで複数選択できるようにしました。
- プラグイン一覧とプラグイン列の並べ替えは `display_sequence`、`plugin_name` の順に揃えました。
- ID、ファイル名、サイズ、アップロード日時、プラグイン、ページ名、ダウンロード数、再生回数の並べ替えを整理しました。
- 検索条件と並べ替えのFeatureテストを追加しました。

## 背景と目的
アップロードファイルが増えると、ファイル名だけでは目的のファイルを探しにくくなります。サイズや日付、利用元のページ、プラグインなどで絞り込めるようにし、管理者が対象ファイルを見つけやすくすることが目的です。

## 特記事項
- DBマイグレーションはありません。
- 検索処理では既存の `uploads.size` をbyteのまま利用します。

# レビュー完了希望日
急ぎません。

# 関連Pull requests/Issues
なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
