### PR TITLE
[コア] ログイン・管理画面等にmeta robots(noindex)を追加しました

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -48,6 +48,12 @@ if (! isset($cc_configs)) {
     if (isset($page)) {
         $page_tree = app('request')->attributes->get('page_tree');
         $meta_robots = $page->getMetaRobots($page_tree);
+    } elseif ($is_manage_page || in_array(\Route::currentRouteName(), [
+        'show_login_form', 'login',
+        'show_register_form', 'register',
+        'password.request', 'password.reset',
+    ])) {
+        $meta_robots = 'noindex, nofollow';
     }
 @endphp
 @if ($meta_robots)

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -51,6 +51,7 @@ if (! isset($cc_configs)) {
     } elseif ($is_manage_page || in_array(\Route::currentRouteName(), [
         'show_login_form', 'login',
         'show_register_form', 'register',
+        'register.confirmToken', 'register.storeToken',
         'password.request', 'password.reset',
     ])) {
         $meta_robots = 'noindex, nofollow';

--- a/tests/Feature/Auth/NoIndexMetaRobotsTest.php
+++ b/tests/Feature/Auth/NoIndexMetaRobotsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\Core\Configs;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * ログイン・ユーザー登録・パスワード再設定の各画面が、検索エンジン向けに
+ * noindexを出力し続けることを守る。Route::currentRouteName()による判定は
+ * ルート名変更時に静かに機能しなくなるため、回帰検知の目的で用意する。
+ */
+class NoIndexMetaRobotsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const NOINDEX_TAG = '<meta name="robots" content="noindex, nofollow">';
+
+    public function testLoginPageHasNoIndexMetaRobots()
+    {
+        $response = $this->get('/login');
+
+        $response->assertOk();
+        $response->assertSee(self::NOINDEX_TAG, false);
+    }
+
+    public function testRegisterPageHasNoIndexMetaRobots()
+    {
+        Configs::factory()->create([
+            'category' => 'user_register',
+            'name' => 'user_register_enable',
+            'value' => '1',
+            'additional1' => 1,
+        ]);
+
+        $response = $this->get('/register');
+
+        $response->assertOk();
+        $response->assertSee(self::NOINDEX_TAG, false);
+    }
+
+    public function testPasswordResetPageHasNoIndexMetaRobots()
+    {
+        Configs::factory()->create([
+            'category' => 'base',
+            'name' => 'base_login_password_reset',
+            'value' => '1',
+        ]);
+
+        $response = $this->get('/password/reset');
+
+        $response->assertOk();
+        $response->assertSee(self::NOINDEX_TAG, false);
+    }
+}


### PR DESCRIPTION
# 概要
/login や /manage/* のような管理機能的なURLは、検索エンジンにインデックスされる想定ではないURLですが、これまで検索避けの設定がされていませんでした。今回、以下のURLに `<meta name="robots" content="noindex, nofollow">` を出力するようにしました。

- ログイン画面（/login）
- 管理画面（/manage/*）
- ユーザー自動登録画面（/register）
- パスワード再設定画面（/password/reset）

既存の `PageMetaRobots` によるページ単位のmeta robots設定（CMSコンテンツページ向け）はそのまま維持しており、今回追加した分岐はそれ以外（`isset($page)` が偽のケース）にのみ適用されます。

なお、robots.txtでのDisallow追加は見送りました。robots.txtでクロール自体をブロックすると、クローラーがnoindexタグを読みに来られなくなり、かえってインデックス制御が効かなくなるためです。

# レビュー完了希望日
軽微な改修なので急ぎません

# 関連Pull requests/Issues
特になし

# 参考
特になし

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule