### PR TITLE
[ページ管理] ページ移動で基準ページの上下を指定できるようにしました

### DIFF
--- a/app/Plugins/Manage/PageManage/PageManage.php
+++ b/app/Plugins/Manage/PageManage/PageManage.php
@@ -425,19 +425,24 @@ class PageManage extends ManagePluginBase
     }
 
     /**
-     * ページ階層移動
+     * ページ移動
      *
-     * @method_title ページ階層移動
-     * @method_desc ページは移動先を指定することで、階層を変更することができます。また、上下矢印でメニューへの表示順番を変更することもできます。
+     * @method_title ページ移動
+     * @method_desc ページは移動先と移動位置を指定することで、階層と表示順番を変更することができます。
      * @spec ページは階層構造を作成できること。
              ページは作成後に階層を変更できること。
      */
     public function movePage($request, $page_id)
     {
+        $move_position = $request->move_position ?? 'child';
+
         // ルートへ移動
         if ($request->destination_id == "0") {
             // 移動元のオブジェクトを取得
             $page = Page::find($page_id);
+            if (empty($page)) {
+                return redirect("/manage/page");
+            }
             $page->saveAsRoot();
             $page->recalcDepthWithDescendants();
         } else {
@@ -449,8 +454,24 @@ class PageManage extends ManagePluginBase
             // 移動先のオブジェクトを取得
             $destination_page = Page::find($request->destination_id);
 
+            if (empty($source_page) || empty($destination_page)) {
+                return redirect("/manage/page");
+            }
+
+            if ($source_page->is($destination_page) || $destination_page->isDescendantOf($source_page)) {
+                return redirect("/manage/page");
+            }
+
             // 移動
-            $source_page->appendToNode($destination_page)->save();
+            if ($move_position === 'before') {
+                $source_page->insertBeforeNode($destination_page);
+            } elseif ($move_position === 'after') {
+                $source_page->insertAfterNode($destination_page);
+            } else {
+                $source_page->appendToNode($destination_page)->save();
+            }
+
+            $source_page->refresh();
             $source_page->recalcDepthWithDescendants();
         }
 

--- a/resources/views/plugins/manage/page/page.blade.php
+++ b/resources/views/plugins/manage/page/page.blade.php
@@ -321,10 +321,14 @@ $base_layout_page->layout = $base_layout;
                             <input type="radio" value="0" id="level_move_modal_page_0" name="level_move_modal_page_id" data-page-name="最上位" class="custom-control-input">
                             <label class="custom-control-label" for="level_move_modal_page_0">最上位</label>
                         </div>
+                        @php
+                            $page_name_stack = [];
+                        @endphp
                         @foreach($pages_select as $page_item)
                             @php
-                                $page_tree = $page_item->getPageTreeByGoingBackParent(null, false);
-                                $page_path = $page_tree->reverse()->pluck('page_name')->implode(' > ');
+                                $page_name_stack[$page_item->depth] = $page_item->page_name;
+                                $page_name_stack = array_slice($page_name_stack, 0, $page_item->depth + 1, true);
+                                $page_path = implode(' > ', $page_name_stack);
                             @endphp
                             <div class="custom-control custom-radio custom-control-block js-level-move-page-option"
                                 data-page-id="{{$page_item->id}}"

--- a/resources/views/plugins/manage/page/page.blade.php
+++ b/resources/views/plugins/manage/page/page.blade.php
@@ -88,52 +88,176 @@ $base_layout_page->layout = $base_layout;
                 form_toggle_display.submit();
             }
 
-            {{-- ページ階層移動モーダル画面でのjavascript --}}
+            let level_move_page_options = [];
+            let level_move_page_option_map = {};
+            let level_move_page_form_url = "{{url('/manage/page/movePage')}}";
+
+            {{-- ページ移動モーダル画面でのjavascript --}}
             $(function(){
                 if (window.connectPageManageTree) {
                     window.connectPageManageTree.init();
                 }
+                init_level_move_page_tree();
                 {{-- 移動先決定ボタン --}}
                 $('#moveLevelDoneBtn').on('click', function() {
                     let destination_id = $('input:radio[name="level_move_modal_page_id"]:checked').val();
                     if (destination_id) {
                         save_page_manage_tree_state();
-                        form_move_page.destination_id.value = destination_id;
-                        form_move_page.submit();
+                        $('#form_move_page_destination_id').val(destination_id);
+                        $('#form_move_page_move_position').val($('input:radio[name="move_position"]:checked').val());
+                        $('#form_move_page').submit();
                     }
                 })
                 {{-- 移動先選択ボタン --}}
                 $('input:radio[name="level_move_modal_page_id"]').on('change', function() {
-                    let level_move_modal_page_radio_id = $(this).attr('id');
-                    let level_move_modal_page_radio_label = $('label[for="' + level_move_modal_page_radio_id + '"]').text();
-                    $('.destination-page').text(level_move_modal_page_radio_label);
+                    if ($(this).val() === '0') {
+                        $('#move_position_before, #move_position_after').prop('disabled', true);
+                        $('#move_position_child').prop('checked', true);
+                    } else {
+                        $('#move_position_before, #move_position_after').prop('disabled', false);
+                    }
+                    update_move_page_destination_text();
                     $('#moveLevelDoneBtn').prop('disabled', false);
                 })
+                {{-- 移動位置選択ボタン --}}
+                $('input:radio[name="move_position"]').on('change', function() {
+                    update_move_page_destination_text();
+                })
+                {{-- 移動先検索 --}}
+                $('#levelMovePageSearch').on('input', function() {
+                    update_level_move_page_search_results();
+                })
             });
-            {{-- ページ階層移動アイコンを押下した際にターゲットのページをセットする --}}
+
+            {{-- 移動先ツリーのDOM参照と親子関係を初期化時にキャッシュする --}}
+            function init_level_move_page_tree() {
+                if (level_move_page_options.length) {
+                    return;
+                }
+
+                $('.js-level-move-page-option').each(function() {
+                    let element = this;
+                    let row = {
+                        element: element,
+                        id: String($(element).attr('data-page-id')),
+                        parent_id: String($(element).attr('data-parent-id') || ''),
+                        search: String($(element).data('search') || '').toLowerCase(),
+                        child_ids: [],
+                    };
+
+                    level_move_page_options.push(row);
+                    level_move_page_option_map[row.id] = row;
+                });
+
+                level_move_page_options.forEach(function(row) {
+                    if (!row.parent_id || !level_move_page_option_map[row.parent_id]) {
+                        return;
+                    }
+                    level_move_page_option_map[row.parent_id].child_ids.push(row.id);
+                });
+            }
+
+            {{-- 親子Mapから子孫ページIDを取得する --}}
+            function collect_level_move_page_descendant_ids(page_id) {
+                let row = level_move_page_option_map[page_id];
+                if (!row || !row.child_ids.length) {
+                    return [];
+                }
+
+                let descendant_ids = [];
+                row.child_ids.forEach(function(child_id) {
+                    descendant_ids.push(child_id);
+                    descendant_ids = descendant_ids.concat(collect_level_move_page_descendant_ids(child_id));
+                });
+
+                return descendant_ids;
+            }
+
+            {{-- 移動先候補行の表示状態を更新する --}}
+            function set_level_move_page_visible(row, visible) {
+                row.element.style.display = visible ? '' : 'none';
+            }
+
+            {{-- 移動先検索結果の表示を更新する --}}
+            function update_level_move_page_search_results() {
+                let keyword = $('#levelMovePageSearch').val().toLowerCase();
+                let matched_count = 0;
+
+                level_move_page_options.forEach(function(row) {
+                    let is_root_option = row.id === '0';
+                    let is_visible = true;
+
+                    is_visible = !keyword || is_root_option || row.search.indexOf(keyword) !== -1;
+
+                    set_level_move_page_visible(row, is_visible);
+                    if (is_visible && !is_root_option) {
+                        matched_count++;
+                    }
+                });
+
+                $('#levelMovePageNoResult').toggle(!!keyword && matched_count === 0);
+            }
+            {{-- 移動先と移動位置を組み合わせた確認文を更新する --}}
+            function update_move_page_destination_text() {
+                let destination = $('input:radio[name="level_move_modal_page_id"]:checked');
+                if (!destination.length) {
+                    $('.destination-page').text('');
+                    return;
+                }
+
+                let move_position = $('input:radio[name="move_position"]:checked').val();
+                if (destination.val() === '0') {
+                    $('.destination-page').text('最上位の末尾');
+                    return;
+                }
+
+                let destination_page_name = destination.attr('data-page-name');
+                let position_label = '配下の末尾';
+                if (move_position === 'before') {
+                    position_label = '上';
+                } else if (move_position === 'after') {
+                    position_label = '下';
+                }
+
+                $('.destination-page').text(destination_page_name + ' の' + position_label);
+            }
+            {{-- ページ移動アイコンを押下した際にターゲットのページをセットする --}}
             function select_page(source_id, page_name) {
                 // ページセット
-                form_move_page.action = form_move_page.action.replace(/movePage(.*$)/g, 'movePage');
-                form_move_page.action = form_move_page.action + "/" + source_id;
+                $('#form_move_page').attr('action', level_move_page_form_url + "/" + source_id);
                 // テキストセット
-                let page_name_txt = '「 <span class="source-page lead">' + page_name + '</span>」を「<span class="destination-page lead"></span>」へ移動します';
+                let page_name_txt = '<span class="source-page lead"></span> を <span class="destination-page lead"></span> へ移動します';
                 $('.modal-title').html(page_name_txt);
+                $('.source-page').text(page_name);
+                $('#levelMoveSourcePageName').text(page_name);
+                $('#levelMoveSourcePageNotice').show();
                 // ラジオボタンを外す
                 if ($('input:radio[name="level_move_modal_page_id"]:checked')[0]) {
                     $('input:radio[name="level_move_modal_page_id"]:checked')[0].checked = false;
                 }
+                // 移動位置を初期化
+                $('#move_position_child').prop('checked', true);
+                $('#move_position_before, #move_position_after').prop('disabled', false);
+                $('#form_move_page_move_position').val('child');
+                // 検索を初期化
+                $('#levelMovePageSearch').val('');
+                update_level_move_page_search_results();
+                // 移動元ラベルを初期化
+                $('.js-level-move-source-label').addClass('d-none');
                 // 選択不可を解除
                 $('input:radio[name="level_move_modal_page_id"]').prop('disabled', false);
                 // 決定ボタンを無効化
                 $('#moveLevelDoneBtn').prop('disabled', true);
                 // 自分自身は選択不可にする
                 $('#level_move_modal_page_' + source_id).prop('disabled', true);
-                // 子孫のノードは選択不可にする data-descendant_idsに子孫格納済
-                let descendant_ids = $('#level_move_modal_page_' + source_id).data('descendant_ids');
-                $(descendant_ids).each(function(i) {
-                    let descendant_id = $(this)[0].valueOf();
-                    $('#level_move_modal_page_' + descendant_id).prop('disabled', true);
-                });
+                $('#level_move_source_label_' + source_id).removeClass('d-none');
+                // 子孫のノードは選択不可にする
+                let source_row = level_move_page_option_map[String(source_id)];
+                if (source_row) {
+                    collect_level_move_page_descendant_ids(source_row.id).forEach(function(descendant_id) {
+                        $('#level_move_modal_page_' + descendant_id).prop('disabled', true);
+                    });
+                }
             }
         </script>
 
@@ -146,7 +270,8 @@ $base_layout_page->layout = $base_layout;
         {{-- ページの指定場所移動用フォーム(POSTのためのフォーム。一つ用意して一覧からJavascriptで呼び出し) --}}
         <form action="{{url('/manage/page/movePage')}}" method="POST" name="form_move_page" id="form_move_page" class="form-horizontal">
             {{ csrf_field() }}
-            <input type="hidden" name="destination_id" value="">
+            <input type="hidden" name="destination_id" id="form_move_page_destination_id" value="">
+            <input type="hidden" name="move_position" id="form_move_page_move_position" value="child">
         </form>
 
         {{-- 表示切り替え用フォーム(POSTのためのフォーム。一つ用意して一覧からJavascriptで呼び出し) --}}
@@ -154,44 +279,72 @@ $base_layout_page->layout = $base_layout;
             {{ csrf_field() }}
         </form>
 
+        @php
+            $page_children = $pages->groupBy('parent_id');
+        @endphp
+
         {{-- 階層変更用モーダル表示 --}}
         <div class="modal fade" id="moveLevlModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-            <div class="modal-dialog">
+            <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <div class="modal-header pb-0">
-                        <h4><div class="modal-title" style="font-size:1rem;">階層移動</div></h4>
+                        <h4><div class="modal-title" style="font-size:1rem;">ページ移動</div></h4>
                     </div>
                     <div class="modal-body" style="max-height: 500px; overflow-y: scroll;">
-                            <div class="custom-control custom-radio custom-control-block">
-                                <input type="radio" value="0" id="level_move_modal_page_0" name="level_move_modal_page_id" class="custom-control-input">
-                                <label class="custom-control-label" for="level_move_modal_page_0">最上位</label>
+                        <div id="levelMoveSourcePageNotice" class="alert alert-info py-2 mb-3" style="display:none;">
+                            移動するページ：<span id="levelMoveSourcePageName"></span>
+                        </div>
+                        <div class="form-group mb-2">
+                            <label for="levelMovePageSearch" class="small mb-1">移動先ページの検索</label>
+                            <input type="search" id="levelMovePageSearch" class="form-control form-control-sm" placeholder="ページ名、固定リンクで検索">
+                        </div>
+                        <div class="form-group mb-2">
+                            <label class="small mb-1">移動位置</label>
+                            <div class="d-flex flex-wrap align-items-center">
+                                <span class="mr-2">選択したページの</span>
+                                <div class="custom-control custom-radio mr-3">
+                                    <input type="radio" value="child" id="move_position_child" name="move_position" class="custom-control-input" checked>
+                                    <label class="custom-control-label" for="move_position_child">配下</label>
+                                </div>
+                                <div class="custom-control custom-radio mr-3">
+                                    <input type="radio" value="before" id="move_position_before" name="move_position" class="custom-control-input">
+                                    <label class="custom-control-label" for="move_position_before">上</label>
+                                </div>
+                                <div class="custom-control custom-radio mr-3">
+                                    <input type="radio" value="after" id="move_position_after" name="move_position" class="custom-control-input">
+                                    <label class="custom-control-label" for="move_position_after">下</label>
+                                </div>
+                                <span>に移動する</span>
                             </div>
-                        @php
-                            $tmp_pages = $pages_select;
-                        @endphp
+                        </div>
+                        <div class="pt-2 mt-2 border-top custom-control custom-radio custom-control-block js-level-move-page-option" data-page-id="0" data-parent-id="" data-search="最上位">
+                            <input type="radio" value="0" id="level_move_modal_page_0" name="level_move_modal_page_id" data-page-name="最上位" class="custom-control-input">
+                            <label class="custom-control-label" for="level_move_modal_page_0">最上位</label>
+                        </div>
                         @foreach($pages_select as $page_item)
-                            {{-- 以下で子孫のIDをdatasetに追加する,子孫がいないページはチェックしない --}}
                             @php
-                                $arr_descendant_ids = [];
-                                $calc_rgt = $page_item->_lft;
-                                $calc_rgt++;
-                                if ($calc_rgt != $page_item->_rgt) {
-                                    foreach ($tmp_pages as $parent_page) {
-                                        if($parent_page->isDescendantOf($page_item)) {
-                                            $arr_descendant_ids[] = $parent_page->id;
-                                        }
-                                    }
-                                }
-                                $str_descendant_ids = implode(',', $arr_descendant_ids);
+                                $page_tree = $page_item->getPageTreeByGoingBackParent(null, false);
+                                $page_path = $page_tree->reverse()->pluck('page_name')->implode(' > ');
                             @endphp
-                            <div class="custom-control custom-radio custom-control-block">
-                                <input type="radio" value="{{$page_item->id}}" id="level_move_modal_page_{{$page_item->id}}" data-descendant_ids="[{{$str_descendant_ids}}]" name="level_move_modal_page_id" class="custom-control-input">
+                            <div class="custom-control custom-radio custom-control-block js-level-move-page-option"
+                                data-page-id="{{$page_item->id}}"
+                                data-parent-id="{{$page_item->parent_id ?? ''}}"
+                                data-search="{{$page_path}} {{$page_item->permanent_link}}">
+                                <input type="radio" value="{{$page_item->id}}" id="level_move_modal_page_{{$page_item->id}}" data-page-name="{{$page_item->page_name}}" name="level_move_modal_page_id" class="custom-control-input">
                                 @for ($i = 0; $i < $page_item->depth; $i++)
                                     @if ($i+1==$page_item->depth) <span class="px-3"></span> @else <span class="px-2"></span>@endif
                                 @endfor
-                                <label class="custom-control-label" for="level_move_modal_page_{{$page_item->id}}" id="level_move_page_{{$page_item->id}}">{{$page_item->page_name}}</label>
+                                <label class="custom-control-label" for="level_move_modal_page_{{$page_item->id}}" id="level_move_page_{{$page_item->id}}">
+                                    {{$page_item->page_name}}
+                                    <span id="level_move_source_label_{{$page_item->id}}" class="badge badge-info ml-1 js-level-move-source-label d-none">移動するページ</span>
+                                    @if ($page_item->base_display_flag == 0)
+                                        <i class="far fa-eye-slash text-muted ml-1" title="メニューから隠す" aria-label="メニューから隠す"></i>
+                                    @endif
+                                    <span class="small text-muted ml-1">{{$page_item->permanent_link}}</span>
+                                </label>
                             </div>
                         @endforeach
+                        <div id="levelMovePageNoResult" class="text-muted" style="display:none;">該当するページがありません。</div>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
@@ -200,10 +353,6 @@ $base_layout_page->layout = $base_layout;
                 </div>
             </div>
         </div>
-
-        @php
-            $page_children = $pages->groupBy('parent_id');
-        @endphp
 
         <div class="cc-table-scroll js-cc-table-scroll" data-page-manage-tree>
             <div class="cc-table-scroll__sticky">
@@ -217,7 +366,7 @@ $base_layout_page->layout = $base_layout;
             <thead>
                 <tr>
                     <th></th>
-                    <th nowrap><i class="fas fa-sitemap" title="階層移動" alt="階層移動"></i></th>
+                    <th nowrap><i class="fas fa-sitemap" title="ページ移動" alt="ページ移動"></i></th>
                     <th nowrap>ページ名</th>
                     <th nowrap class="pl-1"><i class="far fa-eye" title="メニュー表示"></i></th>
                     <th nowrap>固定リンク</th>
@@ -292,8 +441,8 @@ $base_layout_page->layout = $base_layout;
                         </div>
                     </td>
                     <td class="table-text p-1" nowrap>
-                        {{-- 階層移動 --}}
-                        <a class="btn p-1 btn-primary btn-sm" id="move_level_{{$page_item->id}}" style="cursor:pointer;color:#FFF;" data-toggle="modal" data-target="#moveLevlModal" onclick="select_page({{$page_item->id}} , '{{$page_item->page_name}}' );" ><i class="fas fa-sitemap"></i></a>
+                        {{-- ページ移動 --}}
+                        <a class="btn p-1 btn-primary btn-sm" id="move_level_{{$page_item->id}}" style="cursor:pointer;color:#FFF;" data-toggle="modal" data-target="#moveLevlModal" onclick='select_page({{$page_item->id}}, @json($page_item->page_name));' ><i class="fas fa-sitemap"></i></a>
                     </td>
                     <td class="table-text p-1 manage-page-pagename">
                         <div class="manage-page-tree" style="--cc-page-tree-depth: {{$page_item->depth}};">

--- a/tests/Unit/Plugins/Manage/PageManage/PageManageMovePageTest.php
+++ b/tests/Unit/Plugins/Manage/PageManage/PageManageMovePageTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Unit\Plugins\Manage\PageManage;
+
+use App\Models\Common\Page;
+use App\Plugins\Manage\PageManage\PageManage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+/**
+ * PageManage のページ移動処理を対象にした単体テスト。
+ *
+ * 管理画面のフォーム送信に相当する公開メソッド経由で、基準ページの上下と配下へ移動する仕様を検証する。
+ */
+class PageManageMovePageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 基準ページの上へ移動すると、移動元が基準ページと同じ親を持つ直前のページになることを守る。
+     */
+    public function testMovePageBeforeDestination(): void
+    {
+        $parent = Page::factory()->create(['page_name' => 'parent', 'permanent_link' => '/parent']);
+        $destination = $this->createChildPage($parent, 'destination', '/destination');
+        $other = $this->createChildPage($parent, 'other', '/other');
+        $source = $this->createChildPage($parent, 'source', '/source');
+
+        $this->movePage($source, $destination, 'before');
+
+        $this->assertSame(
+            ['source', 'destination', 'other'],
+            $parent->children()->defaultOrder()->pluck('page_name')->all()
+        );
+        $this->assertSame($parent->id, $source->fresh()->parent_id);
+    }
+
+    /**
+     * 基準ページの下へ移動すると、移動元が基準ページと同じ親を持つ直後のページになることを守る。
+     */
+    public function testMovePageAfterDestination(): void
+    {
+        $parent = Page::factory()->create(['page_name' => 'parent', 'permanent_link' => '/parent']);
+        $source = $this->createChildPage($parent, 'source', '/source');
+        $destination = $this->createChildPage($parent, 'destination', '/destination');
+        $other = $this->createChildPage($parent, 'other', '/other');
+
+        $this->movePage($source, $destination, 'after');
+
+        $this->assertSame(
+            ['destination', 'source', 'other'],
+            $parent->children()->defaultOrder()->pluck('page_name')->all()
+        );
+        $this->assertSame($parent->id, $source->fresh()->parent_id);
+    }
+
+    /**
+     * 基準ページの配下へ移動する既存の挙動を維持し、子孫ページの深さも移動先に合わせて更新されることを守る。
+     */
+    public function testMovePageToDestinationChild(): void
+    {
+        $source_parent = Page::factory()->create(['page_name' => 'source parent', 'permanent_link' => '/source-parent']);
+        $destination_parent = Page::factory()->create(['page_name' => 'destination parent', 'permanent_link' => '/destination-parent']);
+        $destination = $this->createChildPage($destination_parent, 'destination', '/destination');
+        $source = $this->createChildPage($source_parent, 'source', '/source');
+        $source_child = $this->createChildPage($source, 'source child', '/source-child');
+
+        $this->movePage($source, $destination, 'child');
+
+        $this->assertSame($destination->id, $source->fresh()->parent_id);
+        $this->assertSame(['source'], $destination->children()->defaultOrder()->pluck('page_name')->all());
+        $this->assertSame($source->fresh()->depth + 1, $source_child->fresh()->depth);
+    }
+
+    /**
+     * 自分自身や子孫ページを基準にした移動は、階層を壊すため実行されないことを守る。
+     */
+    public function testMovePageDoesNotMoveIntoDescendant(): void
+    {
+        $parent = Page::factory()->create(['page_name' => 'parent', 'permanent_link' => '/parent']);
+        $source = $this->createChildPage($parent, 'source', '/source');
+        $source_child = $this->createChildPage($source, 'source child', '/source-child');
+
+        $this->movePage($source, $source_child, 'child');
+
+        $this->assertSame($parent->id, $source->fresh()->parent_id);
+        $this->assertSame($source->id, $source_child->fresh()->parent_id);
+    }
+
+    /**
+     * 指定した親ページの末尾にテスト用ページを作成する。
+     */
+    private function createChildPage(Page $parent, string $page_name, string $permanent_link): Page
+    {
+        $page = Page::factory()->make([
+            'page_name' => $page_name,
+            'permanent_link' => $permanent_link,
+        ]);
+        $page->appendToNode($parent)->save();
+
+        return $page;
+    }
+
+    /**
+     * 管理画面からのページ移動リクエストに相当する入力を組み立てて実行する。
+     */
+    private function movePage(Page $source, Page $destination, string $move_position): void
+    {
+        $request = new Request([
+            'destination_id' => $destination->id,
+            'move_position' => $move_position,
+        ]);
+
+        (new PageManage())->movePage($request, $source->id);
+    }
+}


### PR DESCRIPTION
# 概要

ページ管理のページ移動で、基準ページの上・下・配下を指定して移動できるようにしました。

## 変更内容
- ページ移動ダイアログで、移動先ページと移動位置（配下・上・下）を選択できるようにしました。
- 移動先ページをページ名・固定リンクで検索できるようにしました。
- 移動元ページをダイアログ内で分かるように表示し、移動先として選べないようにしました。
- 非表示ページは目隠しアイコンで判別できるようにしました。
- サーバー側でも、自分自身や子孫ページへの移動を実行しないようにしました。
- ページ移動処理の単体テストを追加しました。

## 背景と目的
ページ数が多いサイトでは、従来の一番上・一番下への移動だけでは目的の位置までページを移動するのに手間がかかっていました。
基準ページを選んで、その上・下・配下へ直接移動できるようにすることで、隠しページを含む多数のページを持つサイトでもページ整理を行いやすくすることが目的です。

## 特記事項
- 既存の「配下へ移動」操作は維持しています。
- ダイアログ内の折り畳み機能は、ページ数が多い場合の負荷を考慮して追加していません。
- ページ移動に関するDB構造変更はありません。

# レビュー完了希望日
急ぎません。

# 関連Pull requests/Issues
なし

# 参考
確認済み:

```bash
docker compose exec -T webapp vendor/bin/phpunit tests/Unit/Plugins/Manage/PageManage/PageManageMovePageTest.php
```

結果:

```text
OK (4 tests, 9 assertions)
```

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule