### PR TITLE
[コア][MS365メール認証] 添付ファイル付き送信時に本文が添付ファイルの中身で上書きされる不具合を修正しました

### DIFF
--- a/app/Mail/Transport/MicrosoftGraphTransport.php
+++ b/app/Mail/Transport/MicrosoftGraphTransport.php
@@ -194,6 +194,10 @@ class MicrosoftGraphTransport extends Transport
     /**
      * メール本文を取得
      *
+     * 本文パートと添付ファイルは同じ children に並ぶため、
+     * Swift_Attachment は本文候補から除外する。
+     * （除外しないと text/html や text/plain の添付ファイルの中身が本文として返ってしまう）
+     *
      * @param Swift_Mime_SimpleMessage $message
      * @return string
      */
@@ -204,12 +208,18 @@ class MicrosoftGraphTransport extends Transport
         // マルチパートの場合、HTMLパートを優先
         if ($message->getChildren()) {
             foreach ($message->getChildren() as $child) {
+                if ($child instanceof \Swift_Attachment) {
+                    continue;
+                }
                 if (strpos($child->getContentType(), self::CONTENT_TYPE_HTML) !== false) {
                     return $child->getBody();
                 }
             }
             // HTMLが見つからなければテキストパート
             foreach ($message->getChildren() as $child) {
+                if ($child instanceof \Swift_Attachment) {
+                    continue;
+                }
                 if (strpos($child->getContentType(), self::CONTENT_TYPE_PLAIN) !== false) {
                     return $child->getBody();
                 }

--- a/tests/Unit/Mail/Transport/MicrosoftGraphTransportTest.php
+++ b/tests/Unit/Mail/Transport/MicrosoftGraphTransportTest.php
@@ -695,4 +695,100 @@ class MicrosoftGraphTransportTest extends TestCase
         // 添付ファイルがない場合はattachmentsキーが存在しない
         $this->assertArrayNotHasKey('attachments', $graph_message);
     }
+
+    /**
+     * 本文取得テスト：HTML添付ファイルは本文として採用されない
+     *
+     * text/html な Swift_Attachment が children に含まれていても、
+     * 本文パート（text/plain の MimePart）が優先されること。
+     */
+    public function testGetBodyIgnoresHtmlAttachment(): void
+    {
+        // 本文パート（text/plain）
+        $text_part = $this->createMock(\Swift_Mime_MimePart::class);
+        $text_part->method('getContentType')->willReturn('text/plain');
+        $text_part->method('getBody')->willReturn('テキスト本文');
+
+        // 添付ファイル（text/html）
+        $html_attachment = $this->createMock(\Swift_Attachment::class);
+        $html_attachment->method('getContentType')->willReturn('text/html');
+        $html_attachment->method('getBody')->willReturn('<html>添付HTMLの中身</html>');
+
+        // メッセージのモック（本文 + HTML添付）
+        $message = $this->createMock(Swift_Mime_SimpleMessage::class);
+        $message->method('getBody')->willReturn('デフォルト本文');
+        $message->method('getChildren')->willReturn([$text_part, $html_attachment]);
+
+        $reflection = new \ReflectionClass($this->transport);
+        $method = $reflection->getMethod('getBody');
+        $method->setAccessible(true);
+
+        $body = $method->invoke($this->transport, $message);
+
+        // HTML添付の中身ではなく、本文パートのテキストが返ること
+        $this->assertEquals('テキスト本文', $body);
+    }
+
+    /**
+     * 本文取得テスト：テキスト添付ファイルは本文として採用されない
+     *
+     * text/plain な Swift_Attachment が children に含まれていても、
+     * 本文パート（text/html の MimePart）が優先されること。
+     */
+    public function testGetBodyIgnoresTextAttachment(): void
+    {
+        // 本文パート（text/html）
+        $html_part = $this->createMock(\Swift_Mime_MimePart::class);
+        $html_part->method('getContentType')->willReturn('text/html');
+        $html_part->method('getBody')->willReturn('<p>HTML本文</p>');
+
+        // 添付ファイル（text/plain）
+        $text_attachment = $this->createMock(\Swift_Attachment::class);
+        $text_attachment->method('getContentType')->willReturn('text/plain');
+        $text_attachment->method('getBody')->willReturn('添付テキストの中身');
+
+        // メッセージのモック（本文 + テキスト添付）
+        $message = $this->createMock(Swift_Mime_SimpleMessage::class);
+        $message->method('getBody')->willReturn('デフォルト本文');
+        $message->method('getChildren')->willReturn([$html_part, $text_attachment]);
+
+        $reflection = new \ReflectionClass($this->transport);
+        $method = $reflection->getMethod('getBody');
+        $method->setAccessible(true);
+
+        $body = $method->invoke($this->transport, $message);
+
+        // テキスト添付の中身ではなく、本文パートのHTMLが返ること
+        $this->assertEquals('<p>HTML本文</p>', $body);
+    }
+
+    /**
+     * 本文取得テスト：children が添付ファイルのみの場合はデフォルト本文を返す
+     */
+    public function testGetBodyReturnsDefaultWhenOnlyAttachments(): void
+    {
+        // 添付ファイル1（text/html）
+        $html_attachment = $this->createMock(\Swift_Attachment::class);
+        $html_attachment->method('getContentType')->willReturn('text/html');
+        $html_attachment->method('getBody')->willReturn('<html>添付HTML</html>');
+
+        // 添付ファイル2（text/plain）
+        $text_attachment = $this->createMock(\Swift_Attachment::class);
+        $text_attachment->method('getContentType')->willReturn('text/plain');
+        $text_attachment->method('getBody')->willReturn('添付テキスト');
+
+        // メッセージのモック（本文 MimePart なし、添付のみ）
+        $message = $this->createMock(Swift_Mime_SimpleMessage::class);
+        $message->method('getBody')->willReturn('シングルパート本文');
+        $message->method('getChildren')->willReturn([$html_attachment, $text_attachment]);
+
+        $reflection = new \ReflectionClass($this->transport);
+        $method = $reflection->getMethod('getBody');
+        $method->setAccessible(true);
+
+        $body = $method->invoke($this->transport, $message);
+
+        // 添付の中身ではなく、メッセージ本体（デフォルト本文）が返ること
+        $this->assertEquals('シングルパート本文', $body);
+    }
 }


### PR DESCRIPTION
# 概要

## 背景
ユーザがファイルを添付してメール送信した場合、メール本文が添付ファイルの内容で上書きされてしまうケースが発生

## 原因
Microsoft Graph API 経由でメール送信を行う `MicrosoftGraphTransport::getBody()` が、メール本文を組み立てる際に **「添付ファイル」も本文候補として走査してしまう** ためでした。

Swift_Message の構造上、本文の `Swift_Mime_MimePart` と添付の `Swift_Attachment` が同じ `children` 配列に並びます。`getBody()` は Content-Type だけで本文を判定していたため、ユーザが `text/html` の HTML ファイルをアップロードして添付されていると、その **添付の中身が本文として返って** しまい、本来の `[[body]]` 展開済みテキストが破棄されていました。

なお、同じクラスの `convertAttachments()` 側では `if ($child instanceof \Swift_Attachment)` で添付を正しく判別しており、`getBody()` でその判別が抜けていたことが本質でした。

## 対策
`MicrosoftGraphTransport::getBody()` で `children` を走査する際に、`Swift_Attachment` を本文候補から除外するようにしました。`convertAttachments()` 側と判別条件を揃えています。

## 変更ファイル
- `app/Mail/Transport/MicrosoftGraphTransport.php` — `getBody()` の2つのループに `Swift_Attachment` 除外ガードを追加
- `tests/Unit/Mail/Transport/MicrosoftGraphTransportTest.php` — 回帰防止用のテスト3件を追加
  - `testGetBodyIgnoresHtmlAttachment`
  - `testGetBodyIgnoresTextAttachment`
  - `testGetBodyReturnsDefaultWhenOnlyAttachments`

## 影響範囲
- メールドライバが `microsoft-graph`（M365 OAuth2 連携）の環境でのみ発生。SMTP ドライバ運用には影響なし。

## 動作確認
- `php artisan test tests/Unit/Mail/Transport/MicrosoftGraphTransportTest.php` で既存22件＋新規3件の計25件すべてパス
- `composer run phpcs-any` で対象2ファイル共にクリーン
- M365 OAuth2 連携環境にて、添付ファイルあり送信を実機で行い、本文が正しく表示・文字化けが解消されることを確認済み

# レビュー完了希望日
不具合対応のため、お早めにご確認いただけると助かります。

# 関連Pull requests/Issues
特になし

# 参考
特になし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule