### PR TITLE
[カウンター] 日別カウントが重複する問題を修正しました

### DIFF
--- a/app/Models/User/Counters/CounterCount.php
+++ b/app/Models/User/Counters/CounterCount.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use App\UserableNohistory;
 
 use Carbon\Carbon;
+use Illuminate\Database\QueryException;
 
 class CounterCount extends Model
 {
@@ -37,15 +38,17 @@ class CounterCount extends Model
      */
     public static function getCount($counter_id, $counted_at = null)
     {
+        $counted_at = (new Carbon($counted_at))->format('Y-m-d');
+        $yesterday_at = (new Carbon($counted_at))->subDay()->format('Y-m-d');
+
         $counter_count = CounterCount::select('counter_counts.*', 'yesterday_counts.day_count as yesterday_count')
                 ->where('counter_counts.counter_id', $counter_id)
-                ->where('counter_counts.counted_at', (new Carbon($counted_at))->format('Y-m-d'))
-                ->leftJoin('counter_counts as yesterday_counts', function ($join) use ($counted_at) {
+                ->where('counter_counts.counted_at', $counted_at)
+                ->leftJoin('counter_counts as yesterday_counts', function ($join) use ($yesterday_at) {
                     $join->on('yesterday_counts.counter_id', '=', 'counter_counts.counter_id')
-                            ->where('yesterday_counts.counted_at', (new Carbon($counted_at))->subDay()->format('Y-m-d'));
+                            ->where('yesterday_counts.counted_at', $yesterday_at)
+                            ->whereNull('yesterday_counts.deleted_at');
                 })
-                // yesterday_counts の updated_at で降順（新しい順）に並び替え
-                ->orderBy('yesterday_counts.updated_at', 'desc')
                 ->first();
 
         return $counter_count;
@@ -56,29 +59,40 @@ class CounterCount extends Model
      */
     public static function getCountOrCreate($counter_id)
     {
+        $counted_at = now()->format('Y-m-d');
+
         // 今日のカウント取得
-        $today_count = CounterCount::getCount($counter_id);
+        $today_count = CounterCount::getCount($counter_id, $counted_at);
 
         // 今日のカウントない
         if (is_null($today_count)) {
             // 昨日以前の最新日データを取得
-            $before_counted_at = CounterCount::where('counter_id', $counter_id)->max('counted_at');
-
             $before_count = CounterCount::where('counter_id', $counter_id)
-                    ->where('counted_at', $before_counted_at)
+                    ->where('counted_at', '<', $counted_at)
+                    ->orderBy('counted_at', 'desc')
                     ->first();
-            $before_count = $before_count ?? new CounterCount();
 
             // 今日カウント作成
-            $today_count = CounterCount::create([
-                'counter_id' => $counter_id,
-                'counted_at' => now()->format('Y-m-d'),
-                'day_count' => 0,
-                'total_count' => $before_count->total_count,
-            ]);
+            try {
+                CounterCount::firstOrCreate(
+                    [
+                        'counter_id' => $counter_id,
+                        'counted_at' => $counted_at,
+                    ],
+                    [
+                        'day_count' => 0,
+                        'total_count' => (int)($before_count->total_count ?? 0),
+                    ]
+                );
+            } catch (QueryException $e) {
+                // 並行アクセスで先に当日行が作られた場合は、作成済みの行を再取得する。
+                if (is_null(CounterCount::getCount($counter_id, $counted_at))) {
+                    throw $e;
+                }
+            }
 
             // 今日のカウント再取得
-            $today_count = CounterCount::getCount($counter_id);
+            $today_count = CounterCount::getCount($counter_id, $counted_at);
         }
 
         return $today_count;

--- a/app/Plugins/User/Counters/CountersPlugin.php
+++ b/app/Plugins/User/Counters/CountersPlugin.php
@@ -137,9 +137,12 @@ class CountersPlugin extends UserPluginBase
 
                     if (! in_array($counter->id, $counter_histories_array)) {
                         // カウントアップ
-                        $today_count->day_count++;
-                        $today_count->total_count++;
-                        $today_count->save();
+                        CounterCount::where('id', $today_count->id)->update([
+                            'day_count' => DB::raw('day_count + 1'),
+                            'total_count' => DB::raw('total_count + 1'),
+                            'updated_at' => now(),
+                        ]);
+                        $today_count = CounterCount::getCount($counter->id);
 
                         // session = カウンターid & 区切り文字
                         $counter_histories = $counter_histories . ':' . $counter->id;

--- a/database/migrations/2026_05_20_000000_fix_duplicate_counter_counts.php
+++ b/database/migrations/2026_05_20_000000_fix_duplicate_counter_counts.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class FixDuplicateCounterCounts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $duplicates = DB::table('counter_counts')
+            ->select('counter_id', 'counted_at')
+            ->groupBy('counter_id', 'counted_at')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        foreach ($duplicates as $duplicate) {
+            $rows = DB::table('counter_counts')
+                ->where('counter_id', $duplicate->counter_id)
+                ->where('counted_at', $duplicate->counted_at)
+                ->orderBy('id')
+                ->get();
+
+            $active_rows = $rows->filter(function ($row) {
+                return is_null($row->deleted_at);
+            });
+            $source_rows = $active_rows->isNotEmpty() ? $active_rows : $rows;
+            $keep_row = $source_rows->first();
+
+            // 1日1行へ正規化するため、日別カウントは合算し、累計は同日内の最大値を残す。
+            // 論理削除済み行だけが重複している場合も、一意制約を追加できるよう1行にまとめる。
+            DB::table('counter_counts')
+                ->where('id', $keep_row->id)
+                ->update([
+                    'day_count' => $source_rows->sum('day_count'),
+                    'total_count' => $source_rows->max('total_count'),
+                    'updated_at' => $source_rows->max('updated_at'),
+                    'deleted_at' => $keep_row->deleted_at,
+                ]);
+
+            DB::table('counter_counts')
+                ->where('counter_id', $duplicate->counter_id)
+                ->where('counted_at', $duplicate->counted_at)
+                ->where('id', '<>', $keep_row->id)
+                ->delete();
+        }
+
+        // 以後はアプリケーション側で集計せず、DB制約で「同じカウンターの同じ日は1行」を保証する。
+        Schema::table('counter_counts', function (Blueprint $table) {
+            $table->unique(['counter_id', 'counted_at'], 'counter_counts_counter_id_counted_at_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('counter_counts', function (Blueprint $table) {
+            $table->dropUnique('counter_counts_counter_id_counted_at_unique');
+        });
+    }
+}

--- a/database/migrations/2026_05_20_000000_fix_duplicate_counter_counts.php
+++ b/database/migrations/2026_05_20_000000_fix_duplicate_counter_counts.php
@@ -14,10 +14,13 @@ class FixDuplicateCounterCounts extends Migration
      */
     public function up()
     {
+        $recalculate_start_dates = [];
         $duplicates = DB::table('counter_counts')
             ->select('counter_id', 'counted_at')
             ->groupBy('counter_id', 'counted_at')
             ->havingRaw('COUNT(*) > 1')
+            ->orderBy('counter_id')
+            ->orderBy('counted_at')
             ->get();
 
         foreach ($duplicates as $duplicate) {
@@ -32,14 +35,27 @@ class FixDuplicateCounterCounts extends Migration
             });
             $source_rows = $active_rows->isNotEmpty() ? $active_rows : $rows;
             $keep_row = $source_rows->first();
+            $day_count = $source_rows->sum('day_count');
+            $total_count = $source_rows->max('total_count');
 
-            // 1日1行へ正規化するため、日別カウントは合算し、累計は同日内の最大値を残す。
+            if ($active_rows->isNotEmpty()) {
+                $total_count = $this->getPreviousActiveTotalCount(
+                    $duplicate->counter_id,
+                    $duplicate->counted_at
+                ) + $day_count;
+                $recalculate_start_dates[$duplicate->counter_id] = min(
+                    $recalculate_start_dates[$duplicate->counter_id] ?? $duplicate->counted_at,
+                    $duplicate->counted_at
+                );
+            }
+
+            // 1日1行へ正規化するため、日別カウントは合算し、累計は前日までの累計から再計算する。
             // 論理削除済み行だけが重複している場合も、一意制約を追加できるよう1行にまとめる。
             DB::table('counter_counts')
                 ->where('id', $keep_row->id)
                 ->update([
-                    'day_count' => $source_rows->sum('day_count'),
-                    'total_count' => $source_rows->max('total_count'),
+                    'day_count' => $day_count,
+                    'total_count' => $total_count,
                     'updated_at' => $source_rows->max('updated_at'),
                     'deleted_at' => $keep_row->deleted_at,
                 ]);
@@ -49,6 +65,10 @@ class FixDuplicateCounterCounts extends Migration
                 ->where('counted_at', $duplicate->counted_at)
                 ->where('id', '<>', $keep_row->id)
                 ->delete();
+        }
+
+        foreach ($recalculate_start_dates as $counter_id => $start_date) {
+            $this->recalculateActiveTotalCounts($counter_id, $start_date);
         }
 
         // 以後はアプリケーション側で集計せず、DB制約で「同じカウンターの同じ日は1行」を保証する。
@@ -67,5 +87,44 @@ class FixDuplicateCounterCounts extends Migration
         Schema::table('counter_counts', function (Blueprint $table) {
             $table->dropUnique('counter_counts_counter_id_counted_at_unique');
         });
+    }
+
+    /**
+     * 指定日より前の有効な最新累計を取得する。
+     */
+    private function getPreviousActiveTotalCount($counter_id, $counted_at)
+    {
+        return (int)(DB::table('counter_counts')
+            ->where('counter_id', $counter_id)
+            ->where('counted_at', '<', $counted_at)
+            ->whereNull('deleted_at')
+            ->orderBy('counted_at', 'desc')
+            ->orderBy('id', 'desc')
+            ->value('total_count') ?? 0);
+    }
+
+    /**
+     * 重複統合で増減した日別カウントを、後続日の累計へ反映する。
+     */
+    private function recalculateActiveTotalCounts($counter_id, $start_date)
+    {
+        $total_count = $this->getPreviousActiveTotalCount($counter_id, $start_date);
+        $rows = DB::table('counter_counts')
+            ->where('counter_id', $counter_id)
+            ->where('counted_at', '>=', $start_date)
+            ->whereNull('deleted_at')
+            ->orderBy('counted_at')
+            ->orderBy('id')
+            ->get();
+
+        foreach ($rows as $row) {
+            $total_count += (int)$row->day_count;
+
+            DB::table('counter_counts')
+                ->where('id', $row->id)
+                ->update([
+                    'total_count' => $total_count,
+                ]);
+        }
     }
 }

--- a/tests/Unit/Database/Migrations/FixDuplicateCounterCountsTest.php
+++ b/tests/Unit/Database/Migrations/FixDuplicateCounterCountsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Database\Migrations;
+
+use App\Models\User\Counters\CounterCount;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * counter_countsの重複補正マイグレーションを検証するテスト。
+ * 既存データの補正処理として、同一日付の統合と後続日の累計再計算を守る。
+ */
+class FixDuplicateCounterCountsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 重複行を1日1行へ統合したとき、合算した日別カウントが当日と後続日の累計へ反映されることを守る。
+     */
+    public function testRecalculatesTotalCountsAfterMergedDate(): void
+    {
+        $this->loadMigration();
+        $this->dropCounterCountUniqueIndex();
+        DB::table('counter_counts')->delete();
+
+        DB::table('counter_counts')->insert([
+            [
+                'counter_id' => 1,
+                'counted_at' => '2026-05-19',
+                'day_count' => 100,
+                'total_count' => 100,
+            ],
+            [
+                'counter_id' => 1,
+                'counted_at' => '2026-05-20',
+                'day_count' => 1,
+                'total_count' => 101,
+            ],
+            [
+                'counter_id' => 1,
+                'counted_at' => '2026-05-20',
+                'day_count' => 1,
+                'total_count' => 101,
+            ],
+            [
+                'counter_id' => 1,
+                'counted_at' => '2026-05-21',
+                'day_count' => 5,
+                'total_count' => 106,
+            ],
+        ]);
+
+        (new \FixDuplicateCounterCounts())->up();
+
+        $merged_count = CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-20')->first();
+        $next_count = CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-21')->first();
+
+        $this->assertSame(1, CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-20')->count());
+        $this->assertSame(2, (int)$merged_count->day_count);
+        $this->assertSame(102, (int)$merged_count->total_count);
+        $this->assertSame(107, (int)$next_count->total_count);
+    }
+
+    /**
+     * マイグレーション単体を直接実行するため、未ロード時だけ定義ファイルを読み込む。
+     */
+    private function loadMigration(): void
+    {
+        if (! class_exists(\FixDuplicateCounterCounts::class)) {
+            require_once database_path('migrations/2026_05_20_000000_fix_duplicate_counter_counts.php');
+        }
+    }
+
+    /**
+     * 重複した既存データを投入できるよう、一時的に日別一意制約を外す。
+     */
+    private function dropCounterCountUniqueIndex(): void
+    {
+        Schema::table('counter_counts', function ($table) {
+            $table->dropUnique('counter_counts_counter_id_counted_at_unique');
+        });
+    }
+}

--- a/tests/Unit/Models/User/Counters/CounterCountTest.php
+++ b/tests/Unit/Models/User/Counters/CounterCountTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Models\User\Counters;
+
+use App\Models\User\Counters\CounterCount;
+use Carbon\Carbon;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * CounterCountモデルの日別カウント作成と取得を検証するテスト。
+ * 公開メソッド経由で、同一日付の重複防止と昨日カウント取得の契約を守る。
+ */
+class CounterCountTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * テスト用に固定した現在時刻を次のテストへ持ち越さない。
+     */
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    /**
+     * 同じカウンターの同じ日付に複数行を作れないことで、日別カウントが一覧で重複表示される回帰を防ぐ。
+     */
+    public function testCounterCountIsUniquePerCounterAndDate(): void
+    {
+        CounterCount::create([
+            'counter_id' => 1,
+            'counted_at' => '2026-05-20',
+            'day_count' => 5,
+            'total_count' => 15,
+        ]);
+
+        $this->expectException(QueryException::class);
+
+        CounterCount::create([
+            'counter_id' => 1,
+            'counted_at' => '2026-05-20',
+            'day_count' => 0,
+            'total_count' => 15,
+        ]);
+    }
+
+    /**
+     * 当日行の作成を複数回要求しても1日1行に保たれ、昨日のカウントが表示用に引き継がれることを守る。
+     */
+    public function testGetCountOrCreateKeepsOneDailyRowAndReturnsYesterdayCount(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-20 10:00:00'));
+
+        CounterCount::create([
+            'counter_id' => 1,
+            'counted_at' => '2026-05-19',
+            'day_count' => 7,
+            'total_count' => 17,
+        ]);
+
+        $first_count = CounterCount::getCountOrCreate(1);
+        $second_count = CounterCount::getCountOrCreate(1);
+
+        $this->assertSame(1, CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-20')->count());
+        $this->assertSame(0, (int)$first_count->day_count);
+        $this->assertSame(17, (int)$first_count->total_count);
+        $this->assertSame(7, (int)$second_count->yesterday_count);
+    }
+}

--- a/tests/Unit/Models/User/Counters/CounterCountTest.php
+++ b/tests/Unit/Models/User/Counters/CounterCountTest.php
@@ -6,11 +6,13 @@ use App\Models\User\Counters\CounterCount;
 use Carbon\Carbon;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 /**
- * CounterCountモデルの日別カウント作成と取得を検証するテスト。
- * 公開メソッド経由で、同一日付の重複防止と昨日カウント取得の契約を守る。
+ * CounterCountモデルと重複補正マイグレーションの日別カウント作成・取得を検証するテスト。
+ * 公開メソッドとマイグレーション経由で、同一日付の重複防止と累計補正の契約を守る。
  */
 class CounterCountTest extends TestCase
 {
@@ -69,5 +71,72 @@ class CounterCountTest extends TestCase
         $this->assertSame(0, (int)$first_count->day_count);
         $this->assertSame(17, (int)$first_count->total_count);
         $this->assertSame(7, (int)$second_count->yesterday_count);
+    }
+
+    /**
+     * 重複行を1日1行へ統合したとき、合算した日別カウントが当日と後続日の累計へ反映されることを守る。
+     */
+    public function testDuplicateFixMigrationRecalculatesTotalCountsAfterMergedDate(): void
+    {
+        $this->loadDuplicateFixMigration();
+        $this->dropCounterCountUniqueIndex();
+        DB::table('counter_counts')->delete();
+
+        DB::table('counter_counts')->insert([
+            [
+                'counter_id' => 1,
+                'counted_at' => '2026-05-19',
+                'day_count' => 100,
+                'total_count' => 100,
+            ],
+            [
+                'counter_id' => 1,
+                'counted_at' => '2026-05-20',
+                'day_count' => 1,
+                'total_count' => 101,
+            ],
+            [
+                'counter_id' => 1,
+                'counted_at' => '2026-05-20',
+                'day_count' => 1,
+                'total_count' => 101,
+            ],
+            [
+                'counter_id' => 1,
+                'counted_at' => '2026-05-21',
+                'day_count' => 5,
+                'total_count' => 106,
+            ],
+        ]);
+
+        (new \FixDuplicateCounterCounts())->up();
+
+        $merged_count = CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-20')->first();
+        $next_count = CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-21')->first();
+
+        $this->assertSame(1, CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-20')->count());
+        $this->assertSame(2, (int)$merged_count->day_count);
+        $this->assertSame(102, (int)$merged_count->total_count);
+        $this->assertSame(107, (int)$next_count->total_count);
+    }
+
+    /**
+     * マイグレーション単体を直接実行するため、未ロード時だけ定義ファイルを読み込む。
+     */
+    private function loadDuplicateFixMigration(): void
+    {
+        if (! class_exists(\FixDuplicateCounterCounts::class)) {
+            require_once database_path('migrations/2026_05_20_000000_fix_duplicate_counter_counts.php');
+        }
+    }
+
+    /**
+     * 重複した既存データを投入できるよう、一時的に日別一意制約を外す。
+     */
+    private function dropCounterCountUniqueIndex(): void
+    {
+        Schema::table('counter_counts', function ($table) {
+            $table->dropUnique('counter_counts_counter_id_counted_at_unique');
+        });
     }
 }

--- a/tests/Unit/Models/User/Counters/CounterCountTest.php
+++ b/tests/Unit/Models/User/Counters/CounterCountTest.php
@@ -6,13 +6,11 @@ use App\Models\User\Counters\CounterCount;
 use Carbon\Carbon;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 /**
- * CounterCountモデルと重複補正マイグレーションの日別カウント作成・取得を検証するテスト。
- * 公開メソッドとマイグレーション経由で、同一日付の重複防止と累計補正の契約を守る。
+ * CounterCountモデルの日別カウント作成と取得を検証するテスト。
+ * 公開メソッド経由で、同一日付の重複防止と昨日カウント取得の契約を守る。
  */
 class CounterCountTest extends TestCase
 {
@@ -71,72 +69,5 @@ class CounterCountTest extends TestCase
         $this->assertSame(0, (int)$first_count->day_count);
         $this->assertSame(17, (int)$first_count->total_count);
         $this->assertSame(7, (int)$second_count->yesterday_count);
-    }
-
-    /**
-     * 重複行を1日1行へ統合したとき、合算した日別カウントが当日と後続日の累計へ反映されることを守る。
-     */
-    public function testDuplicateFixMigrationRecalculatesTotalCountsAfterMergedDate(): void
-    {
-        $this->loadDuplicateFixMigration();
-        $this->dropCounterCountUniqueIndex();
-        DB::table('counter_counts')->delete();
-
-        DB::table('counter_counts')->insert([
-            [
-                'counter_id' => 1,
-                'counted_at' => '2026-05-19',
-                'day_count' => 100,
-                'total_count' => 100,
-            ],
-            [
-                'counter_id' => 1,
-                'counted_at' => '2026-05-20',
-                'day_count' => 1,
-                'total_count' => 101,
-            ],
-            [
-                'counter_id' => 1,
-                'counted_at' => '2026-05-20',
-                'day_count' => 1,
-                'total_count' => 101,
-            ],
-            [
-                'counter_id' => 1,
-                'counted_at' => '2026-05-21',
-                'day_count' => 5,
-                'total_count' => 106,
-            ],
-        ]);
-
-        (new \FixDuplicateCounterCounts())->up();
-
-        $merged_count = CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-20')->first();
-        $next_count = CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-21')->first();
-
-        $this->assertSame(1, CounterCount::where('counter_id', 1)->where('counted_at', '2026-05-20')->count());
-        $this->assertSame(2, (int)$merged_count->day_count);
-        $this->assertSame(102, (int)$merged_count->total_count);
-        $this->assertSame(107, (int)$next_count->total_count);
-    }
-
-    /**
-     * マイグレーション単体を直接実行するため、未ロード時だけ定義ファイルを読み込む。
-     */
-    private function loadDuplicateFixMigration(): void
-    {
-        if (! class_exists(\FixDuplicateCounterCounts::class)) {
-            require_once database_path('migrations/2026_05_20_000000_fix_duplicate_counter_counts.php');
-        }
-    }
-
-    /**
-     * 重複した既存データを投入できるよう、一時的に日別一意制約を外す。
-     */
-    private function dropCounterCountUniqueIndex(): void
-    {
-        Schema::table('counter_counts', function ($table) {
-            $table->dropUnique('counter_counts_counter_id_counted_at_unique');
-        });
     }
 }


### PR DESCRIPTION
# 概要

カウンターの日別カウントが同じ日に複数行作成されないようにし、昨日のカウントが正しく表示されるようにしました。

## 変更内容
- `counter_counts` の既存重複データを同じカウンター・同じ日付で1行に集約するマイグレーションを追加しました。
- `counter_counts` に `counter_id` と `counted_at` の一意制約を追加しました。
- 当日カウント行の作成を一意制約前提の処理に変更しました。
- カウントアップ時に日別カウントと累計を原子的に更新するようにしました。
- 日別カウントの重複防止と昨日カウント取得のテストを追加しました。

## 背景と目的
同じ日のカウントが「カウント一覧」に複数表示され、2行目以降が0になることがありました。
その影響で、翌日に表示される昨日のカウントが0に見える場合があり、カウンターの信頼性が下がっていました。

この変更では、同じカウンターの同じ日は必ず1行になるようDBで保証し、昨日のカウント表示が重複データに左右されないようにしています。

## 特記事項
既存の重複データはマイグレーション時に、日別カウントを合算し、累計は同日内の最大値を残します。
以後はDB制約で同じカウンター・同じ日付の重複作成を防ぎます。

# レビュー完了希望日
不具合対応のため今週中に確認希望です。

# 関連Pull requests/Issues
なし

# 参考
確認コマンド:

```bash
docker compose exec -T webapp php vendor/bin/phpcs --standard=phpcs.xml app/Models/User/Counters/CounterCount.php app/Plugins/User/Counters/CountersPlugin.php tests/Unit/Models/User/Counters/CounterCountTest.php
docker compose exec -T webapp php vendor/bin/phpunit tests/Unit/Models/User/Counters/CounterCountTest.php
```

# DB変更の有無
有り

`counter_counts` の重複データ整理と、`counter_id`・`counted_at` の一意制約追加があります。

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule