### PR TITLE
[フォトアルバム] カスタム順を任意の並び順で初期化できるようにしました

### DIFF
--- a/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
+++ b/app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php
@@ -514,6 +514,48 @@ class PhotoalbumsPlugin extends UserPluginBase
     }
 
     /**
+     * カスタム順の初期化に使える並び順を返す。
+     */
+    private function getManualSortInitializeOptions(): array
+    {
+        $sort_options = PhotoalbumSort::getMembers();
+        unset($sort_options[PhotoalbumSort::manual_order]);
+
+        return $sort_options;
+    }
+
+    /**
+     * カスタム順の初期化に使える並び順か判定する。
+     */
+    private function isManualSortInitializeKey(?string $sort_key): bool
+    {
+        return array_key_exists((string) $sort_key, $this->getManualSortInitializeOptions());
+    }
+
+    /**
+     * 指定した並び順でカスタム順の表示順を再採番する。
+     */
+    private function initializeManualSortSequence(Photoalbum $photoalbum, string $target, string $sort_key): void
+    {
+        if (!$this->isManualSortInitializeKey($sort_key)) {
+            return;
+        }
+
+        $items = $this->getSortedPhotoalbumItemsByTarget($photoalbum->id, $target, $sort_key, $sort_key);
+
+        foreach ($items->groupBy('parent_id') as $siblings) {
+            $sequence = 1;
+            foreach ($siblings as $sibling) {
+                if ($sibling->display_sequence != $sequence) {
+                    $sibling->display_sequence = $sequence;
+                    $sibling->save();
+                }
+                $sequence++;
+            }
+        }
+    }
+
+    /**
      * 親配下の表示可能コンテンツ（対象種別）を並び順付きクエリで取得する。
      */
     private function getSortedVisibleItemsQueryByTarget(
@@ -2191,6 +2233,7 @@ class PhotoalbumsPlugin extends UserPluginBase
             'sort_file' => $sort_file,
             'sorted_children_map' => $sorted_children_map,
             'focus_open_ids' => $focus_open_ids,
+            'manual_sort_initialize_options' => $this->getManualSortInitializeOptions(),
         ]);
     }
 
@@ -2237,11 +2280,15 @@ class PhotoalbumsPlugin extends UserPluginBase
             'description_list_length' => ['nullable', 'integer', 'min:1'],
             'load_more_use_flag' => ['required', Rule::in(\App\Enums\UseType::getMemberKeys())],
             'load_more_count' => ['nullable', 'integer', 'min:1', 'max:' . $max_load_more_limit],
+            'manual_sort_initialize_folder' => ['nullable', Rule::in(array_keys($this->getManualSortInitializeOptions()))],
+            'manual_sort_initialize_file' => ['nullable', Rule::in(array_keys($this->getManualSortInitializeOptions()))],
         ]);
         $validator->setAttributeNames([
             'description_list_length' => PhotoalbumFrameConfig::enum['description_list_length'],
             'load_more_use_flag' => PhotoalbumFrameConfig::enum['load_more_use_flag'],
             'load_more_count' => PhotoalbumFrameConfig::enum['load_more_count'],
+            'manual_sort_initialize_folder' => 'アルバムのカスタム順初期化',
+            'manual_sort_initialize_file' => '写真のカスタム順初期化',
         ]);
 
         // エラーがあった場合は入力画面に戻る。
@@ -2249,8 +2296,23 @@ class PhotoalbumsPlugin extends UserPluginBase
             return redirect()->back()->withErrors($validator)->withInput();
         }
 
-        // フレーム設定保存
-        $this->saveFrameConfigs($request, $frame_id, PhotoalbumFrameConfig::getMemberKeys());
+        DB::transaction(function () use ($request, $frame_id) {
+            // フレーム設定保存
+            $this->saveFrameConfigs($request, $frame_id, PhotoalbumFrameConfig::getMemberKeys());
+
+            $photoalbum = $this->getPluginBucket($this->getBucketId());
+            if (empty($photoalbum->id)) {
+                return;
+            }
+
+            if ($request->sort_folder === PhotoalbumSort::manual_order && !empty($request->manual_sort_initialize_folder)) {
+                $this->initializeManualSortSequence($photoalbum, 'folder', $request->manual_sort_initialize_folder);
+            }
+            if ($request->sort_file === PhotoalbumSort::manual_order && !empty($request->manual_sort_initialize_file)) {
+                $this->initializeManualSortSequence($photoalbum, 'image', $request->manual_sort_initialize_file);
+            }
+        });
+
         // 更新したので、frame_configsを設定しなおす
         $this->refreshFrameConfigs();
 

--- a/resources/views/plugins/user/photoalbums/default/frame.blade.php
+++ b/resources/views/plugins/user/photoalbums/default/frame.blade.php
@@ -14,6 +14,7 @@
     $(function () {
         var detailValue = '{{ \App\Enums\PhotoalbumPlayviewType::play_in_detail }}';
         var loadMoreUseValue = '{{ \App\Enums\UseType::use }}';
+        var manualSortValue = '{{ \App\Enums\PhotoalbumSort::manual_order }}';
 
         function togglePlayViewOptions(value) {
             var isDetail = value == detailValue;
@@ -28,6 +29,17 @@
             $('.photoalbum-load-more-options').toggleClass('text-muted', !isEnabled);
         }
 
+        function toggleManualSortInitializeOptions() {
+            $('.photoalbum-manual-sort-initialize-folder').toggleClass(
+                'd-none',
+                $('select[name="sort_folder"]').val() != manualSortValue
+            );
+            $('.photoalbum-manual-sort-initialize-file').toggleClass(
+                'd-none',
+                $('select[name="sort_file"]').val() != manualSortValue
+            );
+        }
+
         var isVisibilitySaving = false;
         var pendingVisibilitySave = false;
         var $frameForm = $('#photoalbum-frame-settings-{{ $frame_id }}');
@@ -38,6 +50,8 @@
 
         $('input[name="load_more_use_flag"]').on('change', toggleLoadMoreOptions);
         toggleLoadMoreOptions();
+        $('select[name="sort_folder"], select[name="sort_file"]').on('change', toggleManualSortInitializeOptions);
+        toggleManualSortInitializeOptions();
 
         function setVisibilitySaving(isSaving) {
             $('.photoalbum-visibility-toggle__input').prop('disabled', isSaving);
@@ -538,11 +552,23 @@
                         @endif
                     @endforeach
                 </select>
-                @if (($current_sort_folder ?? '') === PhotoalbumSort::manual_order)
-                    <small class="form-text text-muted">
-                        カスタム順の変更は <a href="#photoalbum-preview">表示プレビュー</a> の上下ボタンから行えます。
-                    </small>
-                @endif
+                <small class="form-text text-muted photoalbum-manual-sort-initialize-folder{{ ($current_sort_folder ?? '') === PhotoalbumSort::manual_order ? '' : ' d-none' }}">
+                    カスタム順の変更は <a href="#photoalbum-preview">表示プレビュー</a> の上下ボタンから行えます。
+                </small>
+                <div class="form-inline mt-2 photoalbum-manual-sort-initialize-folder{{ ($current_sort_folder ?? '') === PhotoalbumSort::manual_order ? '' : ' d-none' }}">
+                    <label for="manual_sort_initialize_folder" class="mr-2">カスタム順を初期化</label>
+                    <select class="form-control" name="manual_sort_initialize_folder" id="manual_sort_initialize_folder">
+                        <option value="">初期化しない</option>
+                        @foreach (($manual_sort_initialize_options ?? []) as $sort_key => $sort_view)
+                            <option value="{{ $sort_key }}" @if(old('manual_sort_initialize_folder') == $sort_key) selected @endif>
+                                {{ $sort_view }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <small class="form-text text-muted photoalbum-manual-sort-initialize-folder{{ ($current_sort_folder ?? '') === PhotoalbumSort::manual_order ? '' : ' d-none' }}">
+                    アルバム並び順がカスタム順のときだけ、変更確定時に選択した並び順でカスタム順を作り直します。
+                </small>
             </div>
         </div>
         {{-- 写真並び順 --}}
@@ -559,11 +585,23 @@
                         @endif
                     @endforeach
                 </select>
-                @if (($current_sort_file ?? '') === PhotoalbumSort::manual_order)
-                    <small class="form-text text-muted">
-                        カスタム順の変更は <a href="#photoalbum-preview">表示プレビュー</a> の上下ボタンから行えます。
-                    </small>
-                @endif
+                <small class="form-text text-muted photoalbum-manual-sort-initialize-file{{ ($current_sort_file ?? '') === PhotoalbumSort::manual_order ? '' : ' d-none' }}">
+                    カスタム順の変更は <a href="#photoalbum-preview">表示プレビュー</a> の上下ボタンから行えます。
+                </small>
+                <div class="form-inline mt-2 photoalbum-manual-sort-initialize-file{{ ($current_sort_file ?? '') === PhotoalbumSort::manual_order ? '' : ' d-none' }}">
+                    <label for="manual_sort_initialize_file" class="mr-2">カスタム順を初期化</label>
+                    <select class="form-control" name="manual_sort_initialize_file" id="manual_sort_initialize_file">
+                        <option value="">初期化しない</option>
+                        @foreach (($manual_sort_initialize_options ?? []) as $sort_key => $sort_view)
+                            <option value="{{ $sort_key }}" @if(old('manual_sort_initialize_file') == $sort_key) selected @endif>
+                                {{ $sort_view }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <small class="form-text text-muted photoalbum-manual-sort-initialize-file{{ ($current_sort_file ?? '') === PhotoalbumSort::manual_order ? '' : ' d-none' }}">
+                    写真並び順がカスタム順のときだけ、変更確定時に選択した並び順でカスタム順を作り直します。
+                </small>
             </div>
         </div>
 

--- a/tests/Feature/Plugins/User/Photoalbums/PhotoalbumsManualSortInitializeFeatureTest.php
+++ b/tests/Feature/Plugins/User/Photoalbums/PhotoalbumsManualSortInitializeFeatureTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Photoalbums;
+
+use App\Enums\PhotoalbumFrameConfig;
+use App\Enums\PhotoalbumPlayviewType;
+use App\Enums\PhotoalbumSort;
+use App\Enums\ResizedImageSize;
+use App\Enums\ShowType;
+use App\Enums\UploadMaxSize;
+use App\Enums\UseType;
+use App\Models\Common\Buckets;
+use App\Models\Common\Frame;
+use App\Models\Common\Page;
+use App\Models\Common\Uploads;
+use App\Models\Core\UsersRoles;
+use App\Models\User\Photoalbums\Photoalbum;
+use App\Models\User\Photoalbums\PhotoalbumContent;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * フォトアルバムの表示設定で、既存の並び順を元にカスタム順を作り直す振る舞いを検証する。
+ * 実際の保存リクエスト経由で、フレーム設定保存と表示順の再採番が同時に成立することを守る。
+ */
+class PhotoalbumsManualSortInitializeFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    /**
+     * アルバム並び順をカスタム順にするとき、選択した名前順でカスタム順を初期化できること。
+     */
+    public function testSaveViewInitializesFolderManualSortFromSelectedSort(): void
+    {
+        [$page, $frame, $root, $photoalbum] = $this->makePhotoalbumFrame();
+        $gamma = $this->createFolderContent($root, $photoalbum->id, 1, 'gamma');
+        $alpha = $this->createFolderContent($root, $photoalbum->id, 2, 'alpha');
+        $beta = $this->createFolderContent($root, $photoalbum->id, 3, 'beta');
+
+        $admin = $this->createContentAdminUser();
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/photoalbums/saveView/{$page->id}/{$frame->id}/{$photoalbum->id}",
+            $this->makeSaveViewPayload([
+                'redirect_path' => "/plugin/photoalbums/editView/{$page->id}/{$frame->id}/{$photoalbum->bucket_id}",
+                'sort_folder' => PhotoalbumSort::manual_order,
+                'sort_file' => PhotoalbumSort::name_asc,
+                'manual_sort_initialize_folder' => PhotoalbumSort::name_asc,
+            ])
+        );
+
+        $response->assertStatus(302);
+        $this->assertSame(
+            [$alpha->id, $beta->id, $gamma->id],
+            $this->getOrderedChildIds($root->id, PhotoalbumContent::is_folder_on)
+        );
+        $this->assertDatabaseHas('frame_configs', [
+            'frame_id' => $frame->id,
+            'name' => PhotoalbumFrameConfig::sort_folder,
+            'value' => PhotoalbumSort::manual_order,
+        ]);
+    }
+
+    /**
+     * 写真並び順をカスタム順にするとき、アップロードファイル名の降順でカスタム順を初期化できること。
+     */
+    public function testSaveViewInitializesFileManualSortFromSelectedSort(): void
+    {
+        [$page, $frame, $root, $photoalbum] = $this->makePhotoalbumFrame();
+        $alpha = $this->createImageContent($root, $photoalbum->id, 1, 'alpha.jpg');
+        $gamma = $this->createImageContent($root, $photoalbum->id, 2, 'gamma.jpg');
+        $beta = $this->createImageContent($root, $photoalbum->id, 3, 'beta.jpg');
+
+        $admin = $this->createContentAdminUser();
+        $response = $this->actingAs($admin)->post(
+            "/redirect/plugin/photoalbums/saveView/{$page->id}/{$frame->id}/{$photoalbum->id}",
+            $this->makeSaveViewPayload([
+                'redirect_path' => "/plugin/photoalbums/editView/{$page->id}/{$frame->id}/{$photoalbum->bucket_id}",
+                'sort_folder' => PhotoalbumSort::name_asc,
+                'sort_file' => PhotoalbumSort::manual_order,
+                'manual_sort_initialize_file' => PhotoalbumSort::name_desc,
+            ])
+        );
+
+        $response->assertStatus(302);
+        $this->assertSame(
+            [$gamma->id, $beta->id, $alpha->id],
+            $this->getOrderedChildIds($root->id, PhotoalbumContent::is_folder_off)
+        );
+        $this->assertDatabaseHas('frame_configs', [
+            'frame_id' => $frame->id,
+            'name' => PhotoalbumFrameConfig::sort_file,
+            'value' => PhotoalbumSort::manual_order,
+        ]);
+    }
+
+    /**
+     * フォトアルバム用のページ・フレーム・バケツ・ルートを作る。
+     */
+    private function makePhotoalbumFrame(): array
+    {
+        $page = Page::where('permanent_link', '/')->first() ?? Page::factory()->create([
+            'permanent_link' => '/',
+            'page_name' => 'home',
+        ]);
+
+        $bucket = Buckets::factory()->create([
+            'bucket_name' => 'テストフォトアルバム',
+            'plugin_name' => 'photoalbums',
+        ]);
+
+        $frame = Frame::factory()->create([
+            'page_id' => $page->id,
+            'area_id' => 2,
+            'plugin_name' => 'photoalbums',
+            'bucket_id' => $bucket->id,
+            'template' => 'default',
+            'display_sequence' => 1,
+        ]);
+
+        $photoalbum = Photoalbum::create([
+            'bucket_id' => $bucket->id,
+            'name' => 'テストフォトアルバム',
+            'image_upload_max_size' => UploadMaxSize::two_mega_byte,
+            'image_upload_max_px' => ResizedImageSize::big,
+            'video_upload_max_size' => UploadMaxSize::ten_mega_byte,
+        ]);
+
+        $root = PhotoalbumContent::create([
+            'photoalbum_id' => $photoalbum->id,
+            'upload_id' => null,
+            'name' => $photoalbum->name,
+            'is_folder' => PhotoalbumContent::is_folder_on,
+            'is_cover' => PhotoalbumContent::is_cover_off,
+            'display_sequence' => 1,
+            'parent_id' => null,
+        ]);
+
+        return [$page, $frame, $root, $photoalbum];
+    }
+
+    /**
+     * 表示設定保存に必要な既定リクエストを作る。
+     */
+    private function makeSaveViewPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'redirect_path' => '/',
+            'hidden_folder_ids' => [''],
+            PhotoalbumFrameConfig::download => ShowType::not_show,
+            PhotoalbumFrameConfig::posted_at => ShowType::not_show,
+            PhotoalbumFrameConfig::load_more_use_flag => UseType::not_use,
+            PhotoalbumFrameConfig::embed_code => ShowType::not_show,
+            PhotoalbumFrameConfig::play_view => PhotoalbumPlayviewType::play_in_list,
+            PhotoalbumFrameConfig::description_list_length => null,
+            PhotoalbumFrameConfig::load_more_count => null,
+            PhotoalbumFrameConfig::sort_folder => PhotoalbumSort::name_asc,
+            PhotoalbumFrameConfig::sort_file => PhotoalbumSort::name_asc,
+            'manual_sort_initialize_folder' => null,
+            'manual_sort_initialize_file' => null,
+        ], $overrides);
+    }
+
+    /**
+     * 子アルバムを作成する。
+     */
+    private function createFolderContent(
+        PhotoalbumContent $parent,
+        int $photoalbum_id,
+        int $display_sequence,
+        string $name
+    ): PhotoalbumContent {
+        return $parent->children()->create([
+            'photoalbum_id' => $photoalbum_id,
+            'upload_id' => null,
+            'name' => $name,
+            'is_folder' => PhotoalbumContent::is_folder_on,
+            'is_cover' => PhotoalbumContent::is_cover_off,
+            'display_sequence' => $display_sequence,
+        ]);
+    }
+
+    /**
+     * 画像コンテンツを作成する。
+     */
+    private function createImageContent(
+        PhotoalbumContent $parent,
+        int $photoalbum_id,
+        int $display_sequence,
+        string $original_name
+    ): PhotoalbumContent {
+        $upload = Uploads::factory()->jpg()->create([
+            'client_original_name' => $original_name,
+            'plugin_name' => 'photoalbums',
+        ]);
+
+        return $parent->children()->create([
+            'photoalbum_id' => $photoalbum_id,
+            'upload_id' => $upload->id,
+            'name' => pathinfo($original_name, PATHINFO_FILENAME),
+            'is_folder' => PhotoalbumContent::is_folder_off,
+            'is_cover' => PhotoalbumContent::is_cover_off,
+            'display_sequence' => $display_sequence,
+            'mimetype' => $upload->mimetype,
+        ]);
+    }
+
+    /**
+     * 指定した親直下のコンテンツIDを表示順どおりに返す。
+     */
+    private function getOrderedChildIds(int $parent_id, int $is_folder): array
+    {
+        return PhotoalbumContent::where('parent_id', $parent_id)
+            ->where('is_folder', $is_folder)
+            ->orderBy('display_sequence')
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+    }
+
+    /**
+     * コンテンツ管理者権限を持つユーザーを作成する。
+     */
+    private function createContentAdminUser(): User
+    {
+        $user = User::factory()->create();
+
+        UsersRoles::factory()->create([
+            'users_id' => $user->id,
+            'target' => 'base',
+            'role_name' => 'role_article_admin',
+            'role_value' => 1,
+        ]);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
# 概要

フォトアルバムのカスタム順を、名前順や登録日順などの既存の並び順で初期化できるようにしました。

## 変更内容
- 表示設定に「カスタム順を初期化」の選択肢を追加しました。
- アルバム並び順または写真並び順で「カスタム順」を選んだときだけ、初期化UIを表示するようにしました。
- 変更確定時に、選択した並び順をもとにカスタム順の表示順を再採番する処理を追加しました。
- アルバムと写真それぞれの初期化動作を Feature テストで確認しました。

## 背景と目的
フォトアルバムをカスタム順にした際、登録の古い順から並び替えを始める必要がありました。そのため、多数のアルバムのうち一部だけ順番を変えたい場合でも、全体を手作業で並び替える負担がありました。

この変更により、まず名前順や登録日順など利用者に近い並びでカスタム順を作り直し、その後に必要な一部だけを調整できるようにします。

## 特記事項
- マイグレーションはありません。
- 初期化は「変更確定」時に実行されます。
- 初期化UIは、対象の並び順がカスタム順の場合のみ表示されます。

# レビュー完了希望日
急ぎません。

# 関連Pull requests/Issues
なし

# 参考
確認したコマンド:

```bash
docker compose exec -T webapp php vendor/bin/phpunit tests/Feature/Plugins/User/Photoalbums/PhotoalbumsManualSortInitializeFeatureTest.php
docker compose exec -T webapp php vendor/bin/phpunit tests/Feature/Plugins/User/Photoalbums/PhotoalbumsMoreContentsFeatureTest.php
docker compose exec -T webapp php vendor/bin/phpcs --standard=phpcs.xml app/Plugins/User/Photoalbums/PhotoalbumsPlugin.php tests/Feature/Plugins/User/Photoalbums/PhotoalbumsManualSortInitializeFeatureTest.php
docker compose exec -T webapp php vendor/bin/phpcs --standard=phpcs.xml resources/views/plugins/user/photoalbums/default/frame.blade.php
```

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule