### PR TITLE
[テーマ管理] テーマ名に半角カッコを含むテーマがあると画面がエラーになる問題を修正しました

### DIFF
--- a/app/Plugins/Manage/SiteManage/SiteManage.php
+++ b/app/Plugins/Manage/SiteManage/SiteManage.php
@@ -1660,7 +1660,7 @@ class SiteManage extends ManagePluginBase
         $dirs = array();
         foreach ($tmp_dirs as $tmp_dir) {
             // テーマ設定ファイル取得
-            $theme_inis = parse_ini_file(public_path() . '/themes/Users/' . basename($tmp_dir) . '/themes.ini');
+            $theme_inis = FileUtils::parseIniFile(public_path() . '/themes/Users/' . basename($tmp_dir) . '/themes.ini');
             $theme_name = '';
             if (!empty($theme_inis) && array_key_exists('theme_name', $theme_inis)) {
                 $theme_name = $theme_inis['theme_name'];

--- a/app/Plugins/Manage/ThemeManage/ThemeManage.php
+++ b/app/Plugins/Manage/ThemeManage/ThemeManage.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 
 use App\Plugins\Manage\ManagePluginBase;
+use App\Utilities\File\FileUtils;
 
 /**
  * テーマ管理クラス
@@ -257,7 +258,7 @@ class ThemeManage extends ManagePluginBase
         $dirs = array();
         foreach ($tmp_dirs as $tmp_dir) {
             // テーマ設定ファイル取得
-            $theme_inis = parse_ini_file(public_path() . '/themes/Users/' . basename($tmp_dir) . '/themes.ini');
+            $theme_inis = FileUtils::parseIniFile(public_path() . '/themes/Users/' . basename($tmp_dir) . '/themes.ini');
             $theme_name = '';
             if (!empty($theme_inis) && array_key_exists('theme_name', $theme_inis)) {
                 $theme_name = $theme_inis['theme_name'];
@@ -291,12 +292,14 @@ class ThemeManage extends ManagePluginBase
         $request->flash();
 
         $messages['dir_name.regex'] = '入力された:attributeは使用できません。半角の英数字、アンダースコア(_)、ハイフン(-)のみを使い、先頭がハイフンにならないように入力してください。';
+        $messages['theme_name.not_regex'] = '入力された:attributeは使用できません。ダブルクォート(")と円記号(\)は使用できません。';
 
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
             /* regex：英数字_- OK */
             'dir_name'   => ['required', 'regex:/^\w[\w-]*$/'],
-            'theme_name' => ['required'],
+            /* not_regex：themes.ini に書き出せない文字（"、\）は不可 */
+            'theme_name' => ['required', 'not_regex:/["\\\\]/'],
         ], $messages);
         $validator->setAttributeNames([
             'dir_name'   => 'ディレクトリ名',
@@ -318,7 +321,7 @@ class ThemeManage extends ManagePluginBase
         $result = File::makeDirectory(public_path() . '/themes/Users/' . basename($request->dir_name), 0775);
 
         // themes.ini ファイルの作成
-        $themes_ini = '[base]' . "\n" . 'theme_name = ' . $request->theme_name;
+        $themes_ini = $this->makeThemesIni($request->theme_name);
         $result = File::put(public_path() . '/themes/Users/' . basename($request->dir_name) . '/themes.ini', $themes_ini);
 
         // themes.css ファイルの作成
@@ -529,6 +532,16 @@ class ThemeManage extends ManagePluginBase
     }
 
     /**
+     * themes.ini ファイルの内容の生成
+     *
+     * テーマ名に ini の予約文字（半角カッコ等）が含まれていても読み込めるよう、値はダブルクォートで囲む。
+     */
+    private function makeThemesIni($theme_name): string
+    {
+        return '[base]' . "\n" . 'theme_name = ' . FileUtils::escapeIniValue((string)$theme_name) . "\n";
+    }
+
+    /**
      * ユーザ・テーマ名の取得
      */
     private function getUserThemeName($dir_name)
@@ -538,7 +551,7 @@ class ThemeManage extends ManagePluginBase
             return '';
         }
 
-        $theme_inis = parse_ini_file($theme_ini_path);
+        $theme_inis = FileUtils::parseIniFile($theme_ini_path);
         if (empty($theme_inis) || !array_key_exists('theme_name', $theme_inis)) {
             return '';
         }
@@ -588,10 +601,13 @@ class ThemeManage extends ManagePluginBase
         // セッション初期化などのLaravel 処理
         $request->flash();
 
+        $messages['theme_name.not_regex'] = '入力された:attributeは使用できません。ダブルクォート(")と円記号(\)は使用できません。';
+
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
-            'theme_name' => ['required'],
-        ]);
+            /* not_regex：themes.ini に書き出せない文字（"、\）は不可 */
+            'theme_name' => ['required', 'not_regex:/["\\\\]/'],
+        ], $messages);
         $validator->setAttributeNames([
             'theme_name' => 'テーマ名',
         ]);
@@ -608,7 +624,7 @@ class ThemeManage extends ManagePluginBase
         $theme_name = $request->theme_name;
 
         // themes.ini ファイルの保存
-        $themes_ini = '[base]' . "\n" . 'theme_name = ' . $theme_name;
+        $themes_ini = $this->makeThemesIni($theme_name);
         $result = File::put(public_path() . '/themes/Users/' . $dir_name . '/themes.ini', $themes_ini);
 
         return view('plugins.manage.theme.theme_name_edit', [
@@ -897,12 +913,14 @@ class ThemeManage extends ManagePluginBase
         $request->flash();
 
         $messages['dir_name.regex'] = '入力された:attributeは使用できません。半角の英数字、アンダースコア(_)、ハイフン(-)のみを使い、先頭がハイフンにならないように入力してください。';
+        $messages['theme_name.not_regex'] = '入力された:attributeは使用できません。ダブルクォート(")と円記号(\)は使用できません。';
 
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
             // regex：英数字_- OK
             'dir_name'   => ['required', 'regex:/^\w[\w-]*$/'],
-            'theme_name' => ['required'],
+            /* not_regex：themes.ini に書き出せない文字（"、\）は不可 */
+            'theme_name' => ['required', 'not_regex:/["\\\\]/'],
         ], $messages);
         $validator->setAttributeNames([
             'dir_name'   => 'ディレクトリ名',
@@ -931,7 +949,7 @@ class ThemeManage extends ManagePluginBase
         $result = File::makeDirectory(public_path() . '/themes/Users/' . basename($request->dir_name), 0775);
 
         // themes.ini ファイルの作成
-        $themes_ini = '[base]' . "\n" . 'theme_name = ' . $request->theme_name;
+        $themes_ini = $this->makeThemesIni($request->theme_name);
         $result = File::put(public_path() . '/themes/Users/' . basename($request->dir_name) . '/themes.ini', $themes_ini);
 
         // themes.css ファイルの作成

--- a/app/Plugins/Manage/ThemeManage/ThemeManage.php
+++ b/app/Plugins/Manage/ThemeManage/ThemeManage.php
@@ -292,14 +292,13 @@ class ThemeManage extends ManagePluginBase
         $request->flash();
 
         $messages['dir_name.regex'] = '入力された:attributeは使用できません。半角の英数字、アンダースコア(_)、ハイフン(-)のみを使い、先頭がハイフンにならないように入力してください。';
-        $messages['theme_name.not_regex'] = '入力された:attributeは使用できません。ダブルクォート(")と円記号(\)は使用できません。';
+        $messages['theme_name.not_regex'] = self::THEME_NAME_NG_MESSAGE;
 
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
             /* regex：英数字_- OK */
             'dir_name'   => ['required', 'regex:/^\w[\w-]*$/'],
-            /* not_regex：themes.ini に書き出せない文字（"、\）は不可 */
-            'theme_name' => ['required', 'not_regex:/["\\\\]/'],
+            'theme_name' => $this->getThemeNameRules(),
         ], $messages);
         $validator->setAttributeNames([
             'dir_name'   => 'ディレクトリ名',
@@ -532,6 +531,27 @@ class ThemeManage extends ManagePluginBase
     }
 
     /**
+     * themes.ini に書き出せない文字（ダブルクォート、円記号）
+     *
+     * ini の値はダブルクォートで囲んで書き出すため、予約文字（半角カッコ等）は使えるが、
+     * ダブルクォートと円記号は書き出した値をそのまま読み戻せないため使えない。
+     */
+    private const THEME_NAME_NG_REGEX = '/["\\\\]/';
+
+    /**
+     * themes.ini に書き出せない文字が入力された場合のメッセージ
+     */
+    private const THEME_NAME_NG_MESSAGE = '入力された:attributeは使用できません。ダブルクォート(")と円記号(\)は使用できません。';
+
+    /**
+     * テーマ名の入力チェックルールの取得
+     */
+    private function getThemeNameRules(): array
+    {
+        return ['required', 'not_regex:' . self::THEME_NAME_NG_REGEX];
+    }
+
+    /**
      * themes.ini ファイルの内容の生成
      *
      * テーマ名に ini の予約文字（半角カッコ等）が含まれていても読み込めるよう、値はダブルクォートで囲む。
@@ -601,12 +621,11 @@ class ThemeManage extends ManagePluginBase
         // セッション初期化などのLaravel 処理
         $request->flash();
 
-        $messages['theme_name.not_regex'] = '入力された:attributeは使用できません。ダブルクォート(")と円記号(\)は使用できません。';
+        $messages['theme_name.not_regex'] = self::THEME_NAME_NG_MESSAGE;
 
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
-            /* not_regex：themes.ini に書き出せない文字（"、\）は不可 */
-            'theme_name' => ['required', 'not_regex:/["\\\\]/'],
+            'theme_name' => $this->getThemeNameRules(),
         ], $messages);
         $validator->setAttributeNames([
             'theme_name' => 'テーマ名',
@@ -913,14 +932,13 @@ class ThemeManage extends ManagePluginBase
         $request->flash();
 
         $messages['dir_name.regex'] = '入力された:attributeは使用できません。半角の英数字、アンダースコア(_)、ハイフン(-)のみを使い、先頭がハイフンにならないように入力してください。';
-        $messages['theme_name.not_regex'] = '入力された:attributeは使用できません。ダブルクォート(")と円記号(\)は使用できません。';
+        $messages['theme_name.not_regex'] = self::THEME_NAME_NG_MESSAGE;
 
         // 項目のエラーチェック
         $validator = Validator::make($request->all(), [
             // regex：英数字_- OK
             'dir_name'   => ['required', 'regex:/^\w[\w-]*$/'],
-            /* not_regex：themes.ini に書き出せない文字（"、\）は不可 */
-            'theme_name' => ['required', 'not_regex:/["\\\\]/'],
+            'theme_name' => $this->getThemeNameRules(),
         ], $messages);
         $validator->setAttributeNames([
             'dir_name'   => 'ディレクトリ名',

--- a/app/Plugins/PluginBase.php
+++ b/app/Plugins/PluginBase.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Log;
 
 use App\Models\Common\Numbers;
 use App\Traits\ConnectMailTrait;
+use App\Utilities\File\FileUtils;
 
 /**
  * プラグイン基底クラス
@@ -166,8 +167,8 @@ class PluginBase
         $themes = array();  // 画面に渡すテーマ配列
         foreach ($dirs as $dir) {
             if (File::exists($dir."/themes.ini")) {
-                // テーマ設定ファイルのパース
-                $theme_inis = parse_ini_file($dir."/themes.ini");
+                // テーマ設定ファイルのパース（壊れたファイルがあっても画面が落ちないよう、空配列が返る）
+                $theme_inis = FileUtils::parseIniFile($dir."/themes.ini");
 
                 // ディレクトリがテーマ・グループ用のものなら、その下のディレクトリを探す。
                 if (array_key_exists('theme_dir', $theme_inis) && $theme_inis['theme_dir'] == 'group') {
@@ -178,8 +179,8 @@ class PluginBase
                     asort($group_dirs);  // ディレクトリが名前に対して逆順になることがあるのでソートしておく。
                     foreach ($group_dirs as $group_dir) {
                         if (File::exists($group_dir."/themes.ini")) {
-                            // テーマ設定ファイルのパース
-                            $group_theme_inis = parse_ini_file($group_dir."/themes.ini");
+                            // テーマ設定ファイルのパース（壊れたファイルがあっても画面が落ちないよう、空配列が返る）
+                            $group_theme_inis = FileUtils::parseIniFile($group_dir."/themes.ini");
 
                             // テーマ設定ファイルからテーマ名を探す。設定がなければディレクトリ名をテーマ名とする。
                             $sub_themes[] = $this->getThemeName($group_dir, $group_theme_inis, basename($dir));
@@ -189,7 +190,8 @@ class PluginBase
                     }
                     // 第2階層テーマがある場合は選択肢に追加する。
                     if (!empty($sub_themes)) {
-                        $themes[] = array('name' => $theme_inis['theme_name'], 'dir' => basename($dir), 'themes' => $sub_themes);
+                        // テーマ設定ファイルにテーマ名がない場合はディレクトリ名をテーマ名とする。
+                        $themes[] = array('name' => $theme_inis['theme_name'] ?? basename($dir), 'dir' => basename($dir), 'themes' => $sub_themes);
                     }
                 } else {
                     // テーマ設定ファイルからテーマ名を探す。設定がなければディレクトリ名をテーマ名とする。

--- a/app/Plugins/PluginBase.php
+++ b/app/Plugins/PluginBase.php
@@ -190,8 +190,8 @@ class PluginBase
                     }
                     // 第2階層テーマがある場合は選択肢に追加する。
                     if (!empty($sub_themes)) {
-                        // テーマ設定ファイルにテーマ名がない場合はディレクトリ名をテーマ名とする。
-                        $themes[] = array('name' => $theme_inis['theme_name'] ?? basename($dir), 'dir' => basename($dir), 'themes' => $sub_themes);
+                        // テーマ設定ファイルからテーマ名を探す。設定がなければディレクトリ名をテーマ名とする。
+                        $themes[] = $this->getThemeName($dir, $theme_inis) + array('themes' => $sub_themes);
                     }
                 } else {
                     // テーマ設定ファイルからテーマ名を探す。設定がなければディレクトリ名をテーマ名とする。

--- a/app/Utilities/File/FileUtils.php
+++ b/app/Utilities/File/FileUtils.php
@@ -112,6 +112,58 @@ class FileUtils
     }
 
     /**
+     * ini ファイルを安全に読み込む
+     *
+     * 壊れた ini ファイルがあっても例外を投げず、空配列を返す。
+     * PluginBase::ccErrorHandler() が PHP の警告を ErrorException 化するため、
+     * parse_ini_file() の構文エラーで画面全体がシステムエラーになるのを防ぐ。
+     *
+     * INI_SCANNER_RAW を指定するため、ini の予約文字（( ) { } | & ~ ! ^ " $ ?）を含む値も
+     * ダブルクォートで囲まれていない状態で読み込める。
+     * ※ RAW では 'on'、'true'、'null' 等の値変換や定数展開は行われない。
+     *
+     * @param string $path ini ファイルのパス
+     * @param bool $process_sections セクション名をキーにした多次元配列で受け取るか
+     * @return array 読み込めなかった場合は空配列
+     */
+    public static function parseIniFile(string $path, bool $process_sections = false): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+
+        try {
+            $inis = parse_ini_file($path, $process_sections, INI_SCANNER_RAW);
+        } catch (\Throwable $e) {
+            // エラーハンドラで例外化されるケース
+            \Log::warning('ini ファイルの読み込みに失敗しました。path = ' . $path . ', message = ' . $e->getMessage());
+            return [];
+        }
+
+        if (!is_array($inis)) {
+            // エラーハンドラが設定されていないケース（false が返る）
+            \Log::warning('ini ファイルの読み込みに失敗しました。path = ' . $path);
+            return [];
+        }
+
+        return $inis;
+    }
+
+    /**
+     * ini ファイルの値として使える文字列（ダブルクォート囲み）に変換する
+     *
+     * ini の予約文字を含む値でも、ダブルクォートで囲めば安全に読み書きできる。
+     * ダブルクォート・円記号・改行は ini の値として正しく表現できないため除去する。
+     *
+     * @param string $value ini ファイルに書き出す値
+     * @return string ダブルクォートで囲んだ文字列
+     */
+    public static function escapeIniValue(string $value): string
+    {
+        return '"' . str_replace(['"', '\\', "\r", "\n"], '', $value) . '"';
+    }
+
+    /**
      * 指定ディレクトリの総使用量を計算（フォーマット済み文字列で返却）
      *
      * @param string $dir 計算対象ディレクトリ

--- a/tests/Unit/Plugins/PluginBaseGetThemesTest.php
+++ b/tests/Unit/Plugins/PluginBaseGetThemesTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Unit\Plugins;
+
+use App\Plugins\PluginBase;
+use Illuminate\Support\Facades\File;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * PluginBase::getThemes() を対象にした単体テスト。
+ *
+ * ページ管理・サイト管理・テーマチェンジャーが使うテーマ一覧取得で、
+ * themes.ini にダブルクォートなしの半角カッコがあっても画面が落ちないことを検証する。
+ */
+class PluginBaseGetThemesTest extends TestCase
+{
+    /**
+     * テストで作成したテーマディレクトリ
+     */
+    private $test_theme_dirs = [];
+
+    /**
+     * テストで作成したテーマディレクトリの削除
+     */
+    protected function tearDown(): void
+    {
+        foreach ($this->test_theme_dirs as $test_theme_dir) {
+            if (File::isDirectory($test_theme_dir)) {
+                File::deleteDirectory($test_theme_dir);
+            }
+        }
+        $this->test_theme_dirs = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * テスト用のユーザ・テーマディレクトリと themes.ini を作成する
+     */
+    private function makeUserTheme($dir_name, $themes_ini): string
+    {
+        $theme_dir = public_path() . '/themes/Users/' . $dir_name;
+        File::makeDirectory($theme_dir, 0775, true);
+        $this->test_theme_dirs[] = $theme_dir;
+
+        File::put($theme_dir . '/themes.ini', $themes_ini);
+
+        return $theme_dir;
+    }
+
+    /**
+     * PluginBase::getThemes() の実行（protected のためリフレクションで呼ぶ）
+     */
+    private function getThemes(): array
+    {
+        $plugin_base = new PluginBase();
+        $method = new ReflectionMethod(PluginBase::class, 'getThemes');
+        $method->setAccessible(true);
+
+        try {
+            return $method->invoke($plugin_base);
+        } finally {
+            // PluginBase のコンストラクタで設定されたエラーハンドラを元に戻す
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * テーマ一覧から指定ディレクトリのテーマを探す
+     */
+    private function findUserTheme(array $themes, $dir_name)
+    {
+        foreach ($themes as $theme) {
+            if (!array_key_exists('themes', $theme)) {
+                continue;
+            }
+            foreach ($theme['themes'] as $sub_theme) {
+                if ($sub_theme['dir'] === 'Users/' . $dir_name) {
+                    return $sub_theme;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * ダブルクォートなしの半角カッコを含む themes.ini があっても、
+     * 例外を投げずにテーマ一覧が取得できることを守る。（Issue #2465）
+     */
+    public function testGetThemesWithReservedCharThemeName()
+    {
+        $dir_name = 'cc_test_paren_' . uniqid();
+        $this->makeUserTheme($dir_name, "[base]\ntheme_name = theme_user_02 (clear-steelblue)\n");
+
+        $themes = $this->getThemes();
+
+        $this->assertNotEmpty($themes);
+        $theme = $this->findUserTheme($themes, $dir_name);
+        $this->assertNotNull($theme);
+        $this->assertSame('theme_user_02 (clear-steelblue)', $theme['name']);
+    }
+
+    /**
+     * ダブルクォートなしの既存 themes.ini が、これまで通り読めることを守る。
+     */
+    public function testGetThemesWithExistingThemeName()
+    {
+        $dir_name = 'cc_test_plain_' . uniqid();
+        $this->makeUserTheme($dir_name, "[base]\ntheme_name = カスタムテーマ１\n");
+
+        $themes = $this->getThemes();
+
+        $theme = $this->findUserTheme($themes, $dir_name);
+        $this->assertNotNull($theme);
+        $this->assertSame('カスタムテーマ１', $theme['name']);
+    }
+
+    /**
+     * 復旧できないほど壊れた themes.ini があっても、
+     * 例外を投げずディレクトリ名をテーマ名として一覧が取得できることを守る。
+     */
+    public function testGetThemesWithBrokenThemesIni()
+    {
+        $dir_name = 'cc_test_broken_' . uniqid();
+        // セクション行が閉じていないため、読み込みに失敗する
+        $this->makeUserTheme($dir_name, "[base\ntheme_name = テーマA\n");
+
+        $themes = $this->getThemes();
+
+        $theme = $this->findUserTheme($themes, $dir_name);
+        $this->assertNotNull($theme);
+        $this->assertSame($dir_name, $theme['name']);
+    }
+}

--- a/tests/Unit/Utilities/File/FileUtilsParseIniFileTest.php
+++ b/tests/Unit/Utilities/File/FileUtilsParseIniFileTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Unit\Utilities\File;
+
+use App\Utilities\File\FileUtils;
+use Tests\TestCase;
+
+/**
+ * FileUtils::parseIniFile() を対象にした単体テスト。
+ *
+ * テーマ名に半角カッコ等の ini 予約文字が含まれていても画面が落ちないこと、
+ * および既存の themes.ini（ダブルクォートなし）がこれまで通り読めることを検証する。
+ *
+ * \Log ファサードを使うため、素の PHPUnit ではなく Laravel の TestCase を継承する。
+ */
+class FileUtilsParseIniFileTest extends TestCase
+{
+    /**
+     * テストで作成した ini ファイルのパス
+     */
+    private $test_ini_paths = [];
+
+    /**
+     * テストで作成した ini ファイルの削除
+     */
+    protected function tearDown(): void
+    {
+        foreach ($this->test_ini_paths as $test_ini_path) {
+            if (file_exists($test_ini_path)) {
+                unlink($test_ini_path);
+            }
+        }
+        $this->test_ini_paths = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * ini ファイルを一時ディレクトリに作成する
+     */
+    private function makeIniFile($contents): string
+    {
+        $ini_path = sys_get_temp_dir() . '/cc_test_' . uniqid() . '.ini';
+        file_put_contents($ini_path, $contents);
+        $this->test_ini_paths[] = $ini_path;
+
+        return $ini_path;
+    }
+
+    /**
+     * 既存の themes.ini（ダブルクォートなし）がこれまで通り読めることを守る。
+     *
+     * @dataProvider existingThemesIniProvider
+     */
+    public function testParseIniFileExistingFormat($contents, $expected)
+    {
+        $result = FileUtils::parseIniFile($this->makeIniFile($contents));
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * 既存の themes.ini のパターン（public/themes 配下の実ファイルに合わせたもの）
+     */
+    public function existingThemesIniProvider()
+    {
+        return [
+            // Defaults/Blue/themes.ini など
+            "英数字" => ["[base]\ntheme_name = Blue\n", ['theme_name' => 'Blue']],
+            // Users/hpsc/themes.ini など
+            "アンダースコア" => ["[base]\ntheme_name = hpsc_second\n", ['theme_name' => 'hpsc_second']],
+            // 日本語のテーマ名
+            "日本語" => ["[base]\ntheme_name = カスタムテーマ１\n", ['theme_name' => 'カスタムテーマ１']],
+            // Users/themes.ini などのグループ用
+            "グループ用" => [
+                "[base]\ntheme_name = Users グループ\ntheme_dir = group\n",
+                ['theme_name' => 'Users グループ', 'theme_dir' => 'group'],
+            ],
+            // 値の前後の空白は取り除かれる
+            "前後の空白" => ["[base]\ntheme_name =   Blue  \n", ['theme_name' => 'Blue']],
+            // Users/themes.ini などの先頭コメント
+            "コメント行あり" => [";comment\n[base]\ntheme_name = hpsc\n", ['theme_name' => 'hpsc']],
+            // 数字のみ
+            "数字" => ["[base]\ntheme_name = 2024\n", ['theme_name' => '2024']],
+        ];
+    }
+
+    /**
+     * ダブルクォートで囲まれていない ini 予約文字が、エラーにならず読めることを守る。
+     *
+     * @dataProvider reservedCharThemesIniProvider
+     */
+    public function testParseIniFileReservedChar($contents, $expected)
+    {
+        $result = FileUtils::parseIniFile($this->makeIniFile($contents));
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * ini 予約文字を含む themes.ini のパターン
+     */
+    public function reservedCharThemesIniProvider()
+    {
+        return [
+            // Issue #2465 の再現ケース
+            "半角カッコ" => [
+                "[base]\ntheme_name = theme_user_02 (clear-steelblue)\n",
+                ['theme_name' => 'theme_user_02 (clear-steelblue)'],
+            ],
+            "その他の予約文字" => [
+                "[base]\ntheme_name = A!B|C&D\n",
+                ['theme_name' => 'A!B|C&D'],
+            ],
+        ];
+    }
+
+    /**
+     * ダブルクォートで囲んだ値は、ダブルクォートが外れて読めることを守る。
+     */
+    public function testParseIniFileQuoted()
+    {
+        $ini_path = $this->makeIniFile("[base]\ntheme_name = \"theme_user_02 (clear-steelblue)\"\n");
+
+        $result = FileUtils::parseIniFile($ini_path);
+
+        $this->assertEquals(['theme_name' => 'theme_user_02 (clear-steelblue)'], $result);
+    }
+
+    /**
+     * FileUtils::escapeIniValue() で書き出した値が、そのまま読み戻せることを守る。
+     */
+    public function testParseIniFileRoundTrip()
+    {
+        $theme_name = 'テーマA (clear-steelblue)';
+        $ini_path = $this->makeIniFile('[base]' . "\n" . 'theme_name = ' . FileUtils::escapeIniValue($theme_name) . "\n");
+
+        $result = FileUtils::parseIniFile($ini_path);
+
+        $this->assertEquals($theme_name, $result['theme_name']);
+    }
+
+    /**
+     * 復旧できないほど壊れた ini ファイルでも、例外を投げずに空配列を返すことを守る。
+     */
+    public function testParseIniFileBroken()
+    {
+        // セクション行が閉じていないため、読み込みに失敗する
+        $ini_path = $this->makeIniFile("[base\ntheme_name = テーマA\n");
+
+        $result = FileUtils::parseIniFile($ini_path);
+
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * 存在しないファイルを指定しても、例外を投げずに空配列を返すことを守る。
+     */
+    public function testParseIniFileNotExists()
+    {
+        $result = FileUtils::parseIniFile(sys_get_temp_dir() . '/cc_test_not_exists_' . uniqid() . '.ini');
+
+        $this->assertSame([], $result);
+    }
+}

--- a/tests/Unit/Utilities/File/FileUtilsTest.php
+++ b/tests/Unit/Utilities/File/FileUtilsTest.php
@@ -37,4 +37,40 @@ class FileUtilsTest extends TestCase
             ['', ''],
         ];
     }
+
+    /**
+     * ini ファイルの値に変換するテスト
+     *
+     * @dataProvider escapeIniValueProvider
+     */
+    public function testEscapeIniValue($input, $expected)
+    {
+        $result = FileUtils::escapeIniValue($input);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * ini ファイルの値に変換するテストのデータプロバイダ
+     */
+    public function escapeIniValueProvider()
+    {
+        return [
+            // ini の予約文字はダブルクォートで囲むことで使える
+            ['theme_user_02 (clear-steelblue)', '"theme_user_02 (clear-steelblue)"'],
+            ['テーマA (青)', '"テーマA (青)"'],
+            ['A!B|C&D', '"A!B|C&D"'],
+            ['コメント;付き', '"コメント;付き"'],
+
+            // ダブルクォート・円記号・改行は除去する
+            ['テーマ"A"', '"テーマA"'],
+            ['テーマ\\A', '"テーマA"'],
+            ["テーマ\r\nA", '"テーマA"'],
+
+            // 予約文字を含まない値はそのままダブルクォートで囲むだけ
+            ['Default', '"Default"'],
+
+            // 空文字
+            ['', '""'],
+        ];
+    }
 }


### PR DESCRIPTION
# 概要

テーマ名に半角カッコ `( )` を含むテーマが存在すると、ページ管理の初期表示がシステムエラーになる不具合を修正しました。

## 原因

`public/themes/**/themes.ini` の `theme_name` に半角カッコがダブルクォートなしで書かれていると、`parse_ini_file()` が `syntax error, unexpected '('` の警告を出して `false` を返します。Connect-CMS は `PluginBase::__construct()` で `set_error_handler(ccErrorHandler)` を設定しており、警告を `ErrorException` に変換して throw するため、壊れた `themes.ini` が1つあるだけで画面全体がシステムエラーになっていました。

作り込みの元はテーマ管理側で、`theme_name` を素のまま `themes.ini` に書き出していたことです（バリデーションも `required` のみ）。そのため、**テーマ管理の画面から半角カッコ入りのテーマ名を登録すると、その直後から復旧できなくなる**状態でした。

影響範囲はIssue記載のページ管理だけではなく、`PluginBase::getThemes()` を使う以下の画面すべてです。

- ページ管理（一覧・ページ編集）
- サイト管理
- テーマ管理
- テーマチェンジャープラグイン（**公開画面**）
- サイト設定書（PDF）出力

## 変更内容

Issueに記載いただいた恒久対策案1・2の両方を実施しました。既存サイトには既に壊れた `themes.ini` が存在しうるため、片方だけでは不十分と判断しています。

### 1. 読み込み側の堅牢化（対策案2）

`App\Utilities\File\FileUtils` に `parseIniFile()` を追加し、`themes.ini` を読む5箇所を置き換えました。

- `parse_ini_file()` に `INI_SCANNER_RAW` を指定し、ダブルクォートなしの ini 予約文字も読めるようにしています
- それでも読めない壊れ方（例: セクション行が閉じていない）に備えて try/catch と `is_array()` チェックを行い、失敗時は空配列を返してログに warning を出します
- あわせて `getThemes()` で、グループ用 `themes.ini` に `theme_name` が無い場合に未定義キー参照となっていた箇所も修正しました

置き換え箇所

- `PluginBase::getThemes()`（第1階層・グループ配下の2箇所）
- `ThemeManage::index()` / `ThemeManage::getUserThemeName()`
- `SiteManage`（サイト設定書PDF出力）

なお `ThemeManage::index()` と `SiteManage` はファイル存在チェックが無かったため、`themes.ini` の無いディレクトリがあるだけでもエラーになる状態でしたが、こちらも同時に解消されます。

### 2. 書き出し側の対応（対策案1）

- テーマ管理の themes.ini 書き出し3箇所（テーマ作成・名称変更・カスタムテーマ生成）を `makeThemesIni()` に共通化し、`theme_name` を必ずダブルクォートで囲むようにしました
- 同3箇所の `theme_name` のバリデーションに `not_regex` を追加し、ini の値として表現できない `"` と `\` を弾くようにしました（半角カッコは正しく扱えるため許可しています）

### 3. テスト追加

- `tests/Unit/Utilities/File/FileUtilsTest.php`: `escapeIniValue()` のテストを追加
- `tests/Unit/Utilities/File/FileUtilsParseIniFileTest.php`（新規）: 既存フォーマットの後方互換7パターン、ini予約文字、ダブルクォート付き、書き出し→読み込みの往復、壊れたファイル、存在しないパス
- `tests/Unit/Plugins/PluginBaseGetThemesTest.php`（新規）: 半角カッコ入り `themes.ini` があっても `getThemes()` が例外を投げないこと

## 既存 themes.ini への影響（後方互換）

`INI_SCANNER_RAW` の指定で既存の読み込み結果が変わらないことを、PHP実機で確認しています。

| themes.ini の値（ダブルクォートなし） | 現行 | 変更後 |
| --- | --- | --- |
| `theme_name = Blue` | `Blue` | `Blue`（同一） |
| `theme_name = カスタムテーマ１` | 同左 | 同左（同一） |
| `theme_name = Users グループ` + `theme_dir = group` | 同左 | 同左（同一） |
| `theme_name = clear-steelblue_01.2` | 同左 | 同左（同一） |
| `theme_name =   Blue  `（前後空白） | `Blue` | `Blue`（同一） |
| `;` コメント行あり | 同左 | 同左（同一） |
| `theme_name = theme_user_02 (clear-steelblue)` | **エラーで画面が落ちる** | `theme_user_02 (clear-steelblue)`（本件の修正） |

結果が変わるのは `theme_name` が `on` / `true` / `null` / PHP定義済み定数と完全一致する場合のみで、現行が値を `1` や空文字に変換してしまっていたものが、正しい文字列として読めるようになる方向の差異です。「今まで読めていたものが読めなくなる」パターンはありません。

既存の壊れた `themes.ini` も `INI_SCANNER_RAW` によってそのまま正しく読めるようになるため、修復用のバッチやマイグレーションは不要です。テーマ管理の「名称変更」から保存し直せば、ダブルクォート付きに書き直されます。

## 確認内容

- ユニットテスト
  - `tests/Unit/Utilities/File/`: OK (28 tests, 28 assertions)
  - `tests/Unit/Plugins/PluginBaseGetThemesTest.php`: OK (3 tests, 7 assertions)
- phpcs（PSR-12）: 指摘なし
- 手動テスト
  - テーマ管理の画面から半角カッコ入りのテーマ名でテーマを登録 → `themes.ini` がダブルクォート付きで保存され、ページ管理・ページ編集・サイト管理・テーマ管理・テーマチェンジャー（公開画面）・サイト設定書PDF がいずれもエラーにならないこと
  - 名称変更・カスタムテーマ生成でも同様にダブルクォート付きで保存されること
  - `"` や `\` を含むテーマ名がバリデーションで弾かれ、ファイルが書き換わらないこと
  - 既存テーマ（`Defaults` 配下28件、ユーザ・テーマ）の表示名が従来通りであること、テーマの適用表示が従来通りであること
  - ダブルクォートなしの `themes.ini` を手置きした場合も、エラーにならずテーマ名が正しく表示されること
  - 復旧できないほど壊れた `themes.ini` があっても画面が落ちず、ディレクトリ名にフォールバックしてログに warning が出ること

# レビュー完了希望日

不具合対応ですが、暫定対処（該当 themes.ini をダブルクォートで囲む）があるため、急ぎではありません。

# 関連Pull requests/Issues

- #2465

# 参考

- PHP: [parse_ini_file](https://www.php.net/manual/ja/function.parse-ini-file.php) — ini の予約文字と `INI_SCANNER_RAW` について

# DB変更の有無

無し

# チェックリスト

- [x] プルリクエストにわかりやすいタイトルとラベルを付けました。https://github.com/opensource-workshop/connect-cms/wiki/Pull-requests-Rule
