### PR TITLE
[サイト内検索] 対象フレーム欄を選択時のみ表示するよう修正しました

### DIFF
--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -420,6 +420,11 @@ class SearchsPlugin extends UserPluginBase
             $message = '設定を変更しました。';
         }
 
+        $target_frame_ids = $request->target_frame_ids;
+        if (intval($request->frame_select) == SearchsFrameSelect::all_frames && !$request->has('target_frame_ids')) {
+            $target_frame_ids = empty($searchs->target_frame_ids) ? [] : explode(',', $searchs->target_frame_ids);
+        }
+
         // 設定データ
         $searchs->search_name       = $request->search_name;
         $searchs->count             = $request->count;
@@ -427,7 +432,7 @@ class SearchsPlugin extends UserPluginBase
         $searchs->view_posted_at    = intval($request->view_posted_at);
         $searchs->target_plugins    = implode(',', $request->target_plugin);
         $searchs->frame_select      = intval($request->frame_select);
-        $searchs->target_frame_ids  = empty($request->target_frame_ids) ? "": implode(',', $request->target_frame_ids);
+        $searchs->target_frame_ids  = empty($target_frame_ids) ? "": implode(',', $target_frame_ids);
         $searchs->recieve_keyword   = intval($request->recieve_keyword);
         $searchs->page_select       = intval($request->page_select);
 

--- a/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
@@ -320,10 +320,6 @@ use App\Enums\SearchsPageSelect;
             const disabled = checkedFrameSelect && checkedFrameSelect.value === allFramesValue;
 
             targetFramesArea.setAttribute('aria-disabled', disabled ? 'true' : 'false');
-
-            targetFramesArea.querySelectorAll('input[type="checkbox"]').forEach(function(checkbox) {
-                checkbox.disabled = disabled;
-            });
         };
 
         frameSelects.forEach(function(frameSelect) {

--- a/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
+++ b/resources/views/plugins/user/searchs/default/searchs_edit_search.blade.php
@@ -46,7 +46,7 @@ use App\Enums\SearchsPageSelect;
 @if (isset($searchs))
     @if (!$searchs->id && !$create_flag)
     @else
-        <form action="{{url('/')}}/plugin/searchs/saveBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="POST" class="">
+        <form action="{{url('/')}}/plugin/searchs/saveBuckets/{{$page->id}}/{{$frame_id}}#frame-{{$frame->id}}" method="POST" class="" id="searchs_edit_form_{{$frame->id}}">
             {{ csrf_field() }}
 
             {{-- create_flag がtrue の場合、新規作成するためにsearchs_id を空にする --}}
@@ -167,15 +167,42 @@ use App\Enums\SearchsPageSelect;
                 </div>
             </div>
 
+            @php
+                $selected_frame_select = old('frame_select', $searchs->frame_select);
+            @endphp
+
             <div class="form-group row mb-0">
                 <label class="{{$frame->getSettingLabelClass()}}">フレームの選択</label>
                 <div class="{{$frame->getSettingInputClass(true)}}">
                     @foreach (SearchsFrameSelect::enum as $key => $item)
                         <div class="custom-control custom-radio custom-control-inline">
-                            @if(old('frame_select', $searchs->frame_select) == $key)
-                                <input type="radio" value="{{$key}}" id="frame_select_{{$key}}" name="frame_select" class="custom-control-input" checked="checked">
+                            @if($selected_frame_select == $key)
+                                <input
+                                    type="radio"
+                                    value="{{$key}}"
+                                    id="frame_select_{{$key}}"
+                                    name="frame_select"
+                                    class="custom-control-input"
+                                    checked="checked"
+                                    @if($key == SearchsFrameSelect::all_frames)
+                                        data-toggle="collapse" data-target="#collapse_frame_select{{$frame_id}}.show"
+                                    @else
+                                        data-toggle="collapse" data-target="#collapse_frame_select{{$frame_id}}:not(.show)" aria-expanded="true" aria-controls="collapse_frame_select{{$frame_id}}"
+                                    @endif
+                                >
                             @else
-                                <input type="radio" value="{{$key}}" id="frame_select_{{$key}}" name="frame_select" class="custom-control-input">
+                                <input
+                                    type="radio"
+                                    value="{{$key}}"
+                                    id="frame_select_{{$key}}"
+                                    name="frame_select"
+                                    class="custom-control-input"
+                                    @if($key == SearchsFrameSelect::all_frames)
+                                        data-toggle="collapse" data-target="#collapse_frame_select{{$frame_id}}.show"
+                                    @else
+                                        data-toggle="collapse" data-target="#collapse_frame_select{{$frame_id}}:not(.show)" aria-expanded="true" aria-controls="collapse_frame_select{{$frame_id}}"
+                                    @endif
+                                >
                             @endif
                             <label class="custom-control-label" for="frame_select_{{$key}}">{{ SearchsFrameSelect::getDescription($key) }}</label>
                         </div>
@@ -193,9 +220,9 @@ use App\Enums\SearchsPageSelect;
                 </div>
             </div>
 
-            <div class="form-group row">
+            <div class="form-group row collapse" id="collapse_frame_select{{$frame_id}}">
                 <label class="{{$frame->getSettingLabelClass()}}">対象ページ - フレーム</label>
-                <div class="{{$frame->getSettingInputClass(false, true)}}">
+                <div class="{{$frame->getSettingInputClass(false, true)}}" id="searchs_target_frames_{{$frame->id}}">
                     <ul class="nav nav-pills" role="tablist">
                         @foreach(SearchsTargetPlugin::getPluginsCanSpecifiedFrames() as $target_plugin => $target_plugin_full)
                             <li class="nav-item">
@@ -275,4 +302,39 @@ use App\Enums\SearchsPageSelect;
         @endif
     @endif
 @endif
+
+<script>
+    (function() {
+        const allFramesValue = '{{ SearchsFrameSelect::all_frames }}';
+        const targetFramesArea = document.getElementById('searchs_target_frames_{{ $frame->id }}');
+        const collapseTargetFrames = document.getElementById('collapse_frame_select{{ $frame_id }}');
+        const searchsEditForm = document.getElementById('searchs_edit_form_{{ $frame->id }}');
+        const frameSelects = searchsEditForm ? searchsEditForm.querySelectorAll('input[name="frame_select"]') : [];
+
+        if (!searchsEditForm || !collapseTargetFrames || !targetFramesArea || frameSelects.length === 0) {
+            return;
+        }
+
+        const setTargetFramesDisabled = function() {
+            const checkedFrameSelect = searchsEditForm.querySelector('input[name="frame_select"]:checked');
+            const disabled = checkedFrameSelect && checkedFrameSelect.value === allFramesValue;
+
+            targetFramesArea.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+
+            targetFramesArea.querySelectorAll('input[type="checkbox"]').forEach(function(checkbox) {
+                checkbox.disabled = disabled;
+            });
+        };
+
+        frameSelects.forEach(function(frameSelect) {
+            frameSelect.addEventListener('change', setTargetFramesDisabled);
+        });
+
+        setTargetFramesDisabled();
+
+        @if (isset($selected_frame_select) && $selected_frame_select == SearchsFrameSelect::selected_only)
+            $('#collapse_frame_select{{$frame_id}}').collapse('show')
+        @endif
+    })();
+</script>
 @endsection

--- a/tests/Feature/Plugins/User/Searchs/SearchsTargetFrameSaveFeatureTest.php
+++ b/tests/Feature/Plugins/User/Searchs/SearchsTargetFrameSaveFeatureTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Plugins\User\Searchs;
+
+use App\Enums\SearchsFrameSelect;
+use App\Enums\SearchsPageSelect;
+use App\Models\Common\Buckets;
+use App\Models\User\Searchs\Searchs;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Plugins\User\DefaultBucketRolesFeatureTestTrait;
+use Tests\TestCase;
+
+/**
+ * サイト内検索設定の対象フレーム保存を検証する。
+ *
+ * 設定保存の公開ルートを通して、フレーム選択UIの表示状態に左右されず、
+ * 既存の対象フレーム指定が意図せず失われないことを守る。
+ */
+class SearchsTargetFrameSaveFeatureTest extends TestCase
+{
+    use DefaultBucketRolesFeatureTestTrait;
+    use RefreshDatabase;
+
+    /**
+     * テスト前に初期データを投入する。
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed();
+    }
+
+    /**
+     * 「全て表示する」で保存しても、画面上では使わない既存の対象フレーム指定を保持すること。
+     */
+    public function testSaveBucketsKeepsTargetFrameIdsWhenAllFramesRequestOmitsThem(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('searchs');
+        $searchs = $this->createSearchsBucket($frame->id, '10,20');
+
+        $response = $this->actingAs($admin)->post("/redirect/plugin/searchs/saveBuckets/{$page->id}/{$frame->id}", [
+            'redirect_path' => url("/plugin/searchs/editBuckets/{$page->id}/{$frame->id}#frame-{$frame->id}"),
+            'searchs_id' => $searchs->id,
+            'search_name' => 'サイト内検索を更新',
+            'count' => 20,
+            'view_posted_name' => 0,
+            'view_posted_at' => 0,
+            'target_plugin' => ['blogs' => 'blogs'],
+            'frame_select' => SearchsFrameSelect::all_frames,
+            'recieve_keyword' => 0,
+            'page_select' => SearchsPageSelect::all_pages,
+        ]);
+
+        $response->assertStatus(302);
+        $this->assertDatabaseHas('searchs', [
+            'id' => $searchs->id,
+            'frame_select' => SearchsFrameSelect::all_frames,
+            'target_frame_ids' => '10,20',
+        ]);
+    }
+
+    /**
+     * 「選択したものだけ表示する」で保存した場合は、送信された対象フレーム指定へ更新すること。
+     */
+    public function testSaveBucketsUpdatesTargetFrameIdsWhenSelectedOnlySendsThem(): void
+    {
+        $admin = $this->createContentAdminUser();
+        [$page, $frame] = $this->createPluginFrame('searchs');
+        $searchs = $this->createSearchsBucket($frame->id, '10,20');
+
+        $response = $this->actingAs($admin)->post("/redirect/plugin/searchs/saveBuckets/{$page->id}/{$frame->id}", [
+            'redirect_path' => url("/plugin/searchs/editBuckets/{$page->id}/{$frame->id}#frame-{$frame->id}"),
+            'searchs_id' => $searchs->id,
+            'search_name' => 'サイト内検索を更新',
+            'count' => 20,
+            'view_posted_name' => 0,
+            'view_posted_at' => 0,
+            'target_plugin' => ['blogs' => 'blogs'],
+            'frame_select' => SearchsFrameSelect::selected_only,
+            'target_frame_ids' => [30 => 30],
+            'recieve_keyword' => 0,
+            'page_select' => SearchsPageSelect::all_pages,
+        ]);
+
+        $response->assertStatus(302);
+        $this->assertDatabaseHas('searchs', [
+            'id' => $searchs->id,
+            'frame_select' => SearchsFrameSelect::selected_only,
+            'target_frame_ids' => '30',
+        ]);
+    }
+
+    /**
+     * 既存バケツとサイト内検索設定を作成し、指定フレームに紐づける。
+     */
+    private function createSearchsBucket(int $frame_id, string $target_frame_ids): Searchs
+    {
+        $bucket = Buckets::factory()->create([
+            'bucket_name' => 'サイト内検索',
+            'plugin_name' => 'searchs',
+        ]);
+        $this->assertDatabaseHas('frames', [
+            'id' => $frame_id,
+        ]);
+
+        app('db')->table('frames')
+            ->where('id', $frame_id)
+            ->update(['bucket_id' => $bucket->id]);
+
+        return Searchs::create([
+            'bucket_id' => $bucket->id,
+            'search_name' => 'サイト内検索',
+            'count' => 10,
+            'view_posted_name' => 0,
+            'view_posted_at' => 0,
+            'target_plugins' => 'blogs',
+            'frame_select' => SearchsFrameSelect::selected_only,
+            'target_frame_ids' => $target_frame_ids,
+            'recieve_keyword' => 0,
+            'page_select' => SearchsPageSelect::all_pages,
+        ]);
+    }
+}


### PR DESCRIPTION
# 概要

サイト内検索の設定画面で、フレームの選択が「全て表示する」の場合は「対象ページ - フレーム」を表示しないようにしました。

## 変更内容
- 「フレームの選択」のラジオボタンに、新着情報と同じ折りたたみ動作を追加しました。
- 「選択したものだけ表示する」を選んだ場合のみ、「対象ページ - フレーム」を展開するようにしました。
- 「全て表示する」の場合は、対象フレームのチェックボックスを無効化するようにしました。

## 背景と目的
「全て表示する」を選んでいる場合、個別の対象フレーム指定は検索条件として使われません。
しかし従来はチェックボックスが常に見えて操作できる状態だったため、現在の選択状況が分かりにくくなっていました。
新着情報と同じUIに合わせることで、設定内容を把握しやすくします。

## 特記事項

- 画面表示のみの変更です。検索処理や保存データの形式は変更していません。
- 「全て表示する」で保存した場合も、以前に選択していた対象フレーム設定は保持されるようにしています。
  - これにより、後から「選択したものだけ表示する」に戻した際に、対象フレームを再設定せずに利用できます。

# レビュー完了希望日
軽微なUI修正のため急ぎません。

# 関連Pull requests/Issues
なし

# 参考
確認観点:
- サイト内検索の設定画面で「全て表示する」を選ぶと、「対象ページ - フレーム」が折りたたまれること。
- 「選択したものだけ表示する」を選ぶと、「対象ページ - フレーム」が表示されること。
- 既存の新着情報の設定画面と同じ操作感になっていること。

# DB変更の有無
無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule