### PR TITLE
[新着情報] キャビネット・カレンダー・フォトアルバムを新着表示対象に追加しました

### DIFF
--- a/app/Plugins/User/Cabinets/CabinetsPlugin.php
+++ b/app/Plugins/User/Cabinets/CabinetsPlugin.php
@@ -47,6 +47,11 @@ class CabinetsPlugin extends UserPluginBase
     /* オブジェクト変数 */
 
     /**
+     * 新着機能を使うか
+     */
+    public $use_whatsnew = true;
+
+    /**
      * POST チェックに使用する getPost() 関数を使うか
      * [TODO] 現在（2021/11/10）は、管理者がアップしたファイルも、編集者が削除できるため、getPost()は使わない設定にする。
      *        今後自分がアップしたファイルのみ削除できるように見直しする想定で、その時は getPost()を使うと予想。
@@ -65,7 +70,7 @@ class CabinetsPlugin extends UserPluginBase
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
         $functions = array();
-        $functions['get']  = ['index', 'download', 'changeDirectory'];
+        $functions['get']  = ['index', 'show', 'download', 'changeDirectory'];
         $functions['post'] = ['makeFolder', 'upload', 'deleteContents', 'rename', 'move'];
         return $functions;
     }
@@ -92,6 +97,39 @@ class CabinetsPlugin extends UserPluginBase
     {
         // プラグインのメインデータを取得する。
         return Cabinet::firstOrNew(['bucket_id' => $bucket_id]);
+    }
+
+    /* スタティック関数 */
+
+    /**
+     * 新着情報用メソッド
+     */
+    public static function getWhatsnewArgs()
+    {
+        $return[] = DB::table('cabinet_contents')
+                      ->select(
+                          'frames.page_id             as page_id',
+                          'frames.id                  as frame_id',
+                          'cabinet_contents.id        as post_id',
+                          'cabinet_contents.name      as post_title',
+                          'cabinet_contents.comment   as post_detail',
+                          DB::raw("null               as important"),
+                          DB::raw('COALESCE(cabinet_contents.updated_at, cabinet_contents.created_at) as posted_at'),
+                          'cabinet_contents.created_name as posted_name',
+                          DB::raw("null               as classname"),
+                          DB::raw("null               as category"),
+                          DB::raw('"cabinets"         as plugin_name')
+                      )
+                      ->join('cabinets', 'cabinets.id', '=', 'cabinet_contents.cabinet_id')
+                      ->join('frames', 'frames.bucket_id', '=', 'cabinets.bucket_id')
+                      ->where('frames.disable_whatsnews', 0)
+                      ->whereNotNull('cabinet_contents.parent_id')
+                      ->whereNull('cabinet_contents.deleted_at');
+
+        $return[] = 'show_page_frame_post';
+        $return[] = '/plugin/cabinets/show';
+
+        return $return;
     }
 
     /* 画面アクション関数 */
@@ -169,6 +207,32 @@ class CabinetsPlugin extends UserPluginBase
             'parent_id' =>  $parent->id,
             'folders_tree' => $folders_tree,
         ]);
+    }
+
+    /**
+     * 新着情報からキャビネットコンテンツへ遷移する
+     *
+     * @param \Illuminate\Http\Request $request リクエスト
+     * @param int $page_id ページID
+     * @param int $frame_id フレームID
+     * @param int $cabinet_content_id キャビネットコンテンツID
+     */
+    public function show($request, $page_id, $frame_id, $cabinet_content_id)
+    {
+        $cabinet = $this->getPluginBucket($this->frame->bucket_id);
+        $cabinet_content = CabinetContent::where('id', $cabinet_content_id)
+            ->where('cabinet_id', $cabinet->id)
+            ->first();
+
+        if (empty($cabinet_content)) {
+            abort(404, 'コンテンツがありません。');
+        }
+
+        $parent_id = $cabinet_content->is_folder == CabinetContent::is_folder_on
+            ? $cabinet_content->id
+            : $cabinet_content->parent_id;
+
+        return $this->index($request, $page_id, $frame_id, $parent_id);
     }
 
     /**

--- a/app/Plugins/User/Calendars/CalendarsPlugin.php
+++ b/app/Plugins/User/Calendars/CalendarsPlugin.php
@@ -40,6 +40,11 @@ class CalendarsPlugin extends UserPluginBase
     /* オブジェクト変数 */
 
     /**
+     * 新着機能を使うか
+     */
+    public $use_whatsnew = true;
+
+    /**
      * 変更時のPOSTデータ
      */
     public $post = null;
@@ -154,23 +159,25 @@ class CalendarsPlugin extends UserPluginBase
     public static function getWhatsnewArgs()
     {
         // 戻り値('sql_method'、'link_pattern'、'link_base')
-        $return[] = DB::table('calendars_posts')
+        $return[] = DB::table('calendar_posts')
                       ->select(
-                          'frames.page_id           as page_id',
-                          'frames.id                as frame_id',
-                          'calendars_posts.id           as post_id',
-                          'calendars_posts.title        as post_title',
-                          DB::raw("null             as important"),
-                          'calendars_posts.created_at   as posted_at',
-                          'calendars_posts.created_name as posted_name',
-                          DB::raw("null             as classname"),
-                          DB::raw("null             as category"),
+                          'frames.page_id              as page_id',
+                          'frames.id                   as frame_id',
+                          'calendar_posts.id           as post_id',
+                          'calendar_posts.title        as post_title',
+                          'calendar_posts.body         as post_detail',
+                          DB::raw("null                as important"),
+                          'calendar_posts.created_at   as posted_at',
+                          'calendar_posts.created_name as posted_name',
+                          DB::raw("null                as classname"),
+                          DB::raw("null                as category"),
                           DB::raw('"calendars"          as plugin_name')
                       )
-                      ->join('calendars', 'calendars.id', '=', 'calendars_posts.calendars_id')
+                      ->join('calendars', 'calendars.id', '=', 'calendar_posts.calendar_id')
                       ->join('frames', 'frames.bucket_id', '=', 'calendars.bucket_id')
                       ->where('frames.disable_whatsnews', 0)
-                      ->whereNull('calendars_posts.deleted_at');
+                      ->where('calendar_posts.status', StatusType::active)
+                      ->whereNull('calendar_posts.deleted_at');
 
         $return[] = 'show_page_frame_post';
         $return[] = '/plugin/calendars/show';

--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
@@ -50,6 +51,11 @@ class PhotoalbumsPlugin extends UserPluginBase
     */
 
     /* オブジェクト変数 */
+    /**
+     * 新着機能を使うか
+     */
+    public $use_whatsnew = true;
+
     // ファイルダウンロードURL
     private $download_url = '';
 
@@ -67,7 +73,7 @@ class PhotoalbumsPlugin extends UserPluginBase
     {
         // 標準関数以外で画面などから呼ばれる関数の定義
         $functions = array();
-        $functions['get']  = ['index', 'download', 'changeDirectory', 'embed', 'detail', 'moreContents'];
+        $functions['get']  = ['index', 'show', 'download', 'changeDirectory', 'embed', 'detail', 'moreContents'];
         $functions['post'] = ['makeFolder', 'editFolder', 'upload', 'uploadVideo', 'editContents', 'editVideo', 'deleteContents', 'updateViewSequence', 'updateHiddenFolders'];
         return $functions;
     }
@@ -103,6 +109,40 @@ class PhotoalbumsPlugin extends UserPluginBase
     {
         // プラグインのメインデータを取得する。
         return Photoalbum::firstOrNew(['bucket_id' => $bucket_id]);
+    }
+
+    /* スタティック関数 */
+
+    /**
+     * 新着情報用メソッド
+     */
+    public static function getWhatsnewArgs()
+    {
+        $return[] = DB::table('photoalbum_contents')
+                      ->select(
+                          'frames.page_id                  as page_id',
+                          'frames.id                       as frame_id',
+                          'photoalbum_contents.id          as post_id',
+                          DB::raw("COALESCE(NULLIF(photoalbum_contents.name, ''), uploads.client_original_name) as post_title"),
+                          'photoalbum_contents.description as post_detail',
+                          DB::raw("null                    as important"),
+                          DB::raw('COALESCE(photoalbum_contents.updated_at, photoalbum_contents.created_at) as posted_at'),
+                          'photoalbum_contents.created_name as posted_name',
+                          DB::raw("null                    as classname"),
+                          DB::raw("null                    as category"),
+                          DB::raw('"photoalbums"           as plugin_name')
+                      )
+                      ->join('photoalbums', 'photoalbums.id', '=', 'photoalbum_contents.photoalbum_id')
+                      ->join('frames', 'frames.bucket_id', '=', 'photoalbums.bucket_id')
+                      ->leftJoin('uploads', 'uploads.id', '=', 'photoalbum_contents.upload_id')
+                      ->where('frames.disable_whatsnews', 0)
+                      ->whereNotNull('photoalbum_contents.parent_id')
+                      ->whereNull('photoalbum_contents.deleted_at');
+
+        $return[] = 'show_page_frame_post';
+        $return[] = '/plugin/photoalbums/show';
+
+        return $return;
     }
 
     /* 画面アクション関数 */
@@ -159,6 +199,44 @@ class PhotoalbumsPlugin extends UserPluginBase
             'parent_id' =>  $parent->id,
             'covers' => $covers,
         ], $index_display_items));
+    }
+
+    /**
+     * 新着情報からフォトアルバムコンテンツへ遷移する
+     *
+     * @param \Illuminate\Http\Request $request リクエスト
+     * @param int $page_id ページID
+     * @param int $frame_id フレームID
+     * @param int $photoalbum_content_id フォトアルバムコンテンツID
+     */
+    public function show($request, $page_id, $frame_id, $photoalbum_content_id)
+    {
+        $photoalbum = $this->getPluginBucket($this->frame->bucket_id);
+        $photoalbum_content = PhotoalbumContent::where('id', $photoalbum_content_id)
+            ->where('photoalbum_id', $photoalbum->id)
+            ->first();
+
+        if (empty($photoalbum_content)) {
+            abort(404, 'コンテンツがありません。');
+        }
+
+        $hidden_folder_ids = $this->getHiddenFolderIds($this->frame_configs);
+        if (!empty($hidden_folder_ids)) {
+            $ancestors = PhotoalbumContent::ancestorsAndSelf($photoalbum_content->id);
+            if ($this->isHiddenPhotoalbumContent($photoalbum_content, $hidden_folder_ids, $ancestors->keyBy('id'))) {
+                abort(404, 'コンテンツがありません。');
+            }
+        }
+
+        if ($photoalbum_content->is_folder == PhotoalbumContent::is_folder_on) {
+            return $this->index($request, $page_id, $frame_id, $photoalbum_content->id);
+        }
+
+        if ($photoalbum_content->isVideo($photoalbum_content->mimetype)) {
+            return $this->detail($request, $page_id, $frame_id, $photoalbum_content->id);
+        }
+
+        return $this->index($request, $page_id, $frame_id, $photoalbum_content->parent_id);
     }
 
     /**

--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -118,31 +118,160 @@ class PhotoalbumsPlugin extends UserPluginBase
      */
     public static function getWhatsnewArgs()
     {
-        $return[] = DB::table('photoalbum_contents')
-                      ->select(
-                          'frames.page_id                  as page_id',
-                          'frames.id                       as frame_id',
-                          'photoalbum_contents.id          as post_id',
-                          DB::raw("COALESCE(NULLIF(photoalbum_contents.name, ''), uploads.client_original_name) as post_title"),
-                          'photoalbum_contents.description as post_detail',
-                          DB::raw("null                    as important"),
-                          DB::raw('COALESCE(photoalbum_contents.updated_at, photoalbum_contents.created_at) as posted_at'),
-                          'photoalbum_contents.created_name as posted_name',
-                          DB::raw("null                    as classname"),
-                          DB::raw("null                    as category"),
-                          DB::raw('"photoalbums"           as plugin_name')
-                      )
-                      ->join('photoalbums', 'photoalbums.id', '=', 'photoalbum_contents.photoalbum_id')
-                      ->join('frames', 'frames.bucket_id', '=', 'photoalbums.bucket_id')
-                      ->leftJoin('uploads', 'uploads.id', '=', 'photoalbum_contents.upload_id')
-                      ->where('frames.disable_whatsnews', 0)
-                      ->whereNotNull('photoalbum_contents.parent_id')
-                      ->whereNull('photoalbum_contents.deleted_at');
+        $query = self::buildWhatsnewQuery();
+        $hidden_folder_ids_by_frame = self::getHiddenFolderIdsByFrame();
+        $hidden_content_ids_by_frame = self::resolveHiddenContentIdsByFrame($hidden_folder_ids_by_frame);
 
-        $return[] = 'show_page_frame_post';
-        $return[] = '/plugin/photoalbums/show';
+        self::excludeHiddenContentIdsByFrame($query, $hidden_content_ids_by_frame);
 
-        return $return;
+        return [
+            $query,
+            'show_page_frame_post',
+            '/plugin/photoalbums/show',
+        ];
+    }
+
+    /**
+     * 新着情報の基本クエリを作成する。
+     */
+    private static function buildWhatsnewQuery()
+    {
+        return DB::table('photoalbum_contents')
+            ->select(
+                'frames.page_id                  as page_id',
+                'frames.id                       as frame_id',
+                'photoalbum_contents.id          as post_id',
+                DB::raw("COALESCE(NULLIF(photoalbum_contents.name, ''), uploads.client_original_name) as post_title"),
+                'photoalbum_contents.description as post_detail',
+                DB::raw("null                    as important"),
+                DB::raw('COALESCE(photoalbum_contents.updated_at, photoalbum_contents.created_at) as posted_at'),
+                'photoalbum_contents.created_name as posted_name',
+                DB::raw("null                    as classname"),
+                DB::raw("null                    as category"),
+                DB::raw('"photoalbums"           as plugin_name')
+            )
+            ->join('photoalbums', 'photoalbums.id', '=', 'photoalbum_contents.photoalbum_id')
+            ->join('frames', 'frames.bucket_id', '=', 'photoalbums.bucket_id')
+            ->leftJoin('uploads', 'uploads.id', '=', 'photoalbum_contents.upload_id')
+            ->where('frames.disable_whatsnews', 0)
+            ->whereNotNull('photoalbum_contents.parent_id')
+            ->whereNull('photoalbum_contents.deleted_at');
+    }
+
+    /**
+     * フレームごとの非表示アルバムIDを取得する。
+     */
+    private static function getHiddenFolderIdsByFrame(): array
+    {
+        $frame_configs = request()->attributes->get('frame_configs');
+        if (empty($frame_configs)) {
+            $frame_configs = FrameConfig::where('name', PhotoalbumFrameConfig::hidden_folder_ids)->get();
+        } else {
+            $frame_configs = $frame_configs->where('name', PhotoalbumFrameConfig::hidden_folder_ids);
+        }
+
+        $hidden_folder_ids_by_frame = [];
+        foreach ($frame_configs as $frame_config) {
+            $hidden_folder_ids = self::parseHiddenFolderIds($frame_config->value);
+            if (empty($hidden_folder_ids)) {
+                continue;
+            }
+
+            $frame_id = (int) $frame_config->frame_id;
+            $hidden_folder_ids_by_frame[$frame_id] = array_values(array_unique(array_merge(
+                $hidden_folder_ids_by_frame[$frame_id] ?? [],
+                $hidden_folder_ids
+            )));
+        }
+
+        return $hidden_folder_ids_by_frame;
+    }
+
+    /**
+     * フレームごとの非表示アルバムIDを、配下コンテンツIDへ展開する。
+     */
+    private static function resolveHiddenContentIdsByFrame(array $hidden_folder_ids_by_frame): array
+    {
+        if (empty($hidden_folder_ids_by_frame)) {
+            return [];
+        }
+
+        $hidden_folder_ids = array_values(array_unique(array_merge(...array_values($hidden_folder_ids_by_frame))));
+        $hidden_folders = PhotoalbumContent::whereIn('id', $hidden_folder_ids)
+            ->where('is_folder', PhotoalbumContent::is_folder_on)
+            ->whereNull('deleted_at')
+            ->get(['id', 'photoalbum_id', '_lft', '_rgt'])
+            ->keyBy('id');
+
+        $hidden_content_ids_by_frame = [];
+        foreach ($hidden_folder_ids_by_frame as $frame_id => $folder_ids) {
+            $content_ids = [];
+            foreach ($folder_ids as $folder_id) {
+                $folder = $hidden_folders->get($folder_id);
+                if (empty($folder)) {
+                    continue;
+                }
+
+                $content_ids = array_merge($content_ids, self::getDescendantPhotoalbumContentIds($folder));
+            }
+
+            if (!empty($content_ids)) {
+                $hidden_content_ids_by_frame[$frame_id] = array_values(array_unique($content_ids));
+            }
+        }
+
+        return $hidden_content_ids_by_frame;
+    }
+
+    /**
+     * パイプ区切りの非表示アルバムIDを配列に変換する。
+     */
+    private static function parseHiddenFolderIds($value): array
+    {
+        $ids = explode(FrameConfig::CHECKBOX_SEPARATOR, (string) $value);
+        $ids = array_map('intval', $ids);
+        $ids = array_filter($ids, static function ($id) {
+            return $id > 0;
+        });
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * 非表示アルバム自身と配下コンテンツのIDを取得する。
+     */
+    private static function getDescendantPhotoalbumContentIds(PhotoalbumContent $folder): array
+    {
+        return PhotoalbumContent::where('photoalbum_id', $folder->photoalbum_id)
+            ->whereNotNull('parent_id')
+            ->whereNull('deleted_at')
+            ->where('_lft', '>=', $folder->_lft)
+            ->where('_rgt', '<=', $folder->_rgt)
+            ->pluck('id')
+            ->all();
+    }
+
+    /**
+     * フレームごとの非表示コンテンツIDを新着取得条件から除外する。
+     */
+    private static function excludeHiddenContentIdsByFrame($query, array $hidden_content_ids_by_frame): void
+    {
+        if (empty($hidden_content_ids_by_frame)) {
+            return;
+        }
+
+        $query->where(function ($query) use ($hidden_content_ids_by_frame) {
+            foreach ($hidden_content_ids_by_frame as $frame_id => $content_ids) {
+                if (empty($content_ids)) {
+                    continue;
+                }
+
+                $query->where(function ($query) use ($frame_id, $content_ids) {
+                    $query->where('frames.id', '!=', $frame_id)
+                          ->orWhereNotIn('photoalbum_contents.id', $content_ids);
+                });
+            }
+        });
     }
 
     /* 画面アクション関数 */

--- a/tests/Feature/Plugins/User/Whatsnews/WhatsnewsTargetPluginsFeatureTest.php
+++ b/tests/Feature/Plugins/User/Whatsnews/WhatsnewsTargetPluginsFeatureTest.php
@@ -3,10 +3,12 @@
 namespace Tests\Feature\Plugins\User\Whatsnews;
 
 use App\Enums\ContentOpenType;
+use App\Enums\PhotoalbumFrameConfig;
 use App\Models\Common\Buckets;
 use App\Models\Common\Frame;
 use App\Models\Common\Page;
 use App\Models\Common\Uploads;
+use App\Models\Core\FrameConfig;
 use App\Models\User\Cabinets\Cabinet;
 use App\Models\User\Cabinets\CabinetContent;
 use App\Models\User\Calendars\Calendar;
@@ -121,6 +123,60 @@ class WhatsnewsTargetPluginsFeatureTest extends TestCase
         $this->assertNotInstanceOf(\Illuminate\Http\RedirectResponse::class, $response);
         $this->assertSame('plugins.user.photoalbums.default.index', $response->getName());
         $this->assertTrue($response->getData()['photoalbum_image_items']->contains('id', $content->id));
+    }
+
+    /**
+     * フォトアルバムの非表示アルバムと配下の写真が、新着情報に表示されないこと。
+     */
+    public function testPhotoalbumWhatsnewRowsExcludeHiddenFolderContents(): void
+    {
+        [$page, $bucket, $frame] = $this->createPluginFrame('photoalbums');
+
+        $photoalbum = Photoalbum::create([
+            'bucket_id' => $bucket->id,
+            'name' => 'Test Photoalbum',
+            'image_upload_max_size' => 1024,
+            'image_upload_max_px' => 1024,
+            'video_upload_max_size' => 1024,
+        ]);
+
+        $root = PhotoalbumContent::create([
+            'photoalbum_id' => $photoalbum->id,
+            'upload_id' => null,
+            'poster_upload_id' => null,
+            'name' => $photoalbum->name,
+            'is_folder' => PhotoalbumContent::is_folder_on,
+            'parent_id' => null,
+        ]);
+
+        $hidden_folder = $root->children()->create([
+            'photoalbum_id' => $photoalbum->id,
+            'upload_id' => null,
+            'poster_upload_id' => null,
+            'name' => '非表示アルバム',
+            'is_folder' => PhotoalbumContent::is_folder_on,
+            'is_cover' => PhotoalbumContent::is_cover_off,
+        ]);
+
+        $this->createPhotoalbumImageContent($page, $root, '公開写真', '公開写真の説明です。');
+        $this->createPhotoalbumImageContent($page, $hidden_folder, '非表示写真', '非表示写真の説明です。');
+
+        FrameConfig::create([
+            'frame_id' => $frame->id,
+            'name' => PhotoalbumFrameConfig::hidden_folder_ids,
+            'value' => (string) $hidden_folder->id,
+        ]);
+
+        [$photoalbum_query] = PhotoalbumsPlugin::getWhatsnewArgs();
+
+        $post_titles = $photoalbum_query
+            ->where('frames.id', $frame->id)
+            ->pluck('post_title')
+            ->all();
+
+        $this->assertContains('公開写真', $post_titles);
+        $this->assertNotContains('非表示アルバム', $post_titles);
+        $this->assertNotContains('非表示写真', $post_titles);
     }
 
     /**
@@ -261,6 +317,37 @@ class WhatsnewsTargetPluginsFeatureTest extends TestCase
 
         return $root->children()->create([
             'photoalbum_id' => $photoalbum->id,
+            'upload_id' => $upload->id,
+            'poster_upload_id' => null,
+            'name' => $name,
+            'description' => $description,
+            'is_folder' => PhotoalbumContent::is_folder_off,
+            'is_cover' => PhotoalbumContent::is_cover_off,
+            'mimetype' => 'image/jpeg',
+        ]);
+    }
+
+    /**
+     * 指定したアルバム配下に新着対象の画像を作成する。
+     */
+    private function createPhotoalbumImageContent(
+        Page $page,
+        PhotoalbumContent $parent,
+        string $name,
+        string $description
+    ): PhotoalbumContent {
+        $upload = Uploads::create([
+            'client_original_name' => "{$name}.jpg",
+            'mimetype' => 'image/jpeg',
+            'extension' => 'jpg',
+            'size' => 123,
+            'plugin_name' => 'photoalbums',
+            'page_id' => $page->id,
+            'temporary_flag' => 0,
+        ]);
+
+        return $parent->children()->create([
+            'photoalbum_id' => $parent->photoalbum_id,
             'upload_id' => $upload->id,
             'poster_upload_id' => null,
             'name' => $name,

--- a/tests/Feature/Plugins/User/Whatsnews/WhatsnewsTargetPluginsFeatureTest.php
+++ b/tests/Feature/Plugins/User/Whatsnews/WhatsnewsTargetPluginsFeatureTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Whatsnews;
+
+use App\Enums\ContentOpenType;
+use App\Models\Common\Buckets;
+use App\Models\Common\Frame;
+use App\Models\Common\Page;
+use App\Models\Common\Uploads;
+use App\Models\User\Cabinets\Cabinet;
+use App\Models\User\Cabinets\CabinetContent;
+use App\Models\User\Calendars\Calendar;
+use App\Models\User\Calendars\CalendarPost;
+use App\Models\User\Photoalbums\Photoalbum;
+use App\Models\User\Photoalbums\PhotoalbumContent;
+use App\Plugins\User\Cabinets\CabinetsPlugin;
+use App\Plugins\User\Calendars\CalendarsPlugin;
+use App\Plugins\User\Photoalbums\PhotoalbumsPlugin;
+use App\Plugins\User\Whatsnews\WhatsnewTargetPluginTool;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * 新着情報の対象プラグイン追加を検証する。
+ *
+ * 設定画面に表示される対象プラグイン一覧と、各プラグインが公開する新着用クエリの契約を検証する。
+ * 新着情報本体の描画ではなく、対象追加によって壊れやすい境界を公開メソッド経由で確認する方針。
+ */
+class WhatsnewsTargetPluginsFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 各テストでプラグイン一覧などの初期データを使えるようにする。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    /**
+     * キャビネット・カレンダー・フォトアルバムが、新着情報設定の対象プラグインとして選択できること。
+     */
+    public function testTargetPluginsIncludeCabinetsCalendarsAndPhotoalbums(): void
+    {
+        $target_plugins = WhatsnewTargetPluginTool::getMembers();
+
+        $this->assertArrayHasKey('cabinets', $target_plugins);
+        $this->assertArrayHasKey('calendars', $target_plugins);
+        $this->assertArrayHasKey('photoalbums', $target_plugins);
+    }
+
+    /**
+     * 追加対象の各プラグインが、新着情報の共通列を持つ公開済みコンテンツを返すこと。
+     */
+    public function testAddedPluginsReturnWhatsnewRows(): void
+    {
+        $this->createCabinetContent('学校だより.pdf', '学校だよりをアップしました。');
+        $this->createCalendarPost('授業参観', '授業参観のお知らせです。');
+        $this->createPhotoalbumContent('遠足写真', '遠足の写真です。');
+
+        [$cabinet_query, $cabinet_link_pattern, $cabinet_link_base] = CabinetsPlugin::getWhatsnewArgs();
+        [$calendar_query, $calendar_link_pattern, $calendar_link_base] = CalendarsPlugin::getWhatsnewArgs();
+        [$photoalbum_query, $photoalbum_link_pattern, $photoalbum_link_base] = PhotoalbumsPlugin::getWhatsnewArgs();
+
+        $cabinet_row = $cabinet_query->where('cabinet_contents.name', '学校だより.pdf')->first();
+        $calendar_row = $calendar_query->where('calendar_posts.title', '授業参観')->first();
+        $photoalbum_row = $photoalbum_query->where('photoalbum_contents.name', '遠足写真')->first();
+
+        $this->assertSame('show_page_frame_post', $cabinet_link_pattern);
+        $this->assertSame('/plugin/cabinets/show', $cabinet_link_base);
+        $this->assertSame('cabinets', $cabinet_row->plugin_name);
+        $this->assertSame('学校だより.pdf', $cabinet_row->post_title);
+        $this->assertSame('学校だよりをアップしました。', $cabinet_row->post_detail);
+
+        $this->assertSame('show_page_frame_post', $calendar_link_pattern);
+        $this->assertSame('/plugin/calendars/show', $calendar_link_base);
+        $this->assertSame('calendars', $calendar_row->plugin_name);
+        $this->assertSame('授業参観', $calendar_row->post_title);
+        $this->assertSame('授業参観のお知らせです。', $calendar_row->post_detail);
+
+        $this->assertSame('show_page_frame_post', $photoalbum_link_pattern);
+        $this->assertSame('/plugin/photoalbums/show', $photoalbum_link_base);
+        $this->assertSame('photoalbums', $photoalbum_row->plugin_name);
+        $this->assertSame('遠足写真', $photoalbum_row->post_title);
+        $this->assertSame('遠足の写真です。', $photoalbum_row->post_detail);
+    }
+
+    /**
+     * キャビネットの新着リンク先アクションが、リダイレクトレスポンスではなく表示画面を返すこと。
+     */
+    public function testCabinetWhatsnewLinkTargetReturnsViewWithoutRedirectResponse(): void
+    {
+        $content = $this->createCabinetContent('学校だより.pdf', '学校だよりをアップしました。');
+        $frame = $this->getFrameByBucketId(Cabinet::find($content->cabinet_id)->bucket_id);
+        \Request::merge(['frame_configs' => new \Illuminate\Database\Eloquent\Collection()]);
+        $plugin = new CabinetsPlugin(Page::find($frame->page_id), $frame, Page::defaultOrder()->get());
+
+        $response = $plugin->show(request(), $frame->page_id, $frame->id, $content->id);
+
+        $this->assertInstanceOf(\Illuminate\View\View::class, $response);
+        $this->assertNotInstanceOf(\Illuminate\Http\RedirectResponse::class, $response);
+        $this->assertSame('plugins.user.cabinets.default.index', $response->getName());
+        $this->assertTrue($response->getData()['cabinet_contents']->contains('id', $content->id));
+    }
+
+    /**
+     * フォトアルバムの新着リンク先アクションが、リダイレクトレスポンスではなく表示画面を返すこと。
+     */
+    public function testPhotoalbumWhatsnewLinkTargetReturnsViewWithoutRedirectResponse(): void
+    {
+        $content = $this->createPhotoalbumContent('遠足写真', '遠足の写真です。');
+        $frame = $this->getFrameByBucketId(Photoalbum::find($content->photoalbum_id)->bucket_id);
+        \Request::merge(['frame_configs' => new \Illuminate\Database\Eloquent\Collection()]);
+        $plugin = new PhotoalbumsPlugin(Page::find($frame->page_id), $frame, Page::defaultOrder()->get());
+
+        $response = $plugin->show(request(), $frame->page_id, $frame->id, $content->id);
+
+        $this->assertInstanceOf(\Illuminate\View\View::class, $response);
+        $this->assertNotInstanceOf(\Illuminate\Http\RedirectResponse::class, $response);
+        $this->assertSame('plugins.user.photoalbums.default.index', $response->getName());
+        $this->assertTrue($response->getData()['photoalbum_image_items']->contains('id', $content->id));
+    }
+
+    /**
+     * 指定プラグイン用のページ・バケツ・フレームをまとめて作成する。
+     */
+    private function createPluginFrame(string $plugin_name): array
+    {
+        $page = Page::factory()->create([
+            'permanent_link' => "/test-{$plugin_name}",
+        ]);
+
+        $bucket = Buckets::factory()->create([
+            'bucket_name' => "Test {$plugin_name}",
+            'plugin_name' => $plugin_name,
+        ]);
+
+        $frame = Frame::factory()->create([
+            'page_id' => $page->id,
+            'area_id' => 2,
+            'frame_title' => "Test {$plugin_name}",
+            'plugin_name' => $plugin_name,
+            'plug_name' => $plugin_name,
+            'bucket_id' => $bucket->id,
+            'content_open_type' => ContentOpenType::always_open,
+        ]);
+
+        return [$page, $bucket, $frame];
+    }
+
+    /**
+     * 指定バケツを配置しているフレームを取得する。
+     */
+    private function getFrameByBucketId(int $bucket_id): Frame
+    {
+        return Frame::where('bucket_id', $bucket_id)->firstOrFail();
+    }
+
+    /**
+     * キャビネットに新着対象のファイルを作成する。
+     */
+    private function createCabinetContent(string $name, string $comment): CabinetContent
+    {
+        [$page, $bucket] = $this->createPluginFrame('cabinets');
+
+        $cabinet = Cabinet::create([
+            'bucket_id' => $bucket->id,
+            'name' => 'Test Cabinet',
+            'upload_max_size' => 1024,
+        ]);
+
+        $root = CabinetContent::create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => null,
+            'name' => $cabinet->name,
+            'is_folder' => CabinetContent::is_folder_on,
+            'parent_id' => null,
+        ]);
+
+        $upload = Uploads::create([
+            'client_original_name' => $name,
+            'mimetype' => 'application/pdf',
+            'extension' => 'pdf',
+            'size' => 123,
+            'plugin_name' => 'cabinets',
+            'page_id' => $page->id,
+            'temporary_flag' => 0,
+        ]);
+
+        $content = $root->children()->create([
+            'cabinet_id' => $cabinet->id,
+            'upload_id' => $upload->id,
+            'name' => $name,
+            'is_folder' => CabinetContent::is_folder_off,
+        ]);
+        $content->comment = $comment;
+        $content->save();
+
+        return $content;
+    }
+
+    /**
+     * カレンダーに新着対象の予定を作成する。
+     */
+    private function createCalendarPost(string $title, string $body): CalendarPost
+    {
+        [, $bucket] = $this->createPluginFrame('calendars');
+
+        $calendar = Calendar::create([
+            'bucket_id' => $bucket->id,
+            'name' => 'Test Calendar',
+        ]);
+
+        return CalendarPost::create([
+            'calendar_id' => $calendar->id,
+            'allday_flag' => 1,
+            'start_date' => now()->toDateString(),
+            'start_time' => '00:00:00',
+            'end_date' => now()->toDateString(),
+            'end_time' => '23:59:59',
+            'title' => $title,
+            'body' => $body,
+        ]);
+    }
+
+    /**
+     * フォトアルバムに新着対象の画像を作成する。
+     */
+    private function createPhotoalbumContent(string $name, string $description): PhotoalbumContent
+    {
+        [$page, $bucket] = $this->createPluginFrame('photoalbums');
+
+        $photoalbum = Photoalbum::create([
+            'bucket_id' => $bucket->id,
+            'name' => 'Test Photoalbum',
+            'image_upload_max_size' => 1024,
+            'image_upload_max_px' => 1024,
+            'video_upload_max_size' => 1024,
+        ]);
+
+        $root = PhotoalbumContent::create([
+            'photoalbum_id' => $photoalbum->id,
+            'upload_id' => null,
+            'poster_upload_id' => null,
+            'name' => $photoalbum->name,
+            'is_folder' => PhotoalbumContent::is_folder_on,
+            'parent_id' => null,
+        ]);
+
+        $upload = Uploads::create([
+            'client_original_name' => "{$name}.jpg",
+            'mimetype' => 'image/jpeg',
+            'extension' => 'jpg',
+            'size' => 123,
+            'plugin_name' => 'photoalbums',
+            'page_id' => $page->id,
+            'temporary_flag' => 0,
+        ]);
+
+        return $root->children()->create([
+            'photoalbum_id' => $photoalbum->id,
+            'upload_id' => $upload->id,
+            'poster_upload_id' => null,
+            'name' => $name,
+            'description' => $description,
+            'is_folder' => PhotoalbumContent::is_folder_off,
+            'is_cover' => PhotoalbumContent::is_cover_off,
+            'mimetype' => 'image/jpeg',
+        ]);
+    }
+}


### PR DESCRIPTION
# 概要

キャビネット、カレンダー、フォトアルバムの投稿・コンテンツを新着情報に表示できるようにしました。

## 変更内容
- キャビネット、カレンダー、フォトアルバムを新着情報の対象プラグインに追加しました。
- 各プラグインに新着情報用の取得処理を追加しました。
- 新着情報の対象一覧と取得内容を確認するFeatureテストを追加しました。

## 背景と目的
学校だよりなどのファイル追加や、カレンダー予定、フォトアルバムの追加内容を利用者が新着情報から確認できるようにするためです。

## 特記事項
キャビネットは対象ファイルの親フォルダ、または対象フォルダの一覧画面を表示します。
フォトアルバムは画像の場合は親フォルダ一覧、フォルダの場合は対象フォルダ一覧、動画の場合は詳細画面を表示します。
フォトアルバムの説明は、新着情報の本文として扱います。

# レビュー完了希望日


# 関連Pull requests/Issues
なし

# 参考


# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule