### PR TITLE
[コア・サイト管理] ログインIDを参照するmetaタグの追加とON/OFF機能を追加しました

### DIFF
--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -864,9 +864,9 @@ class SiteManage extends ManagePluginBase
 
         // 機能拡張用meta設定の保存
         Configs::updateOrCreate(
-            ['name'     => 'expose_login_id_meta'],
+            ['name'     => 'expose_login_userid_meta'],
             ['category' => 'meta',
-             'value'    => $request->expose_login_id_meta ?? '0']
+             'value'    => $request->expose_login_userid_meta ?? '0']
         );
 
         // メタ情報の更新完了メッセージ

--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -862,6 +862,13 @@ class SiteManage extends ManagePluginBase
             );
         }
 
+        // 機能拡張用meta設定の保存
+        Configs::updateOrCreate(
+            ['name'     => 'expose_login_id_meta'],
+            ['category' => 'meta',
+             'value'    => $request->expose_login_id_meta ?? '0']
+        );
+
         // メタ情報の更新完了メッセージ
         session()->flash('flash_message', 'メタ情報を更新しました。');
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -96,6 +96,10 @@ if (! isset($cc_configs)) {
 @endif
     {{-- CSRF Token --}}
     <meta name="csrf-token" content="{{csrf_token()}}">
+    {{-- ログインID（使用例：JSから参照する等）。未ログイン時は出力しない --}}
+    @auth
+    <meta name="cc-login-id" content="{{ Auth::user()->userid }}">
+    @endauth
     {{-- cc_configsのセット場所は、app\Http\Middleware\ConnectInit::handle(). 管理画面・一般画面全てのviewで参照できる --}}
     <title>@if(isset($page)){{$page->page_name}} | @endif{{$site_name}}</title>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -98,7 +98,7 @@ if (! isset($cc_configs)) {
     <meta name="csrf-token" content="{{csrf_token()}}">
     {{-- ログインユーザID。未ログイン時 or 機能無効時は出力しない --}}
     @auth
-    @if (Configs::getConfigsValue($cc_configs, 'expose_login_id_meta') == '1')
+    @if (Configs::getConfigsValue($cc_configs, 'expose_login_userid_meta') == '1')
     <meta name="cc-login-userid" content="{{ Auth::user()->userid }}">
     @endif
     @endauth

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -96,9 +96,11 @@ if (! isset($cc_configs)) {
 @endif
     {{-- CSRF Token --}}
     <meta name="csrf-token" content="{{csrf_token()}}">
-    {{-- ログインID（使用例：JSから参照する等）。未ログイン時は出力しない --}}
+    {{-- ログインユーザID。未ログイン時 or 機能無効時は出力しない --}}
     @auth
-    <meta name="cc-login-id" content="{{ Auth::user()->userid }}">
+    @if (Configs::getConfigsValue($cc_configs, 'expose_login_id_meta') == '1')
+    <meta name="cc-login-userid" content="{{ Auth::user()->userid }}">
+    @endif
     @endauth
     {{-- cc_configsのセット場所は、app\Http\Middleware\ConnectInit::handle(). 管理画面・一般画面全てのviewで参照できる --}}
     <title>@if(isset($page)){{$page->page_name}} | @endif{{$site_name}}</title>

--- a/resources/views/plugins/manage/site/meta.blade.php
+++ b/resources/views/plugins/manage/site/meta.blade.php
@@ -92,6 +92,43 @@
             <small class="form-text text-muted">ページのタイプを指定（例：website, article, blog, video.movie等）※初期値：website</small>
         </div>
 
+        {{-- 機能拡張用meta --}}
+        <hr class="mt-4 mb-3">
+        <h5 id="expose_meta_settings">機能拡張用meta</h5>
+        <div class="alert alert-info mb-3">
+            <small>
+                <strong><i class="fas fa-info-circle"></i> 機能拡張用metaとは</strong><br>
+                JavaScript等のフロントエンド拡張から参照する目的で、Connect-CMSのHTMLヘッダにmetaタグを追加出力する設定です。<br>
+                <strong>※ HTMLソースに出力されるため、組織のセキュリティポリシーに合わせて有効化してください。</strong>
+            </small>
+        </div>
+        <div class="form-group">
+            <label class="col-form-label">ログインIDをmetaタグに出力 <small class="text-muted">(cc-login-userid)</small></label>
+            <div class="row">
+                <div class="col-md-3">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if(Configs::getConfigsValueAndOld($configs, "expose_login_id_meta", "0") == "0")
+                            <input type="radio" value="0" id="expose_login_id_meta_off" name="expose_login_id_meta" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="0" id="expose_login_id_meta_off" name="expose_login_id_meta" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="expose_login_id_meta_off">出力しない</label>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="custom-control custom-radio custom-control-inline">
+                        @if(Configs::getConfigsValueAndOld($configs, "expose_login_id_meta", "0") == "1")
+                            <input type="radio" value="1" id="expose_login_id_meta_on" name="expose_login_id_meta" class="custom-control-input" checked="checked">
+                        @else
+                            <input type="radio" value="1" id="expose_login_id_meta_on" name="expose_login_id_meta" class="custom-control-input">
+                        @endif
+                        <label class="custom-control-label" for="expose_login_id_meta_on">出力する</label>
+                    </div>
+                </div>
+            </div>
+            <small class="form-text text-muted">ログイン中のみ &lt;meta name="cc-login-userid" content="{ログインID}"&gt; を出力します。</small>
+        </div>
+
         {{-- Submitボタン --}}
         <div class="form-group text-center">
             <div class="row">

--- a/resources/views/plugins/manage/site/meta.blade.php
+++ b/resources/views/plugins/manage/site/meta.blade.php
@@ -107,22 +107,22 @@
             <div class="row">
                 <div class="col-md-3">
                     <div class="custom-control custom-radio custom-control-inline">
-                        @if(Configs::getConfigsValueAndOld($configs, "expose_login_id_meta", "0") == "0")
-                            <input type="radio" value="0" id="expose_login_id_meta_off" name="expose_login_id_meta" class="custom-control-input" checked="checked">
+                        @if(Configs::getConfigsValueAndOld($configs, "expose_login_userid_meta", "0") == "0")
+                            <input type="radio" value="0" id="expose_login_userid_meta_off" name="expose_login_userid_meta" class="custom-control-input" checked="checked">
                         @else
-                            <input type="radio" value="0" id="expose_login_id_meta_off" name="expose_login_id_meta" class="custom-control-input">
+                            <input type="radio" value="0" id="expose_login_userid_meta_off" name="expose_login_userid_meta" class="custom-control-input">
                         @endif
-                        <label class="custom-control-label" for="expose_login_id_meta_off">出力しない</label>
+                        <label class="custom-control-label" for="expose_login_userid_meta_off">出力しない</label>
                     </div>
                 </div>
                 <div class="col-md-3">
                     <div class="custom-control custom-radio custom-control-inline">
-                        @if(Configs::getConfigsValueAndOld($configs, "expose_login_id_meta", "0") == "1")
-                            <input type="radio" value="1" id="expose_login_id_meta_on" name="expose_login_id_meta" class="custom-control-input" checked="checked">
+                        @if(Configs::getConfigsValueAndOld($configs, "expose_login_userid_meta", "0") == "1")
+                            <input type="radio" value="1" id="expose_login_userid_meta_on" name="expose_login_userid_meta" class="custom-control-input" checked="checked">
                         @else
-                            <input type="radio" value="1" id="expose_login_id_meta_on" name="expose_login_id_meta" class="custom-control-input">
+                            <input type="radio" value="1" id="expose_login_userid_meta_on" name="expose_login_userid_meta" class="custom-control-input">
                         @endif
-                        <label class="custom-control-label" for="expose_login_id_meta_on">出力する</label>
+                        <label class="custom-control-label" for="expose_login_userid_meta_on">出力する</label>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
# 概要
ログイン中ユーザのログインIDを `<head>` 内の meta タグとして出力する機能を追加しました。JavaScript等のフロントエンド拡張から、ログイン中のユーザを起点に動的な処理（リンク生成・DOM操作等）を行えるようにする土台です。

組織のセキュリティポリシーに合わせて有効/無効を切り替えられるよう、サイト管理 > meta情報 から ON/OFF できる設定を併せて追加しました。

## 変更内容
### コア（meta 出力部）
- `resources/views/layouts/app.blade.php` の CSRF トークン meta 直後に、以下のブロックを追加
  ```
  @auth
  @if (Configs::getConfigsValue($cc_configs, 'expose_login_id_meta') == '1')
  <meta name="cc-login-userid" content="{ログインID}">
  @endif
  @endauth
  ```
- 未ログイン時／機能無効時はタグそのものを出力しません

### サイト管理（meta情報タブ）
- `/manage/site/meta` の OGP設定の下に「機能拡張用meta」セクションを追加
- 「ログインIDをmetaタグに出力」のON/OFFラジオボタン（デフォルト：出力しない）
- `expose_login_id_meta` を `Configs` に保存（category=meta）

## 想定ユースケース
- 組織カスタマイズのテーマ JavaScript 等で、ログイン中ユーザに紐づく特定ページへのリンクを動的に追加する用途
- 例：ログインユーザ自身の人材データベース（Rmaps 研究者詳細）ページへのリンクを右上プルダウンに動的追加

# レビュー完了希望日
軽微な追加なので急ぎません

# 関連Pull requests/Issues
特になし

# 参考
- meta 名 `cc-login-userid` は Connect-CMS の `users.userid`（ログイン用文字列）と紐付くカラム名に合わせて命名
- HTMLソースに出力されるため、デフォルトはOFF（明示的にONにした組織のみ出力）

# DB変更の有無
無し（既存の `configs` テーブルに `expose_login_id_meta` レコードを保存・参照するのみ）

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule