### PR TITLE
[固定記事][ブログ] バケツ選択画面にキーワード検索を追加しました

### DIFF
--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1222,6 +1222,8 @@ WHERE status = 0
      */
     public function listBuckets($request, $page_id, $frame_id, $id = null)
     {
+        $keyword = trim((string)$request->keyword);
+
         // Frame データ
         $blog_frame = Frame::select('frames.*', 'blogs.id as blogs_id')
             ->leftJoin('blogs', 'blogs.bucket_id', '=', 'frames.bucket_id')
@@ -1245,7 +1247,13 @@ WHERE status = 0
             ->leftJoin('frames', function ($leftJoin) use ($frame_id) {
                 $leftJoin->on('blogs.bucket_id', '=', 'frames.bucket_id')
                     ->where('frames.id', $frame_id);
-            })
+            });
+
+        if (!empty($keyword)) {
+            $blogs->where('blogs.blog_name', 'like', '%' . $keyword . '%');
+        }
+
+        $blogs = $blogs
             ->groupBy(
                 'blogs.id',
                 'blogs.bucket_id',
@@ -1261,6 +1269,7 @@ WHERE status = 0
         return $this->view('blogs_list_buckets', [
             'blog_frame' => $blog_frame,
             'blogs'      => $blogs,
+            'keyword'    => $keyword,
         ]);
     }
 

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -1249,7 +1249,7 @@ WHERE status = 0
                     ->where('frames.id', $frame_id);
             });
 
-        if (!empty($keyword)) {
+        if ($keyword !== '') {
             $blogs->where('blogs.blog_name', 'like', '%' . $keyword . '%');
         }
 

--- a/app/Plugins/User/Contents/ContentsPlugin.php
+++ b/app/Plugins/User/Contents/ContentsPlugin.php
@@ -762,6 +762,8 @@ class ContentsPlugin extends UserPluginBase
      */
     public function listBuckets($request, $page_id, $frame_id, $id = null)
     {
+        $keyword = trim((string)$request->keyword);
+
         // ソート設定に初期設定値をセット
         $sort_inits = [
             "contents_updated_at" => ["desc", "asc"],
@@ -807,6 +809,15 @@ class ContentsPlugin extends UserPluginBase
                            ->leftJoin('pages', 'pages.id', '=', 'frames.page_id')
                            ->where('buckets.plugin_name', 'contents');
 
+        if (!empty($keyword)) {
+            $buckets_query->where(function ($query) use ($keyword) {
+                $query->where('frames.frame_title', 'like', '%' . $keyword . '%')
+                    ->orWhere('buckets.bucket_name', 'like', '%' . $keyword . '%')
+                    ->orWhere('contents.content_text', 'like', '%' . $keyword . '%')
+                    ->orWhere('contents.content2_text', 'like', '%' . $keyword . '%');
+            });
+        }
+
         // buckets を作っていない状態で、設定の表示コンテンツ選択を開くこともあるので、バケツがあるかの判定
         if (!empty($this->buckets)) {
             // buckets がある場合は、該当buckets を一覧の最初に持ってくる。
@@ -819,7 +830,8 @@ class ContentsPlugin extends UserPluginBase
         return $this->view('contents_list_buckets', [
             'buckets_list'      => $buckets_list,
             'order_link'        => $order_link,
-            'request_order_str' => implode('|', $request_order_by)
+            'request_order_str' => implode('|', $request_order_by),
+            'keyword'           => $keyword,
         ]);
     }
 

--- a/app/Plugins/User/Contents/ContentsPlugin.php
+++ b/app/Plugins/User/Contents/ContentsPlugin.php
@@ -809,7 +809,7 @@ class ContentsPlugin extends UserPluginBase
                            ->leftJoin('pages', 'pages.id', '=', 'frames.page_id')
                            ->where('buckets.plugin_name', 'contents');
 
-        if (!empty($keyword)) {
+        if ($keyword !== '') {
             $buckets_query->where(function ($query) use ($keyword) {
                 $query->where('frames.frame_title', 'like', '%' . $keyword . '%')
                     ->orWhere('buckets.bucket_name', 'like', '%' . $keyword . '%')

--- a/resources/views/plugins/common/list_buckets_keyword_search.blade.php
+++ b/resources/views/plugins/common/list_buckets_keyword_search.blade.php
@@ -1,0 +1,32 @@
+{{--
+ * バケツ選択画面のキーワード検索フォーム共通部品。
+ *
+ * @param $action_url フォーム送信先URL
+ * @param $clear_url 条件クリアURL
+ * @param $frame フレーム
+ * @param $keyword 検索キーワード
+ * @param $hidden_inputs array 維持するGETパラメータ (任意)
+ * @param $placeholder プレースホルダ (任意)
+--}}
+@php
+    $keyword = $keyword ?? '';
+    $hidden_inputs = $hidden_inputs ?? [];
+    $placeholder = $placeholder ?? 'キーワード';
+    $keyword_id = "{$frame->plugin_name}-bucket-keyword-{$frame->id}";
+@endphp
+
+<form action="{{$action_url}}" method="GET" class="form-inline mb-3">
+    @foreach ($hidden_inputs as $name => $value)
+        @if (!is_null($value) && $value !== '')
+            <input type="hidden" name="{{$name}}" value="{{$value}}">
+        @endif
+    @endforeach
+    <label class="sr-only" for="{{$keyword_id}}">キーワード</label>
+    <input type="text" name="keyword" id="{{$keyword_id}}" value="{{$keyword}}" class="form-control mr-sm-2 mb-2 mb-sm-0" placeholder="{{$placeholder}}">
+    <button type="submit" class="btn btn-primary mr-2"><i class="fas fa-search"></i> 検索</button>
+    @if (!empty($keyword))
+        <a class="btn btn-secondary" href="{{$clear_url}}">
+            <i class="fas fa-times"></i> クリア
+        </a>
+    @endif
+</form>

--- a/resources/views/plugins/common/list_buckets_keyword_search.blade.php
+++ b/resources/views/plugins/common/list_buckets_keyword_search.blade.php
@@ -24,7 +24,7 @@
     <label class="sr-only" for="{{$keyword_id}}">キーワード</label>
     <input type="text" name="keyword" id="{{$keyword_id}}" value="{{$keyword}}" class="form-control mr-sm-2 mb-2 mb-sm-0" placeholder="{{$placeholder}}">
     <button type="submit" class="btn btn-primary mr-2"><i class="fas fa-search"></i> 検索</button>
-    @if (!empty($keyword))
+    @if ($keyword !== '')
         <a class="btn btn-secondary" href="{{$clear_url}}">
             <i class="fas fa-times"></i> クリア
         </a>

--- a/resources/views/plugins/user/blogs/default/blogs_list_buckets.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_list_buckets.blade.php
@@ -14,6 +14,13 @@
 
 @section("plugin_setting_$frame->id")
 
+@include('plugins.common.list_buckets_keyword_search', [
+    'action_url' => url('/')."/plugin/blogs/listBuckets/{$page->id}/{$frame_id}#frame-{$frame->id}",
+    'clear_url' => url('/')."/plugin/blogs/listBuckets/{$page->id}/{$frame_id}#frame-{$frame->id}",
+    'frame' => $frame,
+    'keyword' => $keyword,
+])
+
 <form action="{{url('/')}}/redirect/plugin/blogs/changeBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="POST">
     {{ csrf_field() }}
     <input type="hidden" name="redirect_path" value="{{url('/')}}/plugin/blogs/listBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame_id}}">
@@ -51,7 +58,7 @@
     </table>
 
     {{-- ページング処理 --}}
-    @include('plugins.common.user_paginate', ['posts' => $blogs, 'frame' => $frame, 'aria_label_name' => $frame->plugin_name_full . '選択', 'class' => 'form-group'])
+    @include('plugins.common.user_paginate', ['posts' => $blogs, 'frame' => $frame, 'appends' => ['keyword' => $keyword], 'aria_label_name' => $frame->plugin_name_full . '選択', 'class' => 'form-group'])
 
     <div class="text-center">
         <a class="btn btn-secondary mr-2" href="{{URL::to($page->permanent_link)}}">

--- a/resources/views/plugins/user/contents/default/contents_list_buckets.blade.php
+++ b/resources/views/plugins/user/contents/default/contents_list_buckets.blade.php
@@ -15,7 +15,7 @@
 @section("plugin_setting_$frame->id")
 @php
     $base_list_url = url('/')."/plugin/contents/listBuckets/{$page->id}/{$frame_id}";
-    $keyword_query = empty($keyword) ? '' : '&' . http_build_query(['keyword' => $keyword]);
+    $keyword_query = $keyword === '' ? '' : '&' . http_build_query(['keyword' => $keyword]);
 @endphp
 
 @include('plugins.common.list_buckets_keyword_search', [

--- a/resources/views/plugins/user/contents/default/contents_list_buckets.blade.php
+++ b/resources/views/plugins/user/contents/default/contents_list_buckets.blade.php
@@ -13,6 +13,19 @@
 @endsection
 
 @section("plugin_setting_$frame->id")
+@php
+    $base_list_url = url('/')."/plugin/contents/listBuckets/{$page->id}/{$frame_id}";
+    $keyword_query = empty($keyword) ? '' : '&' . http_build_query(['keyword' => $keyword]);
+@endphp
+
+@include('plugins.common.list_buckets_keyword_search', [
+    'action_url' => "{$base_list_url}#frame-{$frame->id}",
+    'clear_url' => "{$base_list_url}?" . http_build_query(['sort' => $request_order_str]) . "#frame-{$frame->id}",
+    'frame' => $frame,
+    'keyword' => $keyword,
+    'hidden_inputs' => ['sort' => $request_order_str],
+])
+
 <form action="{{url('/')}}/redirect/plugin/contents/changeBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="POST" class="">
     {{ csrf_field() }}
     <table class="table table-hover table-responsive">
@@ -20,7 +33,7 @@
         <tr>
             <th nowrap>選択</th>
             <th nowrap>
-                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=contents_updated_at|{{$order_link["contents_updated_at"][0]}}#frame-{{$frame->id}}">更新日</a>
+                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=contents_updated_at|{{$order_link["contents_updated_at"][0]}}{{$keyword_query}}#frame-{{$frame->id}}">更新日</a>
                 @if ($request_order_str == "contents_updated_at|asc")
                     <i class="fas fa-sort-numeric-down"></i>
                 @elseif ($request_order_str == "contents_updated_at|desc")
@@ -28,7 +41,7 @@
                 @endif
             </th>
             <th nowrap>
-                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=page_name|{{$order_link["page_name"][0]}}#frame-{{$frame->id}}">使用ページ</a>
+                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=page_name|{{$order_link["page_name"][0]}}{{$keyword_query}}#frame-{{$frame->id}}">使用ページ</a>
                 @if ($request_order_str == "page_name|asc")
                     <i class="fas fa-sort-alpha-down"></i>
                 @elseif ($request_order_str == "page_name|desc")
@@ -36,7 +49,7 @@
                 @endif
             </th>
             <th nowrap>
-                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=bucket_name|{{$order_link["bucket_name"][0]}}#frame-{{$frame->id}}">データ名</a>
+                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=bucket_name|{{$order_link["bucket_name"][0]}}{{$keyword_query}}#frame-{{$frame->id}}">データ名</a>
                 @if ($request_order_str == "bucket_name|asc")
                     <i class="fas fa-sort-alpha-down"></i>
                 @elseif ($request_order_str == "bucket_name|desc")
@@ -44,7 +57,7 @@
                 @endif
             </th>
             <th nowrap>
-                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=frame_title|{{$order_link["frame_title"][0]}}#frame-{{$frame->id}}">フレームタイトル</a>
+                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=frame_title|{{$order_link["frame_title"][0]}}{{$keyword_query}}#frame-{{$frame->id}}">フレームタイトル</a>
                 @if ($request_order_str == "frame_title|asc")
                     <i class="fas fa-sort-alpha-down"></i>
                 @elseif ($request_order_str == "frame_title|desc")
@@ -52,7 +65,7 @@
                 @endif
             </th>
             <th nowrap>
-                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=content_text|{{$order_link["content_text"][0]}}#frame-{{$frame->id}}">内容</a>
+                <a href="{{url('/')}}/plugin/contents/listBuckets/{{$page->id}}/{{$frame_id}}?sort=content_text|{{$order_link["content_text"][0]}}{{$keyword_query}}#frame-{{$frame->id}}">内容</a>
                 @if ($request_order_str == "content_text|asc")
                     <i class="fas fa-sort-alpha-down"></i>
                 @elseif ($request_order_str == "content_text|desc")
@@ -78,7 +91,7 @@
     </table>
 
     {{-- ページング処理 --}}
-    @include('plugins.common.user_paginate', ['posts' => $buckets_list, 'frame' => $frame, 'appends' => ['sort' => $request_order_str], 'aria_label_name' => $frame->plugin_name_full . '選択', 'class' => 'form-group'])
+    @include('plugins.common.user_paginate', ['posts' => $buckets_list, 'frame' => $frame, 'appends' => ['sort' => $request_order_str, 'keyword' => $keyword], 'aria_label_name' => $frame->plugin_name_full . '選択', 'class' => 'form-group'])
 
     <div class="text-center">
         <button type="button" class="btn btn-secondary mr-2" style="margin-left: 10px;" onclick="location.href='{{URL::to($page->permanent_link)}}#frame-{{$frame->id}}'"><i class="fas fa-times"></i><span class="{{$frame->getSettingButtonCaptionClass()}}"> キャンセル</span></button>

--- a/tests/Feature/Plugins/User/Blogs/BlogsBucketSearchFeatureTest.php
+++ b/tests/Feature/Plugins/User/Blogs/BlogsBucketSearchFeatureTest.php
@@ -52,6 +52,26 @@ class BlogsBucketSearchFeatureTest extends TestCase
     }
 
     /**
+     * ブログ名検索では、数値の0も有効な検索語として扱われ、未指定と同じ全件表示にならないこと。
+     */
+    public function testListBucketsCanSearchByZeroKeyword(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('blogs');
+
+        $this->createBlogBucket('2026年度ブログ', '通常の記事本文');
+        $this->createBlogBucket('通常ブログ', '対象外の記事本文');
+
+        $response = $this->actingAs($admin)->get("/plugin/blogs/listBuckets/{$page->id}/{$frame->id}?keyword=0");
+
+        $response->assertOk();
+        $response->assertSee('2026年度ブログ');
+        $response->assertDontSee('通常ブログ');
+        $response->assertSee('value="0"', false);
+        $response->assertSee('クリア');
+    }
+
+    /**
      * ブログ検索確認に必要なバケツ・ブログ・記事をまとめて作成する。
      */
     private function createBlogBucket(string $blog_name, string $post_text): void

--- a/tests/Feature/Plugins/User/Blogs/BlogsBucketSearchFeatureTest.php
+++ b/tests/Feature/Plugins/User/Blogs/BlogsBucketSearchFeatureTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Blogs;
+
+use App\Enums\StatusType;
+use App\Models\Common\Buckets;
+use App\Models\User\Blogs\Blogs;
+use App\Models\User\Blogs\BlogsPosts;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * ブログのバケツ選択画面におけるキーワード検索を検証する。
+ *
+ * HTTP経路で一覧画面を開き、ブログ名だけを対象に候補が
+ * 絞り込まれることを守る。
+ */
+class BlogsBucketSearchFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * ブログの選択一覧では、ブログ名に一致する候補だけが残り、記事本文だけの一致では候補にしないこと。
+     */
+    public function testListBucketsCanSearchByBlogNameOnly(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('blogs');
+
+        $this->createBlogBucket('MATCHブログ', '検索に一致しない記事本文');
+        $this->createBlogBucket('対象外ブログ', '記事本文にMATCHがあります');
+
+        $response = $this->actingAs($admin)->get("/plugin/blogs/listBuckets/{$page->id}/{$frame->id}?keyword=MATCH");
+
+        $response->assertOk();
+        $response->assertSee('MATCHブログ');
+        $response->assertDontSee('対象外ブログ');
+        $response->assertSee('name="keyword"', false);
+        $response->assertSee('value="MATCH"', false);
+    }
+
+    /**
+     * ブログ検索確認に必要なバケツ・ブログ・記事をまとめて作成する。
+     */
+    private function createBlogBucket(string $blog_name, string $post_text): void
+    {
+        $bucket = Buckets::create([
+            'bucket_name' => $blog_name,
+            'plugin_name' => 'blogs',
+        ]);
+
+        $blog = Blogs::create([
+            'bucket_id' => $bucket->id,
+            'blog_name' => $blog_name,
+        ]);
+
+        BlogsPosts::create([
+            'contents_id' => null,
+            'blogs_id' => $blog->id,
+            'post_title' => $blog_name . 'の記事',
+            'post_text' => $post_text,
+            'status' => StatusType::active,
+            'posted_at' => now(),
+        ]);
+    }
+}

--- a/tests/Feature/Plugins/User/Contents/ContentsBucketSearchFeatureTest.php
+++ b/tests/Feature/Plugins/User/Contents/ContentsBucketSearchFeatureTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Contents;
+
+use App\Enums\StatusType;
+use App\Models\Common\Buckets;
+use App\Models\Common\Frame;
+use App\Models\Common\Page;
+use App\Models\User\Contents\Contents;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * 固定記事のバケツ選択画面におけるキーワード検索を検証する。
+ *
+ * HTTP経路で一覧画面を開き、固定記事の検索対象項目が
+ * 利用者に見える候補の絞り込みとして機能することを守る。
+ */
+class ContentsBucketSearchFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * 固定記事の選択一覧では、フレームタイトル・データ名・本文のいずれに一致しても候補に残ること。
+     */
+    public function testListBucketsCanSearchByFrameTitleBucketNameAndBody(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('contents');
+        $bucket_page = Page::factory()->create();
+
+        $this->createContentBucket($bucket_page, 'search-by-frame-title', '通常本文', 'MATCHフレーム');
+        $this->createContentBucket($bucket_page, 'MATCH-search-by-bucket-name', '通常本文', '通常フレーム');
+        $this->createContentBucket($bucket_page, 'search-by-body', '本文にMATCHがあります', '通常フレーム2');
+        $this->createContentBucket($bucket_page, 'outside-content', '対象外本文', '対象外フレーム');
+
+        $response = $this->actingAs($admin)->get("/plugin/contents/listBuckets/{$page->id}/{$frame->id}?keyword=MATCH");
+
+        $response->assertOk();
+        $response->assertSee('search-by-frame-title');
+        $response->assertSee('MATCH-search-by-bucket-name');
+        $response->assertSee('search-by-body');
+        $response->assertDontSee('outside-content');
+        $response->assertSee('name="keyword"', false);
+        $response->assertSee('value="MATCH"', false);
+    }
+
+    /**
+     * 固定記事の検索確認に必要なバケツ・本文・利用フレームをまとめて作成する。
+     */
+    private function createContentBucket(
+        Page $page,
+        string $bucket_name,
+        string $content_text,
+        string $frame_title
+    ): void {
+        $bucket = Buckets::create([
+            'bucket_name' => $bucket_name,
+            'plugin_name' => 'contents',
+        ]);
+
+        Contents::create([
+            'bucket_id' => $bucket->id,
+            'content_text' => $content_text,
+            'status' => StatusType::active,
+        ]);
+
+        Frame::create([
+            'page_id' => $page->id,
+            'area_id' => 2,
+            'frame_title' => $frame_title,
+            'plugin_name' => 'contents',
+            'bucket_id' => $bucket->id,
+            'template' => 'default',
+            'display_sequence' => 1,
+        ]);
+    }
+}

--- a/tests/Feature/Plugins/User/Contents/ContentsBucketSearchFeatureTest.php
+++ b/tests/Feature/Plugins/User/Contents/ContentsBucketSearchFeatureTest.php
@@ -58,6 +58,28 @@ class ContentsBucketSearchFeatureTest extends TestCase
     }
 
     /**
+     * 固定記事検索では、数値の0も有効な検索語として扱われ、ソートやページングでも条件を維持すること。
+     */
+    public function testListBucketsCanSearchByZeroKeyword(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('contents');
+        $bucket_page = Page::factory()->create();
+
+        $this->createContentBucket($bucket_page, '2026年度固定記事', '通常本文', '通常フレーム');
+        $this->createContentBucket($bucket_page, '通常固定記事', '対象外本文', '対象外フレーム');
+
+        $response = $this->actingAs($admin)->get("/plugin/contents/listBuckets/{$page->id}/{$frame->id}?keyword=0");
+
+        $response->assertOk();
+        $response->assertSee('2026年度固定記事');
+        $response->assertDontSee('通常固定記事');
+        $response->assertSee('value="0"', false);
+        $response->assertSee('keyword=0', false);
+        $response->assertSee('クリア');
+    }
+
+    /**
      * 固定記事の検索確認に必要なバケツ・本文・利用フレームをまとめて作成する。
      */
     private function createContentBucket(


### PR DESCRIPTION
# 概要

固定記事とブログのバケツ選択画面で、キーワード検索により候補を絞り込めるようにしました。

## 変更内容
- 固定記事のバケツ選択画面で、フレームタイトル、データ名、本文、続き本文を対象にキーワード検索できるようにしました。
- ブログのバケツ選択画面で、ブログ名を対象にキーワード検索できるようにしました。
- バケツ選択画面向けのキーワード検索フォームを共通Blade部品として追加しました。
- 固定記事とブログそれぞれのFeatureテストを追加しました。

## 背景と目的
固定記事やブログのバケツが多い場合、一覧から目的のバケツを目視で探す必要がありました。
キーワードで候補を絞り込めるようにすることで、表示対象にしたいバケツを見つけやすくします。

## 特記事項
- DB変更はありません。

# レビュー完了希望日
急ぎません。

# 関連Pull requests/Issues
なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
