### PR TITLE
[新着情報] 各表示要素にCSS用クラスを追加しました

### DIFF
--- a/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/default/whatsnews.blade.php
@@ -39,16 +39,16 @@
         {{-- 登録日時、カテゴリ --}}
         @if ($whatsnews_frame->view_posted_at)
         {{-- 表示設定の記事間の罫線を確認（ただし、投稿日を表示しない場合は、次の項目で罫線を表示） --}}
-        <dt class="@if (!$loop->first && FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::border))border-top @endif">
+        <dt class="whatsnew_posted_at @if (!$loop->first && FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::border))border-top @endif">
             {{(new Carbon($whatsnew->posted_at))->format('Y/m/d')}}
             @if($whatsnew->category)
-                <span class="badge cc_category_{{$whatsnew->classname}}">{{$whatsnew->category}}</span>
+                <span class="whatsnew_category badge cc_category_{{$whatsnew->classname}}">{{$whatsnew->category}}</span>
             @endif
         </dt>
         @endif
         {{-- タイトル＋リンク --}}
         {{-- 投稿日を表示しない場合は、ここで表示設定の記事間の罫線を確認 --}}
-        <dd class="@if (!$whatsnews_frame->view_posted_at && !$loop->first && FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::border))border-top @endif">
+        <dd class="whatsnew_title @if (!$whatsnews_frame->view_posted_at && !$loop->first && FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::border))border-top @endif">
             @if ($link_pattern[$whatsnew->plugin_name] == 'show_page_frame_post')
             <a href="{{url('/')}}{{$link_base[$whatsnew->plugin_name]}}/{{$whatsnew->page_id}}/{{$whatsnew->frame_id}}/{{$whatsnew->post_id}}#frame-{{$whatsnew->frame_id}}">
                 @if ($whatsnew->post_title)
@@ -62,14 +62,14 @@
 
         {{-- 本文 --}}
         @if (FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail))
-        <div>
+        <div class="whatsnew_post_detail">
             {{ $whatsnew->post_detail_strip_tags }}
         </div>
         @endif
 
         {{-- サムネイル (サムネイル表示がon ＆ 記事中にサムネイルがある場合に表示) --}}
         @if (FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail) && $whatsnew->first_image_path)
-        <dd>
+        <dd class="whatsnew_thumbnail">
             @if (empty(FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size)))
                 <img src="{{$whatsnew->first_image_path}}?size=small" style="width: 200px;">
             @else
@@ -80,7 +80,7 @@
 
         {{-- 投稿者 --}}
         @if ($whatsnews_frame->view_posted_name)
-        <dd>
+        <dd class="whatsnew_posted_name">
             {{$whatsnew->posted_name}}
         </dd>
         @endif
@@ -89,28 +89,28 @@
     {{-- 「もっと見る」ボタン押下時、非同期で新着一覧をレンダリング ※templateタグはタグとして出力されないタグです。 --}}
     <template v-for="whatsnews in whatsnewses">
         {{-- 登録日時、カテゴリ --}}
-        <dt v-if="view_posted_at == 1" v-bind:class="{ 'border-top': border == '1' }">
+        <dt v-if="view_posted_at == 1" class="whatsnew_posted_at" v-bind:class="{ 'border-top': border == '1' }">
             @{{ cc_format_date(whatsnews.posted_at) }}
-            <span v-if="whatsnews.category != null && whatsnews.category != ''" :class="'badge cc_category_' + whatsnews.classname">@{{ whatsnews.category }}</span>
+            <span v-if="whatsnews.category != null && whatsnews.category != ''" :class="'whatsnew_category badge cc_category_' + whatsnews.classname">@{{ whatsnews.category }}</span>
         </dt>
         {{-- タイトル＋リンク --}}
-        <dd v-if="link_pattern[whatsnews.plugin_name] == 'show_page_frame_post'" v-bind:class="{ 'border-top': border == '1' && view_posted_at != 1 }">
+        <dd v-if="link_pattern[whatsnews.plugin_name] == 'show_page_frame_post'" class="whatsnew_title" v-bind:class="{ 'border-top': border == '1' && view_posted_at != 1 }">
             <a :href="url + link_base[whatsnews.plugin_name] + '/' + whatsnews.page_id + '/' + whatsnews.frame_id + '/' + whatsnews.post_id + '#frame-' + whatsnews.frame_id">
                 <template v-if="whatsnews.post_title == null || whatsnews.post_title == ''">（無題）</template>
                 <template v-else>@{{ whatsnews.post_title_strip_tags }}</template>
             </a>
         </dd>
         {{-- 本文 --}}
-        <dd v-if="post_detail == '1'">
+        <dd v-if="post_detail == '1'" class="whatsnew_post_detail">
             @{{ whatsnews.post_detail_strip_tags }}
         </dd>
         {{-- サムネイル (サムネイル表示がon ＆ 記事中にサムネイルがある場合に表示) --}}
-        <dd v-if="post_detail == '1' && whatsnews.first_image_path">
+        <dd v-if="post_detail == '1' && whatsnews.first_image_path" class="whatsnew_thumbnail">
             <img v-if="thumbnail_size == 0 || thumbnail_size == ''" v-bind:src="whatsnews.first_image_path" style="max-width: 200px; max-height: 200px;">
             <img v-else v-bind:src="whatsnews.first_image_path" v-bind:style="thumbnail_style">
         </dd>
         {{-- 投稿者 --}}
-        <dd v-if="view_posted_name == 1">
+        <dd v-if="view_posted_name == 1" class="whatsnew_posted_name">
             @{{ whatsnews.posted_name }}
         </dd>
     </template>

--- a/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
+++ b/resources/views/plugins/user/whatsnews/onerow/whatsnews.blade.php
@@ -39,14 +39,14 @@
         <div class="row @if (!$loop->first && FrameConfig::getConfigValue($frame_configs, WhatsnewFrameConfig::border))border-top @endif pt-1">
             {{-- 投稿日 --}}
             @if ($whatsnews_frame->view_posted_at)
-            <div class="p-0 col-md-2 col-lg text-nowrap" style="display: contents;">
+            <div class="whatsnew_posted_at p-0 col-md-2 col-lg text-nowrap" style="display: contents;">
                 <span class="mr-2">{{(new Carbon($whatsnew->posted_at))->format('Y/m/d')}}</span>
             </div>
             @endif
 
             {{-- カテゴリ --}}
             @if( $whatsnew->category )
-            <div class="p-0 col-md-2 col-lg" style="display: contents;">
+            <div class="whatsnew_category p-0 col-md-2 col-lg" style="display: contents;">
                 <div>
                     <span class="badge cc_category_{{$whatsnew->classname}} mr-2">{{$whatsnew->category}}</span>
                 </div>
@@ -54,7 +54,7 @@
             @endif
 
             {{-- タイトル --}}
-            <div class="p-0 col-12 col-sm-12 col-md col-lg mr-2 text-truncate">
+            <div class="whatsnew_title p-0 col-12 col-sm-12 col-md col-lg mr-2 text-truncate">
                 @if ($link_pattern[$whatsnew->plugin_name] == 'show_page_frame_post')
                 <a href="{{url('/')}}{{$link_base[$whatsnew->plugin_name]}}/{{$whatsnew->page_id}}/{{$whatsnew->frame_id}}/{{$whatsnew->post_id}}#frame-{{$whatsnew->frame_id}}">
                     @if ($whatsnew->post_title)
@@ -68,7 +68,7 @@
 
             {{-- 投稿者 --}}
             @if( $whatsnews_frame->view_posted_name )
-            <div class="p-0 col-12 col-sm-12 col-md-3 col-lg-2 text-right text-nowrap">
+            <div class="whatsnew_posted_name p-0 col-12 col-sm-12 col-md-3 col-lg-2 text-right text-nowrap">
                 {{$whatsnew->posted_name}}
             </div>
             @endif
@@ -78,7 +78,7 @@
         <div class="pb-2 mt-1">
             {{-- サムネイル --}}
             @if ($whatsnew->first_image_path && FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail))
-            <div class="p-0 text-right">
+            <div class="whatsnew_thumbnail p-0 text-right">
                 @if (empty(FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::thumbnail_size)))
                     <img src="{{$whatsnew->first_image_path}}?size=small" class="float-right pb-1" style="max-width: 200px; max-height: 200px;">
                 @else
@@ -89,7 +89,7 @@
 
             {{-- 本文 --}}
             @if (FrameConfig::getConfigValueAndOld($frame_configs, WhatsnewFrameConfig::post_detail))
-            <div>
+            <div class="whatsnew_post_detail">
                 {{ $whatsnew->post_detail_strip_tags }}
             </div>
             @endif
@@ -106,36 +106,36 @@
                  v-bind:class="{ 'border-top': border == '1' }"
             >
                 {{-- 登録日時 --}}
-                <div v-if="view_posted_at == 1" class="p-0 col-md-2 col-lg text-nowrap" style="display: contents;">
+                <div v-if="view_posted_at == 1" class="whatsnew_posted_at p-0 col-md-2 col-lg text-nowrap" style="display: contents;">
                     <span class="mr-2">@{{ cc_format_date(whatsnews.posted_at) }}</span>
                 </div>
                 {{-- カテゴリ --}}
-                <div v-if="whatsnews.category != null && whatsnews.category != ''" class="p-0 col-md-2 col-lg" style="display: contents;">
+                <div v-if="whatsnews.category != null && whatsnews.category != ''" class="whatsnew_category p-0 col-md-2 col-lg" style="display: contents;">
                     <div>
                         <span :class="'mr-2 badge cc_category_' + whatsnews.classname">@{{ whatsnews.category }}</span>
                     </div>
                 </div>
                 {{-- タイトル＋リンク --}}
-                <div v-if="link_pattern[whatsnews.plugin_name] == 'show_page_frame_post'" class="p-0 col-12 col-sm-12 col-md col-lg mr-2 text-truncate">
+                <div v-if="link_pattern[whatsnews.plugin_name] == 'show_page_frame_post'" class="whatsnew_title p-0 col-12 col-sm-12 col-md col-lg mr-2 text-truncate">
                     <a :href="url + link_base[whatsnews.plugin_name] + '/' + whatsnews.page_id + '/' + whatsnews.frame_id + '/' + whatsnews.post_id + '#frame-' + whatsnews.frame_id">
                         <template v-if="whatsnews.post_title == null || whatsnews.post_title == ''">（無題）</template>
                         <template v-else>@{{ whatsnews.post_title_strip_tags }}</template>
                     </a>
                 </div>
                 {{-- 投稿者 --}}
-                <div v-if="view_posted_name == 1" class="p-0 col-12 col-sm-12 col-md-3 col-lg-2 text-right text-nowrap">
+                <div v-if="view_posted_name == 1" class="whatsnew_posted_name p-0 col-12 col-sm-12 col-md-3 col-lg-2 text-right text-nowrap">
                     @{{ whatsnews.posted_name }}
                 </div>
             </div>
             {{-- 本文、サムネイル --}}
             <div v-if="post_detail == '1' || thumbnail == '1'" class="pb-2 mt-1">
                 {{-- サムネイル --}}
-                <div v-if="thumbnail == '1' && whatsnews.first_image_path" class="p-0 text-right">
+                <div v-if="thumbnail == '1' && whatsnews.first_image_path" class="whatsnew_thumbnail p-0 text-right">
                     <img v-if="thumbnail_size == 0 || thumbnail_size == ''" v-bind:src="whatsnews.first_image_path" class="float-right pb-1" style="max-width: 200px; max-height: 200px;">
                     <img v-else v-bind:src="whatsnews.first_image_path" class="float-right pb-1" v-bind:style="thumbnail_style">
                 </div>
                 {{-- 本文 --}}
-                <div v-if="post_detail == '1'">
+                <div v-if="post_detail == '1'" class="whatsnew_post_detail">
                     @{{ whatsnews.post_detail_strip_tags }}
                 </div>
             </div>

--- a/tests/Feature/Plugins/User/Whatsnews/WhatsnewsViewClassesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Whatsnews/WhatsnewsViewClassesFeatureTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Whatsnews;
+
+use App\Enums\UseType;
+use App\Enums\WhatsnewFrameConfig;
+use App\Models\Core\FrameConfig;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Tests\TestCase;
+
+/**
+ * 新着情報の表示テンプレートに付与されるCSS用クラスを検証するFeatureテスト。
+ *
+ * 利用者が日付・カテゴリ・タイトル・投稿者・本文・サムネイルを個別にスタイル指定できるよう、
+ * DBではなくBladeの公開された描画結果を対象に、テンプレートごとのHTML契約を確認する方針。
+ */
+class WhatsnewsViewClassesFeatureTest extends TestCase
+{
+    /**
+     * 標準テンプレートで、新着を構成する各要素にCSSで指定できるクラスが付与されること。
+     */
+    public function testDefaultTemplateRendersClassesForEachWhatsnewPart(): void
+    {
+        $html = $this->renderWhatsnewsTemplate('plugins.user.whatsnews.default.whatsnews');
+
+        $this->assertWhatsnewPartClasses($html);
+    }
+
+    /**
+     * 1行表示テンプレートで、表示項目の有無に左右されず各要素をクラスで指定できること。
+     */
+    public function testOnerowTemplateRendersClassesForEachWhatsnewPart(): void
+    {
+        $html = $this->renderWhatsnewsTemplate('plugins.user.whatsnews.onerow.whatsnews');
+
+        $this->assertWhatsnewPartClasses($html);
+    }
+
+    /**
+     * カード表示テンプレートで、既存のカード用HTMLにも各要素のCSS用クラスが維持されること。
+     */
+    public function testCardTemplateRendersClassesForEachWhatsnewPart(): void
+    {
+        $html = $this->renderWhatsnewsTemplate('plugins.user.whatsnews.card_04.whatsnews');
+
+        $this->assertWhatsnewPartClasses($html);
+    }
+
+    /**
+     * 新着情報テンプレートの描画に必要な最小限のデータを用意する。
+     */
+    private function renderWhatsnewsTemplate(string $template): string
+    {
+        $frame = (object) [
+            'id' => 1,
+            'bucket_id' => 1,
+            'frame_design' => 'default',
+            'classname_body' => '',
+        ];
+
+        $whatsnews_frame = (object) [
+            'rss' => UseType::not_use,
+            'whatsnew_name' => 'テスト新着',
+            'view_posted_at' => UseType::use,
+            'view_posted_name' => UseType::use,
+            'read_more_use_flag' => UseType::not_use,
+            'read_more_btn_transparent_flag' => UseType::not_use,
+            'read_more_btn_color_type' => 'primary',
+            'read_more_btn_type' => '',
+            'read_more_name' => 'もっと見る',
+        ];
+
+        $whatsnews = collect([
+            (object) [
+                'posted_at' => Carbon::parse('2026-05-22 10:00:00'),
+                'category' => 'お知らせ',
+                'classname' => 'notice',
+                'plugin_name' => 'blogs',
+                'page_id' => 1,
+                'frame_id' => 2,
+                'post_id' => 3,
+                'post_title' => 'テストタイトル',
+                'post_title_strip_tags' => 'テストタイトル',
+                'post_detail_strip_tags' => 'テスト本文',
+                'first_image_path' => '/file/10',
+                'posted_name' => '投稿者名',
+            ],
+        ]);
+
+        return view($template, [
+            'frame' => $frame,
+            'frame_id' => $frame->id,
+            'page' => (object) ['id' => 1],
+            'whatsnews' => $whatsnews,
+            'whatsnews_frame' => $whatsnews_frame,
+            'whatsnews_total_count' => 1,
+            'link_pattern' => ['blogs' => 'show_page_frame_post'],
+            'link_base' => ['blogs' => '/plugin/blogs/show'],
+            'frame_configs' => $this->createVisiblePartFrameConfigs(),
+        ])->render();
+    }
+
+    /**
+     * 本文・サムネイル・罫線を表示状態にして、対象クラスがHTMLに現れるようにする。
+     */
+    private function createVisiblePartFrameConfigs(): EloquentCollection
+    {
+        return new EloquentCollection([
+            new FrameConfig(['name' => WhatsnewFrameConfig::post_detail, 'value' => UseType::use]),
+            new FrameConfig(['name' => WhatsnewFrameConfig::thumbnail, 'value' => UseType::use]),
+            new FrameConfig(['name' => WhatsnewFrameConfig::border, 'value' => UseType::use]),
+            new FrameConfig(['name' => WhatsnewFrameConfig::async, 'value' => UseType::not_use]),
+        ]);
+    }
+
+    /**
+     * CSS適用対象として公開する6種類のクラスが描画結果に含まれることを確認する。
+     */
+    private function assertWhatsnewPartClasses(string $html): void
+    {
+        $this->assertStringContainsString('whatsnew_posted_at', $html);
+        $this->assertStringContainsString('whatsnew_category', $html);
+        $this->assertStringContainsString('whatsnew_title', $html);
+        $this->assertStringContainsString('whatsnew_posted_name', $html);
+        $this->assertStringContainsString('whatsnew_post_detail', $html);
+        $this->assertStringContainsString('whatsnew_thumbnail', $html);
+    }
+}

--- a/tests/Feature/Plugins/User/Whatsnews/WhatsnewsViewClassesFeatureTest.php
+++ b/tests/Feature/Plugins/User/Whatsnews/WhatsnewsViewClassesFeatureTest.php
@@ -24,7 +24,7 @@ class WhatsnewsViewClassesFeatureTest extends TestCase
     {
         $html = $this->renderWhatsnewsTemplate('plugins.user.whatsnews.default.whatsnews');
 
-        $this->assertWhatsnewPartClasses($html);
+        $this->assertWhatsnewPartClasses($this->extractInitialDisplayMarkup($html));
     }
 
     /**
@@ -34,7 +34,7 @@ class WhatsnewsViewClassesFeatureTest extends TestCase
     {
         $html = $this->renderWhatsnewsTemplate('plugins.user.whatsnews.onerow.whatsnews');
 
-        $this->assertWhatsnewPartClasses($html);
+        $this->assertWhatsnewPartClasses($this->extractInitialDisplayMarkup($html));
     }
 
     /**
@@ -44,13 +44,43 @@ class WhatsnewsViewClassesFeatureTest extends TestCase
     {
         $html = $this->renderWhatsnewsTemplate('plugins.user.whatsnews.card_04.whatsnews');
 
-        $this->assertWhatsnewPartClasses($html);
+        $this->assertWhatsnewPartClasses($this->extractInitialDisplayMarkup($html));
+    }
+
+    /**
+     * 標準テンプレートの追加表示でも、初期表示と同じCSS用クラスで各要素を指定できること。
+     */
+    public function testDefaultTemplateRendersClassesForEachAsyncWhatsnewPart(): void
+    {
+        $html = $this->renderWhatsnewsTemplate('plugins.user.whatsnews.default.whatsnews', UseType::use);
+
+        $this->assertWhatsnewPartClasses($this->extractAsyncDisplayMarkup($html));
+    }
+
+    /**
+     * 1行表示テンプレートの追加表示でも、初期表示と同じCSS用クラスで各要素を指定できること。
+     */
+    public function testOnerowTemplateRendersClassesForEachAsyncWhatsnewPart(): void
+    {
+        $html = $this->renderWhatsnewsTemplate('plugins.user.whatsnews.onerow.whatsnews', UseType::use);
+
+        $this->assertWhatsnewPartClasses($this->extractAsyncDisplayMarkup($html));
+    }
+
+    /**
+     * カード表示テンプレートの追加表示でも、既存のカード用HTMLのCSS用クラスが維持されること。
+     */
+    public function testCardTemplateRendersClassesForEachAsyncWhatsnewPart(): void
+    {
+        $html = $this->renderWhatsnewsTemplate('plugins.user.whatsnews.card_04.whatsnews', UseType::use);
+
+        $this->assertWhatsnewPartClasses($this->extractAsyncDisplayMarkup($html));
     }
 
     /**
      * 新着情報テンプレートの描画に必要な最小限のデータを用意する。
      */
-    private function renderWhatsnewsTemplate(string $template): string
+    private function renderWhatsnewsTemplate(string $template, int $async = UseType::not_use): string
     {
         $frame = (object) [
             'id' => 1,
@@ -69,6 +99,7 @@ class WhatsnewsViewClassesFeatureTest extends TestCase
             'read_more_btn_color_type' => 'primary',
             'read_more_btn_type' => '',
             'read_more_name' => 'もっと見る',
+            'read_more_fetch_count' => 10,
         ];
 
         $whatsnews = collect([
@@ -97,21 +128,41 @@ class WhatsnewsViewClassesFeatureTest extends TestCase
             'whatsnews_total_count' => 1,
             'link_pattern' => ['blogs' => 'show_page_frame_post'],
             'link_base' => ['blogs' => '/plugin/blogs/show'],
-            'frame_configs' => $this->createVisiblePartFrameConfigs(),
+            'frame_configs' => $this->createVisiblePartFrameConfigs($async),
         ])->render();
     }
 
     /**
      * 本文・サムネイル・罫線を表示状態にして、対象クラスがHTMLに現れるようにする。
      */
-    private function createVisiblePartFrameConfigs(): EloquentCollection
+    private function createVisiblePartFrameConfigs(int $async): EloquentCollection
     {
         return new EloquentCollection([
             new FrameConfig(['name' => WhatsnewFrameConfig::post_detail, 'value' => UseType::use]),
             new FrameConfig(['name' => WhatsnewFrameConfig::thumbnail, 'value' => UseType::use]),
             new FrameConfig(['name' => WhatsnewFrameConfig::border, 'value' => UseType::use]),
-            new FrameConfig(['name' => WhatsnewFrameConfig::async, 'value' => UseType::not_use]),
+            new FrameConfig(['name' => WhatsnewFrameConfig::async, 'value' => $async]),
         ]);
+    }
+
+    /**
+     * 追加表示用のVueテンプレートに紛れず、初期表示部分だけを検証できるようにする。
+     */
+    private function extractInitialDisplayMarkup(string $html): string
+    {
+        return preg_replace('/<template\s+v-for="whatsnews in whatsnewses">.*?<\/template>/s', '', $html) ?? $html;
+    }
+
+    /**
+     * 追加表示で差し込まれるHTML断片だけを対象に、初期表示側のクラスで補完されないようにする。
+     */
+    private function extractAsyncDisplayMarkup(string $html): string
+    {
+        $async_markup_position = strpos($html, 'v-for="whatsnews in whatsnewses"');
+
+        $this->assertNotFalse($async_markup_position);
+
+        return substr($html, $async_markup_position);
     }
 
     /**


### PR DESCRIPTION
# 概要

新着情報に表示される日付、カテゴリ、タイトル、投稿者、本文、サムネイルへCSS指定用のクラスを追加しました。

## 変更内容
- 標準テンプレートと1行表示テンプレートの各表示要素に `whatsnew_*` クラスを追加しました。
- 既存のカード表示テンプレートで使われているクラス名と揃えました。
- 主要テンプレートで各クラスが描画されることを確認するFeatureテストを追加しました。

## 背景と目的
新着情報の各要素にクラス名がない場合、タイトルだけにCSSを適用するなど、特定の表示要素を指定したスタイル調整が困難でした。
また、日付の表示有無によってHTML上の順番が変わるため、順番指定に頼ったCSSでは安定して指定できませんでした。
今回、各要素をクラス名で指定できるようにし、表示設定に左右されにくいスタイル調整を可能にしました。

## 特記事項
- 表示構造やリンク先の挙動は変更していません。
- 既存のカード表示テンプレートで使われているクラス名は維持しています。
- 確認コマンド: `docker compose exec -T webapp vendor/bin/phpunit tests/Feature/Plugins/User/Whatsnews`

# レビュー完了希望日
軽微な改修のため急ぎません。

# 関連Pull requests/Issues
なし

# 参考
なし

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule