### PR TITLE
[ブログ] 投稿日時の表示形式を設定できるようにしました

### DIFF
--- a/app/Enums/BlogFrameConfig.php
+++ b/app/Enums/BlogFrameConfig.php
@@ -11,6 +11,8 @@ final class BlogFrameConfig extends EnumsBase
 {
     // 定数メンバ
     const blog_display_created_name = 'blog_display_created_name';
+    const blog_display_posted_time = 'blog_display_posted_time';
+    const blog_posted_at_format = 'blog_posted_at_format';
     const blog_display_twitter_button = 'blog_display_twitter_button';
     const blog_display_facebook_button = 'blog_display_facebook_button';
     const blog_view_count = 'blog_view_count';
@@ -18,6 +20,8 @@ final class BlogFrameConfig extends EnumsBase
     // key/valueの連想配列
     const enum = [
         self::blog_display_created_name => '投稿者名',
+        self::blog_display_posted_time => '投稿日時の時刻表示',
+        self::blog_posted_at_format => '投稿日時表示形式',
         self::blog_display_twitter_button => 'Twitterアイコン表示',
         self::blog_display_facebook_button => 'Facebookアイコン表示',
         self::blog_view_count => '表示件数',

--- a/app/Enums/BlogPostedAtFormat.php
+++ b/app/Enums/BlogPostedAtFormat.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\EnumsBase;
+use Carbon\CarbonInterface;
+
+/**
+ * ブログの投稿日時表示形式
+ */
+final class BlogPostedAtFormat extends EnumsBase
+{
+    // 定数メンバ
+    const japanese = 'japanese';
+    const slash = 'slash';
+    const hyphen = 'hyphen';
+    const dot = 'dot';
+    const japanese_era = 'japanese_era';
+
+    // key/valueの連想配列
+    const enum = [
+        self::japanese => 'yyyy年m月d日 hh時mm分',
+        self::slash => 'yyyy/mm/dd hh:mm',
+        self::hyphen => 'yyyy-mm-dd hh:mm',
+        self::dot => 'yyyy.mm.dd hh:mm',
+        self::japanese_era => '和暦（元号年m月d日 hh時mm分）',
+    ];
+
+    const date_formats = [
+        self::japanese => 'Y年n月j日',
+        self::slash => 'Y/m/d',
+        self::hyphen => 'Y-m-d',
+        self::dot => 'Y.m.d',
+        self::japanese_era => '',
+    ];
+
+    const time_formats = [
+        self::japanese => 'H時i分',
+        self::slash => 'H:i',
+        self::hyphen => 'H:i',
+        self::dot => 'H:i',
+        self::japanese_era => 'H時i分',
+    ];
+
+    /**
+     * key/valueの連想配列を返す。
+     */
+    public static function getMembers()
+    {
+        $members = parent::getMembers();
+        if (!self::canUseJapaneseEra()) {
+            unset($members[self::japanese_era]);
+        }
+
+        return $members;
+    }
+
+    /**
+     * key配列を返す。
+     */
+    public static function getMemberKeys()
+    {
+        return array_keys(self::getMembers());
+    }
+
+    /**
+     * 日付部分を表示形式に応じて返す。
+     */
+    public static function formatDate(CarbonInterface $date, ?string $key): string
+    {
+        if ($key === self::japanese_era) {
+            if (self::canUseJapaneseEra()) {
+                return self::formatJapaneseEraDate($date);
+            }
+
+            return $date->format(self::date_formats[self::japanese]);
+        }
+
+        return $date->format(self::getDateFormat($key));
+    }
+
+    /**
+     * 和暦表示が利用できるかを返す。
+     */
+    private static function canUseJapaneseEra(): bool
+    {
+        return class_exists(\IntlDateFormatter::class);
+    }
+
+    /**
+     * 日付部分の表示形式を返す。
+     */
+    public static function getDateFormat(?string $key): string
+    {
+        return self::date_formats[$key] ?? self::date_formats[self::japanese];
+    }
+
+    /**
+     * 時刻部分の表示形式を返す。
+     */
+    public static function getTimeFormat(?string $key): string
+    {
+        return self::time_formats[$key] ?? self::time_formats[self::japanese];
+    }
+
+    /**
+     * 日付を和暦で返す。
+     */
+    private static function formatJapaneseEraDate(CarbonInterface $date): string
+    {
+        $formatter = new \IntlDateFormatter(
+            'ja_JP@calendar=japanese',
+            \IntlDateFormatter::NONE,
+            \IntlDateFormatter::NONE,
+            $date->getTimezone()->getName(),
+            \IntlDateFormatter::TRADITIONAL,
+            'Gy年M月d日'
+        );
+
+        return $formatter->format($date->getTimestamp());
+    }
+}

--- a/app/Plugins/User/Blogs/BlogsPlugin.php
+++ b/app/Plugins/User/Blogs/BlogsPlugin.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
 
 use App\Models\Core\Configs;
 use App\Models\Core\FrameConfig;
@@ -27,8 +28,10 @@ use App\Enums\BlogFrameConfig;
 use App\Enums\BlogFrameScope;
 use App\Enums\BlogNarrowingDownTypeForCreatedId;
 use App\Enums\BlogNarrowingDownTypeForPostedMonth;
+use App\Enums\BlogPostedAtFormat;
 use App\Enums\BlogNoticeEmbeddedTag;
 use App\Enums\NoticeEmbeddedTag;
+use App\Enums\ShowType;
 use App\Enums\StatusType;
 
 use App\Rules\CustomValiWysiwygMax;
@@ -1645,11 +1648,15 @@ EOD;
         // 項目のエラーチェック
         $validator_values['scope_value'] = ['nullable', 'digits:4'];
         $validator_values[BlogFrameConfig::blog_view_count] = ['required', 'numeric', 'min:1', 'max:100'];
+        $validator_values[BlogFrameConfig::blog_display_posted_time] = ['required', Rule::in(ShowType::getMemberKeys())];
+        $validator_values[BlogFrameConfig::blog_posted_at_format] = ['required', Rule::in(BlogPostedAtFormat::getMemberKeys())];
         if ($request->scope == BlogFrameScope::year || $request->scope == BlogFrameScope::fiscal) {
             $validator_values['scope_value'][] = ['required'];
         }
         $validator_attributes['scope_value'] = '指定年';
         $validator_attributes[BlogFrameConfig::blog_view_count] = BlogFrameConfig::getDescription('blog_view_count');
+        $validator_attributes[BlogFrameConfig::blog_display_posted_time] = BlogFrameConfig::getDescription(BlogFrameConfig::blog_display_posted_time);
+        $validator_attributes[BlogFrameConfig::blog_posted_at_format] = BlogFrameConfig::getDescription(BlogFrameConfig::blog_posted_at_format);
 
         $validator = Validator::make($request->all(), $validator_values);
         $validator->setAttributeNames($validator_attributes);

--- a/config/app.php
+++ b/config/app.php
@@ -284,6 +284,7 @@ $app_array = [
         'BaseLoginRedirectPage' => \App\Enums\BaseLoginRedirectPage::class,
         'BlogFrameConfig' => \App\Enums\BlogFrameConfig::class,
         'BlogDisplayCreatedName' => \App\Enums\BlogDisplayCreatedName::class,
+        'BlogPostedAtFormat' => \App\Enums\BlogPostedAtFormat::class,
         'BlogFrameScope' => \App\Enums\BlogFrameScope::class,
         'BaseHeaderFontColorClass' => \App\Enums\BaseHeaderFontColorClass::class,
         'UploadMaxSize' => \App\Enums\UploadMaxSize::class,

--- a/resources/views/plugins/user/blogs/default/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs.blade.php
@@ -84,7 +84,7 @@
             {{-- datafirstテンプレート --}}
             <header>
                 {{-- 投稿日時 --}}
-                <b>{{$post->posted_at->format('Y年n月j日 H時i分')}}</b>
+                <b>@include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at])</b>
 
                 {{-- 投稿者名 --}}
                 @if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_created_name) === BlogDisplayCreatedName::display)
@@ -99,7 +99,7 @@
             {{-- titleindexテンプレート --}}
             <header>
                 {{-- 投稿日時 --}}
-                <span class="date">{{$post->posted_at->format('Y年n月j日')}}</span>
+                <span class="date">@include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at, 'default_display_posted_time' => ShowType::not_show])</span>
 
                 {{-- タイトル --}}
                 <a href="{{url('/')}}/plugin/blogs/show/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}"><span class="title">{{$post->post_title}}</span></a>
@@ -119,7 +119,7 @@
 
             <header>
                 {{-- 投稿日時 --}}
-                <span class="date">{{$post->posted_at->format('Y年n月j日')}}</span>
+                <span class="date">@include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at, 'default_display_posted_time' => ShowType::not_show])</span>
 
                 {{-- タイトル --}}
                 <a href="{{url('/')}}/plugin/blogs/show/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}"><span class="title">{{$post->post_title}}</span></a>
@@ -138,7 +138,7 @@
                 <h2><a href="{{url('/')}}/plugin/blogs/show/{{$page->id}}/{{$frame_id}}/{{$post->id}}#frame-{{$frame->id}}">{{$post->post_title}}</a></h2>
 
                 {{-- 投稿日時 --}}
-                <b>{{$post->posted_at->format('Y年n月j日 H時i分')}}</b>
+                <b>@include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at])</b>
 
                 {{-- 投稿者名 --}}
                 @if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_created_name) === BlogDisplayCreatedName::display)

--- a/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
@@ -21,6 +21,11 @@
     </div>
 @else
 
+    @php
+        $default_display_posted_time = in_array($frame->template, ['titleindex', 'sidetitleindex', 'designbase'], true) ? ShowType::not_show : ShowType::show;
+        $default_posted_at_format = $frame->template == 'designbase' ? BlogPostedAtFormat::slash : BlogPostedAtFormat::japanese;
+    @endphp
+
     {{-- 共通エラーメッセージ 呼び出し --}}
     @include('plugins.common.errors_form_line')
 
@@ -63,7 +68,7 @@
                 <div class="{{$frame->getSettingInputClass(true)}}">
                     @foreach (ShowType::getMembers() as $enum_value => $enum_label)
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_posted_time, ShowType::show) == $enum_value)
+                            @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_posted_time, $default_display_posted_time) == $enum_value)
                                 <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::blog_display_posted_time}}_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_posted_time}}" class="custom-control-input" checked="checked">
                             @else
                                 <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::blog_display_posted_time}}_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_posted_time}}" class="custom-control-input">
@@ -80,7 +85,7 @@
                 <div class="{{$frame->getSettingInputClass()}}">
                     <select name="{{BlogFrameConfig::blog_posted_at_format}}" class="form-control col-sm-5 @if ($errors->has(BlogFrameConfig::blog_posted_at_format)) border-danger @endif">
                         @foreach (BlogPostedAtFormat::getMembers() as $enum_value => $enum_label)
-                            <option value="{{$enum_value}}" @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_posted_at_format, BlogPostedAtFormat::japanese) == $enum_value) selected @endif>{{$enum_label}}</option>
+                            <option value="{{$enum_value}}" @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_posted_at_format, $default_posted_at_format) == $enum_value) selected @endif>{{$enum_label}}</option>
                         @endforeach
                     </select>
                     @include('plugins.common.errors_inline', ['name' => BlogFrameConfig::blog_posted_at_format])

--- a/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_setting_frame.blade.php
@@ -57,6 +57,37 @@
                 </div>
             </div>
 
+            {{-- 投稿日時の時刻表示 --}}
+            <div class="form-group row">
+                <label class="{{$frame->getSettingLabelClass()}}">{{BlogFrameConfig::getDescription(BlogFrameConfig::blog_display_posted_time)}}</label>
+                <div class="{{$frame->getSettingInputClass(true)}}">
+                    @foreach (ShowType::getMembers() as $enum_value => $enum_label)
+                        <div class="custom-control custom-radio custom-control-inline">
+                            @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_display_posted_time, ShowType::show) == $enum_value)
+                                <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::blog_display_posted_time}}_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_posted_time}}" class="custom-control-input" checked="checked">
+                            @else
+                                <input type="radio" value="{{$enum_value}}" id="{{BlogFrameConfig::blog_display_posted_time}}_{{$enum_value}}" name="{{BlogFrameConfig::blog_display_posted_time}}" class="custom-control-input">
+                            @endif
+                            <label class="custom-control-label text-nowrap" for="{{BlogFrameConfig::blog_display_posted_time}}_{{$enum_value}}" id="label_{{BlogFrameConfig::blog_display_posted_time}}_{{$enum_value}}">{{$enum_label}}</label>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+
+            {{-- 投稿日時表示形式 --}}
+            <div class="form-group row">
+                <label class="{{$frame->getSettingLabelClass()}}">{{BlogFrameConfig::getDescription(BlogFrameConfig::blog_posted_at_format)}}</label>
+                <div class="{{$frame->getSettingInputClass()}}">
+                    <select name="{{BlogFrameConfig::blog_posted_at_format}}" class="form-control col-sm-5 @if ($errors->has(BlogFrameConfig::blog_posted_at_format)) border-danger @endif">
+                        @foreach (BlogPostedAtFormat::getMembers() as $enum_value => $enum_label)
+                            <option value="{{$enum_value}}" @if (FrameConfig::getConfigValueAndOld($frame_configs, BlogFrameConfig::blog_posted_at_format, BlogPostedAtFormat::japanese) == $enum_value) selected @endif>{{$enum_label}}</option>
+                        @endforeach
+                    </select>
+                    @include('plugins.common.errors_inline', ['name' => BlogFrameConfig::blog_posted_at_format])
+                    <small class="text-muted">※ 時刻を表示しない場合は、選択した形式の日付部分のみ表示します。</small>
+                </div>
+            </div>
+
             <div class="form-group row">
                 <label class="{{$frame->getSettingLabelClass()}}">表示条件</label>
                 <div class="{{$frame->getSettingInputClass(true)}}">

--- a/resources/views/plugins/user/blogs/default/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/default/blogs_show.blade.php
@@ -17,7 +17,7 @@
 
     <header>
         {{-- 投稿日時 --}}
-        <b>{{$post->posted_at->format('Y年n月j日 H時i分')}}</b>
+        <b>@include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at])</b>
 
         {{-- 投稿者名 --}}
         @if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_created_name) === BlogDisplayCreatedName::display)
@@ -33,7 +33,7 @@
 
     <header>
         {{-- 投稿日時 --}}
-        <b>{{$post->posted_at->format('Y年n月j日 H時i分')}}</b>
+        <b>@include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at])</b>
 
         {{-- 投稿者名 --}}
         @if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_created_name) === BlogDisplayCreatedName::display)
@@ -49,7 +49,7 @@
 
     <header>
         {{-- 投稿日時 --}}
-        <b>{{$post->posted_at->format('Y年n月j日 H時i分')}}</b>
+        <b>@include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at])</b>
 
 
         {{-- 投稿者名 --}}
@@ -69,7 +69,7 @@
         <h2>{{$post->post_title}}</h2>
 
         {{-- 投稿日時 --}}
-        <b>{{$post->posted_at->format('Y年n月j日 H時i分')}}</b>
+        <b>@include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at])</b>
 
         {{-- 投稿者名 --}}
         @if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_created_name) === BlogDisplayCreatedName::display)

--- a/resources/views/plugins/user/blogs/default/include_posted_at.blade.php
+++ b/resources/views/plugins/user/blogs/default/include_posted_at.blade.php
@@ -1,0 +1,14 @@
+{{--
+ * ブログ投稿日時の表示部品。
+ *
+ * フレーム設定が未保存の場合は、呼び出し元テンプレートの改修前表示に合わせるため、
+ * default_display_posted_time で時刻表示の既定値を指定できる。
+--}}
+@php
+    $posted_at_format = FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_posted_at_format, BlogPostedAtFormat::japanese);
+    $default_display_posted_time = $default_display_posted_time ?? ShowType::show;
+    $display_posted_time = FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_posted_time, $default_display_posted_time);
+@endphp
+<time class="blog-posted-at" datetime="{{$posted_at->format('c')}}">
+    <span class="blog-posted-at-date">{{BlogPostedAtFormat::formatDate($posted_at, $posted_at_format)}}</span>@if ($display_posted_time == ShowType::show)<span class="blog-posted-at-time"> {{$posted_at->format(BlogPostedAtFormat::getTimeFormat($posted_at_format))}}</span>@endif
+</time>

--- a/resources/views/plugins/user/blogs/default/include_posted_at.blade.php
+++ b/resources/views/plugins/user/blogs/default/include_posted_at.blade.php
@@ -2,10 +2,11 @@
  * ブログ投稿日時の表示部品。
  *
  * フレーム設定が未保存の場合は、呼び出し元テンプレートの改修前表示に合わせるため、
- * default_display_posted_time で時刻表示の既定値を指定できる。
+ * default_display_posted_time と default_posted_at_format で既定値を指定できる。
 --}}
 @php
-    $posted_at_format = FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_posted_at_format, BlogPostedAtFormat::japanese);
+    $default_posted_at_format = $default_posted_at_format ?? BlogPostedAtFormat::japanese;
+    $posted_at_format = FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_posted_at_format, $default_posted_at_format);
     $default_display_posted_time = $default_display_posted_time ?? ShowType::show;
     $display_posted_time = FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_posted_time, $default_display_posted_time);
 @endphp

--- a/resources/views/plugins/user/blogs/designbase/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs.blade.php
@@ -65,7 +65,7 @@
     @forelse($blogs_posts as $post)
         {{-- 投稿日時 --}}
         <dt>
-            {{$post->posted_at->format('Y/m/d')}}
+            @include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at, 'default_display_posted_time' => ShowType::not_show])
             {{-- 投稿者名 --}}
             @if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_created_name) === BlogDisplayCreatedName::display)
                 [{{$post->created_name}}]

--- a/resources/views/plugins/user/blogs/designbase/blogs.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs.blade.php
@@ -65,7 +65,7 @@
     @forelse($blogs_posts as $post)
         {{-- 投稿日時 --}}
         <dt>
-            @include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at, 'default_display_posted_time' => ShowType::not_show])
+            @include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at, 'default_display_posted_time' => ShowType::not_show, 'default_posted_at_format' => BlogPostedAtFormat::slash])
             {{-- 投稿者名 --}}
             @if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_created_name) === BlogDisplayCreatedName::display)
                 [{{$post->created_name}}]

--- a/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
@@ -14,7 +14,7 @@
     <header>
         {{-- 投稿日時 --}}
         <p>
-        {{$post->posted_at->format('Y/m/d')}}
+        @include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at, 'default_display_posted_time' => ShowType::not_show])
         {{-- 投稿者名 --}}
         @if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_created_name) === BlogDisplayCreatedName::display)
             [{{$post->created_name}}]

--- a/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
+++ b/resources/views/plugins/user/blogs/designbase/blogs_show.blade.php
@@ -14,7 +14,7 @@
     <header>
         {{-- 投稿日時 --}}
         <p>
-        @include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at, 'default_display_posted_time' => ShowType::not_show])
+        @include('plugins.user.blogs.default.include_posted_at', ['posted_at' => $post->posted_at, 'default_display_posted_time' => ShowType::not_show, 'default_posted_at_format' => BlogPostedAtFormat::slash])
         {{-- 投稿者名 --}}
         @if (FrameConfig::getConfigValue($frame_configs, BlogFrameConfig::blog_display_created_name) === BlogDisplayCreatedName::display)
             [{{$post->created_name}}]

--- a/tests/Unit/Plugins/User/Blogs/BlogPostedAtFormatTest.php
+++ b/tests/Unit/Plugins/User/Blogs/BlogPostedAtFormatTest.php
@@ -66,10 +66,24 @@ class BlogPostedAtFormatTest extends TestCase
     public function testPostedAtCanUseTemplateDefaultToHideTime(): void
     {
         $html = $this->renderPostedAt(
-            [
-                BlogFrameConfig::blog_posted_at_format => BlogPostedAtFormat::slash,
-            ],
+            [],
             ShowType::not_show
+        );
+
+        $this->assertStringContainsString('class="blog-posted-at-date">2026年5月20日', $html);
+        $this->assertStringNotContainsString('09:30', strip_tags($html));
+        $this->assertStringNotContainsString('blog-posted-at-time', $html);
+    }
+
+    /**
+     * テンプレート側が日付形式も既定にしている場合は、設定未保存でも既存テンプレートの表示形式を保つこと。
+     */
+    public function testPostedAtCanUseTemplateDefaultFormat(): void
+    {
+        $html = $this->renderPostedAt(
+            [],
+            ShowType::not_show,
+            BlogPostedAtFormat::slash
         );
 
         $this->assertStringContainsString('class="blog-posted-at-date">2026/05/20', $html);
@@ -94,7 +108,7 @@ class BlogPostedAtFormatTest extends TestCase
     /**
      * 表示部品に渡すフレーム設定を組み立てて、投稿日時のHTMLを返す。
      */
-    private function renderPostedAt(array $configs, ?string $default_display_posted_time = null): string
+    private function renderPostedAt(array $configs, ?string $default_display_posted_time = null, ?string $default_posted_at_format = null): string
     {
         $frame_configs = new Collection();
         foreach ($configs as $name => $value) {
@@ -107,6 +121,9 @@ class BlogPostedAtFormatTest extends TestCase
         ];
         if (!is_null($default_display_posted_time)) {
             $view_data['default_display_posted_time'] = $default_display_posted_time;
+        }
+        if (!is_null($default_posted_at_format)) {
+            $view_data['default_posted_at_format'] = $default_posted_at_format;
         }
 
         return view('plugins.user.blogs.default.include_posted_at', $view_data)->render();

--- a/tests/Unit/Plugins/User/Blogs/BlogPostedAtFormatTest.php
+++ b/tests/Unit/Plugins/User/Blogs/BlogPostedAtFormatTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Unit\Plugins\User\Blogs;
+
+use App\Enums\BlogFrameConfig;
+use App\Enums\BlogPostedAtFormat;
+use App\Enums\ShowType;
+use App\Models\Core\FrameConfig;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+use Tests\TestCase;
+
+/**
+ * ブログの投稿日時表示形式を検証する。
+ *
+ * DBを使わず表示部品を直接描画し、時刻だけを消せることと日時形式の選択結果が
+ * HTMLのクラス分けに反映されることを守る。
+ */
+class BlogPostedAtFormatTest extends TestCase
+{
+    /**
+     * スラッシュ区切りの形式を選ぶと、日付と時刻が別々のspanで yyyy/mm/dd hh:mm として出力されること。
+     */
+    public function testPostedAtCanBeDisplayedWithConfiguredFormat(): void
+    {
+        $html = $this->renderPostedAt([
+            BlogFrameConfig::blog_posted_at_format => BlogPostedAtFormat::slash,
+            BlogFrameConfig::blog_display_posted_time => ShowType::show,
+        ]);
+
+        $this->assertStringContainsString('class="blog-posted-at-date">2026/05/20', $html);
+        $this->assertStringContainsString('class="blog-posted-at-time"> 09:30', $html);
+    }
+
+    /**
+     * 時刻を表示しない設定では、日付だけを残し、時刻用spanを出力しないこと。
+     */
+    public function testPostedAtCanHideOnlyTime(): void
+    {
+        $html = $this->renderPostedAt([
+            BlogFrameConfig::blog_posted_at_format => BlogPostedAtFormat::slash,
+            BlogFrameConfig::blog_display_posted_time => ShowType::not_show,
+        ]);
+
+        $this->assertStringContainsString('class="blog-posted-at-date">2026/05/20', $html);
+        $this->assertStringNotContainsString('09:30', strip_tags($html));
+        $this->assertStringNotContainsString('blog-posted-at-time', $html);
+    }
+
+    /**
+     * 時刻表示が未設定の場合は、改修前の挙動に合わせて時刻を表示すること。
+     */
+    public function testPostedAtDisplaysTimeByDefault(): void
+    {
+        $html = $this->renderPostedAt([
+            BlogFrameConfig::blog_posted_at_format => BlogPostedAtFormat::slash,
+        ]);
+
+        $this->assertStringContainsString('class="blog-posted-at-date">2026/05/20', $html);
+        $this->assertStringContainsString('class="blog-posted-at-time"> 09:30', $html);
+    }
+
+    /**
+     * テンプレート側が日付のみを既定にしている場合は、時刻設定が未保存でも改修前どおり時刻を出さないこと。
+     */
+    public function testPostedAtCanUseTemplateDefaultToHideTime(): void
+    {
+        $html = $this->renderPostedAt(
+            [
+                BlogFrameConfig::blog_posted_at_format => BlogPostedAtFormat::slash,
+            ],
+            ShowType::not_show
+        );
+
+        $this->assertStringContainsString('class="blog-posted-at-date">2026/05/20', $html);
+        $this->assertStringNotContainsString('09:30', strip_tags($html));
+        $this->assertStringNotContainsString('blog-posted-at-time', $html);
+    }
+
+    /**
+     * 和暦形式を選ぶと、日付部分が元号と年で表示されること。
+     */
+    public function testPostedAtCanBeDisplayedWithJapaneseEraFormat(): void
+    {
+        $html = $this->renderPostedAt([
+            BlogFrameConfig::blog_posted_at_format => BlogPostedAtFormat::japanese_era,
+            BlogFrameConfig::blog_display_posted_time => ShowType::show,
+        ]);
+
+        $this->assertStringContainsString('class="blog-posted-at-date">令和8年5月20日', $html);
+        $this->assertStringContainsString('class="blog-posted-at-time"> 09時30分', $html);
+    }
+
+    /**
+     * 表示部品に渡すフレーム設定を組み立てて、投稿日時のHTMLを返す。
+     */
+    private function renderPostedAt(array $configs, ?string $default_display_posted_time = null): string
+    {
+        $frame_configs = new Collection();
+        foreach ($configs as $name => $value) {
+            $frame_configs->push(new FrameConfig(['name' => $name, 'value' => $value]));
+        }
+
+        $view_data = [
+            'frame_configs' => $frame_configs,
+            'posted_at' => Carbon::parse('2026-05-20 09:30:00'),
+        ];
+        if (!is_null($default_display_posted_time)) {
+            $view_data['default_display_posted_time'] = $default_display_posted_time;
+        }
+
+        return view('plugins.user.blogs.default.include_posted_at', $view_data)->render();
+    }
+}

--- a/tests/Unit/Plugins/User/Blogs/BlogPostedAtFormatTest.php
+++ b/tests/Unit/Plugins/User/Blogs/BlogPostedAtFormatTest.php
@@ -96,6 +96,10 @@ class BlogPostedAtFormatTest extends TestCase
      */
     public function testPostedAtCanBeDisplayedWithJapaneseEraFormat(): void
     {
+        if (!class_exists(\IntlDateFormatter::class)) {
+            $this->markTestSkipped('IntlDateFormatter が利用できない環境では和暦表示を検証しない。');
+        }
+
         $html = $this->renderPostedAt([
             BlogFrameConfig::blog_posted_at_format => BlogPostedAtFormat::japanese_era,
             BlogFrameConfig::blog_display_posted_time => ShowType::show,


### PR DESCRIPTION
# 概要

ブログ記事の投稿日時について、時刻のみを非表示にできる設定と、表示形式を選択できる設定を追加しました。

## 変更内容
- ブログのフレーム設定に「投稿日時の時刻表示」と「投稿日時表示形式」を追加しました。
- 投稿日時の表示を共通部品化し、日付部分と時刻部分に個別の class を付けました。
- 表示形式に `yyyy年m月d日`、`yyyy/mm/dd`、`yyyy-mm-dd`、`yyyy.mm.dd`、和暦を追加しました。
- 和暦表示は intl 拡張が利用できる環境でのみ選択肢に表示します。
- 既存テンプレートで日付のみだった箇所は、設定未保存時も改修前どおり日付のみになるようにしました。
- 投稿日時表示の単体テストを追加しました。

## 背景と目的
これまでブログの投稿日時は、テンプレートによって固定の形式で表示されていました。
特に時刻部分だけを非表示にしたい場合でも、日時全体を隠すか、時刻を出したままにする必要がありました。
この変更により、利用者がフレーム設定から表示形式と時刻表示の有無を選べるようになります。

## 特記事項
- DB変更はありません。設定値は既存のフレーム設定に保存します。
- intl 拡張がない環境では、和暦の選択肢は表示しません。
- 保存済み設定が和暦で intl 拡張がない場合は、通常の日本語日付表示にフォールバックします。

# レビュー完了希望日
軽微な表示設定追加のため急ぎません。

# 関連Pull requests/Issues
なし

# 参考
確認済みです。

- `docker compose exec -T webapp vendor/bin/phpunit tests/Unit/Plugins/User/Blogs/BlogPostedAtFormatTest.php`
- `docker compose exec -T webapp vendor/bin/phpcs --standard=phpcs.xml app/Enums/BlogFrameConfig.php app/Enums/BlogPostedAtFormat.php app/Plugins/User/Blogs/BlogsPlugin.php tests/Unit/Plugins/User/Blogs/BlogPostedAtFormatTest.php`

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule