### PR TITLE
[カレンダー] 繰り返し予定を登録・編集・削除できるようにしました

### DIFF
--- a/app/Models/User/Calendars/CalendarPost.php
+++ b/app/Models/User/Calendars/CalendarPost.php
@@ -36,6 +36,7 @@ class CalendarPost extends Model
         'body',
         'location',
         'contact',
+        'repeat_group_id',
     ];
 
     /**

--- a/app/Plugins/User/Calendars/CalendarsPlugin.php
+++ b/app/Plugins/User/Calendars/CalendarsPlugin.php
@@ -502,8 +502,7 @@ class CalendarsPlugin extends UserPluginBase
             return new Collection([$post]);
         }
 
-        $query = CalendarPost::where('calendar_id', $post->calendar_id)
-            ->where('repeat_group_id', $post->repeat_group_id)
+        $query = $this->getRepeatPostsQuery($post)
             ->orderBy('start_date')
             ->orderBy('id');
 
@@ -520,6 +519,17 @@ class CalendarsPlugin extends UserPluginBase
         }
 
         return $query->get();
+    }
+
+    /**
+     * 権限範囲内の同一繰り返し予定を取得するクエリを返す。
+     */
+    private function getRepeatPostsQuery(CalendarPost $post)
+    {
+        $query = CalendarPost::where('calendar_id', $post->calendar_id)
+            ->where('repeat_group_id', $post->repeat_group_id);
+
+        return $this->appendAuthWhereBase($query, 'calendar_posts');
     }
 
     /**
@@ -722,8 +732,7 @@ class CalendarsPlugin extends UserPluginBase
             return [$post->id];
         }
 
-        $query = CalendarPost::where('calendar_id', $post->calendar_id)
-            ->where('repeat_group_id', $post->repeat_group_id);
+        $query = $this->getRepeatPostsQuery($post);
 
         if ($repeat_delete_type === 'after') {
             $query->where(function ($query) use ($post) {

--- a/app/Plugins/User/Calendars/CalendarsPlugin.php
+++ b/app/Plugins/User/Calendars/CalendarsPlugin.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 
 use App\Enums\StatusType;
 
@@ -37,6 +38,9 @@ use Carbon\Exceptions\Exception;
  */
 class CalendarsPlugin extends UserPluginBase
 {
+    /** 繰り返し予定の最大登録件数 */
+    private const REPEAT_MAX_OCCURRENCES = 200;
+
     /* オブジェクト変数 */
 
     /**
@@ -374,6 +378,9 @@ class CalendarsPlugin extends UserPluginBase
      */
     public function save($request, $page_id, $frame_id, $post_id = null)
     {
+        $repeat_type = $request->get('repeat_type') ?: 'none';
+        $request->merge(['repeat_type' => $repeat_type]);
+
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
             'title'      => ['required', 'max:191'],
@@ -381,6 +388,9 @@ class CalendarsPlugin extends UserPluginBase
             'location'   => ['nullable', 'max:191'],
             'contact'    => ['nullable', 'max:191'],
             'start_date' => ['required', 'date'],
+            'repeat_type' => ['nullable', 'in:none,weekly,monthly_date,monthly_weekday'],
+            'repeat_until' => ['nullable', 'required_unless:repeat_type,none', 'date'],
+            'repeat_edit_type' => ['nullable', 'in:only,after,all'],
         ]);
         $validator->setAttributeNames([
             'title'      => 'タイトル',
@@ -388,6 +398,9 @@ class CalendarsPlugin extends UserPluginBase
             'location'   => '場所',
             'contact'    => '連絡先',
             'start_date' => '開始日時',
+            'repeat_type' => '繰り返し',
+            'repeat_until' => '繰り返し終了日',
+            'repeat_edit_type' => '変更範囲',
         ]);
         // エラーがあった場合は入力画面に戻る。
         if ($validator->fails()) {
@@ -410,46 +423,248 @@ class CalendarsPlugin extends UserPluginBase
             }
         }
 
-        // POSTデータのモデル取得
-        $post = CalendarPost::firstOrNew(['id' => $post_id]);
+        $base_post = null;
+        if (!empty($post_id)) {
+            $base_post = $this->getPost($post_id);
+            if (empty($base_post->id)) {
+                return;
+            }
+        }
+
+        if ($repeat_type !== 'none' && !empty($post_id)) {
+            $validator = Validator::make($request->all(), []);
+            $validator->errors()->add('repeat_type', '繰り返し予定は新規登録時のみ設定できます。');
+            return back()->withErrors($validator)->withInput();
+        }
+
+        $repeat_dates = [$request->start_date];
+        if ($repeat_type !== 'none') {
+            if ($request->repeat_until < $request->start_date) {
+                $validator = Validator::make($request->all(), []);
+                $validator->errors()->add('repeat_until', '繰り返し終了日が開始日の前は設定できません。');
+                return back()->withErrors($validator)->withInput();
+            }
+
+            $repeat_dates = $this->getRepeatStartDates($request->start_date, $request->repeat_until, $repeat_type);
+            if (count($repeat_dates) > self::REPEAT_MAX_OCCURRENCES) {
+                $validator = Validator::make($request->all(), []);
+                $validator->errors()->add('repeat_until', '繰り返し予定は一度に' . self::REPEAT_MAX_OCCURRENCES . '件まで登録できます。');
+                return back()->withErrors($validator)->withInput();
+            }
+        }
 
         // フレームから calendar_id 取得
         $calendar_frame = $this->getPluginFrame($frame_id);
 
-        // 値のセット
-        $post->calendar_id = $calendar_frame->calendar_id;
-        $post->allday_flag = $request->get('allday_flag');
-        $post->start_date  = $request->start_date;
-        $post->start_time  = $request->start_time;
-        $post->end_date    = $request->end_date;
-        $post->end_time    = $request->end_time;
-        $post->title       = $request->title;
-        $post->body        = $this->clean($request->body);   // wysiwygのXSS対応のJavaScript等の制限
-        $post->location    = $request->location;
-        $post->contact     = $request->contact;
-
-        // bugfix: 【カレンダー】承認機能ONで一般が書き込んだ内容を、管理者が編集すると、以後その予定が一般で編集できなくなるバグ修正. created_idは UserableNohistory で自動セットするよう修正
-        // 投稿者をセット
-        // if (Auth::check()) {
-        //     $post->created_id = Auth::user()->id;
-        // }
-
         // 承認の要否確認とステータス処理
         if ($request->status == StatusType::temporary) {
-            $post->status = StatusType::temporary;  // 一時保存
+            $status = StatusType::temporary;  // 一時保存
         // } elseif ($this->buckets->needApprovalUser(Auth::user())) {
         } elseif ($this->isApproval()) {
-            $post->status = StatusType::approval_pending;  // 承認待ち
+            $status = StatusType::approval_pending;  // 承認待ち
         } else {
-            $post->status = StatusType::active;  // 公開
+            $status = StatusType::active;  // 公開
         }
 
         // 保存
-        $post->save();
+        if (!empty($base_post)) {
+            DB::transaction(function () use ($request, $base_post, $calendar_frame, $status) {
+                $posts = $this->getRepeatEditPosts($base_post, $request->get('repeat_edit_type', 'only'));
+                foreach ($posts as $post) {
+                    $start_date = $this->getShiftedDate($post->start_date, $base_post->start_date, $request->start_date);
+                    $end_date = $this->getShiftedEndDate($post, $base_post, $request, $start_date);
+                    $this->setPostValues($post, $request, $calendar_frame->calendar_id, $status, $start_date, null, $end_date);
+                    $post->save();
+                }
+            });
+        } else {
+            $repeat_group_id = count($repeat_dates) > 1 ? (string)Str::uuid() : null;
+            DB::transaction(function () use ($request, $calendar_frame, $status, $repeat_dates, $repeat_group_id) {
+                foreach ($repeat_dates as $repeat_date) {
+                    $post = new CalendarPost();
+                    $this->setPostValues($post, $request, $calendar_frame->calendar_id, $status, $repeat_date, $repeat_group_id);
+                    $post->save();
+                }
+            });
+        }
 
         // 登録後は初期表示へ
         // return new Collection(['redirect_path' => url('/') . "/plugin/calendars/edit/" . $page_id . "/" . $frame_id . "/" . $post->id . "#frame-" . $frame_id]);
         return collect(['redirect_path' => url($this->page->permanent_link) . "#frame-{$frame_id}"]);
+    }
+
+    /**
+     * 繰り返し予定の編集対象を取得する。
+     */
+    private function getRepeatEditPosts(CalendarPost $post, string $repeat_edit_type): Collection
+    {
+        if (empty($post->repeat_group_id) || $repeat_edit_type === 'only') {
+            return new Collection([$post]);
+        }
+
+        $query = CalendarPost::where('calendar_id', $post->calendar_id)
+            ->where('repeat_group_id', $post->repeat_group_id)
+            ->orderBy('start_date')
+            ->orderBy('id');
+
+        if ($repeat_edit_type === 'after') {
+            $query->where(function ($query) use ($post) {
+                $query->where('start_date', '>', $post->start_date)
+                    ->orWhere(function ($query) use ($post) {
+                        $query->where('start_date', $post->start_date)
+                            ->where('id', '>=', $post->id);
+                    });
+            });
+        } elseif ($repeat_edit_type !== 'all') {
+            return new Collection([$post]);
+        }
+
+        return $query->get();
+    }
+
+    /**
+     * 基準予定からの差分で日付をずらす。
+     */
+    private function getShiftedDate(string $target_date, string $base_date, string $new_base_date): string
+    {
+        $diff_days = CarbonImmutable::parse($base_date)->diffInDays(CarbonImmutable::parse($new_base_date), false);
+        return CarbonImmutable::parse($target_date)->addDays($diff_days)->format('Y-m-d');
+    }
+
+    /**
+     * 編集対象の終了日を取得する。
+     */
+    private function getShiftedEndDate(CalendarPost $post, CalendarPost $base_post, $request, string $start_date): string
+    {
+        if (empty($request->end_date)) {
+            return $start_date;
+        }
+
+        $base_end_date = empty($base_post->end_date) ? $base_post->start_date : $base_post->end_date;
+        $post_end_date = empty($post->end_date) ? $post->start_date : $post->end_date;
+        return $this->getShiftedDate($post_end_date, $base_end_date, $request->end_date);
+    }
+
+    /**
+     * 登録する予定の値をセットする。
+     */
+    private function setPostValues(
+        CalendarPost $post,
+        $request,
+        int $calendar_id,
+        int $status,
+        string $start_date,
+        ?string $repeat_group_id,
+        ?string $end_date = null
+    ): void {
+        $post->calendar_id      = $calendar_id;
+        $post->allday_flag      = $request->get('allday_flag');
+        $post->start_date       = $start_date;
+        $post->start_time       = $request->start_time;
+        $post->end_date         = $end_date ?? $this->getRepeatedEndDate($request->start_date, $request->end_date, $start_date);
+        $post->end_time         = $request->end_time;
+        $post->title            = $request->title;
+        $post->body             = $this->clean($request->body);   // wysiwygのXSS対応のJavaScript等の制限
+        $post->location         = $request->location;
+        $post->contact          = $request->contact;
+        if (empty($post->id) || !empty($repeat_group_id)) {
+            $post->repeat_group_id = $repeat_group_id;
+        }
+        $post->status           = $status;
+    }
+
+    /**
+     * 繰り返し予定の開始日一覧を取得する。
+     */
+    private function getRepeatStartDates(string $start_date, string $repeat_until, string $repeat_type): array
+    {
+        $start = CarbonImmutable::parse($start_date);
+        $until = CarbonImmutable::parse($repeat_until);
+
+        if ($repeat_type === 'weekly') {
+            return $this->getWeeklyRepeatStartDates($start, $until);
+        }
+        if ($repeat_type === 'monthly_date') {
+            return $this->getMonthlyDateRepeatStartDates($start, $until);
+        }
+        if ($repeat_type === 'monthly_weekday') {
+            return $this->getMonthlyWeekdayRepeatStartDates($start, $until);
+        }
+
+        return [$start->format('Y-m-d')];
+    }
+
+    /**
+     * 毎週の開始日一覧を取得する。
+     */
+    private function getWeeklyRepeatStartDates(CarbonImmutable $start, CarbonImmutable $until): array
+    {
+        $dates = [];
+        for ($date = $start; $date->lte($until); $date = $date->addWeek()) {
+            $dates[] = $date->format('Y-m-d');
+        }
+        return $dates;
+    }
+
+    /**
+     * 毎月同日の開始日一覧を取得する。存在しない日付の月は登録しない。
+     */
+    private function getMonthlyDateRepeatStartDates(CarbonImmutable $start, CarbonImmutable $until): array
+    {
+        $dates = [];
+        $day = $start->day;
+
+        for ($date = $start->startOfMonth(); $date->lte($until); $date = $date->addMonthNoOverflow()) {
+            if (!checkdate($date->month, $day, $date->year)) {
+                continue;
+            }
+
+            $repeat_date = $date->setDay($day);
+            if ($repeat_date->lt($start) || $repeat_date->gt($until)) {
+                continue;
+            }
+
+            $dates[] = $repeat_date->format('Y-m-d');
+        }
+
+        return $dates;
+    }
+
+    /**
+     * 毎月第n曜日の開始日一覧を取得する。該当する第n曜日がない月は登録しない。
+     */
+    private function getMonthlyWeekdayRepeatStartDates(CarbonImmutable $start, CarbonImmutable $until): array
+    {
+        $dates = [];
+        $week_number = (int)ceil($start->day / 7);
+        $day_of_week = $start->dayOfWeek;
+
+        for ($date = $start->startOfMonth(); $date->lte($until); $date = $date->addMonthNoOverflow()) {
+            $repeat_date = $date->firstOfMonth($day_of_week)->addWeeks($week_number - 1);
+            if ($repeat_date->month !== $date->month || $repeat_date->lt($start) || $repeat_date->gt($until)) {
+                continue;
+            }
+
+            $dates[] = $repeat_date->format('Y-m-d');
+        }
+
+        return $dates;
+    }
+
+    /**
+     * 繰り返し後の終了日を取得する。
+     */
+    private function getRepeatedEndDate(string $base_start_date, ?string $base_end_date, string $repeated_start_date): string
+    {
+        if (empty($base_end_date)) {
+            return $repeated_start_date;
+        }
+
+        $base_start = CarbonImmutable::parse($base_start_date);
+        $base_end = CarbonImmutable::parse($base_end_date);
+        $repeated_start = CarbonImmutable::parse($repeated_start_date);
+
+        return $repeated_start->addDays($base_start->diffInDays($base_end))->format('Y-m-d');
     }
 
     /**
@@ -481,14 +696,48 @@ class CalendarsPlugin extends UserPluginBase
     {
         // id がある場合、データを削除
         if ($post_id) {
+            $post = $this->getPost($post_id);
+            if (empty($post->id)) {
+                return;
+            }
+
+            $delete_post_ids = $this->getDeletePostIds($post, $request->get('repeat_delete_type', 'only'));
+
             // データを削除する。（論理削除で削除日、ID などを残すためにupdate）
-            CalendarPost::where('id', $post_id)->update([
+            CalendarPost::whereIn('id', $delete_post_ids)->update([
                 'deleted_at'   => date('Y-m-d H:i:s'),
                 'deleted_id'   => Auth::user()->id,
                 'deleted_name' => Auth::user()->name,
             ]);
         }
         return;
+    }
+
+    /**
+     * 削除対象の予定IDを取得する。
+     */
+    private function getDeletePostIds(CalendarPost $post, string $repeat_delete_type): array
+    {
+        if (empty($post->repeat_group_id) || $repeat_delete_type === 'only') {
+            return [$post->id];
+        }
+
+        $query = CalendarPost::where('calendar_id', $post->calendar_id)
+            ->where('repeat_group_id', $post->repeat_group_id);
+
+        if ($repeat_delete_type === 'after') {
+            $query->where(function ($query) use ($post) {
+                $query->where('start_date', '>', $post->start_date)
+                    ->orWhere(function ($query) use ($post) {
+                        $query->where('start_date', $post->start_date)
+                            ->where('id', '>=', $post->id);
+                    });
+            });
+        } elseif ($repeat_delete_type !== 'all') {
+            return [$post->id];
+        }
+
+        return $query->pluck('id')->all();
     }
 
     /**

--- a/app/Plugins/User/Calendars/CalendarsPlugin.php
+++ b/app/Plugins/User/Calendars/CalendarsPlugin.php
@@ -426,7 +426,7 @@ class CalendarsPlugin extends UserPluginBase
         $base_post = null;
         if (!empty($post_id)) {
             $base_post = $this->getPost($post_id);
-            if (empty($base_post->id)) {
+            if (empty($base_post->id) || !$base_post->exists) {
                 return;
             }
         }
@@ -697,7 +697,7 @@ class CalendarsPlugin extends UserPluginBase
         // id がある場合、データを削除
         if ($post_id) {
             $post = $this->getPost($post_id);
-            if (empty($post->id)) {
+            if (empty($post->id) || !$post->exists) {
                 return;
             }
 

--- a/database/migrations/2026_05_20_010000_add_repeat_group_id_to_calendar_posts.php
+++ b/database/migrations/2026_05_20_010000_add_repeat_group_id_to_calendar_posts.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddRepeatGroupIdToCalendarPosts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('calendar_posts', function (Blueprint $table) {
+            $table->string('repeat_group_id', 36)->nullable()->after('contact')->comment('繰り返し予定グループID');
+            $table->index('repeat_group_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('calendar_posts', function (Blueprint $table) {
+            $table->dropIndex(['repeat_group_id']);
+            $table->dropColumn('repeat_group_id');
+        });
+    }
+}

--- a/resources/views/plugins/user/calendars/default/edit.blade.php
+++ b/resources/views/plugins/user/calendars/default/edit.blade.php
@@ -40,6 +40,18 @@
     }
 </script>
 
+{{-- 繰り返し予定の終了日を制御 --}}
+<script type="text/javascript">
+    function change_repeat_type{{$frame_id}}() {
+        if (form_calendars_posts{{$frame_id}}.repeat_type.value == 'none') {
+            form_calendars_posts{{$frame_id}}.repeat_until.value = '';
+            form_calendars_posts{{$frame_id}}.repeat_until.disabled = true;
+        } else {
+            form_calendars_posts{{$frame_id}}.repeat_until.disabled = false;
+        }
+    }
+</script>
+
 @if ($errors && $errors->has('reply_role_error'))
     <div class="alert alert-danger">
         <span class="font-weight-bold">{{$errors->first('reply_role_error')}}</span>
@@ -177,6 +189,55 @@
         @include('plugins.common.errors_inline', ['name' => 'end_date', 'class' => $errors_div_class])
     </div>
 
+    @if (empty($post->id))
+    <div class="form-group form-row mb-0">
+        <label class="{{$label_class}}">繰り返し</label>
+        <div class="col-md-4 col-12">
+            <select name="repeat_type" class="form-control @if ($errors && $errors->has('repeat_type')) border-danger @endif" onchange="change_repeat_type{{$frame_id}}();">
+                <option value="none" @if(old('repeat_type', 'none') == 'none') selected @endif>繰り返しなし</option>
+                <option value="weekly" @if(old('repeat_type') == 'weekly') selected @endif>毎週（開始日と同じ曜日）</option>
+                <option value="monthly_date" @if(old('repeat_type') == 'monthly_date') selected @endif>毎月（開始日と同じ日）</option>
+                <option value="monthly_weekday" @if(old('repeat_type') == 'monthly_weekday') selected @endif>毎月（開始日と同じ第n曜日）</option>
+            </select>
+            @include('plugins.common.errors_inline', ['name' => 'repeat_type'])
+        </div>
+        <div class="{{$input_area_date_class}}">
+            <div class="input-group date" id="repeat_until{{$frame_id}}" data-target-input="nearest">
+                <input type="text" name="repeat_until" value="{{old('repeat_until')}}" class="form-control datetimepicker-input @if ($errors && $errors->has('repeat_until')) border-danger @endif" data-target="#repeat_until{{$frame_id}}" @if(old('repeat_type', 'none') == 'none') disabled @endif />
+                <div class="input-group-append" data-target="#repeat_until{{$frame_id}}" data-toggle="datetimepicker">
+                    <div class="input-group-text @if ($errors && $errors->has('repeat_until')) border-danger @endif"><i class="fas fa-calendar-alt"></i></div>
+                </div>
+            </div>
+            @include('plugins.common.datetimepicker', ['element_id' => 'repeat_until' . $frame_id, 'format' => 'yyyy-MM-dd', 'clock_icon' => false])
+        </div>
+        <div class="col-md-3 col-12">
+            <small class="text-muted">指定日まで同じ予定を登録します。</small>
+        </div>
+    </div>
+    <div class="form-group form-row">
+        @include('plugins.common.errors_inline', ['name' => 'repeat_until', 'class' => $errors_div_class])
+    </div>
+    @elseif (!empty($post->repeat_group_id))
+    <div class="form-group form-row">
+        <label class="{{$label_class}}">変更範囲</label>
+        <div class="{{$input_area_class}}">
+            <div class="custom-control custom-radio">
+                <input type="radio" name="repeat_edit_type" value="only" class="custom-control-input" id="repeat_edit_only{{$frame_id}}" @if(old('repeat_edit_type', 'only') == 'only') checked @endif>
+                <label class="custom-control-label" for="repeat_edit_only{{$frame_id}}">この予定のみ変更する</label>
+            </div>
+            <div class="custom-control custom-radio">
+                <input type="radio" name="repeat_edit_type" value="after" class="custom-control-input" id="repeat_edit_after{{$frame_id}}" @if(old('repeat_edit_type') == 'after') checked @endif>
+                <label class="custom-control-label" for="repeat_edit_after{{$frame_id}}">この予定以降の繰り返し予定を変更する</label>
+            </div>
+            <div class="custom-control custom-radio">
+                <input type="radio" name="repeat_edit_type" value="all" class="custom-control-input" id="repeat_edit_all{{$frame_id}}" @if(old('repeat_edit_type') == 'all') checked @endif>
+                <label class="custom-control-label" for="repeat_edit_all{{$frame_id}}">この繰り返し予定をすべて変更する</label>
+            </div>
+            @include('plugins.common.errors_inline', ['name' => 'repeat_edit_type'])
+        </div>
+    </div>
+    @endif
+
     <div class="form-group form-row">
         <label class="{{$label_class}}">場所</label>
         <div class="{{$input_area_class}}">
@@ -254,6 +315,22 @@
                 <form action="{{url('/')}}/redirect/plugin/calendars/delete/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}" method="POST">
                     {{csrf_field()}}
                     <input type="hidden" name="redirect_path" value="{{$page->permanent_link}}#frame-{{$frame_id}}">
+                    @if (!empty($post->repeat_group_id))
+                    <div class="text-left d-inline-block mb-3">
+                        <div class="custom-control custom-radio">
+                            <input type="radio" name="repeat_delete_type" value="only" class="custom-control-input" id="repeat_delete_only{{$frame_id}}" checked>
+                            <label class="custom-control-label" for="repeat_delete_only{{$frame_id}}">この予定のみ削除する</label>
+                        </div>
+                        <div class="custom-control custom-radio">
+                            <input type="radio" name="repeat_delete_type" value="after" class="custom-control-input" id="repeat_delete_after{{$frame_id}}">
+                            <label class="custom-control-label" for="repeat_delete_after{{$frame_id}}">この予定以降の繰り返し予定を削除する</label>
+                        </div>
+                        <div class="custom-control custom-radio">
+                            <input type="radio" name="repeat_delete_type" value="all" class="custom-control-input" id="repeat_delete_all{{$frame_id}}">
+                            <label class="custom-control-label" for="repeat_delete_all{{$frame_id}}">この繰り返し予定をすべて削除する</label>
+                        </div>
+                    </div>
+                    @endif
                     <button type="submit" class="btn btn-danger" onclick="javascript:return confirm('データを削除します。\nよろしいですか？')"><i class="fas fa-check"></i> 本当に削除する</button>
                 </form>
             </div>

--- a/tests/Feature/Plugins/User/Calendars/CalendarsRepeatPostsFeatureTest.php
+++ b/tests/Feature/Plugins/User/Calendars/CalendarsRepeatPostsFeatureTest.php
@@ -293,6 +293,33 @@ class CalendarsRepeatPostsFeatureTest extends TestCase
     }
 
     /**
+     * 存在しない予定IDを指定した更新では、新しい予定を作らないこと。
+     */
+    public function testUpdateMissingPostIdDoesNotCreatePost(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/calendars/save/{$page->id}/{$frame->id}/999999",
+            $this->makePayload([
+                'title' => '存在しない予定の更新',
+                'start_date' => '2026-06-01',
+                'start_time' => '10:00',
+                'end_date' => '2026-06-01',
+                'end_time' => '11:00',
+            ])
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+        $this->assertSame(0, CalendarPost::where('calendar_id', $calendar->id)->count());
+        $this->assertDatabaseMissing('calendar_posts', [
+            'id' => 999999,
+            'title' => '存在しない予定の更新',
+        ]);
+    }
+
+    /**
      * 指定フレームに紐づくカレンダーを作成する。
      */
     private function createCalendarFrame(): array

--- a/tests/Feature/Plugins/User/Calendars/CalendarsRepeatPostsFeatureTest.php
+++ b/tests/Feature/Plugins/User/Calendars/CalendarsRepeatPostsFeatureTest.php
@@ -4,11 +4,14 @@ namespace Tests\Feature\Plugins\User\Calendars;
 
 use App\Enums\StatusType;
 use App\Models\Common\Buckets;
+use App\Models\Common\BucketsRoles;
 use App\Models\Common\Frame;
 use App\Models\Common\Page;
+use App\Models\Core\UsersRoles;
 use App\Models\User\Calendars\Calendar;
 use App\Models\User\Calendars\CalendarFrame;
 use App\Models\User\Calendars\CalendarPost;
+use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
 use Tests\TestCase;
@@ -320,6 +323,81 @@ class CalendarsRepeatPostsFeatureTest extends TestCase
     }
 
     /**
+     * 繰り返し予定の一括編集では、同じグループでも利用者の権限外の予定を更新しないこと。
+     */
+    public function testUpdateRepeatPostsAfterDoesNotUpdateUnauthorizedPosts(): void
+    {
+        $reporter = $this->createReporterUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+        $this->allowReporterToPost($calendar);
+        $posts = $this->createMixedPermissionRepeatPosts($calendar, $reporter);
+
+        $response = $this->actingAs($reporter)->post(
+            "/redirect/plugin/calendars/save/{$page->id}/{$frame->id}/{$posts['target']->id}",
+            [
+                'redirect_path' => '/',
+                'status' => StatusType::active,
+                'allday_flag' => 0,
+                'title' => '権限内だけ変更',
+                'start_date' => '2026-06-09',
+                'start_time' => '11:00',
+                'end_date' => '2026-06-09',
+                'end_time' => '12:00',
+                'body' => '',
+                'location' => '',
+                'contact' => '',
+                'repeat_edit_type' => 'after',
+            ]
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+        $this->assertDatabaseHas('calendar_posts', [
+            'id' => $posts['target']->id,
+            'title' => '権限内だけ変更',
+            'start_date' => '2026-06-09',
+        ]);
+        $this->assertDatabaseHas('calendar_posts', [
+            'id' => $posts['authorized_future']->id,
+            'title' => '権限内だけ変更',
+            'start_date' => '2026-06-23',
+        ]);
+        $this->assertDatabaseHas('calendar_posts', [
+            'id' => $posts['unauthorized_future']->id,
+            'title' => '権限外の一時保存',
+            'start_date' => '2026-06-15',
+            'status' => StatusType::temporary,
+        ]);
+    }
+
+    /**
+     * 繰り返し予定の一括削除では、同じグループでも利用者の権限外の予定を削除しないこと。
+     */
+    public function testDeleteRepeatPostsAfterDoesNotDeleteUnauthorizedPosts(): void
+    {
+        $reporter = $this->createReporterUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+        $this->allowReporterToPost($calendar);
+        $posts = $this->createMixedPermissionRepeatPosts($calendar, $reporter);
+
+        $response = $this->actingAs($reporter)->post(
+            "/redirect/plugin/calendars/delete/{$page->id}/{$frame->id}/{$posts['target']->id}",
+            [
+                'redirect_path' => '/',
+                'repeat_delete_type' => 'after',
+            ]
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+        $this->assertSoftDeleted('calendar_posts', ['id' => $posts['target']->id]);
+        $this->assertSoftDeleted('calendar_posts', ['id' => $posts['authorized_future']->id]);
+        $this->assertDatabaseHas('calendar_posts', [
+            'id' => $posts['unauthorized_future']->id,
+            'title' => '権限外の一時保存',
+            'deleted_at' => null,
+        ]);
+    }
+
+    /**
      * 指定フレームに紐づくカレンダーを作成する。
      */
     private function createCalendarFrame(): array
@@ -350,6 +428,36 @@ class CalendarsRepeatPostsFeatureTest extends TestCase
     }
 
     /**
+     * 編集者権限を持つユーザーを作成する。
+     */
+    private function createReporterUser(): User
+    {
+        $user = User::factory()->create();
+
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_reporter',
+            'role_value' => 1,
+        ]);
+
+        return $user;
+    }
+
+    /**
+     * 編集者がカレンダーに投稿できるよう、バケツの投稿権限を付与する。
+     */
+    private function allowReporterToPost(Calendar $calendar): void
+    {
+        BucketsRoles::create([
+            'buckets_id' => $calendar->bucket_id,
+            'role' => 'role_reporter',
+            'post_flag' => 1,
+            'approval_flag' => 0,
+        ]);
+    }
+
+    /**
      * 毎週の繰り返し予定を削除テスト用に作成する。
      */
     private function createWeeklyRepeatPosts($admin, Page $page, Frame $frame): void
@@ -366,6 +474,69 @@ class CalendarsRepeatPostsFeatureTest extends TestCase
                 'repeat_until' => '2026-06-22',
             ])
         );
+    }
+
+    /**
+     * 権限内と権限外の予定が混在する繰り返しグループを作成する。
+     */
+    private function createMixedPermissionRepeatPosts(Calendar $calendar, User $reporter): array
+    {
+        $other_user = User::factory()->create();
+        $repeat_group_id = 'repeat-permission-boundary';
+
+        return [
+            'target' => $this->createCalendarPost($calendar, [
+                'created_id' => $reporter->id,
+                'repeat_group_id' => $repeat_group_id,
+                'title' => '権限内の対象予定',
+                'start_date' => '2026-06-08',
+                'end_date' => '2026-06-08',
+                'status' => StatusType::active,
+            ]),
+            'unauthorized_future' => $this->createCalendarPost($calendar, [
+                'created_id' => $other_user->id,
+                'repeat_group_id' => $repeat_group_id,
+                'title' => '権限外の一時保存',
+                'start_date' => '2026-06-15',
+                'end_date' => '2026-06-15',
+                'status' => StatusType::temporary,
+            ]),
+            'authorized_future' => $this->createCalendarPost($calendar, [
+                'created_id' => $reporter->id,
+                'repeat_group_id' => $repeat_group_id,
+                'title' => '権限内の後続予定',
+                'start_date' => '2026-06-22',
+                'end_date' => '2026-06-22',
+                'status' => StatusType::active,
+            ]),
+        ];
+    }
+
+    /**
+     * 境界条件を検証するため、必要な予定データだけを直接作成する。
+     */
+    private function createCalendarPost(Calendar $calendar, array $overrides): CalendarPost
+    {
+        $post = new CalendarPost();
+        $post->calendar_id = $calendar->id;
+        $post->allday_flag = 0;
+        $post->start_date = '2026-06-01';
+        $post->start_time = '10:00';
+        $post->end_date = '2026-06-01';
+        $post->end_time = '11:00';
+        $post->title = '繰り返し予定';
+        $post->body = '';
+        $post->location = '';
+        $post->contact = '';
+        $post->status = StatusType::active;
+
+        foreach ($overrides as $key => $value) {
+            $post->$key = $value;
+        }
+
+        $post->save();
+
+        return $post;
     }
 
     /**

--- a/tests/Feature/Plugins/User/Calendars/CalendarsRepeatPostsFeatureTest.php
+++ b/tests/Feature/Plugins/User/Calendars/CalendarsRepeatPostsFeatureTest.php
@@ -1,0 +1,359 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Calendars;
+
+use App\Enums\StatusType;
+use App\Models\Common\Buckets;
+use App\Models\Common\Frame;
+use App\Models\Common\Page;
+use App\Models\User\Calendars\Calendar;
+use App\Models\User\Calendars\CalendarFrame;
+use App\Models\User\Calendars\CalendarPost;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * Calendars の繰り返し予定登録を検証する。
+ *
+ * 予定登録の公開HTTP経路を通して、利用者が1回の入力で複数日の予定を
+ * 作成できることと、日付の展開規則が崩れないことを守る。
+ */
+class CalendarsRepeatPostsFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * 毎週の繰り返し指定では、開始日と同じ曜日の予定が終了日まで作成されること。
+     */
+    public function testSaveCreatesWeeklyRepeatPosts(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/calendars/save/{$page->id}/{$frame->id}",
+            $this->makePayload([
+                'title' => '毎週の定例会',
+                'start_date' => '2026-06-01',
+                'start_time' => '10:00',
+                'end_date' => '2026-06-01',
+                'end_time' => '11:00',
+                'repeat_type' => 'weekly',
+                'repeat_until' => '2026-06-22',
+            ])
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+
+        foreach (['2026-06-01', '2026-06-08', '2026-06-15', '2026-06-22'] as $date) {
+            $this->assertDatabaseHas('calendar_posts', [
+                'calendar_id' => $calendar->id,
+                'title' => '毎週の定例会',
+                'start_date' => $date,
+                'end_date' => $date,
+                'status' => StatusType::active,
+            ]);
+        }
+
+        $this->assertSame(4, CalendarPost::where('calendar_id', $calendar->id)->count());
+        $this->assertSame(1, CalendarPost::where('calendar_id', $calendar->id)->distinct()->count('repeat_group_id'));
+    }
+
+    /**
+     * 毎月第n曜日の繰り返し指定では、開始日と同じ第n曜日だけが作成されること。
+     */
+    public function testSaveCreatesMonthlyWeekdayRepeatPosts(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/calendars/save/{$page->id}/{$frame->id}",
+            $this->makePayload([
+                'title' => '毎月第2火曜の定例会',
+                'start_date' => '2026-05-12',
+                'start_time' => '13:00',
+                'end_date' => '2026-05-12',
+                'end_time' => '14:00',
+                'repeat_type' => 'monthly_weekday',
+                'repeat_until' => '2026-08-31',
+            ])
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+
+        foreach (['2026-05-12', '2026-06-09', '2026-07-14', '2026-08-11'] as $date) {
+            $this->assertDatabaseHas('calendar_posts', [
+                'calendar_id' => $calendar->id,
+                'title' => '毎月第2火曜の定例会',
+                'start_date' => $date,
+                'end_date' => $date,
+                'status' => StatusType::active,
+            ]);
+        }
+
+        $this->assertSame(4, CalendarPost::where('calendar_id', $calendar->id)->count());
+        $this->assertSame(1, CalendarPost::where('calendar_id', $calendar->id)->distinct()->count('repeat_group_id'));
+    }
+
+    /**
+     * 繰り返し予定の「これ以降」削除では、選択した予定より前の予定が残ること。
+     */
+    public function testDeleteRepeatPostsAfterSelectedDate(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+        $this->createWeeklyRepeatPosts($admin, $page, $frame);
+
+        $target = CalendarPost::where('calendar_id', $calendar->id)
+            ->where('start_date', '2026-06-15')
+            ->firstOrFail();
+
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/calendars/delete/{$page->id}/{$frame->id}/{$target->id}",
+            [
+                'redirect_path' => '/',
+                'repeat_delete_type' => 'after',
+            ]
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+        $this->assertSame(
+            ['2026-06-01', '2026-06-08'],
+            CalendarPost::where('calendar_id', $calendar->id)->orderBy('start_date')->pluck('start_date')->all()
+        );
+        $this->assertSoftDeleted('calendar_posts', ['id' => $target->id]);
+    }
+
+    /**
+     * 繰り返し予定の1件を編集しても、同じ繰り返しグループとして削除できる状態が残ること。
+     */
+    public function testUpdateRepeatPostKeepsRepeatGroup(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+        $this->createWeeklyRepeatPosts($admin, $page, $frame);
+
+        $target = CalendarPost::where('calendar_id', $calendar->id)
+            ->where('start_date', '2026-06-08')
+            ->firstOrFail();
+        $repeat_group_id = $target->repeat_group_id;
+
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/calendars/save/{$page->id}/{$frame->id}/{$target->id}",
+            [
+                'redirect_path' => '/',
+                'status' => StatusType::active,
+                'allday_flag' => 0,
+                'title' => '編集後の定例会',
+                'start_date' => '2026-06-08',
+                'start_time' => '10:30',
+                'end_date' => '2026-06-08',
+                'end_time' => '11:30',
+                'body' => '',
+                'location' => '',
+                'contact' => '',
+            ]
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+        $this->assertDatabaseHas('calendar_posts', [
+            'id' => $target->id,
+            'title' => '編集後の定例会',
+            'repeat_group_id' => $repeat_group_id,
+        ]);
+        $this->assertSame(4, CalendarPost::where('repeat_group_id', $repeat_group_id)->count());
+        $this->assertSame(1, CalendarPost::where('repeat_group_id', $repeat_group_id)->where('title', '編集後の定例会')->count());
+        $this->assertSame(3, CalendarPost::where('repeat_group_id', $repeat_group_id)->where('title', '毎週の定例会')->count());
+    }
+
+    /**
+     * 繰り返し予定の「これ以降」編集では、選択した予定以降へ同じ差分が反映されること。
+     */
+    public function testUpdateRepeatPostsAfterSelectedDate(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+        $this->createWeeklyRepeatPosts($admin, $page, $frame);
+
+        $target = CalendarPost::where('calendar_id', $calendar->id)
+            ->where('start_date', '2026-06-08')
+            ->firstOrFail();
+
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/calendars/save/{$page->id}/{$frame->id}/{$target->id}",
+            [
+                'redirect_path' => '/',
+                'status' => StatusType::active,
+                'allday_flag' => 0,
+                'title' => '以降の定例会',
+                'start_date' => '2026-06-09',
+                'start_time' => '11:00',
+                'end_date' => '2026-06-09',
+                'end_time' => '12:00',
+                'body' => '',
+                'location' => '',
+                'contact' => '',
+                'repeat_edit_type' => 'after',
+            ]
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+        $this->assertSame(
+            ['2026-06-01', '2026-06-09', '2026-06-16', '2026-06-23'],
+            CalendarPost::where('calendar_id', $calendar->id)->orderBy('start_date')->pluck('start_date')->all()
+        );
+        $this->assertDatabaseHas('calendar_posts', [
+            'calendar_id' => $calendar->id,
+            'start_date' => '2026-06-01',
+            'title' => '毎週の定例会',
+            'start_time' => '10:00:00',
+        ]);
+        $this->assertSame(3, CalendarPost::where('calendar_id', $calendar->id)->where('title', '以降の定例会')->count());
+    }
+
+    /**
+     * 繰り返し予定の「すべて」編集では、同じ繰り返しグループの予定がすべて更新されること。
+     */
+    public function testUpdateAllRepeatPosts(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+        $this->createWeeklyRepeatPosts($admin, $page, $frame);
+
+        $target = CalendarPost::where('calendar_id', $calendar->id)
+            ->where('start_date', '2026-06-08')
+            ->firstOrFail();
+        $repeat_group_id = $target->repeat_group_id;
+
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/calendars/save/{$page->id}/{$frame->id}/{$target->id}",
+            [
+                'redirect_path' => '/',
+                'status' => StatusType::active,
+                'allday_flag' => 0,
+                'title' => '全体変更後の定例会',
+                'start_date' => '2026-06-08',
+                'start_time' => '10:30',
+                'end_date' => '2026-06-08',
+                'end_time' => '11:30',
+                'body' => '全体変更',
+                'location' => '会議室A',
+                'contact' => '担当者',
+                'repeat_edit_type' => 'all',
+            ]
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+        $this->assertSame(4, CalendarPost::where('repeat_group_id', $repeat_group_id)->count());
+        $this->assertSame(4, CalendarPost::where('repeat_group_id', $repeat_group_id)->where('title', '全体変更後の定例会')->count());
+        $this->assertSame(4, CalendarPost::where('repeat_group_id', $repeat_group_id)->where('location', '会議室A')->count());
+    }
+
+    /**
+     * 繰り返し予定の「すべて」削除では、同じ繰り返しグループの予定がすべて消えること。
+     */
+    public function testDeleteAllRepeatPosts(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame, $calendar] = $this->createCalendarFrame();
+        $this->createWeeklyRepeatPosts($admin, $page, $frame);
+
+        $target = CalendarPost::where('calendar_id', $calendar->id)
+            ->where('start_date', '2026-06-08')
+            ->firstOrFail();
+        $repeat_group_id = $target->repeat_group_id;
+
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/calendars/delete/{$page->id}/{$frame->id}/{$target->id}",
+            [
+                'redirect_path' => '/',
+                'repeat_delete_type' => 'all',
+            ]
+        );
+
+        $this->assertContains($response->getStatusCode(), [200, 302]);
+        $this->assertSame(0, CalendarPost::where('calendar_id', $calendar->id)->count());
+        $this->assertSame(
+            4,
+            CalendarPost::onlyTrashed()->where('repeat_group_id', $repeat_group_id)->count()
+        );
+    }
+
+    /**
+     * 指定フレームに紐づくカレンダーを作成する。
+     */
+    private function createCalendarFrame(): array
+    {
+        $page = Page::factory()->create();
+        $bucket = Buckets::factory()->create([
+            'bucket_name' => '繰り返し予定テスト',
+            'plugin_name' => 'calendars',
+        ]);
+        $calendar = Calendar::create([
+            'bucket_id' => $bucket->id,
+            'name' => '繰り返し予定テスト',
+        ]);
+        $frame = Frame::create([
+            'page_id' => $page->id,
+            'area_id' => 2,
+            'plugin_name' => 'calendars',
+            'bucket_id' => $bucket->id,
+            'template' => 'default',
+            'display_sequence' => 1,
+        ]);
+        CalendarFrame::create([
+            'calendar_id' => $calendar->id,
+            'frame_id' => $frame->id,
+        ]);
+
+        return [$page, $frame, $calendar];
+    }
+
+    /**
+     * 毎週の繰り返し予定を削除テスト用に作成する。
+     */
+    private function createWeeklyRepeatPosts($admin, Page $page, Frame $frame): void
+    {
+        $this->actingAs($admin)->post(
+            "/redirect/plugin/calendars/save/{$page->id}/{$frame->id}",
+            $this->makePayload([
+                'title' => '毎週の定例会',
+                'start_date' => '2026-06-01',
+                'start_time' => '10:00',
+                'end_date' => '2026-06-01',
+                'end_time' => '11:00',
+                'repeat_type' => 'weekly',
+                'repeat_until' => '2026-06-22',
+            ])
+        );
+    }
+
+    /**
+     * 予定登録に必要な標準入力を作成する。
+     */
+    private function makePayload(array $overrides): array
+    {
+        return array_merge([
+            'redirect_path' => '/',
+            'status' => StatusType::active,
+            'allday_flag' => 0,
+            'body' => '',
+            'location' => '',
+            'contact' => '',
+            'repeat_type' => 'none',
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
# 概要

カレンダーで、毎週・毎月同日・毎月第n曜日の繰り返し予定を一度に登録できるようにしました。

## 変更内容
- 予定登録画面に繰り返し種別と終了日を追加しました。
- 繰り返し予定を同じグループとして扱うため、予定データに繰り返しグループIDを追加しました。
- 繰り返し予定の編集時に「この予定のみ」「この予定以降」「すべて」を選べるようにしました。
- 繰り返し予定の削除時に「この予定のみ」「この予定以降」「すべて」を選べるようにしました。
- 繰り返し登録・一括編集・一括削除のFeatureテストを追加しました。

## 背景と目的
定例行事を毎回個別に入力する必要があり、毎週や毎月の予定登録に手間がかかっていました。
一度の操作で繰り返し予定を登録し、必要に応じてまとめて編集・削除できるようにすることで、カレンダー運用の負担を減らします。

## 特記事項
- 繰り返し予定は、期間内の予定を個別レコードとして作成します。
- 編集・削除の範囲は、「この予定のみ」「この予定以降」「すべて」から選択できます。
- 繰り返し条件そのものを後から変更して再生成する機能は、このPRの対象外です。

# レビュー完了希望日
急ぎません。

# 関連Pull requests/Issues
なし

# 参考
確認済みコマンド:

```bash
docker compose exec -T webapp php vendor/bin/phpcs --standard=phpcs.xml app/Plugins/User/Calendars/CalendarsPlugin.php app/Models/User/Calendars/CalendarPost.php database/migrations/2026_05_20_010000_add_repeat_group_id_to_calendar_posts.php tests/Feature/Plugins/User/Calendars/CalendarsRepeatPostsFeatureTest.php
docker compose exec -T webapp php vendor/bin/phpunit tests/Feature/Plugins/User/Calendars
```

テスト結果:

```text
OK (8 tests, 37 assertions)
```

# DB変更の有無
有り

`calendar_posts` に `repeat_group_id` カラムとインデックスを追加します。
既存予定は `repeat_group_id` が `null` のまま扱われるため、通常予定として従来どおり編集・削除できます。

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
