### PR TITLE
[サイト内検索] ページの選択「ページ管理のメニュー表示条件に従う」がうまく機能していない不具合を修正

### DIFF
--- a/app/Models/Common/Page.php
+++ b/app/Models/Common/Page.php
@@ -492,6 +492,19 @@ class Page extends Model
     }
 
     /**
+     * 親子ページを加味して メニュー表示（基本表示フラグ）の判断
+     *
+     * - isVisibleAncestorsAndSelf() は権限判定用で base_display_flag を見ないため、こちらで判定する。
+     * - 親がメニュー非表示なら子孫もメニュー非表示（defaultOrderWithDepth() の継承ルールと同じ）。
+     */
+    public function isVisibleMenuAncestorsAndSelf(Collection $page_tree): bool
+    {
+        return $page_tree->every(function ($page_obj) {
+            return $page_obj->base_display_flag == 1;
+        });
+    }
+
+    /**
      * ページのURLを返す
      */
     public function getUrl()

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -524,13 +524,10 @@ class SearchsPlugin extends UserPluginBase
 
             // ページの選択「ページ管理のメニュー表示条件に従う」 ＆ フレームの選択「選択したものだけ表示する」以外
             if ($searchs_frame->page_select == SearchsPageSelect::menu_visible_only
-                && $searchs_frame->frame_select != SearchsFrameSelect::selected_only) {
-                // 親子関係をループ（自分 ➔ 親 ➔ ルート）して、base_display_flag が 0 の場合は見れないページとして除外する
-                foreach ($page_tree as $ancestor_page) {
-                    if (!$ancestor_page->base_display_flag) {
-                        continue 2;
-                    }
-                }
+                    && $searchs_frame->frame_select != SearchsFrameSelect::selected_only
+                    && !$page->isVisibleMenuAncestorsAndSelf($page_tree)) {
+                // メニュー非表示（隠しページ）なので、見れないページ
+                continue;
             }
 
             // 見れるページ

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -517,16 +517,16 @@ class SearchsPlugin extends UserPluginBase
                 continue;
             }
 
-            // 親子ページを加味してページ表示できるか
-            if (!$page->isVisibleAncestorsAndSelf($page_tree)) {
-                continue;
-            }
-
             // ページの選択「ページ管理のメニュー表示条件に従う」 ＆ フレームの選択「選択したものだけ表示する」以外
             if ($searchs_frame->page_select == SearchsPageSelect::menu_visible_only
                     && $searchs_frame->frame_select != SearchsFrameSelect::selected_only
                     && !$page->isVisibleMenuAncestorsAndSelf($page_tree)) {
                 // メニュー非表示（隠しページ）なので、見れないページ
+                continue;
+            }
+
+            // 親子ページを加味してページ表示できるか
+            if (!$page->isVisibleAncestorsAndSelf($page_tree)) {
                 continue;
             }
 

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -522,8 +522,9 @@ class SearchsPlugin extends UserPluginBase
                 continue;
             }
 
-            // ページの選択「ページ管理のメニュー表示条件に従う」
-            if ($searchs_frame->page_select == SearchsPageSelect::menu_visible_only) {
+            // ページの選択「ページ管理のメニュー表示条件に従う」 ＆ フレームの選択「選択したものだけ表示する」以外
+            if ($searchs_frame->page_select == SearchsPageSelect::menu_visible_only
+                && $searchs_frame->frame_select != SearchsFrameSelect::selected_only) {
                 // 親子関係をループ（自分 ➔ 親 ➔ ルート）して、base_display_flag が 0 の場合は見れないページとして除外する
                 foreach ($page_tree as $ancestor_page) {
                     if (!$ancestor_page->base_display_flag) {

--- a/app/Plugins/User/Searchs/SearchsPlugin.php
+++ b/app/Plugins/User/Searchs/SearchsPlugin.php
@@ -522,6 +522,16 @@ class SearchsPlugin extends UserPluginBase
                 continue;
             }
 
+            // ページの選択「ページ管理のメニュー表示条件に従う」
+            if ($searchs_frame->page_select == SearchsPageSelect::menu_visible_only) {
+                // 親子関係をループ（自分 ➔ 親 ➔ ルート）して、base_display_flag が 0 の場合は見れないページとして除外する
+                foreach ($page_tree as $ancestor_page) {
+                    if (!$ancestor_page->base_display_flag) {
+                        continue 2;
+                    }
+                }
+            }
+
             // 見れるページ
             $visible_page_ids[] = $page->id;
         }


### PR DESCRIPTION
# 概要
<!-- 変更するに至った背景や目的、及び、変更内容 -->

* https://github.com/opensource-workshop/connect-cms/pull/2386

前述の不具合修正です。

`SearchsPlugin::fetchSearchablePageIds()` 内の以下で、親子ページを加味してページ表示　対応が出来ていると思い込みましたが、違っていました。

```php
            // 親子ページを加味してページ表示できるか
            if (!$page->isVisibleAncestorsAndSelf($page_tree)) {
                continue;
            }
```

このメソッドは権限に基づいて見れる・見れないを判定するメソッドで、メニューの表示・非表示 `page->base_display_flag` は判定していなかったため、親子の`page->base_display_flag`を判定する処理を追加しました。

# レビュー完了希望日
<!-- 「〇月〇日」、「不具合対応なので急ぎたいです」、「軽微な改修なので急ぎません」等、対応時期の目安が判断できる内容 -->

急ぎません

# 関連Pull requests/Issues
<!-- 関連するPR、Issuseがあればそのリンク -->

* https://github.com/opensource-workshop/connect-cms-ideas/issues/183

# 参考
<!-- レビューするに当たって参考にできる情報があればそのリンク -->
なし

# DB変更の有無
<!-- Pull requestsにマイグレーションの追加があるか -->

なし

# チェックリスト

- [ ] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
